### PR TITLE
Added common tests for dockerconfigjson and SSH Auth types. Added test case in vault provider for specific case and for more detailed error messages. SSH Auth type not currently supported by vault due to lack of current support for a certificate/key specific secret type/plugin.

### DIFF
--- a/e2e/suite/aws/secretsmanager.go
+++ b/e2e/suite/aws/secretsmanager.go
@@ -121,5 +121,6 @@ var _ = Describe("[aws] ", func() {
 		Entry(common.JSONDataWithProperty(f)),
 		Entry(common.JSONDataWithTemplate(f)),
 		Entry("should sync secrets with jwt auth", jwt),
+		Entry(common.DockerJSONConfig(f)),
 	)
 })

--- a/e2e/suite/aws/secretsmanager.go
+++ b/e2e/suite/aws/secretsmanager.go
@@ -122,6 +122,8 @@ var _ = Describe("[aws] ", func() {
 		Entry(common.JSONDataWithTemplate(f)),
 		Entry("should sync secrets with jwt auth", jwt),
 		Entry(common.DockerJSONConfig(f)),
+		Entry(common.DataPropertyDockerconfigJSON(f)),
 		Entry(common.SSHKeySync(f)),
+		Entry(common.SSHKeySyncDataProperty(f)),
 	)
 })

--- a/e2e/suite/aws/secretsmanager.go
+++ b/e2e/suite/aws/secretsmanager.go
@@ -122,5 +122,6 @@ var _ = Describe("[aws] ", func() {
 		Entry(common.JSONDataWithTemplate(f)),
 		Entry("should sync secrets with jwt auth", jwt),
 		Entry(common.DockerJSONConfig(f)),
+		Entry(common.SSHKeySync(f)),
 	)
 })

--- a/e2e/suite/azure/azure.go
+++ b/e2e/suite/azure/azure.go
@@ -41,5 +41,6 @@ var _ = Describe("[azure] ", func() {
 		Entry(common.JSONDataWithProperty(f)),
 		Entry(common.JSONDataWithTemplate(f)),
 		Entry(common.DockerJSONConfig(f)),
+		Entry(common.SSHKeySync(f)),
 	)
 })

--- a/e2e/suite/azure/azure.go
+++ b/e2e/suite/azure/azure.go
@@ -40,5 +40,6 @@ var _ = Describe("[azure] ", func() {
 		// Entry(common.JSONDataFromSync(f)),
 		Entry(common.JSONDataWithProperty(f)),
 		Entry(common.JSONDataWithTemplate(f)),
+		Entry(common.DockerJSONConfig(f)),
 	)
 })

--- a/e2e/suite/azure/azure.go
+++ b/e2e/suite/azure/azure.go
@@ -41,6 +41,8 @@ var _ = Describe("[azure] ", func() {
 		Entry(common.JSONDataWithProperty(f)),
 		Entry(common.JSONDataWithTemplate(f)),
 		Entry(common.DockerJSONConfig(f)),
+		Entry(common.DataPropertyDockerconfigJSON(f)),
 		Entry(common.SSHKeySync(f)),
+		Entry(common.SSHKeySyncDataProperty(f)),
 	)
 })

--- a/e2e/suite/common/common.go
+++ b/e2e/suite/common/common.go
@@ -228,3 +228,48 @@ func NestedJSONWithGJSON(f *framework.Framework) (string, func(*framework.TestCa
 		}
 	}
 }
