### PR TITLE
fix(template): fix templateFrom tpl execution

### DIFF
--- a/docs/api-externalsecret.md
+++ b/docs/api-externalsecret.md
@@ -9,7 +9,7 @@ be transformed and saved as a `Kind=Secret`:
 
 ## Template
 
-When the controller reconciles the `ExternalSecret` it will use the `spec.template` as a blueprint to construct a new `Kind=Secret`. You can use golang templates to define the blueprint and use template functions to transform secret values. See [advanced templating](guides-templating.md) for details.
+When the controller reconciles the `ExternalSecret` it will use the `spec.template` as a blueprint to construct a new `Kind=Secret`. You can use golang templates to define the blueprint and use template functions to transform secret values. You can also pull in `ConfigMaps` that contain golang-template data using `templateFrom`. See [advanced templating](guides-templating.md) for details.
 
 ## Update Behavior
 

--- a/docs/guides-templating.md
+++ b/docs/guides-templating.md
@@ -12,6 +12,14 @@ You can also use pre-defined functions to extract data from your secrets. Here: 
 {% include 'pkcs12-template-external-secret.yaml' %}
 ```
 
+### TemplateFrom
+
+You do not have to define your templates inline in an ExternalSecret but you can pull `ConfigMaps` or other Secrets that contain a template. Consider the following example:
+
+``` yaml
+{% include 'template-from-secret.yaml' %}
+```
+
 ## Helper functions
 We provide a bunch of convenience functions that help you transform your secrets. A secret value is a `[]byte`.
 

--- a/docs/snippets/template-from-secret.yaml
+++ b/docs/snippets/template-from-secret.yaml
@@ -1,0 +1,40 @@
+{% raw %}
+# define your tempalte in a config map
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-config-tpl
+data:
+  config.yaml: |
+    datasources:
+      - name: Graphite
+        type: graphite
+        access: proxy
+        url: http://localhost:8080
+        password: "{{ .password | toString }}" # <-- convert []byte to string
+        user: "{{ .user | toString }}"         # <-- convert []byte to string
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: my-template-example
+spec:
+  # ...
+  target:
+    name: secret-to-be-created
+    template:
+      templateFrom:
+      - configMap:
+          # name of the configmap to pull in
+          name: grafana-config-tpl
+          # here you define the keys that should be used as template
+          items:
+          - key: config.yaml
+  data:
+  - secretKey: user
+    remoteRef:
+      key: /grafana/user
+  - secretKey: password
+    remoteRef:
+      key: /grafana/password
+{% endraw %}

--- a/pkg/controllers/externalsecret/externalsecret_controller_test.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller_test.go
@@ -233,7 +233,7 @@ var _ = Describe("ExternalSecret controller", func() {
 		const tplStaticVal = "tplstaticvalue"
 		const tplFromCMName = "template-cm"
 		const tplFromKey = "tpl-from-key"
-		const tplFromVal = "tpl-from-value"
+		const tplFromVal = "tpl-from-value: {{ .targetProperty | toString }} // {{ .bar | toString }}"
 		Expect(k8sClient.Create(context.Background(), &v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "template-cm",
@@ -282,7 +282,7 @@ var _ = Describe("ExternalSecret controller", func() {
 			Expect(string(secret.Data[targetProp])).To(Equal(expectedSecretVal))
 			Expect(string(secret.Data[tplStaticKey])).To(Equal(tplStaticVal))
 			Expect(string(secret.Data["bar"])).To(Equal("value from map: map-bar-value"))
-			Expect(string(secret.Data[tplFromKey])).To(Equal(tplFromVal))
+			Expect(string(secret.Data[tplFromKey])).To(Equal("tpl-from-value: someValue // map-bar-value"))
 		}
 	}
 

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -27,8 +27,6 @@ import (
 	"github.com/youmark/pkcs8"
 	"golang.org/x/crypto/pkcs12"
 	corev1 "k8s.io/api/core/v1"
-
-	esv1alpha1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
 )
 
 var tplFuncs = tpl.FuncMap{
@@ -67,12 +65,12 @@ const (
 )
 
 // Execute renders the secret data as template. If an error occurs processing is stopped immediately.
-func Execute(template *esv1alpha1.ExternalSecretTemplate, secret *corev1.Secret, data map[string][]byte) error {
-	if template == nil {
+func Execute(tpl, data map[string][]byte, secret *corev1.Secret) error {
+	if tpl == nil {
 		return nil
 	}
-	for k, v := range template.Data {
-		val, err := execute(k, v, data)
+	for k, v := range tpl {
+		val, err := execute(k, string(v), data)
 		if err != nil {
 			return fmt.Errorf(errExecute, k, err)
 		}


### PR DESCRIPTION
fixes #255 
fixes #232

This PR adds an example for using `templateFrom` to the docs. 
This PR also fixes an bug: templates from `templateFrom` weren't executed. Tests cover that now.