### PR TITLE
Refactor parameterstore unit test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 /vendor
 cover.out
 
+# ignore vim swp
+*.swp
+
 # ignore ide files (debug config etc...)
 /.vscode
 /.idea

--- a/pkg/provider/aws/parameterstore/parameterstore_test.go
+++ b/pkg/provider/aws/parameterstore/parameterstore_test.go
@@ -126,12 +126,20 @@ func TestGetSecret(t *testing.T) {
 		pstc.expectError = "parameter value is nil for key"
 	}
 
+	// base case: api output return error
+	setAPIError := func(pstc *parameterstoreTestCase) {
+		pstc.apiOutput = &ssm.GetParameterOutput{}
+		pstc.apiErr = fmt.Errorf("oh no")
+		pstc.expectError = "oh no"
+	}
+
 	successCases := []*parameterstoreTestCase{
 		makeValidParameterStoreTestCaseCustom(setSecretString),
 		makeValidParameterStoreTestCaseCustom(setExtractProperty),
 		makeValidParameterStoreTestCaseCustom(setMissingProperty),
 		makeValidParameterStoreTestCaseCustom(setPropertyFail),
 		makeValidParameterStoreTestCaseCustom(setParameterValueNil),
+		makeValidParameterStoreTestCaseCustom(setAPIError),
 	}
 
 	ps := ParameterStore{}

--- a/pkg/provider/aws/parameterstore/parameterstore_test.go
+++ b/pkg/provider/aws/parameterstore/parameterstore_test.go
@@ -37,6 +37,49 @@ func TestConstructor(t *testing.T) {
 	assert.NotNil(t, c.client)
 }
 
+type parameterstoreTestCase struct {
+	fakeClient     *fake.Client
+	apiInput       *ssm.GetParameterInput
+	apiOutput      *ssm.GetParameterOutput
+	remoteRef      *esv1alpha1.ExternalSecretDataRemoteRef
+	apiErr         error
+	expectError    string
+	expectedSecret string
+}
+
+func makeValidParameterStoreTestCase() *parameterstoreTestCase {
+	return &parameterstoreTestCase{
+		fakeClient:     &fake.Client{},
+		apiInput:       makeValidAPIInput(),
+		apiOutput:      makeValidAPIOutput(),
+		remoteRef:      makeValidRemoteRef(),
+		apiErr:         nil,
+		expectError:    "",
+		expectedSecret: "",
+	}
+}
+
+func makeValidAPIInput() *ssm.GetParameterInput {
+	return &ssm.GetParameterInput{
+		Name:           aws.String("/baz"),
+		WithDecryption: aws.Bool(true),
+	}
+}
+
+func makeValidAPIOutput() *ssm.GetParameterOutput {
+	return &ssm.GetParameterOutput{
+		Parameter: &ssm.Parameter{
+			Value: aws.String("RRRRR"),
+		},
+	}
+}
+
+func makeValidRemoteRef() *esv1alpha1.ExternalSecretDataRemoteRef {
+	return &esv1alpha1.ExternalSecretDataRemoteRef{
+		Key: "/baz",
+	}
+}
+
 // test the ssm<->aws interface
 // make sure correct values are passed and errors are handled accordingly.
 func TestGetSecret(t *testing.T) {

--- a/pkg/provider/aws/parameterstore/parameterstore_test.go
+++ b/pkg/provider/aws/parameterstore/parameterstore_test.go
@@ -104,6 +104,7 @@ func TestGetSecret(t *testing.T) {
 	setExtractProperty := func(pstc *parameterstoreTestCase) {
 		pstc.apiOutput.Parameter.Value = aws.String(`{"/shmoo": "bang"}`)
 		pstc.expectedSecret = "bang"
+		pstc.remoteRef.Property = "/shmoo"
 	}
 
 	// bad case: missing property
@@ -149,8 +150,8 @@ func TestGetSecret(t *testing.T) {
 		if !ErrorContains(err, v.expectError) {
 			t.Errorf("[%d] unexpected error: %s, expected: '%s'", k, err.Error(), v.expectError)
 		}
-		if cmp.Equal(out, v.expectedData) {
-			t.Errorf("[%d] unexpected secret data: expected %#v, got %#v", k, v.expectedData, out)
+		if cmp.Equal(out, v.expectedSecret) {
+			t.Errorf("[%d] unexpected secret data: expected %#v, got %#v", k, v.expectedSecret, out)
 		}
 	}
 }


### PR DESCRIPTION
- refactor `parameterstore_test.go`, I try to follow the style with `secretsmanager_test.go` to keep it consistent
- ignore vim swp files 😁 
