### PR TITLE
docs: Update readme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,70 +4,130 @@
 
 ----
 
-The External Secrets Kubernetes operator reads information from a third party service
+The External Secrets Operator reads information from a third party service
 like [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/) and automatically injects the values as [Kubernetes Secrets](https://kubernetes.io/docs/concepts/configuration/secret/).
 
 Multiple people and organizations are joining efforts to create a single External Secrets solution based on existing projects. If you are curious about the origins of this project, check out this [issue](https://github.com/external-secrets/kubernetes-external-secrets/issues/47) and this [PR](https://github.com/external-secrets/kubernetes-external-secrets/pull/477).
 
-<a name="original-projects"></a>
+# Supported Backends
 
-# ⚠️ Please bear in mind
+- [AWS Secrets Manager](https://external-secrets.io/provider-aws-secrets-manager/)
+- [AWS Parameter Store](https://external-secrets.io/provider-aws-parameter-store/)
+- Hashicorp Vault
+- [Azure Key Vault](https://external-secrets.io/provider-azure-key-vault/) (being implemented)
+- [Google Cloud Secrets Manager](https://external-secrets.io/provider-google-secrets-manager/) (being implemented)
 
-While this project is not ready, you might consider using the following:
+## ESO installation with an AWS example
 
-- [Kubernetes External Secrets](https://github.com/external-secrets/kubernetes-external-secrets)
-- [Secrets Manager](https://github.com/itscontained/secret-manager)
-- [External Secrets Operator](https://github.com/ContainerSolutions/externalsecret-operator/)
 
-## Installation
-Clone this repository:
-```shell
-git clone https://github.com/external-secrets/external-secrets.git
-```
-
-Install the Custom Resource Definitions:
-```shell
-make install
-```
-
-Run the controller against the active Kubernetes cluster context:
-```shell
-make run
-```
-
-Apply the sample resources:
-```shell
-kubectl apply -f config/samples/external-secrets_v1alpha1_secretstore.yaml
-kubectl apply -f config/samples/external-secrets_v1alpha1_externalsecret.yaml
-```
-
-If you want to use helm:
+If you want to use Helm:
 
 ```shell
 helm repo add external-secrets https://charts.external-secrets.io
-helm install RELEASE_NAME external-secrets/external-secrets
+
+helm install external-secrets \
+   external-secrets/external-secrets \
+    -n external-secrets \
+    --create-namespace \
+  # --set installCRDs=true
+```
+
+If you want to run it locally against the active Kubernetes cluster context:
+
+```shell
+git clone https://github.com/external-secrets/external-secrets.git
+make crds.install
+make run
+```
+
+Create a secret containing your AWS credentials:
+
+```shell
+echo -n 'KEYID' > ./access-key
+echo -n 'SECRETKEY' > ./secret-access-key
+kubectl create secret generic awssm-secret --from-file=./access-key  --from-file=./secret-access-key
+```
+
+Create a secret inside AWS Secret Manager with name `my-json-secret` with the following data:
+
+```json
+{
+  "name": {"first": "Tom", "last": "Anderson"},
+  "friends": [
+    {"first": "Dale", "last": "Murphy"},
+    {"first": "Roger", "last": "Craig"},
+    {"first": "Jane", "last": "Murphy"}
+  ]
+}
+```
+
+Apply the sample resources (omitting role and controller keys here, you should not omit them in production):
+
+```yaml
+# secretstore.yaml
+apiVersion: external-secrets.io/v1alpha1
+kind: SecretStore
+metadata:
+  name: secretstore-sample
+spec:
+  provider:
+    aws:
+      service: SecretsManager
+      region: us-east-2
+      auth:
+        secretRef:
+          accessKeyIDSecretRef:
+            name: awssm-secret
+            key: access-key
+          secretAccessKeySecretRef:
+            name: awssm-secret
+            key: secret-access-key
+```
+
+```yaml
+# externalsecret.yaml
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: example
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: secretstore-sample
+    kind: SecretStore
+  target:
+    name: secret-to-be-created
+    creationPolicy: Owner
+  data:
+  - secretKey: firstname
+    remoteRef:
+      key: my-json-secret
+      property: name.first # Tom
+  - secretKey: first_friend
+    remoteRef:
+      key: my-json-secret
+      property: friends.1.first # Roger
+```
+
+```shell
+kubectl apply -f secretstore.yaml
+kubectl apply -f externalsecret.yaml
+```
+
+Running `kubectl get secret secret-to-be-created` should return a new secret created by the operator.
+
+You can get one of its values with jsonpath (This should return `Roger`):
+
+```shell
+kubectl get secret secret-to-be-created   -o jsonpath='{.data.first_friend}' | base64 -d
 ```
 
 We will add more documentation once we have the implementation for the different providers. You can find some here: https://external-secrets.io
 
-<a name="features"></a>
-
-## Features
-
-- Support to multiple Provider stores (AWS Secret Manager, GCP Secret Manger, Vault and more) simultaneously.
-- Multiple External Secrets operator instances for different contexts/environments.
-- A custom refresh interval to sync the data from the Providers, syncing your Kubernetes Secrets up to date.
-- Select specific versions of the Provider data.
-- Advanced [templating](https://external-secrets.io/guides-templating/)
-
-
-<a name="contributing"></a>
 
 ## Contributing
 
 We welcome and encourage contributions to this project! Please read the [Developer](https://www.external-secrets.io/contributing-devguide/) and [Contribution process](https://www.external-secrets.io/contributing-process/) guides. Also make sure to check the [Code of Conduct](https://www.external-secrets.io/contributing-coc/) and adhere to its guidelines.
-
-<a name="partners"></a>
 
 ## Kicked off by
 

--- a/docs/guides-getting-started.md
+++ b/docs/guides-getting-started.md
@@ -39,6 +39,13 @@ helm install external-secrets \
   # --set installCRDs=true
 ```
 
+### Create a secret containing your AWS credentials
+
+```shell
+echo -n 'KEYID' > ./access-key
+echo -n 'SECRETKEY' > ./secret-access-key
+kubectl create secret generic awssm-secret --from-file=./access-key  --from-file=./secret-access-key
+```
 
 ### Create your first SecretStore
 


### PR DESCRIPTION
Got some complains regarding the README.md being outdated and with no quick example of a provider. This PR fixes that. Also removing the 'not ready' notice. I think it is clear since ESO version is 0.1.0. Let me know if you think that we should keep it.