+
+// This case creates a secret with a Docker json configuration value.
+// The values from the nested data are extracted using gjson.
+// not supported by: vault.
+func DockerJSONConfig(f *framework.Framework) (string, func(*framework.TestCase)) {
+	return "[specific] should do something I guess but not sure what!", func(tc *framework.TestCase) {
+		cloudSecretName := fmt.Sprintf("%s-%s", f.Namespace.Name, "docker-config-example")
+		cloudSecretValue := `{"auths":{"https://index.docker.io/v1/": {"auth": "c3R...zE2"}}}`
+
+		tc.Secrets = map[string]string{
+			cloudSecretName: cloudSecretValue,
+		}
+
+		tc.ExpectedSecret = &v1.Secret{
+			Type: v1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				".dockerconfigjson": []byte(cloudSecretValue),
+			},
+		}
+
+		tc.ExternalSecret.Spec.Data = []esv1alpha1.ExternalSecretData{
+			{
+				SecretKey: "mysecret",
+				RemoteRef: esv1alpha1.ExternalSecretDataRemoteRef{
+					Key: cloudSecretName,
+				},
+			},
+		}
+
+		tc.ExternalSecret.Spec.Target.Template = &esv1alpha1.ExternalSecretTemplate{
+			Metadata: esv1alpha1.ExternalSecretTemplateMetadata{
+				Annotations: map[string]string{
+					"example": "annotation",
+				},
+				Labels: map[string]string{
+					"example": "label",
+				},
+			},
+			Data: map[string]string{
+				".dockerconfigjson": "{{ .mysecret | toString }}",
+			},
+		}
+
+	}
+}

