### PR TITLE
chore: add artifacthub repository ID to appear as verified

### DIFF
--- a/docs/artifacthub-repo.yml
+++ b/docs/artifacthub-repo.yml
@@ -1,0 +1,1 @@
+repositoryID: 0be51c62-4e1d-47d5-b586-3662456e2a89


### PR DESCRIPTION
This should make the chart appear as verifeid ( ![image](https://user-images.githubusercontent.com/326929/124471834-a43d0b00-dd9d-11eb-980a-c36ffbe9f880.png) ) on artifacthub 😄 

Not sure if this is the best place to put it, but eh. it should live next to index.yaml (the repo index) and putting it here should land it in the right place when deployed, to my understanding anyway.