### PR TITLE
adjusting code smells

### DIFF
--- a/e2e/suite/common/common.go
+++ b/e2e/suite/common/common.go
@@ -24,10 +24,10 @@ import (
 
 const (
 	// Constants.
-	dockerConfigExampleString = "docker-config-example"
-	dockerConfigJSONString    = ".dockerconfigjson"
-	mysecretToStringString    = "{{ .mysecret | toString }}"
-	sshPrivatekeyString       = "ssh-privatekey"
+	dockerConfigExampleName    = "docker-config-example"
+	dockerConfigJSONKey        = ".dockerconfigjson"
+	mysecretToStringTemplating = "{{ .mysecret | toString }}"
+	sshPrivateKey              = "ssh-privatekey"
 )
 
 // This case creates multiple secrets with simple key/value pairs and syncs them using multiple .Spec.Data blocks.
@@ -297,7 +297,7 @@ func NestedJSONWithGJSON(f *framework.Framework) (string, func(*framework.TestCa
 // not supported by: vault.
 func DockerJSONConfig(f *framework.Framework) (string, func(*framework.TestCase)) {
 	return "[common] should sync docker configurated json secrets with template simple", func(tc *framework.TestCase) {
-		cloudSecretName := fmt.Sprintf("%s-%s", f.Namespace.Name, dockerConfigExampleString)
+		cloudSecretName := fmt.Sprintf("%s-%s", f.Namespace.Name, dockerConfigExampleName)
 		dockerconfig := `{"auths":{"https://index.docker.io/v1/": {"auth": "c3R...zE2"}}}`
 		cloudSecretValue := fmt.Sprintf(`{"dockerconfig": %s}`, dockerconfig)
 		tc.Secrets = map[string]string{
@@ -307,7 +307,7 @@ func DockerJSONConfig(f *framework.Framework) (string, func(*framework.TestCase)
 		tc.ExpectedSecret = &v1.Secret{
 			Type: v1.SecretTypeOpaque,
 			Data: map[string][]byte{
-				dockerConfigJSONString: []byte(dockerconfig),
+				dockerConfigJSONKey: []byte(dockerconfig),
 			},
 		}
 
@@ -323,7 +323,7 @@ func DockerJSONConfig(f *framework.Framework) (string, func(*framework.TestCase)
 
 		tc.ExternalSecret.Spec.Target.Template = &esv1alpha1.ExternalSecretTemplate{
 			Data: map[string]string{
-				dockerConfigJSONString: mysecretToStringString,
+				dockerConfigJSONKey: mysecretToStringTemplating,
 			},
 		}
 	}
@@ -334,7 +334,7 @@ func DockerJSONConfig(f *framework.Framework) (string, func(*framework.TestCase)
 // Need to have a key holding dockerconfig to be supported by vault.
 func DataPropertyDockerconfigJSON(f *framework.Framework) (string, func(*framework.TestCase)) {
 	return "[common] should sync docker configurated json secrets with template", func(tc *framework.TestCase) {
-		cloudSecretName := fmt.Sprintf("%s-%s", f.Namespace.Name, dockerConfigExampleString)
+		cloudSecretName := fmt.Sprintf("%s-%s", f.Namespace.Name, dockerConfigExampleName)
 		dockerconfigString := `"{\"auths\":{\"https://index.docker.io/v1/\": {\"auth\": \"c3R...zE2\"}}}"`
 		dockerconfig := `{"auths":{"https://index.docker.io/v1/": {"auth": "c3R...zE2"}}}`
 		cloudSecretValue := fmt.Sprintf(`{"dockerconfig": %s}`, dockerconfigString)
@@ -345,7 +345,7 @@ func DataPropertyDockerconfigJSON(f *framework.Framework) (string, func(*framewo
 		tc.ExpectedSecret = &v1.Secret{
 			Type: v1.SecretTypeDockerConfigJson,
 			Data: map[string][]byte{
-				dockerConfigJSONString: []byte(dockerconfig),
+				dockerConfigJSONKey: []byte(dockerconfig),
 			},
 		}
 
@@ -362,7 +362,7 @@ func DataPropertyDockerconfigJSON(f *framework.Framework) (string, func(*framewo
 		tc.ExternalSecret.Spec.Target.Template = &esv1alpha1.ExternalSecretTemplate{
 			Type: v1.SecretTypeDockerConfigJson,
 			Data: map[string]string{
-				dockerConfigJSONString: mysecretToStringString,
+				dockerConfigJSONKey: mysecretToStringTemplating,
 			},
 		}
 	}
@@ -419,7 +419,7 @@ func SSHKeySync(f *framework.Framework) (string, func(*framework.TestCase)) {
 		tc.ExpectedSecret = &v1.Secret{
 			Type: v1.SecretTypeSSHAuth,
 			Data: map[string][]byte{
-				sshPrivatekeyString: []byte(sshSecretValue),
+				sshPrivateKey: []byte(sshSecretValue),
 			},
 		}
 
@@ -435,7 +435,7 @@ func SSHKeySync(f *framework.Framework) (string, func(*framework.TestCase)) {
 		tc.ExternalSecret.Spec.Target.Template = &esv1alpha1.ExternalSecretTemplate{
 			Type: v1.SecretTypeSSHAuth,
 			Data: map[string]string{
-				sshPrivatekeyString: mysecretToStringString,
+				sshPrivateKey: mysecretToStringTemplating,
 			},
 		}
 	}
@@ -444,7 +444,7 @@ func SSHKeySync(f *framework.Framework) (string, func(*framework.TestCase)) {
 // This case adds an ssh private key secret and syncs it.
 func SSHKeySyncDataProperty(f *framework.Framework) (string, func(*framework.TestCase)) {
 	return "[common] should sync ssh key with provider.", func(tc *framework.TestCase) {
-		cloudSecretName := fmt.Sprintf("%s-%s", f.Namespace.Name, dockerConfigExampleString)
+		cloudSecretName := fmt.Sprintf("%s-%s", f.Namespace.Name, dockerConfigExampleName)
 		SSHKey := `-----BEGIN OPENSSH PRIVATE KEY-----
 		b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABlwAAAAdzc2gtcn
 		NhAAAAAwEAAQAAAYEAsARoZUqo6L5dd0WRjZ2QPq/kKlbjtUY1njzJ01UtdC1u1eSJFUnV
@@ -491,7 +491,7 @@ func SSHKeySyncDataProperty(f *framework.Framework) (string, func(*framework.Tes
 		tc.ExpectedSecret = &v1.Secret{
 			Type: v1.SecretTypeSSHAuth,
 			Data: map[string][]byte{
-				sshPrivatekeyString: []byte(SSHKey),
+				sshPrivateKey: []byte(SSHKey),
 			},
 		}
 
@@ -508,7 +508,7 @@ func SSHKeySyncDataProperty(f *framework.Framework) (string, func(*framework.Tes
 		tc.ExternalSecret.Spec.Target.Template = &esv1alpha1.ExternalSecretTemplate{
 			Type: v1.SecretTypeSSHAuth,
 			Data: map[string]string{
-				sshPrivatekeyString: mysecretToStringString,
+				sshPrivateKey: mysecretToStringTemplating,
 			},
 		}
 	}


### PR DESCRIPTION

at e2e/suite/common/common.go:

Define a constant instead of duplicating this literal "docker-config-example" 3 times.
Define a constant instead of duplicating this literal ".dockerconfigjson" 4 times.
Define a constant instead of duplicating this literal "{{ .mysecret | toString }}" 4 times.

    Define a constant instead of duplicating this literal "ssh-privatekey" 4 times.

at pkg/provider/aws/auth/auth_test.go:

Define a constant instead of duplicating this literal "es-namespace" 3 times.
Define a constant instead of duplicating this literal "platform-team-ns" 3 times.
Define a constant instead of duplicating this literal "my-service-account" 4 times.
Define a constant instead of duplicating this literal "other-ns" 4 times.