### PR TITLE
Add support for Google Cloud Identity

### DIFF
--- a/apis/externalsecrets/v1alpha1/secretstore_gcpsm_types.go
+++ b/apis/externalsecrets/v1alpha1/secretstore_gcpsm_types.go
@@ -31,7 +31,8 @@ type GCPSMAuthSecretRef struct {
 // GCPSMProvider Configures a store to sync secrets using the GCP Secret Manager provider.
 type GCPSMProvider struct {
 	// Auth defines the information necessary to authenticate against GCP
-	Auth GCPSMAuth `json:"auth"`
+	// +optional
+	Auth GCPSMAuth `json:"auth,omitempty"`
 
 	// ProjectID project where secret is located
 	ProjectID string `json:"projectID,omitempty"`

--- a/apis/meta/v1/types.go
+++ b/apis/meta/v1/types.go
@@ -18,7 +18,7 @@ package v1
 // In some instances, `key` is a required field.
 type SecretKeySelector struct {
 	// The name of the Secret resource being referred to.
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 	// Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
 	// to the namespace of the referent.
 	// +optional

--- a/deploy/crds/external-secrets.io_clustersecretstores.yaml
+++ b/deploy/crds/external-secrets.io_clustersecretstores.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/deploy/crds/external-secrets.io_clustersecretstores.yaml
+++ b/deploy/crds/external-secrets.io_clustersecretstores.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -108,8 +110,6 @@ spec:
                                       cluster-scoped defaults to the namespace of
                                       the referent.
                                     type: string
-                                required:
-                                - name
                                 type: object
                               secretAccessKeySecretRef:
                                 description: The SecretAccessKey is used for authentication
@@ -130,8 +130,6 @@ spec:
                                       cluster-scoped defaults to the namespace of
                                       the referent.
                                     type: string
-                                required:
-                                - name
                                 type: object
                             type: object
                         type: object
@@ -179,8 +177,6 @@ spec:
                                   to. Ignored if referent is not cluster-scoped. cluster-scoped
                                   defaults to the namespace of the referent.
                                 type: string
-                            required:
-                            - name
                             type: object
                           clientSecret:
                             description: The Azure ClientSecret of the service principle
@@ -200,8 +196,6 @@ spec:
                                   to. Ignored if referent is not cluster-scoped. cluster-scoped
                                   defaults to the namespace of the referent.
                                 type: string
-                            required:
-                            - name
                             type: object
                         required:
                         - clientId
@@ -249,8 +243,6 @@ spec:
                                       cluster-scoped defaults to the namespace of
                                       the referent.
                                     type: string
-                                required:
-                                - name
                                 type: object
                             type: object
                         required:
@@ -291,8 +283,6 @@ spec:
                                       cluster-scoped defaults to the namespace of
                                       the referent.
                                     type: string
-                                required:
-                                - name
                                 type: object
                             type: object
                         required:
@@ -351,8 +341,6 @@ spec:
                                       cluster-scoped defaults to the namespace of
                                       the referent.
                                     type: string
-                                required:
-                                - name
                                 type: object
                             required:
                             - path
@@ -384,8 +372,6 @@ spec:
                                       cluster-scoped defaults to the namespace of
                                       the referent.
                                     type: string
-                                required:
-                                - name
                                 type: object
                               secretRef:
                                 description: SecretRef to a key in a Secret resource
@@ -408,8 +394,6 @@ spec:
                                       cluster-scoped defaults to the namespace of
                                       the referent.
                                     type: string
-                                required:
-                                - name
                                 type: object
                             type: object
                           jwt:
@@ -441,8 +425,6 @@ spec:
                                       cluster-scoped defaults to the namespace of
                                       the referent.
                                     type: string
-                                required:
-                                - name
                                 type: object
                             type: object
                           kubernetes:
@@ -483,8 +465,6 @@ spec:
                                       cluster-scoped defaults to the namespace of
                                       the referent.
                                     type: string
-                                required:
-                                - name
                                 type: object
                               serviceAccountRef:
                                 description: Optional service account field containing
@@ -537,8 +517,6 @@ spec:
                                       cluster-scoped defaults to the namespace of
                                       the referent.
                                     type: string
-                                required:
-                                - name
                                 type: object
                               username:
                                 description: Username is a LDAP user name used to
@@ -566,8 +544,6 @@ spec:
                                   to. Ignored if referent is not cluster-scoped. cluster-scoped
                                   defaults to the namespace of the referent.
                                 type: string
-                            required:
-                            - name
                             type: object
                         type: object
                       caBundle:

--- a/deploy/crds/external-secrets.io_clustersecretstores.yaml
+++ b/deploy/crds/external-secrets.io_clustersecretstores.yaml
@@ -249,8 +249,6 @@ spec:
                       projectID:
                         description: ProjectID project where secret is located
                         type: string
-                    required:
-                    - auth
                     type: object
                   ibm:
                     description: IBM configures this store to sync secrets using IBM

--- a/deploy/crds/external-secrets.io_externalsecrets.yaml
+++ b/deploy/crds/external-secrets.io_externalsecrets.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/deploy/crds/external-secrets.io_externalsecrets.yaml
+++ b/deploy/crds/external-secrets.io_externalsecrets.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/deploy/crds/external-secrets.io_secretstores.yaml
+++ b/deploy/crds/external-secrets.io_secretstores.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/deploy/crds/external-secrets.io_secretstores.yaml
+++ b/deploy/crds/external-secrets.io_secretstores.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -108,8 +110,6 @@ spec:
                                       cluster-scoped defaults to the namespace of
                                       the referent.
                                     type: string
-                                required:
-                                - name
                                 type: object
                               secretAccessKeySecretRef:
                                 description: The SecretAccessKey is used for authentication
@@ -130,8 +130,6 @@ spec:
                                       cluster-scoped defaults to the namespace of
                                       the referent.
                                     type: string
-                                required:
-                                - name
                                 type: object
                             type: object
                         type: object
@@ -179,8 +177,6 @@ spec:
                                   to. Ignored if referent is not cluster-scoped. cluster-scoped
                                   defaults to the namespace of the referent.
                                 type: string
-                            required:
-                            - name
                             type: object
                           clientSecret:
                             description: The Azure ClientSecret of the service principle
@@ -200,8 +196,6 @@ spec:
                                   to. Ignored if referent is not cluster-scoped. cluster-scoped
                                   defaults to the namespace of the referent.
                                 type: string
-                            required:
-                            - name
                             type: object
                         required:
                         - clientId
@@ -249,8 +243,6 @@ spec:
                                       cluster-scoped defaults to the namespace of
                                       the referent.
                                     type: string
-                                required:
-                                - name
                                 type: object
                             type: object
                         required:
@@ -291,8 +283,6 @@ spec:
                                       cluster-scoped defaults to the namespace of
                                       the referent.
                                     type: string
-                                required:
-                                - name
                                 type: object
                             type: object
                         required:
@@ -351,8 +341,6 @@ spec:
                                       cluster-scoped defaults to the namespace of
                                       the referent.
                                     type: string
-                                required:
-                                - name
                                 type: object
                             required:
                             - path
@@ -384,8 +372,6 @@ spec:
                                       cluster-scoped defaults to the namespace of
                                       the referent.
                                     type: string
-                                required:
-                                - name
                                 type: object
                               secretRef:
                                 description: SecretRef to a key in a Secret resource
@@ -408,8 +394,6 @@ spec:
                                       cluster-scoped defaults to the namespace of
                                       the referent.
                                     type: string
-                                required:
-                                - name
                                 type: object
                             type: object
                           jwt:
@@ -441,8 +425,6 @@ spec:
                                       cluster-scoped defaults to the namespace of
                                       the referent.
                                     type: string
-                                required:
-                                - name
                                 type: object
                             type: object
                           kubernetes:
@@ -483,8 +465,6 @@ spec:
                                       cluster-scoped defaults to the namespace of
                                       the referent.
                                     type: string
-                                required:
-                                - name
                                 type: object
                               serviceAccountRef:
                                 description: Optional service account field containing
@@ -537,8 +517,6 @@ spec:
                                       cluster-scoped defaults to the namespace of
                                       the referent.
                                     type: string
-                                required:
-                                - name
                                 type: object
                               username:
                                 description: Username is a LDAP user name used to
@@ -566,8 +544,6 @@ spec:
                                   to. Ignored if referent is not cluster-scoped. cluster-scoped
                                   defaults to the namespace of the referent.
                                 type: string
-                            required:
-                            - name
                             type: object
                         type: object
                       caBundle:

--- a/deploy/crds/external-secrets.io_secretstores.yaml
+++ b/deploy/crds/external-secrets.io_secretstores.yaml
@@ -249,8 +249,6 @@ spec:
                       projectID:
                         description: ProjectID project where secret is located
                         type: string
-                    required:
-                    - auth
                     type: object
                   ibm:
                     description: IBM configures this store to sync secrets using IBM


### PR DESCRIPTION
If the name of the service account secret is kept
empty, this means we want to use Google Cloud Identity
to authenticate against the GCP project