### PR TITLE
fix: appVersion needs prefix

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -79,6 +79,7 @@ jobs:
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.2.0
+        if: github.ref == 'refs/heads/main'
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_RELEASE_NAME_TEMPLATE: "helm-chart-{{ .Version }}"

--- a/deploy/charts/external-secrets/Chart.yaml
+++ b/deploy/charts/external-secrets/Chart.yaml
@@ -3,7 +3,7 @@ name: external-secrets
 description: External secret management for Kubernetes
 type: application
 version: "0.1.1"
-appVersion: "0.1.0"
+appVersion: "v0.1.0"
 kubeVersion: ">= 1.11.0"
 keywords:
   - kubernetes-external-secrets


### PR DESCRIPTION
Our Chart uses `appVersion` as image tag. The images we produce have a `v` prefix, this PR aligns that. `appVersion` needn't be semver ([docs](https://helm.sh/docs/topics/charts/)) / cert-manager does that, too.