### PR TITLE
Nil interface check - Comparison test changes

### DIFF
--- a/pkg/provider/aws/secretsmanager/secretsmanager_test.go
+++ b/pkg/provider/aws/secretsmanager/secretsmanager_test.go
@@ -181,7 +181,7 @@ func TestSecretsManagerGetSecret(t *testing.T) {
 		if !ErrorContains(err, v.expectError) {
 			t.Errorf("[%d] unexpected error: %s, expected: '%s'", k, err.Error(), v.expectError)
 		}
-		if string(out) != v.expectedSecret {
+		if err == nil && string(out) != v.expectedSecret {
 			t.Errorf("[%d] unexpected secret: expected %s, got %s", k, v.expectedSecret, string(out))
 		}
 	}

--- a/pkg/provider/gcp/secretmanager/fake/fake.go
+++ b/pkg/provider/gcp/secretmanager/fake/fake.go
@@ -43,12 +43,14 @@ func (mc *MockSMClient) NilClose() {
 }
 
 func (mc *MockSMClient) WithValue(ctx context.Context, req *secretmanagerpb.AccessSecretVersionRequest, val *secretmanagerpb.AccessSecretVersionResponse, err error) {
-	mc.accessSecretFn = func(paramCtx context.Context, paramReq *secretmanagerpb.AccessSecretVersionRequest, paramOpts ...grpc.CallOption) (*secretmanagerpb.AccessSecretVersionResponse, error) {
-		// type secretmanagerpb.AccessSecretVersionRequest contains unexported fields
-		// use cmpopts.IgnoreUnexported to ignore all the unexported fields in the cmp.
-		if !cmp.Equal(paramReq, req, cmpopts.IgnoreUnexported(secretmanagerpb.AccessSecretVersionRequest{})) {
-			return nil, fmt.Errorf("unexpected test argument")
+	if mc != nil {
+		mc.accessSecretFn = func(paramCtx context.Context, paramReq *secretmanagerpb.AccessSecretVersionRequest, paramOpts ...grpc.CallOption) (*secretmanagerpb.AccessSecretVersionResponse, error) {
+			// type secretmanagerpb.AccessSecretVersionRequest contains unexported fields
+			// use cmpopts.IgnoreUnexported to ignore all the unexported fields in the cmp.
+			if !cmp.Equal(paramReq, req, cmpopts.IgnoreUnexported(secretmanagerpb.AccessSecretVersionRequest{})) {
+				return nil, fmt.Errorf("unexpected test argument")
+			}
+			return val, err
 		}
-		return val, err
 	}
 }

--- a/pkg/provider/gcp/secretmanager/secretsmanager.go
+++ b/pkg/provider/gcp/secretmanager/secretsmanager.go
@@ -31,6 +31,7 @@ import (
 	esv1alpha1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
 	"github.com/external-secrets/external-secrets/pkg/provider"
 	"github.com/external-secrets/external-secrets/pkg/provider/schema"
+	"github.com/external-secrets/external-secrets/pkg/utils"
 )
 
 const (
@@ -137,7 +138,7 @@ func (sm *ProviderGCP) NewClient(ctx context.Context, store esv1alpha1.GenericSt
 
 // GetSecret returns a single secret from the provider.
 func (sm *ProviderGCP) GetSecret(ctx context.Context, ref esv1alpha1.ExternalSecretDataRemoteRef) ([]byte, error) {
-	if sm.SecretManagerClient == nil || sm.projectID == "" {
+	if utils.IsNil(sm.SecretManagerClient) || sm.projectID == "" {
 		return nil, fmt.Errorf(errUninitalizedGCPProvider)
 	}
 

--- a/pkg/provider/gcp/secretmanager/secretsmanager_test.go
+++ b/pkg/provider/gcp/secretmanager/secretsmanager_test.go
@@ -93,6 +93,11 @@ var setAPIErr = func(smtc *secretManagerTestCase) {
 	smtc.expectError = "oh no"
 }
 
+var setNilMockClient = func(smtc *secretManagerTestCase) {
+	smtc.mockClient = nil
+	smtc.expectError = errUninitalizedGCPProvider
+}
+
 // test the sm<->gcp interface
 // make sure correct values are passed and errors are handled accordingly.
 func TestSecretManagerGetSecret(t *testing.T) {
@@ -137,6 +142,7 @@ func TestSecretManagerGetSecret(t *testing.T) {
 		makeValidSecretManagerTestCaseCustom(setCustomVersion),
 		makeValidSecretManagerTestCaseCustom(setAPIErr),
 		makeValidSecretManagerTestCaseCustom(setCustomRef),
+		makeValidSecretManagerTestCaseCustom(setNilMockClient),
 	}
 
 	sm := ProviderGCP{}
@@ -169,6 +175,7 @@ func TestGetSecretMap(t *testing.T) {
 	successCases := []*secretManagerTestCase{
 		makeValidSecretManagerTestCaseCustom(setDeserialization),
 		makeValidSecretManagerTestCaseCustom(setAPIErr),
+		makeValidSecretManagerTestCaseCustom(setNilMockClient),
 		makeValidSecretManagerTestCaseCustom(setInvalidJSON),
 	}
 

--- a/pkg/provider/gcp/secretmanager/secretsmanager_test.go
+++ b/pkg/provider/gcp/secretmanager/secretsmanager_test.go
@@ -147,7 +147,7 @@ func TestSecretManagerGetSecret(t *testing.T) {
 		if !ErrorContains(err, v.expectError) {
 			t.Errorf("[%d] unexpected error: %s, expected: '%s'", k, err.Error(), v.expectError)
 		}
-		if string(out) != v.expectedSecret {
+		if err == nil && string(out) != v.expectedSecret {
 			t.Errorf("[%d] unexpected secret: expected %s, got %s", k, v.expectedSecret, string(out))
 		}
 	}


### PR DESCRIPTION
Add error condition in the secrets manager tests
Add check to see if the interface is nil in the GCP provider 