### PR TITLE
Add configmap rules for templateFrom

### DIFF
--- a/deploy/charts/external-secrets/templates/rbac.yaml
+++ b/deploy/charts/external-secrets/templates/rbac.yaml
@@ -35,6 +35,14 @@ rules:
   - apiGroups:
     - ""
     resources:
+    - "configmaps"
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+  - apiGroups:
+    - ""
+    resources:
     - "secrets"
     verbs:
     - "get"


### PR DESCRIPTION
The controller needs access to ConfigMaps in order to use `templateFrom` feature.
https://github.com/external-secrets/external-secrets/issues/179