### PR TITLE
chore: remove sonar manual step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,13 +178,6 @@ jobs:
           export KUBEBUILDER_ATTACH_CONTROL_PLANE_OUTPUT=true
           make test
 
-      - name: SonarCloud Scans
-        if: env.SONAR_TOKEN != ''
-        uses: SonarSource/sonarcloud-github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
 
   publish-artifacts:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
We only added sonar manual step to have coverage, but in the end it will be better to just have sonar for code quality and any other coverage tool for coverage. 