### PR TITLE
Fix Openshift 4.7 issues

### DIFF
--- a/deploy/charts/external-secrets/templates/rbac.yaml
+++ b/deploy/charts/external-secrets/templates/rbac.yaml
@@ -21,6 +21,7 @@ rules:
     resources:
     - "externalsecrets"
     - "externalsecrets/status"
+    - "externalsecrets/finalizers"
     verbs:
     - "update"
     - "patch"


### PR DESCRIPTION
Fixes #277.

Updates the helm chart ClusterRole to allow updating and patching the `externalsecrets/finalizers` resource.

Changes the vault.go ServiceAccount logic to attempt every Secret listed in the ServiceAccount before returning an error indicating that no secret with a `token` key was found.