### PR TITLE
Remove arg of external-secrets container when no arg passed

### DIFF
--- a/deploy/charts/external-secrets/templates/deployment.yaml
+++ b/deploy/charts/external-secrets/templates/deployment.yaml
@@ -38,6 +38,7 @@ spec:
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if or (.Values.leaderElect) (.Values.extraArgs) }}
           args:
           {{- if .Values.leaderElect }}
           - --enable-leader-election=true
@@ -48,6 +49,7 @@ spec:
             {{- else }}
           - --{{ $key }}
             {{- end }}
+          {{- end }}
           {{- end }}
           ports:
             - containerPort: {{ .Values.prometheus.service.port }}


### PR DESCRIPTION
## What

By default, this chart added an `arg` field with no values.

Example:

1. Command on README.md

```
$ helm template external-secrets \
        external-secrets/external-secrets \
         -n external-secrets \
         --create-namespace > hoge.yml
```


2. Nothing specified

```
$ helm template external-secrets 
```

It generates this Deployment which is causing errors.

<details><summary>Generated YAML</summary>

```yaml
# Source: external-secrets/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: hoho-external-secrets
  labels:
    helm.sh/chart: external-secrets-0.1.1
    app.kubernetes.io/name: external-secrets
    app.kubernetes.io/instance: external-secreats
    app.kubernetes.io/version: "v0.1.0"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: external-secrets
      app.kubernetes.io/instance: hoho
  template:
    metadata:
      labels:
        app.kubernetes.io/name: external-secrets
        app.kubernetes.io/instance: hoho
    spec:
      serviceAccountName: hoho-external-secrets
      containers:
        - name: external-secrets
          image: "ghcr.io/external-secrets/external-secrets:v0.1.0"
          imagePullPolicy: IfNotPresent
          args:
          ports:
            - containerPort: 8080
```

</details>

![image](https://user-images.githubusercontent.com/23056537/118404282-45b4b400-b6ad-11eb-82b6-b4d17acdcebc.png)

This PR is to fix this.
