### PR TITLE
ci: print diff error on failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ reviewable: generate helm.generate
 # Ensure branch is clean.
 check-diff: reviewable
 	@$(INFO) checking that branch is clean
-	@test -z "$$(git status --porcelain)" || $(FAIL)
+	@test -z "$$(git status --porcelain)" || (echo "$$(git status --porcelain)" && $(FAIL))
 	@$(OK) branch is clean
 
 # ====================================================================================


### PR DESCRIPTION
In response to https://github.com/external-secrets/external-secrets/pull/144#issuecomment-843077877

Small CI change to make errors available in CI without needing to check on the issue locally. 

Example output:

```bash
11:39 $ make check-diff
11:39:37 [ OK ] Finished generating deepcopy and crds
11:39:37 [ OK ] Finished generating helm chart files
11:39:38 [ .. ] checking that branch is clean
 M go.mod
11:39:38 [FAIL]
make: *** [Makefile:72: check-diff] Error 1
```