### PR TITLE
Fix the Dockerfile ENTRYPOINT to match the Kubernetes YAML resources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM alpine:3.13
 
-COPY bin/external-secrets /bin/external-secrets
+COPY bin/external-secrets manager
 
 # Run as UID for nobody
 USER 65534
 
-ENTRYPOINT ["/bin/external-secrets"]
+ENTRYPOINT ["/manager"]


### PR DESCRIPTION
Hey there 👋 

This PR fixes the Dockerfile by matching its ENTRYPOINT with the one in `config/manager/manager.yaml`.

Deploying without this change was raising the "cannot find /manager exec" error (paraphrasing hahaha).