### PR TITLE
Stability of providers and support notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,30 @@ kubectl get secret secret-to-be-created   -o jsonpath='{.data.first_friend}' | b
 
 We will add more documentation once we have the implementation for the different providers. You can find some here: https://external-secrets.io
 
+## Stability and Support Level
+
+### Internally maintained:
+
+| Provider        | Stability     |                   Contact                      | 
+| --------------- |:-------------:|-----------------------------------------------:|
+| AWS SM          |     alpha     | [ESO Org](https://github.com/external-secrets) |
+| AWS PS          |     alpha     | [ESO Org](https://github.com/external-secrets) |
+| Hashicorp Vault |     alpha     | [ESO Org](https://github.com/external-secrets) |
+| GCP SM          |     alpha     | [ESO Org](https://github.com/external-secrets) |
+
+
+### Community maintained:
+
+| Provider        | Stability     |                   Contact                  | 
+| --------------- |:-------------:|:------------------------------------------:|
+| Azure KV        |     alpha     | @ahmedmus-1A @asnowfix @ncourbet-1A @1A-mj |
+
+## Support
+
+You can use GitHub's [issues](https://github.com/external-secrets/external-secrets/issues) to report bugs/suggest features or use GitHub's [discussions](https://github.com/external-secrets/external-secrets/discussions) to ask for help and figure out problems.
+
+Even though we have active maintainers and people assigned to this project, we kindly ask for patience when asking for support. We will try to get to priority issues as fast as possible, but there may be some delays.
+
 
 ## Contributing
 


### PR DESCRIPTION
Adding some info to Readme regarding stability, who to look for when we need to figure out things about specific providers, and the support level that we can offer. I added Azure KV as community maintained, let me know if this does not make sense to you. It is one of the big Cloud providers, and of course we will also fix stuff and improve it, but I think it would be cool to let original devs take a bit of ownership, and be on the list of contacts.

 @ahmedmus219 @ahmedmus-1A @asnowfix @ncourbet-1A @1A-mj you folks should of course have a say here :D

Basing this idea on https://github.com/kubernetes-sigs/external-dns