### PR TITLE
fix: validate refresh interval, refresh externalsecret

### DIFF
--- a/apis/externalsecrets/v1alpha1/externalsecret_types.go
+++ b/apis/externalsecrets/v1alpha1/externalsecret_types.go
@@ -105,10 +105,10 @@ type ExternalSecretSpec struct {
 	Target ExternalSecretTarget `json:"target"`
 
 	// RefreshInterval is the amount of time before the values reading again from the SecretStore provider
-	// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h" (from time.ParseDuration)
-	// May be set to zero to fetch and create it once
-	// TODO: Default to some value?
-	// +optional
+	// We support a subset of time.ParseDuration: Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+	// May be set to zero to fetch and create it once. Defaults to 1h.
+	// +kubebuilder:validation:Pattern=`(^0$)|([0-9]+(µs|us|ns|ms|s|m|h))`
+	// +kubebuilder:default="1h"
 	RefreshInterval string `json:"refreshInterval,omitempty"`
 
 	// Data defines the connection between the Kubernetes Secret keys and the Provider data
@@ -163,6 +163,8 @@ type ExternalSecretStatus struct {
 // ExternalSecret is the Schema for the external-secrets API.
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Namespaced,categories={externalsecrets},shortName=es
+// +kubebuilder:printcolumn:name="Store",type=string,JSONPath=`.spec.secretStoreRef.name`
+// +kubebuilder:printcolumn:name="Refresh Interval",type=string,JSONPath=`.spec.refreshInterval`
 type ExternalSecret struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/externalsecrets/v1alpha1/externalsecret_types.go
+++ b/apis/externalsecrets/v1alpha1/externalsecret_types.go
@@ -104,12 +104,11 @@ type ExternalSecretSpec struct {
 
 	Target ExternalSecretTarget `json:"target"`
 
-	// RefreshInterval is the amount of time before the values reading again from the SecretStore provider
-	// We support a subset of time.ParseDuration: Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+	// RefreshInterval is the amount of time before the values are read again from the SecretStore provider
+	// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
 	// May be set to zero to fetch and create it once. Defaults to 1h.
-	// +kubebuilder:validation:Pattern=`(^0$)|([0-9]+(µs|us|ns|ms|s|m|h))`
 	// +kubebuilder:default="1h"
-	RefreshInterval string `json:"refreshInterval,omitempty"`
+	RefreshInterval *metav1.Duration `json:"refreshInterval,omitempty"`
 
 	// Data defines the connection between the Kubernetes Secret keys and the Provider data
 	// +optional

--- a/apis/externalsecrets/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/externalsecrets/v1alpha1/zz_generated.deepcopy.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -228,6 +229,11 @@ func (in *ExternalSecretSpec) DeepCopyInto(out *ExternalSecretSpec) {
 	*out = *in
 	out.SecretStoreRef = in.SecretStoreRef
 	out.Target = in.Target
+	if in.RefreshInterval != nil {
+		in, out := &in.RefreshInterval, &out.RefreshInterval
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.Data != nil {
 		in, out := &in.Data, &out.Data
 		*out = make([]ExternalSecretData, len(*in))

--- a/config/crd/bases/external-secrets.io_externalsecrets.yaml
+++ b/config/crd/bases/external-secrets.io_externalsecrets.yaml
@@ -101,12 +101,10 @@ spec:
                 type: array
               refreshInterval:
                 default: 1h
-                description: 'RefreshInterval is the amount of time before the values
-                  reading again from the SecretStore provider We support a subset
-                  of time.ParseDuration: Valid time units are "ns", "us" (or "µs"),
-                  "ms", "s", "m", "h" May be set to zero to fetch and create it once.
-                  Defaults to 1h.'
-                pattern: (^0$)|([0-9]+(µs|us|ns|ms|s|m|h))
+                description: RefreshInterval is the amount of time before the values
+                  are read again from the SecretStore provider Valid time units are
+                  "ns", "us" (or "µs"), "ms", "s", "m", "h" May be set to zero to
+                  fetch and create it once. Defaults to 1h.
                 type: string
               secretStoreRef:
                 description: SecretStoreRef defines which SecretStore to fetch the

--- a/config/crd/bases/external-secrets.io_externalsecrets.yaml
+++ b/config/crd/bases/external-secrets.io_externalsecrets.yaml
@@ -18,7 +18,14 @@ spec:
     singular: externalsecret
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.secretStoreRef.name
+      name: Store
+      type: string
+    - jsonPath: .spec.refreshInterval
+      name: Refresh Interval
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ExternalSecret is the Schema for the external-secrets API.
@@ -93,11 +100,13 @@ spec:
                   type: object
                 type: array
               refreshInterval:
+                default: 1h
                 description: 'RefreshInterval is the amount of time before the values
-                  reading again from the SecretStore provider Valid time units are
-                  "ns", "us" (or "µs"), "ms", "s", "m", "h" (from time.ParseDuration)
-                  May be set to zero to fetch and create it once TODO: Default to
-                  some value?'
+                  reading again from the SecretStore provider We support a subset
+                  of time.ParseDuration: Valid time units are "ns", "us" (or "µs"),
+                  "ms", "s", "m", "h" May be set to zero to fetch and create it once.
+                  Defaults to 1h.'
+                pattern: (^0$)|([0-9]+(µs|us|ns|ms|s|m|h))
                 type: string
               secretStoreRef:
                 description: SecretStoreRef defines which SecretStore to fetch the

--- a/pkg/controllers/externalsecret/externalsecret_controller.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller.go
@@ -131,10 +131,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{RequeueAfter: requeueAfter}, nil
 	}
 
-	dur, err := time.ParseDuration(externalSecret.Spec.RefreshInterval)
-	if err != nil {
-		// this should be catched by validation
-		log.Error(err, "unable to parse RefreshInterval duration")
+	dur := time.Hour
+	if externalSecret.Spec.RefreshInterval != nil {
+		dur = externalSecret.Spec.RefreshInterval.Duration
 	}
 
 	conditionSynced := NewExternalSecretCondition(esv1alpha1.ExternalSecretReady, corev1.ConditionTrue, esv1alpha1.ConditionReasonSecretSynced, "Secret was synced")

--- a/pkg/controllers/externalsecret/externalsecret_controller_test.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller_test.go
@@ -179,7 +179,7 @@ var _ = Describe("ExternalSecret controller", func() {
 					Namespace: ExternalSecretNamespace,
 				},
 				Spec: esv1alpha1.ExternalSecretSpec{
-					RefreshInterval: "1s",
+					RefreshInterval: &metav1.Duration{Duration: time.Second},
 					SecretStoreRef: esv1alpha1.SecretStoreRef{
 						Name: ExternalSecretStore,
 					},


### PR DESCRIPTION
I'd like to add some minor improvements and tests to ensure `refreshInterval` works as expected.

* add validation pattern to support both use-cases: zero-value and duration. AFAIK OpenAPI does not support golang-style time.Duration
* pass `es.refreshInterval` into ctrl result
* add printer columns for `refresh interval` and `store` 
