### PR TITLE
fix: update go/dockerfile 1.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.13 as builder
+FROM golang:1.15 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
i accidentally pushed https://github.com/external-secrets/external-secrets/commit/adb4de943d8bda69eee95c2ac354c3ce92d605ed to main; this commit fixes the docker-build.

I enforced the review restrictions for administrators in the repository settings