### PR TITLE
fix: promote main on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,3 +76,4 @@ jobs:
         run: make docker.promote
         env:
           RELEASE_TAG: ${{ github.event.inputs.version }}
+          SOURCE_TAG: main


### PR DESCRIPTION
Previously the "last tag" was promoted  (e.g. `v0.3.1-5-gbc62415`). This tag can point to a container image that doesn't exist. This is the case if a PR skipped the container image creation.