### PR TITLE
fix: increase kind timeout

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -65,7 +65,8 @@ jobs:
     - name: Setup kind
       uses: engineerd/setup-kind@v0.5.0
       with:
-        version: "v0.10.0"
+        version: "v0.11.1"
+        wait: 10m
         node_image: kindest/node:v1.20.2
         name: external-secrets
 
@@ -121,7 +122,8 @@ jobs:
     - name: Setup kind
       uses: engineerd/setup-kind@v0.5.0
       with:
-        version: "v0.10.0"
+        version: "v0.11.1"
+        wait: 10m
         node_image: kindest/node:v1.20.2
         name: external-secrets
 

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -27,6 +27,7 @@ cd $DIR
 
 echo "Kubernetes cluster:"
 kubectl get nodes -o wide
+kubectl describe node external-secrets-control-plane
 
 echo -e "Granting permissions to e2e service account..."
 kubectl create serviceaccount external-secrets-e2e || true


### PR DESCRIPTION
Increasing kind timeout when waiting for a ready cluster. This needs to be on main to be able to test with ok-to-test on the other PRs