### PR TITLE
feat(ctrl): implement creationPolicy=Merge/None

### DIFF
--- a/apis/externalsecrets/v1alpha1/externalsecret_types.go
+++ b/apis/externalsecrets/v1alpha1/externalsecret_types.go
@@ -97,6 +97,7 @@ type ExternalSecretTarget struct {
 	// CreationPolicy defines rules on how to create the resulting Secret
 	// Defaults to 'Owner'
 	// +optional
+	// +kubebuilder:default="Owner"
 	CreationPolicy ExternalSecretCreationPolicy `json:"creationPolicy,omitempty"`
 
 	// Template defines a blueprint for the created Secret resource.

--- a/deploy/crds/external-secrets.io_externalsecrets.yaml
+++ b/deploy/crds/external-secrets.io_externalsecrets.yaml
@@ -125,6 +125,7 @@ spec:
                   be created There can be only one target per ExternalSecret.
                 properties:
                   creationPolicy:
+                    default: Owner
                     description: CreationPolicy defines rules on how to create the
                       resulting Secret Defaults to 'Owner'
                     type: string

--- a/pkg/controllers/externalsecret/suite_test.go
+++ b/pkg/controllers/externalsecret/suite_test.go
@@ -20,6 +20,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"go.uber.org/zap/zapcore"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -44,7 +45,8 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	log := zap.New(zap.WriteTo(GinkgoWriter))
+	log := zap.New(zap.WriteTo(GinkgoWriter), zap.Level(zapcore.DebugLevel))
+
 	logf.SetLogger(log)
 
 	By("bootstrapping test environment")


### PR DESCRIPTION
closes #229 

This PR adds the `creatonPolicy=Merge|None|Owner`. The CRD now defaults to `Owner`.

Existing ExternalSecrets with an empty creationPolicy may exist. 
After an upgrade they should be properly synced due to the `default:` case in the controller.

Im not sure what to do with `creationPolicy=None`. There is no real use-case for as far as i can see. In this implementation it is a no-op. 
