### PR TITLE
docs: Fix documentation for externalsecret dataFrom

### DIFF
--- a/design/design-crd-spec.md
+++ b/design/design-crd-spec.md
@@ -187,10 +187,9 @@ spec:
   # Used to fetch all properties from the Provider key
   # If multiple dataFrom are specified, secrets are merged in the specified order
   dataFrom:
-  - remoteRef:
-      key: provider-key
-      version: provider-key-version
-      property: provider-key-property
+  - key: provider-key
+    version: provider-key-version
+    property: provider-key-property
 
 status:
   # refreshTime is the time and date the external secret was fetched and

--- a/docs/snippets/basic-external-secret.yaml
+++ b/docs/snippets/basic-external-secret.yaml
@@ -17,5 +17,4 @@ spec:
       version: provider-key-version
       property: provider-key-property
   dataFrom:
-  - remoteRef:
-    key: remote-key-in-the-provider
+  - key: remote-key-in-the-provider

--- a/docs/snippets/full-external-secret.yaml
+++ b/docs/snippets/full-external-secret.yaml
@@ -73,10 +73,9 @@ spec:
   # Used to fetch all properties from the Provider key
   # If multiple dataFrom are specified, secrets are merged in the specified order
   dataFrom:
-  - remoteRef:
-      key: provider-key
-      version: provider-key-version
-      property: provider-key-property
+  - key: provider-key
+    version: provider-key-version
+    property: provider-key-property
 
 status:
   # refreshTime is the time and date the external secret was fetched and


### PR DESCRIPTION
Documentation of externalsecret `dataFrom` was just copy and paste from `data`. This PR updates the examples to reflect the expected structure.