### PR TITLE
Update rbac.yaml to give the controller "create" permission on leases

### DIFF
--- a/deploy/charts/external-secrets/templates/rbac.yaml
+++ b/deploy/charts/external-secrets/templates/rbac.yaml
@@ -139,6 +139,7 @@ rules:
     - "leases"
     verbs:
     - "get"
+    - "create"
     - "update"
     - "patch"
 ---


### PR DESCRIPTION
The current helm chart does not grant the controller the appropriate "create" permission on leases for leader election to work.