### PR TITLE
fix azure GetSecretMap

### DIFF
--- a/e2e/suite/azure/azure.go
+++ b/e2e/suite/azure/azure.go
@@ -35,9 +35,7 @@ var _ = Describe("[azure] ", func() {
 	DescribeTable("sync secrets", framework.TableFunc(f, prov),
 		Entry(common.SimpleDataSync(f)),
 		Entry(common.NestedJSONWithGJSON(f)),
-		// TODO: dataFrom is not working as expected RN
-		// see: https://github.com/external-secrets/external-secrets/issues/263
-		// Entry(common.JSONDataFromSync(f)),
+		Entry(common.JSONDataFromSync(f)),
 		Entry(common.JSONDataWithProperty(f)),
 		Entry(common.JSONDataWithTemplate(f)),
 	)

--- a/pkg/provider/azure/keyvault/keyvault.go
+++ b/pkg/provider/azure/keyvault/keyvault.go
@@ -151,7 +151,7 @@ func (a *Azure) GetSecretMap(ctx context.Context, ref esv1alpha1.ExternalSecretD
 	kv := make(map[string]string)
 	err = json.Unmarshal(data, &kv)
 	if err != nil {
-		return nil, fmt.Errorf("Error unmarshalling json data: %w", err)
+		return nil, fmt.Errorf("error unmarshalling json data: %w", err)
 	}
 
 	secretData := make(map[string][]byte)

--- a/pkg/provider/azure/keyvault/keyvault_test.go
+++ b/pkg/provider/azure/keyvault/keyvault_test.go
@@ -154,30 +154,31 @@ func TestGetSecretWithoutVersion(t *testing.T) {
 	tassert.Equal(t, []byte("My Secret"), secret)
 }
 
-func TestGetSecretMap(t *testing.T) {
-	testAzure, azureMock := newAzure()
-	ctx := context.Background()
-	rf := esv1alpha1.ExternalSecretDataRemoteRef{}
-	azureMock.AddSecret(testAzure.vaultURL, "testName", "My Secret", true)
-	azureMock.ExpectsGetSecretsComplete(ctx, testAzure.vaultURL, nil)
-	azureMock.ExpectsGetSecret(ctx, testAzure.vaultURL, "testName", "")
-	secretMap, err := testAzure.GetSecretMap(ctx, rf)
-	azureMock.AssertExpectations(t)
-	tassert.Nil(t, err, "the return err should be nil")
-	tassert.Equal(t, secretMap, map[string][]byte{"testName": []byte("My Secret")})
-}
+// Need to be altered to reflect changes to Azure GetSecretMap
+// func TestGetSecretMap(t *testing.T) {
+// 	testAzure, azureMock := newAzure()
+// 	ctx := context.Background()
+// 	rf := esv1alpha1.ExternalSecretDataRemoteRef{}
+// 	azureMock.AddSecret(testAzure.vaultURL, "testName", "My Secret", true)
+// 	azureMock.ExpectsGetSecretsComplete(ctx, testAzure.vaultURL, nil)
+// 	azureMock.ExpectsGetSecret(ctx, testAzure.vaultURL, "testName", "")
+// 	secretMap, err := testAzure.GetSecretMap(ctx, rf)
+// 	azureMock.AssertExpectations(t)
+// 	tassert.Nil(t, err, "the return err should be nil")
+// 	tassert.Equal(t, secretMap, map[string][]byte{"testName": []byte("My Secret")})
+// }
 
-func TestGetSecretMapNotEnabled(t *testing.T) {
-	testAzure, azureMock := newAzure()
-	ctx := context.Background()
-	rf := esv1alpha1.ExternalSecretDataRemoteRef{}
-	azureMock.AddSecret(testAzure.vaultURL, "testName", "My Secret", false)
-	azureMock.ExpectsGetSecretsComplete(ctx, testAzure.vaultURL, nil)
-	secretMap, err := testAzure.GetSecretMap(ctx, rf)
-	azureMock.AssertExpectations(t)
-	tassert.Nil(t, err, "the return err should be nil")
-	tassert.Empty(t, secretMap)
-}
+// func TestGetSecretMapNotEnabled(t *testing.T) {
+// 	testAzure, azureMock := newAzure()
+// 	ctx := context.Background()
+// 	rf := esv1alpha1.ExternalSecretDataRemoteRef{}
+// 	azureMock.AddSecret(testAzure.vaultURL, "testName", "My Secret", false)
+// 	azureMock.ExpectsGetSecretsComplete(ctx, testAzure.vaultURL, nil)
+// 	secretMap, err := testAzure.GetSecretMap(ctx, rf)
+// 	azureMock.AssertExpectations(t)
+// 	tassert.Nil(t, err, "the return err should be nil")
+// 	tassert.Empty(t, secretMap)
+// }
 
 func newKVJWK(b []byte) *keyvault.JSONWebKey {
 	var key keyvault.JSONWebKey

--- a/pkg/provider/azure/keyvault/keyvault_test.go
+++ b/pkg/provider/azure/keyvault/keyvault_test.go
@@ -154,31 +154,19 @@ func TestGetSecretWithoutVersion(t *testing.T) {
 	tassert.Equal(t, []byte("My Secret"), secret)
 }
 
-// Need to be altered to reflect changes to Azure GetSecretMap
-// func TestGetSecretMap(t *testing.T) {
-// 	testAzure, azureMock := newAzure()
-// 	ctx := context.Background()
-// 	rf := esv1alpha1.ExternalSecretDataRemoteRef{}
-// 	azureMock.AddSecret(testAzure.vaultURL, "testName", "My Secret", true)
-// 	azureMock.ExpectsGetSecretsComplete(ctx, testAzure.vaultURL, nil)
-// 	azureMock.ExpectsGetSecret(ctx, testAzure.vaultURL, "testName", "")
-// 	secretMap, err := testAzure.GetSecretMap(ctx, rf)
-// 	azureMock.AssertExpectations(t)
-// 	tassert.Nil(t, err, "the return err should be nil")
-// 	tassert.Equal(t, secretMap, map[string][]byte{"testName": []byte("My Secret")})
-// }
-
-// func TestGetSecretMapNotEnabled(t *testing.T) {
-// 	testAzure, azureMock := newAzure()
-// 	ctx := context.Background()
-// 	rf := esv1alpha1.ExternalSecretDataRemoteRef{}
-// 	azureMock.AddSecret(testAzure.vaultURL, "testName", "My Secret", false)
-// 	azureMock.ExpectsGetSecretsComplete(ctx, testAzure.vaultURL, nil)
-// 	secretMap, err := testAzure.GetSecretMap(ctx, rf)
-// 	azureMock.AssertExpectations(t)
-// 	tassert.Nil(t, err, "the return err should be nil")
-// 	tassert.Empty(t, secretMap)
-// }
+func TestGetSecretMap(t *testing.T) {
+	testAzure, azureMock := newAzure()
+	ctx := context.Background()
+	rf := esv1alpha1.ExternalSecretDataRemoteRef{
+		Key: "testName",
+	}
+	azureMock.AddSecret(testAzure.vaultURL, "testName", "{\"username\": \"user1\", \"pass\": \"123\"}", true)
+	azureMock.ExpectsGetSecret(ctx, testAzure.vaultURL, "testName", "")
+	secretMap, err := testAzure.GetSecretMap(ctx, rf)
+	azureMock.AssertExpectations(t)
+	tassert.Nil(t, err, "the return err should be nil")
+	tassert.Equal(t, secretMap, map[string][]byte{"username": []byte("user1"), "pass": []byte("123")})
+}
 
 func newKVJWK(b []byte) *keyvault.JSONWebKey {
 	var key keyvault.JSONWebKey


### PR DESCRIPTION
Change Azure GetSecretMap to be similar to GCP implementation. Unit tests are not working for GetSecretMap - to be fixed in a future pull request. Closes #263 