### PR TITLE
Add the ability of ESO to reconcile only in scoped namespace

### DIFF
--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -54,6 +54,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | rbac.create | bool | `true` | Specifies whether role and rolebinding resources should be created. |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
+| scopedNamespace | string | `""` | If set external secrets are only reconciled in the provided namespace |
 | securityContext | object | `{}` |  |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |

--- a/deploy/charts/external-secrets/templates/deployment.yaml
+++ b/deploy/charts/external-secrets/templates/deployment.yaml
@@ -38,10 +38,13 @@ spec:
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if or (.Values.leaderElect) (.Values.extraArgs) }}
+          {{- if or (.Values.leaderElect) (.Values.scopedNamespace) (.Values.extraArgs) }}
           args:
           {{- if .Values.leaderElect }}
           - --enable-leader-election=true
+          {{- end }}
+          {{- if .Values.scopedNamespace }}
+          - --namespace={{ .Values.scopedNamespace }}
           {{- end }}
           {{- range $key, $value := .Values.extraArgs }}
             {{- if $value }}

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -17,6 +17,10 @@ fullnameOverride: ""
 # than one instance of external-secrets operates at a time.
 leaderElect: false
 
+# -- If set external secrets are only reconciled in the
+# provided namespace
+scopedNamespace: ""
+
 serviceAccount:
   # -- Specifies whether a service account should be created.
   create: true

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -43,6 +43,9 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 	By("installing eso")
 	addon.InstallGlobalAddon(addon.NewESO(), cfg)
+
+	By("installing scoped eso")
+	addon.InstallGlobalAddon(addon.NewScopedESO(), cfg)
 	return nil
 }, func([]byte) {})
 

--- a/e2e/framework/addon/eso.go
+++ b/e2e/framework/addon/eso.go
@@ -27,3 +27,14 @@ func NewESO() *ESO {
 		},
 	}
 }
+
+func NewScopedESO() *ESO {
+	return &ESO{
+		&HelmChart{
+			Namespace:   "default",
+			ReleaseName: "eso-aws-sm",
+			Chart:       "/k8s/deploy/charts/external-secrets",
+			Values:      []string{"/k8s/eso.scoped.values.yaml"},
+		},
+	}
+}

--- a/e2e/k8s/eso.scoped.values.yaml
+++ b/e2e/k8s/eso.scoped.values.yaml
@@ -1,0 +1,12 @@
+installCRDs: false
+image:
+  repository: local/external-secrets
+  tag: test
+scopedNamespace: test
+extraEnv:
+  - name: AWS_SECRETSMANAGER_ENDPOINT
+    value: "http://localstack.default"
+  - name: AWS_STS_ENDPOINT
+    value: "http://localstack.default"
+  - name: AWS_SSM_ENDPOINT
+    value: "http://localstack.default"

--- a/main.go
+++ b/main.go
@@ -46,12 +46,14 @@ func main() {
 	var controllerClass string
 	var enableLeaderElection bool
 	var loglevel string
+	var namespace string
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&controllerClass, "controller-class", "default", "the controller is instantiated with a specific controller name and filters ES based on this property")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&loglevel, "loglevel", "info", "loglevel to use, one of: debug, info, warn, error, dpanic, panic, fatal")
+	flag.StringVar(&namespace, "namespace", "", "watch external secrets scoped in the provided namespace only")
 	flag.Parse()
 
 	var lvl zapcore.Level
@@ -69,6 +71,7 @@ func main() {
 		Port:               9443,
 		LeaderElection:     enableLeaderElection,
 		LeaderElectionID:   "external-secrets-controller",
+		Namespace:          namespace,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
By default ESO reconciles `Kind=ExternalSecret` across every namespace
in a k8s cluster. With the new flag `--nameespace` we can scope the
reconciling only to the provided namespace.

Ticket: #289