### PR TITLE
chore: Fix reference to appversion to get right image

### DIFF
--- a/deploy/charts/external-secrets/Chart.yaml
+++ b/deploy/charts/external-secrets/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: external-secrets
 description: External secret management for Kubernetes
 type: application
-version: "0.1.3"
-appVersion: "v0.1.3"
+version: "0.1.4"
+appVersion: "helm-chart-0.1.4"
 kubeVersion: ">= 1.11.0-0"
 keywords:
   - kubernetes-external-secrets


### PR DESCRIPTION
Released 0.1.3 but appVersion needs to actually be the image tag that will be created by the workflow, and I did not realize that before. Fixing it now. To take advantage of the release workflow automation I need to bump everything, that's why I am going to 0.1.4 here.

Please let me know if something should be different.