### PR TITLE
fix: ok-to-test trigger

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -90,8 +90,8 @@ jobs:
     runs-on: ubuntu-latest
     if:
       github.event_name == 'repository_dispatch' &&
-      github.event.client_payload.slash_command.sha != '' &&
-      contains(github.event.client_payload.pull_request.head.sha, github.event.client_payload.slash_command.sha)
+      github.event.client_payload.slash_command.args.named.sha != '' &&
+      contains(github.event.client_payload.pull_request.head.sha, github.event.client_payload.slash_command.args.named.sha)
     steps:
 
     # Check out merge commit


### PR DESCRIPTION
#285 introduced a new schema for the e2e test trigger. The e2e integration-fork action would skip bc the sha doesn't match.

This PR tries to fix this issue.