### PR TITLE
fix(docs): typo in secret name

### DIFF
--- a/docs/snippets/gcpsm-tls-externalsecret.yaml
+++ b/docs/snippets/gcpsm-tls-externalsecret.yaml
@@ -22,5 +22,5 @@ spec:
   # a cert and a private key
   - secretKey: mysecret
     remoteRef:
-      key: docker-config-example
+      key: ssl-certificate-p12-example
 {% endraw %}


### PR DESCRIPTION
Fixing typo to secret name