--- a/e2e/suite/common/common.go
+++ b/e2e/suite/common/common.go
@@ -233,7 +233,7 @@ func NestedJSONWithGJSON(f *framework.Framework) (string, func(*framework.TestCa
 // The values from the nested data are extracted using gjson.
 // not supported by: vault.
 func DockerJSONConfig(f *framework.Framework) (string, func(*framework.TestCase)) {
-	return "[specific] should do something I guess but not sure what!", func(tc *framework.TestCase) {
+	return "[common] should sync docker configurated json secrets with template", func(tc *framework.TestCase) {
 		cloudSecretName := fmt.Sprintf("%s-%s", f.Namespace.Name, "docker-config-example")
 		cloudSecretValue := `{"auths":{"https://index.docker.io/v1/": {"auth": "c3R...zE2"}}}`
 

--- a/e2e/suite/common/common.go
+++ b/e2e/suite/common/common.go
@@ -2,9 +2,7 @@
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,8 +26,7 @@ func SimpleDataSync(f *framework.Framework) (string, func(*framework.TestCase)) 
 	return "[common] should sync simple secrets from .Data[]", func(tc *framework.TestCase) {
 		secretKey1 := fmt.Sprintf("%s-%s", f.Namespace.Name, "one")
 		secretKey2 := fmt.Sprintf("%s-%s", f.Namespace.Name, "other")
-		//secretValue := "bar"
-		secretValue := "{\"foo1\":\"foo1-val\",\"bar1\":\"bar1-val\"}"
+		secretValue := "bar"
 		tc.Secrets = map[string]string{
 			secretKey1: secretValue,
 			secretKey2: secretValue,
@@ -37,10 +34,8 @@ func SimpleDataSync(f *framework.Framework) (string, func(*framework.TestCase)) 
 		tc.ExpectedSecret = &v1.Secret{
 			Type: v1.SecretTypeOpaque,
 			Data: map[string][]byte{
-				secretKey1: []byte("foo1-val"),
-				secretKey2: []byte("bar1-val"),
-				/*secretKey1: []byte(secretValue),
-				secretKey2: []byte(secretValue),*/
+				secretKey1: []byte(secretValue),
+				secretKey2: []byte(secretValue),
 			},
 		}
 		tc.ExternalSecret.Spec.Data = []esv1alpha1.ExternalSecretData{
@@ -48,16 +43,12 @@ func SimpleDataSync(f *framework.Framework) (string, func(*framework.TestCase)) 
 				SecretKey: secretKey1,
 				RemoteRef: esv1alpha1.ExternalSecretDataRemoteRef{
 					Key: secretKey1,
-					//
-					Property: "foo1",
 				},
 			},
 			{
 				SecretKey: secretKey2,
 				RemoteRef: esv1alpha1.ExternalSecretDataRemoteRef{
 					Key: secretKey2,
-					//
-					Property: "bar1",
 				},
 			},
 		}

--- a/e2e/suite/common/common.go
+++ b/e2e/suite/common/common.go
@@ -28,7 +28,8 @@ func SimpleDataSync(f *framework.Framework) (string, func(*framework.TestCase)) 
 	return "[common] should sync simple secrets from .Data[]", func(tc *framework.TestCase) {
 		secretKey1 := fmt.Sprintf("%s-%s", f.Namespace.Name, "one")
 		secretKey2 := fmt.Sprintf("%s-%s", f.Namespace.Name, "other")
-		secretValue := "bar"
+		//secretValue := "bar"
+		secretValue := "{\"foo1\":\"foo1-val\",\"bar1\":\"bar1-val\"}"
 		tc.Secrets = map[string]string{
 			secretKey1: secretValue,
 			secretKey2: secretValue,
@@ -36,8 +37,10 @@ func SimpleDataSync(f *framework.Framework) (string, func(*framework.TestCase)) 
 		tc.ExpectedSecret = &v1.Secret{
 			Type: v1.SecretTypeOpaque,
 			Data: map[string][]byte{
-				secretKey1: []byte(secretValue),
-				secretKey2: []byte(secretValue),
+				secretKey1: []byte("foo1-val"),
+				secretKey2: []byte("bar1-val"),
+				/*secretKey1: []byte(secretValue),
+				secretKey2: []byte(secretValue),*/
 			},
 		}
 		tc.ExternalSecret.Spec.Data = []esv1alpha1.ExternalSecretData{
@@ -45,12 +48,16 @@ func SimpleDataSync(f *framework.Framework) (string, func(*framework.TestCase)) 
 				SecretKey: secretKey1,
 				RemoteRef: esv1alpha1.ExternalSecretDataRemoteRef{
 					Key: secretKey1,
+					//
+					Property: "foo1",
 				},
 			},
 			{
 				SecretKey: secretKey2,
 				RemoteRef: esv1alpha1.ExternalSecretDataRemoteRef{
 					Key: secretKey2,
+					//
+					Property: "bar1",
 				},
 			},
 		}

--- a/e2e/suite/common/common.go
+++ b/e2e/suite/common/common.go
@@ -281,25 +281,23 @@ func DockerJSONConfigVault(f *framework.Framework) (string, func(*framework.Test
 	return "[common] should sync docker configurated json secrets with template", func(tc *framework.TestCase) {
 		cloudSecretName := fmt.Sprintf("%s-%s", f.Namespace.Name, "docker-config-example")
 		//cloudSecretValue := `{"auths":{"https://index.docker.io/v1/": {"auth": "c3R...zE2"}}}`
+		//dockerconfig := "{\"auths\":{\"https://index.docker.io/v1/\": {\"auth\": \"c3R...zE2\"}}}" // so we have the json string that is the final docker config that we want
+		//cloudSecretValue := "{\"dockerconfig\": {\"auths\":{\"https://index.docker.io/v1/\": {\"auth\": \"c3R...zE2\"}}}}"
+		// cloudSecretValue := fmt.Sprintf(`{"dockerconfig": %s}`, dockerconfig)
+		//dockerconfig := "{\"auths\":{\"https://index.docker.io/v1/\": {\"auth\": \"c3R...zE2\"}}}"
+
+		dockerconfigString := `"{\"auths\":{\"https://index.docker.io/v1/\": {\"auth\": \"c3R...zE2\"}}}"`
 		dockerconfig := `{"auths":{"https://index.docker.io/v1/": {"auth": "c3R...zE2"}}}`
-		cloudSecretValue := fmt.Sprintf(`{"dockerconfig": %s}`, dockerconfig)
-		/*cloudSecretValue := `{
-			"dockerconfig": {
-				"auths": {
-					"https://index.docker.io/v1/": {
-						"auth": "c3R...zE2"
-					}
-				}
-			}
-		}`*/
+		cloudSecretValue := fmt.Sprintf(`{"dockerconfig": %s}`, dockerconfigString)
+
 		tc.Secrets = map[string]string{
 			cloudSecretName: cloudSecretValue,
 		}
 
 		tc.ExpectedSecret = &v1.Secret{
-			Type: v1.SecretTypeOpaque,
+			Type: v1.SecretTypeDockerConfigJson, // we forgot to change this type
 			Data: map[string][]byte{
-				".dockerconfigjson": []byte(dockerconfig),
+				cloudSecretName: []byte(dockerconfig),
 			},
 		}
 

--- a/e2e/suite/common/common.go
+++ b/e2e/suite/common/common.go
@@ -258,18 +258,9 @@ func DockerJSONConfig(f *framework.Framework) (string, func(*framework.TestCase)
 		}
 
 		tc.ExternalSecret.Spec.Target.Template = &esv1alpha1.ExternalSecretTemplate{
-			Metadata: esv1alpha1.ExternalSecretTemplateMetadata{
-				Annotations: map[string]string{
-					"example": "annotation",
-				},
-				Labels: map[string]string{
-					"example": "label",
-				},
-			},
 			Data: map[string]string{
 				".dockerconfigjson": "{{ .mysecret | toString }}",
 			},
 		}
-
 	}
 }

--- a/e2e/suite/common/common.go
+++ b/e2e/suite/common/common.go
@@ -308,8 +308,43 @@ func DataPropertyDockerconfigJSON(f *framework.Framework) (string, func(*framewo
 func SSHKeySync(f *framework.Framework) (string, func(*framework.TestCase)) {
 	return "[common] should sync ssh key secret", func(tc *framework.TestCase) {
 		sshSecretName := fmt.Sprintf("%s-%s", f.Namespace.Name, "ssh-priv-key-example")
-		sshSecretValue := `EY2NNWddRADTFdNvEojrCwo+DUxy6va2JltQAbxmhyvSZsL1eYsutunsKEwonGSru0Zd+m
-		z5DHJOOQdHEsH3AAAACmFub3RoZXJvbmU=
+		sshSecretValue := `-----BEGIN OPENSSH PRIVATE KEY-----
+		b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABlwAAAAdzc2gtcn
+		NhAAAAAwEAAQAAAYEAsARoZUqo6L5dd0WRjZ2QPq/kKlbjtUY1njzJ01UtdC1u1eSJFUnV
+		K1J+9b1kEqI4lgAaItaYbpJNSgCe97z6DRxEMTUQ3VhB+X+mPfcN2/I0bYklRxh59OTJcL
+		FsPX0oCR/5eLXz9MCmelxDX7H8XDh9hP6PThooYP60oaDt0xsZvEyo6OQ43n5FuorSg4vL
+		aMIQYK/znhBq9kR6XKMO8mULoDa+LnhOWsAY8kJ3fowF/UsQmh6PY/w4DJaypm85+a6Sak
+		Lpn80ur7L6nV7yTqufYqXa4hgNsJHmJ7NGKqOxT/8vcvVRqRadNLl79g9bRRavBiYt/8fy
+		DJGxOuutcVTzYlzS593Vo95In853cT+HuK4guaWkQdTrThG7jHAi0wVueaEDCTnDkuTk2h
+		7PXFBkYTUwE3y+NHo1X+nTE3LhiUJ0RBr3aaj5UBYKHK1uMo1C4zZH3GMvB5K2KmXwG/oB
+		gCcD1j5hlp6QwOzBVfXsXBF4ewtf7g3RQF8DS3mBAAAFkDc7Drc3Ow63AAAAB3NzaC1yc2
+		EAAAGBALAEaGVKqOi+XXdFkY2dkD6v5CpW47VGNZ48ydNVLXQtbtXkiRVJ1StSfvW9ZBKi
+		OJYAGiLWmG6STUoAnve8+g0cRDE1EN1YQfl/pj33DdvyNG2JJUcYefTkyXCxbD19KAkf+X
+		i18/TApnpcQ1+x/Fw4fYT+j04aKGD+tKGg7dMbGbxMqOjkON5+RbqK0oOLy2jCEGCv854Q
+		avZEelyjDvJlC6A2vi54TlrAGPJCd36MBf1LEJoej2P8OAyWsqZvOfmukmpC6Z/NLq+y+p
+		1e8k6rn2Kl2uIYDbCR5iezRiqjsU//L3L1UakWnTS5e/YPW0UWrwYmLf/H8gyRsTrrrXFU
+		82Jc0ufd1aPeSJ/Od3E/h7iuILmlpEHU604Ru4xwItMFbnmhAwk5w5Lk5Noez1xQZGE1MB
+		N8vjR6NV/p0xNy4YlCdEQa92mo+VAWChytbjKNQuM2R9xjLweStipl8Bv6AYAnA9Y+YZae
+		kMDswVX17FwReHsLX+4N0UBfA0t5gQAAAAMBAAEAAAGAey4agQiGvJq8fkPJYPnrgHNHkf
+		nM0YeY7mxMMgFiFfPVpQqShLtu2yqYfxFTf1bXkuHvaIIVmwv32tokZetycspdTrJ8Yurp
+		ANo8VREYOdx+pEleNSsD7kZOUvdXcJCt+/TMeZWcbKSF3QvEeqvsl/1Qmkorr9TOfVLCxn
+		oA9cP5drWPX6yXv91OnwWX3UdvyphFLeT08KE8uauilkHmq+va/vxQi+TVsNzOmHu7dGw5
+		pNFrhO/uGWLhNq4fyCn9l33vpHZdMe2h/N32MnKZgjFOWLqyHy2Cx5BDJTfXyHwjVTqGN1
+		8fzrC+o3OuFsR1pPugwlYUW8B9XaxPI6h+Ke6GIxacNtVvOe67GrkdYbQkyrs4/EMqbXTl
+		/BG/JZIMuchk0Da0TKDDjBwchMjAiwjsFp/wawlL9Y0dJIG0muEuHXxjInEa7xQoisAUCf
+		B7lasXeUPOy/Z76qFwjVvyfkiVgWygncjGL44b0rgEC81L/dTZUyvNoCM9Bn7wSbuBAAAA
+		wQDHw6NkJCvGOYa9lt2lMou6hSudokHejOo+J9jJCJdUlMXIbHhBUzrmSh47OSkgpAo4qf
+		iVGHvBO55pZ5pI7o4woTQxaPFM8a/5BhMWcZ2LDMqU5iov9C2Dz8yKUyQmAodNkOGacQJU
+		MDAVBJYeBFJSu04bj2EEhEd+9rIazeqVl91qkV1uGTz4aJ360PSmLuLAFT12BYGjIBfHrS
+		yom+1HbBoUziG4a/kzzbJGTC7U66YTjpHAMEtz4mbpU0AhNg4AAADBANgTs8yjrEkL4pcC
+		gfUr9oR42/BVl3ZxaFQ7PAvs9m0aut7b/ZRmsSF8F2TAl0H4H9M8uUKTTOhqRtdnTtDqm9
+		QBUIQBzA6Blb5oP+yL+Eiez4gMFd9HumFXG3JoRu/JmDE19KviHaldV47QcvG6B3p0eb5Q
+		hgVcNsrOGyBUZA0kBmzQBwv6gUoo++ETQMH89BlljZVCiPW7F6FCrPxHp7EB5txYJ62Qpu
+		2U40qgb2ONiUOuiI84EYRAgmDTbboMPQAAAMEA0Inn71l7LsYv81vstbmMQz0qLvhHkBcp
+		mMhh6tyzI0dvLZabBLTPhIT4R/0VDMJGsH5X1cEaap47XDpu0/g3mfOV6PToUfYA2Ugw7N
+		bs23UlVH1n0zL2x0QOMHX/Fkfc3OdIuc97ZHoMeW6Nf7Ii0iH7slIpH4hPVYcGXk/bX6wt
+		PKDc8xGEXdd4A6jnwJBifJs+UpPrHAh0c63KfjO3rryDycvmxeWRnyU1yRCUjIuH31vi+L
+		OkcGfqTaOoz2KVAAAAFGtpYW5AREVTS1RPUC1TNFI5S1JQAQIDBAUG
 		-----END OPENSSH PRIVATE KEY-----`
 
 		tc.Secrets = map[string]string{
@@ -345,7 +380,45 @@ func SSHKeySync(f *framework.Framework) (string, func(*framework.TestCase)) {
 func SSHKeySyncDataProperty(f *framework.Framework) (string, func(*framework.TestCase)) {
 	return "[common] should sync ssh key with provider.", func(tc *framework.TestCase) {
 		cloudSecretName := fmt.Sprintf("%s-%s", f.Namespace.Name, "docker-config-example")
-		SSHKey := "EY2NNWddRADTFdNvEojrCwo+DUxy6va2JltQAbxmhyvSZsL1eYsutunsKEwonGSru0Zd+m z5DHJOOQdHEsH3AAAACmFub3RoZXJvbmU= -----END OPENSSH PRIVATE KEY-----"
+		//SSHKey := "EY2NNWddRADTFdNvEojrCwo+DUxy6va2JltQAbxmhyvSZsL1eYsutunsKEwonGSru0Zd+m z5DHJOOQdHEsH3AAAACmFub3RoZXJvbmU= -----END OPENSSH PRIVATE KEY-----"
+		SSHKey := `-----BEGIN OPENSSH PRIVATE KEY-----
+		b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABlwAAAAdzc2gtcn
+		NhAAAAAwEAAQAAAYEAsARoZUqo6L5dd0WRjZ2QPq/kKlbjtUY1njzJ01UtdC1u1eSJFUnV
+		K1J+9b1kEqI4lgAaItaYbpJNSgCe97z6DRxEMTUQ3VhB+X+mPfcN2/I0bYklRxh59OTJcL
+		FsPX0oCR/5eLXz9MCmelxDX7H8XDh9hP6PThooYP60oaDt0xsZvEyo6OQ43n5FuorSg4vL
+		aMIQYK/znhBq9kR6XKMO8mULoDa+LnhOWsAY8kJ3fowF/UsQmh6PY/w4DJaypm85+a6Sak
+		Lpn80ur7L6nV7yTqufYqXa4hgNsJHmJ7NGKqOxT/8vcvVRqRadNLl79g9bRRavBiYt/8fy
+		DJGxOuutcVTzYlzS593Vo95In853cT+HuK4guaWkQdTrThG7jHAi0wVueaEDCTnDkuTk2h
+		7PXFBkYTUwE3y+NHo1X+nTE3LhiUJ0RBr3aaj5UBYKHK1uMo1C4zZH3GMvB5K2KmXwG/oB
+		gCcD1j5hlp6QwOzBVfXsXBF4ewtf7g3RQF8DS3mBAAAFkDc7Drc3Ow63AAAAB3NzaC1yc2
+		EAAAGBALAEaGVKqOi+XXdFkY2dkD6v5CpW47VGNZ48ydNVLXQtbtXkiRVJ1StSfvW9ZBKi
+		OJYAGiLWmG6STUoAnve8+g0cRDE1EN1YQfl/pj33DdvyNG2JJUcYefTkyXCxbD19KAkf+X
+		i18/TApnpcQ1+x/Fw4fYT+j04aKGD+tKGg7dMbGbxMqOjkON5+RbqK0oOLy2jCEGCv854Q
+		avZEelyjDvJlC6A2vi54TlrAGPJCd36MBf1LEJoej2P8OAyWsqZvOfmukmpC6Z/NLq+y+p
+		1e8k6rn2Kl2uIYDbCR5iezRiqjsU//L3L1UakWnTS5e/YPW0UWrwYmLf/H8gyRsTrrrXFU
+		82Jc0ufd1aPeSJ/Od3E/h7iuILmlpEHU604Ru4xwItMFbnmhAwk5w5Lk5Noez1xQZGE1MB
+		N8vjR6NV/p0xNy4YlCdEQa92mo+VAWChytbjKNQuM2R9xjLweStipl8Bv6AYAnA9Y+YZae
+		kMDswVX17FwReHsLX+4N0UBfA0t5gQAAAAMBAAEAAAGAey4agQiGvJq8fkPJYPnrgHNHkf
+		nM0YeY7mxMMgFiFfPVpQqShLtu2yqYfxFTf1bXkuHvaIIVmwv32tokZetycspdTrJ8Yurp
+		ANo8VREYOdx+pEleNSsD7kZOUvdXcJCt+/TMeZWcbKSF3QvEeqvsl/1Qmkorr9TOfVLCxn
+		oA9cP5drWPX6yXv91OnwWX3UdvyphFLeT08KE8uauilkHmq+va/vxQi+TVsNzOmHu7dGw5
+		pNFrhO/uGWLhNq4fyCn9l33vpHZdMe2h/N32MnKZgjFOWLqyHy2Cx5BDJTfXyHwjVTqGN1
+		8fzrC+o3OuFsR1pPugwlYUW8B9XaxPI6h+Ke6GIxacNtVvOe67GrkdYbQkyrs4/EMqbXTl
+		/BG/JZIMuchk0Da0TKDDjBwchMjAiwjsFp/wawlL9Y0dJIG0muEuHXxjInEa7xQoisAUCf
+		B7lasXeUPOy/Z76qFwjVvyfkiVgWygncjGL44b0rgEC81L/dTZUyvNoCM9Bn7wSbuBAAAA
+		wQDHw6NkJCvGOYa9lt2lMou6hSudokHejOo+J9jJCJdUlMXIbHhBUzrmSh47OSkgpAo4qf
+		iVGHvBO55pZ5pI7o4woTQxaPFM8a/5BhMWcZ2LDMqU5iov9C2Dz8yKUyQmAodNkOGacQJU
+		MDAVBJYeBFJSu04bj2EEhEd+9rIazeqVl91qkV1uGTz4aJ360PSmLuLAFT12BYGjIBfHrS
+		yom+1HbBoUziG4a/kzzbJGTC7U66YTjpHAMEtz4mbpU0AhNg4AAADBANgTs8yjrEkL4pcC
+		gfUr9oR42/BVl3ZxaFQ7PAvs9m0aut7b/ZRmsSF8F2TAl0H4H9M8uUKTTOhqRtdnTtDqm9
+		QBUIQBzA6Blb5oP+yL+Eiez4gMFd9HumFXG3JoRu/JmDE19KviHaldV47QcvG6B3p0eb5Q
+		hgVcNsrOGyBUZA0kBmzQBwv6gUoo++ETQMH89BlljZVCiPW7F6FCrPxHp7EB5txYJ62Qpu
+		2U40qgb2ONiUOuiI84EYRAgmDTbboMPQAAAMEA0Inn71l7LsYv81vstbmMQz0qLvhHkBcp
+		mMhh6tyzI0dvLZabBLTPhIT4R/0VDMJGsH5X1cEaap47XDpu0/g3mfOV6PToUfYA2Ugw7N
+		bs23UlVH1n0zL2x0QOMHX/Fkfc3OdIuc97ZHoMeW6Nf7Ii0iH7slIpH4hPVYcGXk/bX6wt
+		PKDc8xGEXdd4A6jnwJBifJs+UpPrHAh0c63KfjO3rryDycvmxeWRnyU1yRCUjIuH31vi+L
+		OkcGfqTaOoz2KVAAAAFGtpYW5AREVTS1RPUC1TNFI5S1JQAQIDBAUG
+		-----END OPENSSH PRIVATE KEY-----`
 		cloudSecretValue := fmt.Sprintf(`{"ssh-auth": "%s"}`, SSHKey)
 		tc.Secrets = map[string]string{
 			cloudSecretName: cloudSecretValue,

--- a/e2e/suite/gcp/gcp.go
+++ b/e2e/suite/gcp/gcp.go
@@ -36,5 +36,6 @@ var _ = Describe("[gcp] ", func() {
 		Entry(common.JSONDataFromSync(f)),
 		Entry(common.NestedJSONWithGJSON(f)),
 		Entry(common.JSONDataWithTemplate(f)),
+		Entry(common.DockerJSONConfig(f)),
 	)
 })

--- a/e2e/suite/gcp/gcp.go
+++ b/e2e/suite/gcp/gcp.go
@@ -37,6 +37,8 @@ var _ = Describe("[gcp] ", func() {
 		Entry(common.NestedJSONWithGJSON(f)),
 		Entry(common.JSONDataWithTemplate(f)),
 		Entry(common.DockerJSONConfig(f)),
+		Entry(common.DataPropertyDockerconfigJSON(f)),
 		Entry(common.SSHKeySync(f)),
+		Entry(common.SSHKeySyncDataProperty(f)),
 	)
 })

--- a/e2e/suite/gcp/gcp.go
+++ b/e2e/suite/gcp/gcp.go
@@ -37,5 +37,6 @@ var _ = Describe("[gcp] ", func() {
 		Entry(common.NestedJSONWithGJSON(f)),
 		Entry(common.JSONDataWithTemplate(f)),
 		Entry(common.DockerJSONConfig(f)),
+		Entry(common.SSHKeySync(f)),
 	)
 })

--- a/e2e/suite/vault/vault.go
+++ b/e2e/suite/vault/vault.go
@@ -32,6 +32,7 @@ var _ = Describe("[vault] ", func() {
 		Entry(common.JSONDataFromSync(f)),
 		Entry(common.JSONDataWithProperty(f)),
 		Entry(common.JSONDataWithTemplate(f)),
-		Entry(common.DockerJSONConfigVault(f)),
+		Entry(common.DataPropertyDockerconfigJSON(f)),
+		Entry(common.SSHKeySyncDataProperty(f)),
 	)
 })

--- a/e2e/suite/vault/vault.go
+++ b/e2e/suite/vault/vault.go
@@ -33,6 +33,5 @@ var _ = Describe("[vault] ", func() {
 		Entry(common.JSONDataWithProperty(f)),
 		Entry(common.JSONDataWithTemplate(f)),
 		Entry(common.DataPropertyDockerconfigJSON(f)),
-		Entry(common.SSHKeySyncDataProperty(f)),
 	)
 })

--- a/e2e/suite/vault/vault.go
+++ b/e2e/suite/vault/vault.go
@@ -32,7 +32,6 @@ var _ = Describe("[vault] ", func() {
 		Entry(common.JSONDataFromSync(f)),
 		Entry(common.JSONDataWithProperty(f)),
 		Entry(common.JSONDataWithTemplate(f)),
-		//Entry(common.DockerJSONConfig(f)),
-		//Entry(common.DockerJSONConfigVault(f)),
+		Entry(common.DockerJSONConfigVault(f)),
 	)
 })

--- a/e2e/suite/vault/vault.go
+++ b/e2e/suite/vault/vault.go
@@ -32,5 +32,7 @@ var _ = Describe("[vault] ", func() {
 		Entry(common.JSONDataFromSync(f)),
 		Entry(common.JSONDataWithProperty(f)),
 		Entry(common.JSONDataWithTemplate(f)),
+		//Entry(common.DockerJSONConfig(f)),
+		//Entry(common.DockerJSONConfigVault(f)),
 	)
 })


### PR DESCRIPTION
Added common tests for dockerconfigjson and SSH Auth types. Added test case in vault provider for specific case and for more detailed error messages. SSH Auth type not currently supported by vault due to lack of current support for a certificate/key specific secret type/plugin.