### PR TITLE
Add Sonar analysis to CI and push coverage to it #168

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,11 +175,11 @@ jobs:
           export KUBEBUILDER_ATTACH_CONTROL_PLANE_OUTPUT=true
           make test
 
-      - name: Publish Unit Test Coverage
-        uses: codecov/codecov-action@v2.0.3
-        with:
-          flags: unittests
-          file: ./cover.out
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
 
   publish-artifacts:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,24 @@
+sonar.projectKey=external-secrets_external-secrets
+sonar.organization=external-secrets
+
+# This is the name and version displayed in the SonarCloud UI.
+#sonar.projectVersion=1.0
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+#sonar.sources=.
+
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8
+
+sonar.sources=./apis
+sonar.exclusions=**/*_test.go,**/vendor/**
+ 
+sonar.tests=./apis
+sonar.test.inclusions=**/*_test.go
+sonar.test.exclusions=**/vendor/**
+sonar.go.coverage.reportPaths=./cover.out
+# =====================================================
+#   Meta-data for the project
+# =====================================================
+
+sonar.links.homepage=https://github.com/external-secrets/external-secrets/


### PR DESCRIPTION
Added sonar-prpoject.properties file which is used by SonarQube to determine what the project/organization is and it also includes where the coverage file is.
I also updated ci.yaml to delete CodeCov step and added SonarQube analysis instead of that. This way Sonar analysis will run in a push manner instead of its default.
Before this PR is approved, the steps I mentioned in the issue must be taken. #168