### PR TITLE
Fix ci docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,10 @@ jobs:
           restore-keys: ${{ runner.os }}-pkg-
 
       - name: Build Artifacts
+        env:
+          # We're using docker buildx, which doesn't actually load the images it
+          # builds by default. Specifying --load does so.
+          BUILD_ARGS: "--load"
         run: make docker.build
 
       - name: Login to Docker
@@ -231,8 +235,8 @@ jobs:
           password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Publish Artifacts
-        run: make docker.push
         if: env.GHCR_USERNAME != ''
+        run: make docker.push
 
       - name: Promote Artifacts to main release channel
         if: github.ref == 'refs/heads/main' && env.GHCR_USERNAME != ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ env:
   KUBEBUILDER_VERSION: '2.3.1'
   DOCKER_BUILDX_VERSION: 'v0.4.2'
 
-  # Common users. We can't run a step 'if secrets.GHCR_USER != ""' but we can run
-  # a step 'if env.GHCR_USER' != ""', so we copy these to succinctly test whether
+  # Common users. We can't run a step 'if secrets.GHCR_USERNAME != ""' but we can run
+  # a step 'if env.GHCR_USERNAME' != ""', so we copy these to succinctly test whether
   # credentials have been provided before trying to run steps that need them.
-  GHCR_USER: ${{ secrets.GHCR_USERNAME }}
+  GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
 
 jobs:
   detect-noop:

--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ build.all: docker.build helm.build
 
 docker.build: build ## Build the docker image
 	@$(INFO) docker build
-	@docker build . -t $(IMAGE_REGISTRY):$(VERSION)
+	@docker build . $(BUILD_ARGS) -t $(IMAGE_REGISTRY):$(VERSION)
 	@$(OK) docker build
 
 docker.push:


### PR DESCRIPTION
Incorporates fix from https://github.com/external-secrets/external-secrets/pull/70 to also fix missing docker buildx argument. Docker builds were not being persisted locally so they could not be pushed in the later workflow action.