### PR TITLE
chore: add missing region key to aws provider in docs

### DIFF
--- a/docs/provider-aws-parameter-store.md
+++ b/docs/provider-aws-parameter-store.md
@@ -19,7 +19,7 @@ way users of the `SecretStore` can only access the secrets necessary.
 
 ### IAM Policy
 
-Create a IAM Policy to pin down access to secrets matching `dev-*`, for futher information see [AWS Documentation](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-access.html):
+Create a IAM Policy to pin down access to secrets matching `dev-*`, for further information see [AWS Documentation](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-access.html):
 
 ``` json
 {

--- a/docs/snippets/provider-aws-access.md
+++ b/docs/snippets/provider-aws-access.md
@@ -19,6 +19,7 @@ spec:
   provider:
     aws:
       service: SecretsManager
+      region: eu-central-1
       # optional: do a sts:assumeRole before fetching secrets
       role: team-b
 ```
@@ -37,6 +38,7 @@ spec:
   provider:
     aws:
       service: SecretsManager
+      region: eu-central-1
       # optional: assume role before fetching secrets
       role: team-b
       auth:
@@ -78,6 +80,7 @@ spec:
   provider:
     aws:
       service: SecretsManager
+      region: eu-central-1
       auth:
         jwt:
           serviceAccountRef:


### PR DESCRIPTION
Fixes https://github.com/external-secrets/external-secrets/issues/342

There were several places in docs where region was missing. 