### PR TITLE
add synced resource version status

### DIFF
--- a/apis/externalsecrets/v1alpha1/externalsecret_types.go
+++ b/apis/externalsecrets/v1alpha1/externalsecret_types.go
@@ -161,6 +161,9 @@ type ExternalSecretStatus struct {
 	// the target secret updated
 	RefreshTime metav1.Time `json:"refreshTime,omitempty"`
 
+	// SyncedResourceVersion keeps track of the last synced version
+	SyncedResourceVersion string `json:"syncedResourceVersion,omitempty"`
+
 	// +optional
 	Conditions []ExternalSecretStatusCondition `json:"conditions,omitempty"`
 }

--- a/deploy/crds/external-secrets.io_externalsecrets.yaml
+++ b/deploy/crds/external-secrets.io_externalsecrets.yaml
@@ -189,6 +189,10 @@ spec:
                 format: date-time
                 nullable: true
                 type: string
+              syncedResourceVersion:
+                description: SyncedResourceVersion keeps track of the last synced
+                  version
+                type: string
             type: object
         type: object
     served: true


### PR DESCRIPTION
This fixes #169.

Adds a `SyncedResourceVersion` to the Status field: it keeps track of the last synced external secret.

It's a string and has the schema `{generation}-{meta-hash}`. We can not rely solely on the metadata.generation, because it is not updated when object-meta changes. The hash is generated only from the `labels` and `annotations` fields.

We need this to: 
A) prevent the controller from reconciling an already synced secret (within the refresh interval)
B) do not reconcile if only the status field was changed (to prevent controller recon loops on status updates)


Example:
```
Status:
  Conditions:
    Last Transition Time:   2021-06-09T17:28:53Z
    Message:                Secret was synced
    Reason:                 SecretSynced
    Status:                 True
    Type:                   Ready
  Refresh Time:             2021-06-09T18:00:46Z
  Synced Resource Version:  2-9c4307d314852c669189b819592d73e6
```


Minor changes:
* using Status().Patch() instead of Update()
* using `defer` to ~update~ patch the status field after the controller is done
* the metrics in the controller tests can now be exact (ES is reconciled exactly once in the changed test cases) 