### PR TITLE
Only Create Client When Necessary

### DIFF
--- a/pkg/controllers/externalsecret/externalsecret_controller.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller.go
@@ -17,6 +17,7 @@ package externalsecret
 import (
 	"context"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -41,7 +42,7 @@ import (
 )
 
 const (
-	requeueAfter = time.Second * 30
+	requeueAfter = time.Second * 300
 )
 
 // Reconciler reconciles a ExternalSecret object.
@@ -94,56 +95,157 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		syncCallsError.With(syncCallsMetricLabels).Inc()
 		return ctrl.Result{RequeueAfter: requeueAfter}, nil
 	}
-
-	secretClient, err := storeProvider.NewClient(ctx, store, r.Client, req.Namespace)
+  // Check if Secret exists from from this ExternalSecret
+	foundSecret := &corev1.Secret{}
+	err = r.Get(ctx, types.NamespacedName{Name: externalSecret.Spec.Target.Name, Namespace: externalSecret.Namespace}, foundSecret)
 	if err != nil {
-		log.Error(err, "could not get provider client")
-		conditionSynced := NewExternalSecretCondition(esv1alpha1.ExternalSecretReady, corev1.ConditionFalse, esv1alpha1.ConditionReasonSecretSyncedError, err.Error())
-		SetExternalSecretCondition(&externalSecret, *conditionSynced)
-		err = r.Status().Update(ctx, &externalSecret)
-		syncCallsError.With(syncCallsMetricLabels).Inc()
-		return ctrl.Result{RequeueAfter: requeueAfter}, nil
-	}
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      externalSecret.Spec.Target.Name,
-			Namespace: externalSecret.Namespace,
-		},
-		Data: make(map[string][]byte),
-	}
-	_, err = ctrl.CreateOrUpdate(ctx, r.Client, secret, func() error {
-		err = controllerutil.SetControllerReference(&externalSecret, &secret.ObjectMeta, r.Scheme)
-		if err != nil {
-			return fmt.Errorf("could not set ExternalSecret controller reference: %w", err)
-		}
-		mergeTemplate(secret, externalSecret)
-		data, err := r.getProviderSecretData(ctx, secretClient, &externalSecret)
-		if err != nil {
-			return fmt.Errorf("could not get secret data from provider: %w", err)
-		}
-		// overwrite data
-		for k, v := range data {
-			secret.Data[k] = v
-		}
-		err = template.Execute(externalSecret.Spec.Target.Template, secret, data)
-		if err != nil {
-			return fmt.Errorf("could not execute template: %w", err)
-		}
-		return nil
-	})
+		// Make this new Secret since it is not found.
+		if apierrors.IsNotFound(err) {
+			log.Info("Making new Secret")
+			secretClient, err := storeProvider.NewClient(ctx, store, r.Client, req.Namespace)
+			if err != nil {
+				log.Error(err, "could not get provider client")
+				conditionSynced := NewExternalSecretCondition(esv1alpha1.ExternalSecretReady, corev1.ConditionFalse, esv1alpha1.ConditionReasonSecretSyncedError, err.Error())
+				SetExternalSecretCondition(&externalSecret, *conditionSynced)
+				err = r.Status().Update(ctx, &externalSecret)
+				syncCallsError.With(syncCallsMetricLabels).Inc()
+				return ctrl.Result{RequeueAfter: requeueAfter}, nil
+			}
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      externalSecret.Spec.Target.Name,
+					Namespace: externalSecret.Namespace,
+				},
+				Data: make(map[string][]byte),
+			}
 
