### PR TITLE
docs: add ibm secret types docs

### DIFF
--- a/docs/provider-ibm-secrets-manager.md
+++ b/docs/provider-ibm-secrets-manager.md
@@ -31,7 +31,7 @@ You have created a key. Press the eyeball to show the key. Copy or save it becau
 Create a secret containing your apiKey:
 
 ```shell
-kubectl create secret generic ibm-secret --from-literal=apiKey='API_KEY_VALUE' 
+kubectl create secret generic ibm-secret --from-literal=apiKey='API_KEY_VALUE'
 ```
 
 ### Update secret store
@@ -46,14 +46,33 @@ To find your serviceURL, under your Secrets Manager resource, go to "Endpoints" 
 
 ![iam-create-success](./pictures/screenshot_service_url.png)
 
-### Creating the secret inside the provider
+### Secret Types
+We support all secret types of [IBM Secrets Manager](https://cloud.ibm.com/apidocs/secrets-manager): `arbitrary`, `username_password`, `iam_credentials` and `imported_cert`. To define the type of secret you would like to sync you need to prefix the secret id with the desired type. If the secret type is not specified it is defaulted to `arbitrary`:
 
-For now we only support secrets of type arbitrary. So you need to go to your Secrets Manager UI and, click 'Add Secret', and then choose 'Other Secret Type'. You can now enter your value as text or as a file. This will be the value synchronized with the secret directly.
+```yaml
+{% include 'ibm-es-types.yaml' %}
 
-### Other types of secret
+```
 
-!!! note "Not implemented" 
-    This is currently not yet implemented. See [#242](https://github.com/external-secrets/external-secrets/issues/242) for details. Feel free to contribute.
+The behavior for the different secret types is as following:
+
+#### arbitrary
+
+* `remoteRef` retrieves a string from secrets manager and sets it for specified `secretKey`
+* `dataFrom` retrieves a string from secrets manager and tries to parse it as JSON object setting the key:values pairs in resulting Kubernetes secret if successful
+
+#### username_password
+* `remoteRef` requires a `property` to be set for either `username` or `password` to retrieve respective fields from the secrets manager secret and set in specified `secretKey`
+* `dataFrom` retrieves both `username` and `password` fields from the secrets manager secret and sets appropriate key:value pairs in the resulting Kubernetes secret
+
+#### iam_credentials
+* `remoteRef` retrieves an apikey from secrets manager and sets it for specified `secretKey`
+* `dataFrom` retrieves an apikey from secrets manager and sets it for the `apikey` Kubernetes secret key
+
+#### imported_cert
+* `remoteRef` requires a `property` to be set for either `certificate`, `private_key` or `intermediate` to retrieve respective fields from the secrets manager secret and set in specified `secretKey`
+* `dataFrom` retrieves all `certificate`, `private_key` and `intermediate` fields from the secrets manager secret and sets appropriate key:value pairs in the resulting Kubernetes secret
+
 
 ### Creating external secret
 

--- a/docs/provider-ibm-secrets-manager.md
+++ b/docs/provider-ibm-secrets-manager.md
@@ -41,8 +41,9 @@ Be sure the `ibm` provider is listed in the `Kind=SecretStore`
 {% include 'ibm-secret-store.yaml' %}
 ```
 
-To find your serviceURL, under your Secrets Manager resource, go to "Endpoints" on the left:
-
+To find your serviceURL, under your Secrets Manager resource, go to "Endpoints" on the left.
+Note: Use the url without the `/api` suffix that is presented in the UI.
+See here for a list of [publicly available endpoints](https://cloud.ibm.com/apidocs/secrets-manager#getting-started-endpoints).
 
 ![iam-create-success](./pictures/screenshot_service_url.png)
 

--- a/docs/snippets/ibm-es-types.yaml
+++ b/docs/snippets/ibm-es-types.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: ibm-sample
+spec:
+  # [...]
+  data:
+  - secretKey: test
+    remoteRef:
+      # defaults to type=arbitrary
+      key: xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  - secretKey: foo
+    remoteRef:
+      key: username_password/yyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy
+  - secretKey: bar
+    remoteRef:
+      key: iam_credentials/zzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz
+  - secretKey: baz
+    remoteRef:
+      key: imported_cert/zzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz

--- a/docs/snippets/ibm-secret-store.yaml
+++ b/docs/snippets/ibm-secret-store.yaml
@@ -5,9 +5,9 @@ metadata:
 spec:
   provider:
     ibm:
+      serviceUrl: "https://SECRETS_MANAGER_ID.REGION.secrets-manager.appdomain.cloud"
       auth:
         secretRef:
           secretApiKeySecretRef:
             name: ibm-secret
             key: apiKey
-      serviceUrl: "https://SECRETS_MANAGER_ID.REGION.secrets-manager.appdomain.cloud"

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -19,7 +19,7 @@ Resource Types:
 <p>
 <p>AWSAuth tells the controller how to do authentication with aws.
 Only one of secretRef or jwt can be specified.
-if none is specified the controller will load credentials using the aws sdk defaults</p>
+if none is specified the controller will load credentials using the aws sdk defaults.</p>
 </p>
 <table>
 <thead>
@@ -106,7 +106,7 @@ github.com/external-secrets/external-secrets/apis/meta/v1.SecretKeySelector
 <a href="#external-secrets.io/v1alpha1.AWSAuth">AWSAuth</a>)
 </p>
 <p>
-<p>Authenticate against AWS using service account tokens</p>
+<p>Authenticate against AWS using service account tokens.</p>
 </p>
 <table>
 <thead>
@@ -1843,7 +1843,7 @@ resource is used as the app role secret.</p>
 </p>
 <p>
 <p>VaultAuth is the configuration used to authenticate with a Vault server.
-Only one of <code>tokenSecretRef</code>, <code>appRole</code>,  <code>kubernetes</code>, <code>ldap</code> or <code>jwt</code>
+Only one of <code>tokenSecretRef</code>, <code>appRole</code>,  <code>kubernetes</code>, <code>ldap</code>, <code>jwt</code> or <code>cert</code>
 can be specified.</p>
 </p>
 <table>
@@ -1924,6 +1924,66 @@ VaultJwtAuth
 <em>(Optional)</em>
 <p>Jwt authenticates with Vault by passing role and JWT token using the
 JWT/OIDC authentication method</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>cert</code></br>
+<em>
+<a href="#external-secrets.io/v1alpha1.VaultCertAuth">
+VaultCertAuth
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Cert authenticates with TLS Certificates by passing client certificate, private key and ca certificate
+Cert authentication method</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="external-secrets.io/v1alpha1.VaultCertAuth">VaultCertAuth
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#external-secrets.io/v1alpha1.VaultAuth">VaultAuth</a>)
+</p>
+<p>
+<p>VaultJwtAuth authenticates with Vault using the JWT/OIDC authentication
+method, with the role name and token stored in a Kubernetes Secret resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>clientCert</code></br>
+<em>
+github.com/external-secrets/external-secrets/apis/meta/v1.SecretKeySelector
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ClientCert is a certificate to authenticate using the Cert Vault
+authentication method</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>secretRef</code></br>
+<em>
+github.com/external-secrets/external-secrets/apis/meta/v1.SecretKeySelector
+</em>
+</td>
+<td>
+<p>SecretRef to a key in a Secret resource containing client private key to
+authenticate with Vault using the Cert authentication method</p>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
Fixes: #301 
This PR adds documentation around secret types for the IBM Secrets Manager that were introduced in #271.

Co-Authored-By: Tymofii Polekhin <tpolekhin@users.noreply.github.com>
