### PR TITLE
add namespace to deployment and service account templates

### DIFF
--- a/deploy/charts/external-secrets/templates/deployment.yaml
+++ b/deploy/charts/external-secrets/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "external-secrets.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "external-secrets.labels" . | nindent 4 }}
 spec:

--- a/deploy/charts/external-secrets/templates/serviceaccount.yaml
+++ b/deploy/charts/external-secrets/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "external-secrets.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "external-secrets.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}


### PR DESCRIPTION
pr for issue: #326 

Added namespace to the deployment and Service account chart templates so `helm template --include-crds --output-dir ./output_dir deploy/charts/external-secrets` will generate k8s resources with the supplied namespace. If no namespace is provide the helm will default the namespace to `default` preserving the current functionality.