### PR TITLE
fix: use external secret name if target secret is not specified

### DIFF
--- a/pkg/controllers/externalsecret/externalsecret_controller.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller.go
@@ -167,9 +167,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{RequeueAfter: refreshInt}, nil
 	}
 
+	// Target Secret Name should default to the ExternalSecret name if not explicitly specified
+	secretName := externalSecret.Spec.Target.Name
+	if secretName == "" {
+		secretName = externalSecret.ObjectMeta.Name
+	}
+
 	secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      externalSecret.Spec.Target.Name,
+			Name:      secretName,
 			Namespace: externalSecret.Namespace,
 		},
 		Data: make(map[string][]byte),


### PR DESCRIPTION
Now if the target Secret name is not specified it should use the ExternalSecret name.

fix #321 

I still need to work on the tests.