### PR TITLE
Set the metric when is deleted to condition deleted and false

### DIFF
--- a/apis/externalsecrets/v1alpha1/externalsecret_types.go
+++ b/apis/externalsecrets/v1alpha1/externalsecret_types.go
@@ -151,7 +151,8 @@ type ExternalSecretSpec struct {
 type ExternalSecretConditionType string
 
 const (
-	ExternalSecretReady ExternalSecretConditionType = "Ready"
+	ExternalSecretReady   ExternalSecretConditionType = "Ready"
+	ExternalSecretDeleted ExternalSecretConditionType = "Deleted"
 )
 
 type ExternalSecretStatusCondition struct {
@@ -173,6 +174,8 @@ const (
 	ConditionReasonSecretSynced = "SecretSynced"
 	// ConditionReasonSecretSyncedError indicates that there was an error syncing the secret.
 	ConditionReasonSecretSyncedError = "SecretSyncedError"
+	// ConditionReasonSecretDeleted indicates that the secret has been deleted.
+	ConditionReasonSecretDeleted = "SecretDeleted"
 )
 
 type ExternalSecretStatus struct {

--- a/pkg/controllers/externalsecret/externalsecret_controller.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller.go
@@ -90,6 +90,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	err := r.Get(ctx, req.NamespacedName, &externalSecret)
 	if apierrors.IsNotFound(err) {
 		syncCallsTotal.With(syncCallsMetricLabels).Inc()
+		conditionSynced := NewExternalSecretCondition(esv1alpha1.ExternalSecretDeleted, v1.ConditionFalse, esv1alpha1.ConditionReasonSecretDeleted, "Secret was deleted")
+		SetExternalSecretCondition(&externalSecret, *conditionSynced)
 		return ctrl.Result{}, nil
 	} else if err != nil {
 		log.Error(err, errGetES)

--- a/pkg/controllers/externalsecret/externalsecret_controller.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller.go
@@ -91,7 +91,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if apierrors.IsNotFound(err) {
 		syncCallsTotal.With(syncCallsMetricLabels).Inc()
 		conditionSynced := NewExternalSecretCondition(esv1alpha1.ExternalSecretDeleted, v1.ConditionFalse, esv1alpha1.ConditionReasonSecretDeleted, "Secret was deleted")
-		SetExternalSecretCondition(&externalSecret, *conditionSynced)
+		SetExternalSecretCondition(&esv1alpha1.ExternalSecret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      req.Name,
+				Namespace: req.Namespace,
+			},
+		}, *conditionSynced)
 		return ctrl.Result{}, nil
 	} else if err != nil {
 		log.Error(err, errGetES)


### PR DESCRIPTION
When a metrics is deleted metrics are still shown ready and condition true.
In practice this gives the wrong monitoring as the external secret in practice
is deleted.

Issue: #231