### PR TITLE
Validate pre-release kubeVersions in helm chart

### DIFF
--- a/deploy/charts/external-secrets/Chart.yaml
+++ b/deploy/charts/external-secrets/Chart.yaml
@@ -4,7 +4,7 @@ description: External secret management for Kubernetes
 type: application
 version: "0.1.1"
 appVersion: "v0.1.0"
-kubeVersion: ">= 1.11.0"
+kubeVersion: ">= 1.11.0-0"
 keywords:
   - kubernetes-external-secrets
   - secrets


### PR DESCRIPTION
Fixes https://github.com/external-secrets/external-secrets/issues/142

Tested against EKS cluster with gitVersion of `v1.17.17-eks-c5067d`