### PR TITLE
fix: make vault version optional w/ defaults

### DIFF
--- a/apis/externalsecrets/v1alpha1/secretstore_vault_types.go
+++ b/apis/externalsecrets/v1alpha1/secretstore_vault_types.go
@@ -42,6 +42,7 @@ type VaultProvider struct {
 
 	// Version is the Vault KV secret engine version. This can be either "v1" or
 	// "v2". Version defaults to "v2".
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Enum="v1";"v2"
 	// +kubebuilder:default:="v2"
 	Version VaultKVStoreVersion `json:"version"`

--- a/deploy/crds/external-secrets.io_clustersecretstores.yaml
+++ b/deploy/crds/external-secrets.io_clustersecretstores.yaml
@@ -314,7 +314,6 @@ spec:
                     - auth
                     - path
                     - server
-                    - version
                     type: object
                 type: object
             required:

--- a/deploy/crds/external-secrets.io_secretstores.yaml
+++ b/deploy/crds/external-secrets.io_secretstores.yaml
@@ -314,7 +314,6 @@ spec:
                     - auth
                     - path
                     - server
-                    - version
                     type: object
                 type: object
             required:


### PR DESCRIPTION
fixes #117

`vault.version` needs to be declared optional to get correct defaulting behavior