### PR TITLE
fix: template issues

### DIFF
--- a/apis/externalsecrets/v1alpha1/externalsecret_types.go
+++ b/apis/externalsecrets/v1alpha1/externalsecret_types.go
@@ -63,7 +63,7 @@ type ExternalSecretTemplate struct {
 	Metadata ExternalSecretTemplateMetadata `json:"metadata,omitempty"`
 
 	// +optional
-	Data map[string][]byte `json:"data,omitempty"`
+	Data map[string]string `json:"data,omitempty"`
 }
 
 // ExternalSecretTarget defines the Kubernetes Secret to be created

--- a/apis/externalsecrets/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/externalsecrets/v1alpha1/zz_generated.deepcopy.go
@@ -322,17 +322,9 @@ func (in *ExternalSecretTemplate) DeepCopyInto(out *ExternalSecretTemplate) {
 	in.Metadata.DeepCopyInto(&out.Metadata)
 	if in.Data != nil {
 		in, out := &in.Data, &out.Data
-		*out = make(map[string][]byte, len(*in))
+		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
-			var outVal []byte
-			if val == nil {
-				(*out)[key] = nil
-			} else {
-				in, out := &val, &outVal
-				*out = make([]byte, len(*in))
-				copy(*out, *in)
-			}
-			(*out)[key] = outVal
+			(*out)[key] = val
 		}
 	}
 }

--- a/deploy/crds/external-secrets.io_externalsecrets.yaml
+++ b/deploy/crds/external-secrets.io_externalsecrets.yaml
@@ -139,7 +139,6 @@ spec:
                     properties:
                       data:
                         additionalProperties:
-                          format: byte
                           type: string
                         type: object
                       metadata:

--- a/hack/api-docs/Makefile
+++ b/hack/api-docs/Makefile
@@ -64,7 +64,7 @@ clean:
 # serve runs mkdocs as a local webserver for interactive development.
 # This will serve the live copy of the docs on 127.0.0.1:8000.
 .PHONY: serve
-serve:
+serve: build
 	$(DOCKER) run \
 		-it \
 		--sig-proxy=true \

--- a/pkg/controllers/externalsecret/externalsecret_controller_test.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller_test.go
@@ -264,8 +264,8 @@ var _ = Describe("ExternalSecret controller", func() {
 									"hihi": "ga",
 								},
 							},
-							Data: map[string][]byte{
-								templateSecretKey: []byte(templateSecretVal),
+							Data: map[string]string{
+								templateSecretKey: templateSecretVal,
 							},
 						},
 					},


### PR DESCRIPTION
This fixes #124 and #125.

What was the issue? 
It did not work as documented.

1. `Secret.Metadata` and `Secret.Data` was not updated after the external-secret has been changed: `CreateOrUpdate` does a `.Get()` before `.Update()` and modifies the object at the pointer.
2. #125 Template.Data was basically unusable due to having a `Data: []byte`. users would have to base64 encode the template string :cold_sweat:. This is now a simple `string` like it should have been from the get-go.
3. #124 Data from the secret provider could not be overridden with a template. Now the template takes precedence.

Example:

```yaml
apiVersion: external-secrets.io/v1alpha1
kind: ExternalSecret
metadata:
  name: example
spec:
  ...
  target:
    name: secret-to-be-created
    template:
      data:
        firstname: "yadayada {{ .firstname | toString }}!"
  data:
  - secretKey: firstname
    remoteRef:
      key: json-string
      property: mykey
```

Given a `json-string={"mykey": "foobar"}` we get a Secret with:

```yaml
data:
  firstname: "yadayada foobar!"
```
When we update the ExternalSecret's metadata or template then the secret will change aswell.

I will add proper template-tests later (i did the tests manually for now), i feel like we should refactor the controller_tests like the aws/secrets-manager.