### PR TITLE
Fix the issue for non deleting one/more key-value pair

### DIFF
--- a/pkg/controllers/externalsecret/externalsecret_controller.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller.go
@@ -194,9 +194,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 		// no template: copy data and return
 		if externalSecret.Spec.Target.Template == nil {
-			for k, v := range dataMap {
-				secret.Data[k] = v
-			}
+			secret.Data = dataMap
 			return nil
 		}
 


### PR DESCRIPTION
The issue is that the `dataMap` from the provider returns only the remaining data
and we were updating partially the current `secretMap` only for the keys included
in the new value.

Ticket: #315