### PR TITLE
fix(docs): correct parameter store policy typo

### DIFF
--- a/docs/provider-aws-parameter-store.md
+++ b/docs/provider-aws-parameter-store.md
@@ -26,7 +26,7 @@ Create a IAM Policy to pin down access to secrets matching `dev-*`, for futher i
   "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Deny",
+      "Effect": "Allow",
       "Action": [
         "ssm:GetParameter*"
       ],


### PR DESCRIPTION
fix aws parameter store typo