### PR TITLE
feat: add open-collective funding button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+open_collective: external-secrets-org


### PR DESCRIPTION
fixes #256 
As per docs: https://docs.github.com/en/github/administering-a-repository/managing-repository-settings/displaying-a-sponsor-button-in-your-repository

This PR adds a funding button to this repo.