-	if err != nil {
-		log.Error(err, "could not reconcile ExternalSecret")
-		conditionSynced := NewExternalSecretCondition(esv1alpha1.ExternalSecretReady, corev1.ConditionFalse, esv1alpha1.ConditionReasonSecretSyncedError, err.Error())
-		SetExternalSecretCondition(&externalSecret, *conditionSynced)
-		err = r.Status().Update(ctx, &externalSecret)
-		if err != nil {
-			log.Error(err, "unable to update status")
+			_, err = ctrl.CreateOrUpdate(ctx, r.Client, secret, func() error {
+				err = controllerutil.SetControllerReference(&externalSecret, &secret.ObjectMeta, r.Scheme)
+				if err != nil {
+					return fmt.Errorf("could not set ExternalSecret controller reference: %w", err)
+				}
+				mergeTemplate(secret, externalSecret)
+				data, err := r.getProviderSecretData(ctx, secretClient, &externalSecret)
+				if err != nil {
+					return fmt.Errorf("could not get secret data from provider: %w", err)
+				}
+				// overwrite data
+				for k, v := range data {
+					secret.Data[k] = v
+				}
+				err = template.Execute(externalSecret.Spec.Target.Template, secret, data)
+				if err != nil {
+					return fmt.Errorf("could not execute template: %w", err)
+				}
+				return nil
+			})
+			if err != nil {
+				log.Error(err, "could not reconcile ExternalSecret")
+				conditionSynced := NewExternalSecretCondition(esv1alpha1.ExternalSecretReady, corev1.ConditionFalse, esv1alpha1.ConditionReasonSecretSyncedError, err.Error())
+				SetExternalSecretCondition(&externalSecret, *conditionSynced)
+				err = r.Status().Update(ctx, &externalSecret)
+				if err != nil {
+					log.Error(err, "unable to update status")
+				}
+				syncCallsError.With(syncCallsMetricLabels).Inc()
+				return ctrl.Result{RequeueAfter: requeueAfter}, nil
+			}
+			dur := time.Hour
+			if externalSecret.Spec.RefreshInterval != nil {
+				dur = externalSecret.Spec.RefreshInterval.Duration
+			}
+		
+			conditionSynced := NewExternalSecretCondition(esv1alpha1.ExternalSecretReady, corev1.ConditionTrue, esv1alpha1.ConditionReasonSecretSynced, "Secret was synced")
+			SetExternalSecretCondition(&externalSecret, *conditionSynced)
+			externalSecret.Status.RefreshTime = metav1.NewTime(time.Now())
+			err = r.Status().Update(ctx, &externalSecret)
+			if err != nil {
+				log.Error(err, "unable to update status")
+			}
+		
+			syncCallsTotal.With(syncCallsMetricLabels).Inc()
+			return ctrl.Result{
+				RequeueAfter: dur,
+			}, nil
 		}
-		syncCallsError.With(syncCallsMetricLabels).Inc()
-		return ctrl.Result{RequeueAfter: requeueAfter}, nil
+	} else {
+		if externalSecret.Status.Conditions != nil {
+			// Check if it is time to renew. This prevents unnecessary client token creation in secret providers.
+			timeUntil := time.Until(externalSecret.Status.Conditions[0].LastTransitionTime.Time.Add(externalSecret.Spec.RefreshInterval.Duration))
+			res := math.Signbit(float64(timeUntil))
+			if res {
+				log.Info("Time to renew. New Secret Client.")
+				secretClient, err := storeProvider.NewClient(ctx, store, r.Client, req.Namespace)
+				if err != nil {
+					log.Error(err, "could not get provider client")
+					conditionSynced := NewExternalSecretCondition(esv1alpha1.ExternalSecretReady, corev1.ConditionFalse, esv1alpha1.ConditionReasonSecretSyncedError, err.Error())
+					SetExternalSecretCondition(&externalSecret, *conditionSynced)
+					err = r.Status().Update(ctx, &externalSecret)
+					syncCallsError.With(syncCallsMetricLabels).Inc()
+					return ctrl.Result{RequeueAfter: requeueAfter}, nil
+				}
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      externalSecret.Spec.Target.Name,
+						Namespace: externalSecret.Namespace,
+					},
+					Data: make(map[string][]byte),
+				}
+				_, err = ctrl.CreateOrUpdate(ctx, r.Client, secret, func() error {
+					err = controllerutil.SetControllerReference(&externalSecret, &secret.ObjectMeta, r.Scheme)
+					if err != nil {
+						return fmt.Errorf("could not set ExternalSecret controller reference: %w", err)
+					}
+					mergeTemplate(secret, externalSecret)
+					data, err := r.getProviderSecretData(ctx, secretClient, &externalSecret)
+					if err != nil {
+						return fmt.Errorf("could not get secret data from provider: %w", err)
+					}
+					// overwrite data
+					for k, v := range data {
+						secret.Data[k] = v
+					}
+					err = template.Execute(externalSecret.Spec.Target.Template, secret, data)
+					if err != nil {
+						return fmt.Errorf("could not execute template: %w", err)
+					}
+					return nil
+				})
+			
+				if err != nil {
+					log.Error(err, "could not reconcile ExternalSecret")
+					conditionSynced := NewExternalSecretCondition(esv1alpha1.ExternalSecretReady, corev1.ConditionFalse, esv1alpha1.ConditionReasonSecretSyncedError, err.Error())
+					SetExternalSecretCondition(&externalSecret, *conditionSynced)
+					err = r.Status().Update(ctx, &externalSecret)
+					if err != nil {
+						log.Error(err, "unable to update status")
+					}
+					syncCallsError.With(syncCallsMetricLabels).Inc()
+					return ctrl.Result{RequeueAfter: requeueAfter}, nil
+				}
+			
+				dur := time.Hour
+				if externalSecret.Spec.RefreshInterval != nil {
+					dur = externalSecret.Spec.RefreshInterval.Duration
+				}
+			
+				conditionSynced := NewExternalSecretCondition(esv1alpha1.ExternalSecretReady, corev1.ConditionTrue, esv1alpha1.ConditionReasonSecretSynced, "Secret was synced")
+				SetExternalSecretCondition(&externalSecret, *conditionSynced)
+				externalSecret.Status.Conditions[0].LastTransitionTime = metav1.NewTime(time.Now())
+				externalSecret.Status.RefreshTime = metav1.NewTime(time.Now())
+				err = r.Status().Update(ctx, &externalSecret)
+				if err != nil {
+					log.Error(err, "unable to update status")
+				}
+			
+				syncCallsTotal.With(syncCallsMetricLabels).Inc()
+			
+				return ctrl.Result{
+					RequeueAfter: dur,
+				}, nil
+			}
+		}
 	}
