### PR TITLE
Feature/ibm support more secret types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,8 +37,8 @@ require (
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.7
 	github.com/Azure/go-autorest/autorest/to v0.4.0 // indirect
 	github.com/Azure/go-autorest/autorest/validation v0.3.1 // indirect
-	github.com/IBM/go-sdk-core/v5 v5.4.5
-	github.com/IBM/secrets-manager-go-sdk v0.1.21
+	github.com/IBM/go-sdk-core/v5 v5.5.0
+	github.com/IBM/secrets-manager-go-sdk v1.0.23
 	github.com/aws/aws-sdk-go v1.38.6
 	github.com/crossplane/crossplane-runtime v0.13.0
 	github.com/fatih/color v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -63,13 +63,8 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
-github.com/IBM/go-sdk-core/v5 v5.4.2/go.mod h1:Sn+z+qTDREQvCr+UFa22TqqfXNxx3o723y8GsfLV8e0=
-github.com/IBM/go-sdk-core/v5 v5.4.5 h1:fP/SLOMxRzhHaqS+I5XN+1CWrAAWn8fdzWuZvbR5KxE=
-github.com/IBM/go-sdk-core/v5 v5.4.5/go.mod h1:Sn+z+qTDREQvCr+UFa22TqqfXNxx3o723y8GsfLV8e0=
 github.com/IBM/go-sdk-core/v5 v5.5.0 h1:etP4m0kzMCxjZRI4Bu6cRTfK9YDvY3xFuagXugkCyxc=
 github.com/IBM/go-sdk-core/v5 v5.5.0/go.mod h1:Sn+z+qTDREQvCr+UFa22TqqfXNxx3o723y8GsfLV8e0=
-github.com/IBM/secrets-manager-go-sdk v0.1.21 h1:llT2ryUHpSvNwqzNQ+8cxInIXi7WgRtgUz9ycerJKvA=
-github.com/IBM/secrets-manager-go-sdk v0.1.21/go.mod h1:aw+EgLmbwxGDxlcohb/ye46O4nLeBSapAapHmWLZ2fY=
 github.com/IBM/secrets-manager-go-sdk v1.0.23 h1:YvRB2jmCfXVwTiTozCNVIRfl6q9Qcl2JiL4x6chOSI4=
 github.com/IBM/secrets-manager-go-sdk v1.0.23/go.mod h1:ruP6eQ0/J/zHBbnMfUyWeMsTe9vgnGL4rDeLiSKhZhU=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
@@ -531,7 +526,6 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.2/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
-github.com/onsi/gomega v1.12.0/go.mod h1:lRk9szgn8TxENtWd0Tp4c3wjlRfMTMH27I+3Je41yGY=
 github.com/onsi/gomega v1.13.0 h1:7lLHu94wT9Ij0o6EWWclhu0aOh32VxhkwEJvzuWPeak=
 github.com/onsi/gomega v1.13.0/go.mod h1:lRk9szgn8TxENtWd0Tp4c3wjlRfMTMH27I+3Je41yGY=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,12 @@ github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3
 github.com/IBM/go-sdk-core/v5 v5.4.2/go.mod h1:Sn+z+qTDREQvCr+UFa22TqqfXNxx3o723y8GsfLV8e0=
 github.com/IBM/go-sdk-core/v5 v5.4.5 h1:fP/SLOMxRzhHaqS+I5XN+1CWrAAWn8fdzWuZvbR5KxE=
 github.com/IBM/go-sdk-core/v5 v5.4.5/go.mod h1:Sn+z+qTDREQvCr+UFa22TqqfXNxx3o723y8GsfLV8e0=
+github.com/IBM/go-sdk-core/v5 v5.5.0 h1:etP4m0kzMCxjZRI4Bu6cRTfK9YDvY3xFuagXugkCyxc=
+github.com/IBM/go-sdk-core/v5 v5.5.0/go.mod h1:Sn+z+qTDREQvCr+UFa22TqqfXNxx3o723y8GsfLV8e0=
 github.com/IBM/secrets-manager-go-sdk v0.1.21 h1:llT2ryUHpSvNwqzNQ+8cxInIXi7WgRtgUz9ycerJKvA=
 github.com/IBM/secrets-manager-go-sdk v0.1.21/go.mod h1:aw+EgLmbwxGDxlcohb/ye46O4nLeBSapAapHmWLZ2fY=
+github.com/IBM/secrets-manager-go-sdk v1.0.23 h1:YvRB2jmCfXVwTiTozCNVIRfl6q9Qcl2JiL4x6chOSI4=
+github.com/IBM/secrets-manager-go-sdk v1.0.23/go.mod h1:ruP6eQ0/J/zHBbnMfUyWeMsTe9vgnGL4rDeLiSKhZhU=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/pkg/provider/ibm/provider.go
+++ b/pkg/provider/ibm/provider.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/IBM/go-sdk-core/v5/core"
 	sm "github.com/IBM/secrets-manager-go-sdk/secretsmanagerv1"
@@ -95,51 +96,203 @@ func (ibm *providerIBM) GetSecret(ctx context.Context, ref esv1alpha1.ExternalSe
 	if utils.IsNil(ibm.IBMClient) {
 		return nil, fmt.Errorf(errUninitalizedIBMProvider)
 	}
-	response, _, err := ibm.IBMClient.GetSecret(
-		&sm.GetSecretOptions{
-			SecretType: core.StringPtr(sm.GetSecretOptionsSecretTypeArbitraryConst),
-			ID:         &ref.Key,
-		})
 
-	if err != nil {
-		return nil, err
+	secretType := "arbitrary"
+	secretName := ref.Key
+	nameSplitted := strings.Split(secretName, "/")
+
+	if len(nameSplitted) > 1 {
+		secretType = nameSplitted[0]
+		secretName = nameSplitted[1]
 	}
 
-	secret := response.Resources[0].(*sm.SecretResource)
-	secretData := secret.SecretData.(map[string]interface{})
-	arbitrarySecretPayload := secretData["payload"].(string)
-	return []byte(arbitrarySecretPayload), nil
+	switch secretType {
+
+		case "arbitrary":
+			response, _, err := ibm.IBMClient.GetSecret(
+				&sm.GetSecretOptions{
+					SecretType: core.StringPtr(sm.GetSecretOptionsSecretTypeArbitraryConst),
+					ID:         &secretName,
+				})
+			if err != nil {
+				return nil, err
+			}
+
+			secret := response.Resources[0].(*sm.SecretResource)
+			secretData := secret.SecretData.(map[string]interface{})
+			arbitrarySecretPayload := secretData["payload"].(string)
+			return []byte(arbitrarySecretPayload), nil
+
+		case "username_password":
+			if ref.Property == "" {
+				return nil, fmt.Errorf("remoteRef.property required for secret type username_password")
+			}
+			response, _, err := ibm.IBMClient.GetSecret(
+				&sm.GetSecretOptions{
+					SecretType: core.StringPtr(sm.CreateSecretOptionsSecretTypeUsernamePasswordConst),
+					ID:         &secretName,
+				})
+			if err != nil {
+				return nil, err
+			}
+
+			secret := response.Resources[0].(*sm.SecretResource)
+			secretData := secret.SecretData.(map[string]interface{})
+
+			if val, ok := secretData[ref.Property]; ok {
+				return []byte(val.(string)), nil
+			} else {
+				return nil, fmt.Errorf("key %s does not exist in secret %s", ref.Property, ref.Key)
+			}
+
+		case "iam_credentials":
+			response, _, err := ibm.IBMClient.GetSecret(
+				&sm.GetSecretOptions{
+					SecretType: core.StringPtr(sm.CreateSecretOptionsSecretTypeIamCredentialsConst),
+					ID:         &secretName,
+				})
+			if err != nil {
+				return nil, err
+			}
+
+			secret := response.Resources[0].(*sm.SecretResource)
+			secretData := *secret.APIKey
+
+			return []byte(secretData), nil
+
+		case "imported_cert":
+			if ref.Property == "" {
+				return nil, fmt.Errorf("remoteRef.property required for secret type imported_cert")
+			}
+			response, _, err := ibm.IBMClient.GetSecret(
+				&sm.GetSecretOptions{
+					SecretType: core.StringPtr(sm.CreateSecretOptionsSecretTypeImportedCertConst),
+					ID:         &secretName,
+				})
+			if err != nil {
+				return nil, err
+			}
+
+			secret := response.Resources[0].(*sm.SecretResource)
+			secretData := secret.SecretData.(map[string]interface{})
+
+			if val, ok := secretData[ref.Property]; ok {
+				return []byte(val.(string)), nil
+			} else {
+				return nil, fmt.Errorf("key %s does not exist in secret %s", ref.Property, ref.Key)
+			}
+
+		default:
+			return nil, fmt.Errorf("unknown secret type %s", secretType)
+	}
+
 }
 
 func (ibm *providerIBM) GetSecretMap(ctx context.Context, ref esv1alpha1.ExternalSecretDataRemoteRef) (map[string][]byte, error) {
 	if utils.IsNil(ibm.IBMClient) {
 		return nil, fmt.Errorf(errUninitalizedIBMProvider)
 	}
-	response, _, err := ibm.IBMClient.GetSecret(
-		&sm.GetSecretOptions{
-			SecretType: core.StringPtr(sm.GetSecretOptionsSecretTypeArbitraryConst),
-			ID:         &ref.Key,
-		})
-	if err != nil {
-		return nil, err
+
+
+	secretType := "arbitrary"
+	secretName := ref.Key
+	nameSplitted := strings.Split(secretName, "/")
+
+	if len(nameSplitted) > 1 {
+		secretType = nameSplitted[0]
+		secretName = nameSplitted[1]
 	}
 
-	secret := response.Resources[0].(*sm.SecretResource)
-	secretData := secret.SecretData.(map[string]interface{})
-	arbitrarySecretPayload := secretData["payload"].(string)
+	switch secretType {
 
-	kv := make(map[string]string)
-	err = json.Unmarshal([]byte(arbitrarySecretPayload), &kv)
-	if err != nil {
-		return nil, fmt.Errorf(errJSONSecretUnmarshal, err)
+		case "arbitrary":
+			response, _, err := ibm.IBMClient.GetSecret(
+				&sm.GetSecretOptions{
+					SecretType: core.StringPtr(sm.GetSecretOptionsSecretTypeArbitraryConst),
+					ID:         &ref.Key,
+				})
+			if err != nil {
+				return nil, err
+			}
+
+			secret := response.Resources[0].(*sm.SecretResource)
+			secretData := secret.SecretData.(map[string]interface{})
+			arbitrarySecretPayload := secretData["payload"].(string)
+
+			kv := make(map[string]string)
+			err = json.Unmarshal([]byte(arbitrarySecretPayload), &kv)
+			if err != nil {
+				return nil, fmt.Errorf(errJSONSecretUnmarshal, err)
+			}
+
+			secretMap := make(map[string][]byte)
+			for k, v := range kv {
+				secretMap[k] = []byte(v)
+			}
+
+			return secretMap, nil
+
+		case "username_password":
+			response, _, err := ibm.IBMClient.GetSecret(
+				&sm.GetSecretOptions{
+					SecretType: core.StringPtr(sm.CreateSecretOptionsSecretTypeUsernamePasswordConst),
+					ID:         &secretName,
+				})
+			if err != nil {
+				return nil, err
+			}
+
+			secret := response.Resources[0].(*sm.SecretResource)
+			secretData := secret.SecretData.(map[string]interface{})
+
+			secretMap := make(map[string][]byte)
+			for k, v := range secretData {
+				secretMap[k] = []byte(v.(string))
+			}
+
+			return secretMap, nil
+
+		case "iam_credentials":
+			response, _, err := ibm.IBMClient.GetSecret(
+				&sm.GetSecretOptions{
+					SecretType: core.StringPtr(sm.CreateSecretOptionsSecretTypeIamCredentialsConst),
+					ID:         &secretName,
+				})
+			if err != nil {
+				return nil, err
+			}
+
+			secret := response.Resources[0].(*sm.SecretResource)
+			secretData := *secret.APIKey
+
+			secretMap := make(map[string][]byte)
+			secretMap["apikey"] = []byte(secretData)
+
+			return secretMap, nil
+
+		case "imported_cert":
+			response, _, err := ibm.IBMClient.GetSecret(
+				&sm.GetSecretOptions{
+					SecretType: core.StringPtr(sm.CreateSecretOptionsSecretTypeImportedCertConst),
+					ID:         &secretName,
+				})
+			if err != nil {
+				return nil, err
+			}
+
+			secret := response.Resources[0].(*sm.SecretResource)
+			secretData := secret.SecretData.(map[string]interface{})
+
+			secretMap := make(map[string][]byte)
+			for k, v := range secretData {
+				secretMap[k] = []byte(v.(string))
+			}
+
+			return secretMap, nil
+
+		default:
+			return nil, fmt.Errorf("unknown secret type %s", secretType)
 	}
-
-	secretMap := make(map[string][]byte)
-	for k, v := range kv {
-		secretMap[k] = []byte(v)
-	}
-
-	return secretMap, nil
 }
 
 func (ibm *providerIBM) Close() error {

--- a/pkg/provider/ibm/provider.go
+++ b/pkg/provider/ibm/provider.go
@@ -182,7 +182,6 @@ func (ibm *providerIBM) GetSecret(ctx context.Context, ref esv1alpha1.ExternalSe
 	default:
 		return nil, fmt.Errorf("unknown secret type %s", secretType)
 	}
-
 }
 
 func (ibm *providerIBM) GetSecretMap(ctx context.Context, ref esv1alpha1.ExternalSecretDataRemoteRef) (map[string][]byte, error) {

--- a/pkg/provider/ibm/provider_test.go
+++ b/pkg/provider/ibm/provider_test.go
@@ -78,7 +78,7 @@ func makeValidAPIOutput() *sm.GetSecret {
 	return &sm.GetSecret{
 		Resources: []sm.SecretResourceIntf{
 			&sm.SecretResource{
-				Type:       utilpointer.StringPtr("testytype"),
+				SecretType: utilpointer.StringPtr("testytype"),
 				Name:       utilpointer.StringPtr("testyname"),
 				SecretData: secretData,
 			},
@@ -118,7 +118,7 @@ func TestIBMSecretManagerGetSecret(t *testing.T) {
 	setSecretString := func(smtc *secretManagerTestCase) {
 		resources := []sm.SecretResourceIntf{
 			&sm.SecretResource{
-				Type:       utilpointer.StringPtr("testytype"),
+				SecretType: utilpointer.StringPtr("testytype"),
 				Name:       utilpointer.StringPtr("testyname"),
 				SecretData: secretData,
 			}}
@@ -131,7 +131,7 @@ func TestIBMSecretManagerGetSecret(t *testing.T) {
 	setCustomKey := func(smtc *secretManagerTestCase) {
 		resources := []sm.SecretResourceIntf{
 			&sm.SecretResource{
-				Type:       utilpointer.StringPtr("testytype"),
+				SecretType: utilpointer.StringPtr("testytype"),
 				Name:       utilpointer.StringPtr("testyname"),
 				SecretData: secretData,
 			}}
@@ -170,7 +170,7 @@ func TestGetSecretMap(t *testing.T) {
 		secretData["payload"] = secretValue
 		resources := []sm.SecretResourceIntf{
 			&sm.SecretResource{
-				Type:       utilpointer.StringPtr("testytype"),
+				SecretType: utilpointer.StringPtr("testytype"),
 				Name:       utilpointer.StringPtr("testyname"),
 				SecretData: secretData,
 			}}
@@ -186,7 +186,7 @@ func TestGetSecretMap(t *testing.T) {
 
 		resources := []sm.SecretResourceIntf{
 			&sm.SecretResource{
-				Type:       utilpointer.StringPtr("testytype"),
+				SecretType: utilpointer.StringPtr("testytype"),
 				Name:       utilpointer.StringPtr("testyname"),
 				SecretData: secretData,
 			}}


### PR DESCRIPTION
Closes #242 

This PR implements support for other IBM Cloud Secrets Manager secret types:
- username_password
- iam_credentials
- imported_cert

This change requires one to specify secret type in front of the secret ID like this:
```
arbitrary/11111111-222-333-4444-555555555555
username_password/11111111-222-333-4444-555555555555
iam_credentials/11111111-222-333-4444-555555555555
imported_cert/11111111-222-333-4444-555555555555
```
If secret type is not specified it is defaulted to `arbitrary`

The behaviour for different secret types is following:
### arbitrary
- `remoteRef` retrieves a string from secrets manager and sets it for specified `secretKey`
- `dataFrom` retrieves a string from secrets manager and tries to parse it as JSON object setting the key:values pairs in resulting Kubernetes secret if successful

### username_password
- `remoteRef` requires a `property` to be set for either `username` or `password` to retrieve respective fields from the secrets manager secret and set in specified `secretKey`
- `dataFrom` retrieves both `username` and `password` fields from the secrets manager secret and sets appropriate key:value pairs in the resulting Kubernetes secret

### iam_credentials
- `remoteRef` retrieves an apikey from secrets manager and sets it for specified `secretKey`
- `dataFrom` retrieves an apikey from secrets manager and sets it for the `apikey` Kubernetes secret key

### imported_cert
- `remoteRef` requires a `property` to be set for either `certificate`, `private_key` or `intermediate` to retrieve respective fields from the secrets manager secret and set in specified `secretKey`
- `dataFrom` retrieves all `certificate`, `private_key` and `intermediate` fields from the secrets manager secret and sets appropriate key:value pairs in the resulting Kubernetes secret


Controller logs error message if it fails to retrieve secret because of incorrect ExternalSecret config for a secret type, but it would be better to surface this messages in the ExternalSecret CRD events for visibility