### PR TITLE
chore(docs): AWSSM quick example changes

### DIFF
--- a/docs/provider-aws-secrets-manager.md
+++ b/docs/provider-aws-secrets-manager.md
@@ -52,23 +52,9 @@ Consider the following JSON object that is stored in the SecretsManager key `my-
 ```
 
 This is an example on how you would look up nested keys in the above json object:
-``` yaml
-apiVersion: external-secrets.io/v1alpha1
-kind: ExternalSecret
-metadata:
-  name: example
-spec:
-  # [omitted for brevity]
-  data:
-  - secretKey: firstname
-    remoteRef:
-      key: my-json-secret
-      property: name.first # Tom
-  - secretKey: first_friend
-    remoteRef:
-      key: my-json-secret
-      property: friends.1.first # Roger
 
+``` yaml
+{% include 'aws-sm-external-secret.yaml' %}
 ```
 
 --8<-- "snippets/provider-aws-access.md"

--- a/docs/snippets/aws-sm-external-secret.yaml
+++ b/docs/snippets/aws-sm-external-secret.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: example
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: secretstore-sample
+    kind: SecretStore
+  target:
+    name: secret-to-be-created
+    creationPolicy: Owner
+  data:
+  - secretKey: firstname
+    remoteRef:
+      key: my-json-secret
+      property: name.first # Tom
+  - secretKey: first_friend
+    remoteRef:
+      key: my-json-secret
+      property: friends.1.first # Roger

--- a/docs/snippets/aws-sm-store.yaml
+++ b/docs/snippets/aws-sm-store.yaml
@@ -8,7 +8,9 @@ spec:
     aws:
       service: SecretsManager
       # define a specific role to limit access
-      # to certain secrets
+      # to certain secrets.
+      # role is a optional field that 
+      # can be omitted for test purposes
       role: iam-role
       region: eu-central-1
       auth:


### PR DESCRIPTION
Changed some stuff on the AWS SM example to enable people that want to get this quickly up to test and not think that much about the specification.

- Made it clear that role is a optional field, if they want to omit it for test purposes.
- Made the ExternalSecret example there be the complete file since people would want to just copy and paste and apply it right away :smile: 

The reasoning is that awssm is the most popular provider and this will probably be the doc page with most accesses with people trying out the project. 