-
 	dur := time.Hour
 	if externalSecret.Spec.RefreshInterval != nil {
 		dur = externalSecret.Spec.RefreshInterval.Duration
@@ -158,7 +260,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	syncCallsTotal.With(syncCallsMetricLabels).Inc()
-
 	return ctrl.Result{
 		RequeueAfter: dur,
 	}, nil
@@ -252,3 +353,4 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.Secret{}).
 		Complete(r)
 }
+

--- a/pkg/controllers/externalsecret/externalsecret_controller.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller.go
@@ -42,7 +42,7 @@ import (
 )
 
 const (
-	requeueAfter = time.Second * 300
+	requeueAfter = time.Second * 30
 )
 
 // Reconciler reconciles a ExternalSecret object.


### PR DESCRIPTION
Added some logic to when `storeProvider.NewClient()` is called because every reconciliation loop creates a new token in Vault. This will create a `client` when the corresponding target secret does not exist (new ExternalSecret object) or when `spec.refreshInterval` has been met.

Any feedback or suggestions are welcome. There are probably better Go developers out there that can tidy this up as I'm just starting out so there may be a lot of repeats. 

Fixes: https://github.com/external-secrets/external-secrets/issues/169

Though if a user were to add a label to the ExternalSecret object the reconciliation loop would not update the target Secret until the `spec.refreshInterval` has been met. Is there a way to only create a client (and thus a remote token) when it is a `spec.data` change? Thank you for any guidance.