### PR TITLE
add arm build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,13 +230,6 @@ jobs:
           key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-pkg-
 
-      - name: Build Artifacts
-        env:
-          # We're using docker buildx, which doesn't actually load the images it
-          # builds by default. Specifying --load does so.
-          BUILD_ARGS: "--load"
-        run: make docker.build
-
       - name: Login to Docker
         uses: docker/login-action@v1
         if: env.GHCR_USERNAME != ''
@@ -245,9 +238,11 @@ jobs:
           username: ${{ secrets.GHCR_USERNAME }}
           password: ${{ secrets.GHCR_TOKEN }}
 
-      - name: Publish Artifacts
+      - name: Build & Publish Artifacts
         if: env.GHCR_USERNAME != ''
-        run: make docker.push
+        env:
+          BUILD_ARGS: "--push --platform linux/amd64,linux/arm64"
+        run: make docker.build
 
       - name: Promote Artifacts to main release channel
         if: github.ref == 'refs/heads/main' && env.GHCR_USERNAME != ''

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -71,7 +71,15 @@ jobs:
         node_image: kindest/node:v1.20.7
         name: external-secrets
 
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v1
+      with:
+        version: ${{ env.DOCKER_BUILDX_VERSION }}
+        install: true
+
     - name: Run e2e Tests
+      env:
+        BUILD_ARGS: "--load"
       run: |
         export PATH=$PATH:$(go env GOPATH)/bin
         go get github.com/onsi/ginkgo/ginkgo
@@ -128,7 +136,15 @@ jobs:
         node_image: kindest/node:v1.20.7
         name: external-secrets
 
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v1
+      with:
+        version: ${{ env.DOCKER_BUILDX_VERSION }}
+        install: true
+
     - name: Run e2e Tests
+      env:
+        BUILD_ARGS: "--load"
       run: |
         export PATH=$PATH:$(go env GOPATH)/bin
         go get github.com/onsi/ginkgo/ginkgo

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ cover.out
 # helm chart dependencies
 **/charts/*.tgz
 **/charts/**/requirements.lock
-
+.tagmanifest
 deploy/charts/external-secrets/templates/crds/*.yaml
 
 site/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.14.0
-
-COPY bin/external-secrets /bin/external-secrets
+ARG TARGETOS
+ARG TARGETARCH
+COPY bin/external-secrets-${TARGETOS}-${TARGETARCH} /bin/external-secrets
 
 # Run as UID for nobody
 USER 65534

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -5,6 +5,7 @@ SHELL       := /bin/bash
 IMG_TAG     = test
 IMG         = local/external-secrets-e2e:$(IMG_TAG)
 K8S_VERSION = "1.20.7"
+BUILD_ARGS  ?=
 export FOCUS := $(FOCUS)
 
 start-kind: ## Start kind cluster
@@ -18,7 +19,7 @@ test: e2e-image ## Run e2e tests against current kube context
 	$(MAKE) -C ../ docker.build \
 		IMAGE_REGISTRY=local/external-secrets \
 		VERSION=$(IMG_TAG) \
-		BUILD_ARGS="--build-arg ARCHS=amd64"
+		ARCH=amd64
 	kind load docker-image --name="external-secrets" local/external-secrets:$(IMG_TAG)
 	kind load docker-image --name="external-secrets" $(IMG)
 	./run.sh
@@ -31,7 +32,7 @@ e2e-image: e2e-bin
 	mkdir -p k8s
 	$(MAKE) -C ../ helm.generate
 	cp -r ../deploy ./k8s
-	docker build -t $(IMG) .
+	docker build $(BUILD_ARGS) -t $(IMG) .
 
 stop-kind: ## Stop kind cluster
 	kind delete cluster \


### PR DESCRIPTION
fixes #181 

This PR adds arm build in the ci pipeline. I would like to propose to use a "fat manifest" (aka [image-index](https://github.com/opencontainers/image-spec/blob/main/image-index.md)) that allows us to reference two platforms with a single tag. So a user does not need to specify a different tag when using the `arm64` platform.


**Notes for the reviewer:**
We can not use `docker buildx` with `--load` when using multiple platforms, see: https://github.com/docker/buildx/issues/59. I removed the build phase and do a build+push instead using `--push --platform linux/amd64,linux/arm64`.

The promotion process seems a bit hacky, but that's afaik the only way to re-use the existing, already pushed images.

I tested the promotion process during a test run, see here: https://github.com/external-secrets/external-secrets/pkgs/container/external-secrets/4243477. As you can see it now contains two archs.

```
$ docker manifest inspect ghcr.io/external-secrets/external-secrets:refactor-test-7
```
```json
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 740,
         "digest": "sha256:00d5ebf30e72c67de3cc787e5fb6ef988f58827f336c96feabbeceddcad4e9e8",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 740,
         "digest": "sha256:d0dc5af975fb7c6b9ef4869137c30fef266d1a27452339773c169be7954d64ed",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      }
   ]
}
```