### PR TITLE
design proposal: Add SecretStore & ClusterSecretStore selector

### DIFF
--- a/apis/externalsecrets/v1alpha1/externalsecret_types.go
+++ b/apis/externalsecrets/v1alpha1/externalsecret_types.go
@@ -116,6 +116,17 @@ type ExternalSecretData struct {
 	RemoteRef ExternalSecretDataRemoteRef `json:"remoteRef"`
 }
 
+// A Selector selects an object.
+type Selector struct {
+	// MatchLabels ensures an object with matching labels is selected.
+	MatchLabels map[string]string `json:"matchLabels,omitempty"`
+
+	// Kind of the SecretStore resource (SecretStore or ClusterSecretStore)
+	// Defaults to `SecretStore`
+	// +optional
+	Kind string `json:"kind,omitempty"`
+}
+
 // ExternalSecretDataRemoteRef defines Provider data location.
 type ExternalSecretDataRemoteRef struct {
 	// Key is the key used in the Provider, mandatory
@@ -133,6 +144,10 @@ type ExternalSecretDataRemoteRef struct {
 // ExternalSecretSpec defines the desired state of ExternalSecret.
 type ExternalSecretSpec struct {
 	SecretStoreRef SecretStoreRef `json:"secretStoreRef"`
+
+	// SecretStoreSelector defines which SecretStore to fetch the ExternalSecret data using selector
+	// If multiple match, the first match will be used
+	SecretStoreSelector SecretStoreRef `json:"secretStoreSelector"`
 
 	Target ExternalSecretTarget `json:"target"`
 

--- a/design/design-crd-spec.md
+++ b/design/design-crd-spec.md
@@ -133,6 +133,15 @@ spec:
     name: secret-store-name
     kind: SecretStore  # or ClusterSecretStore
 
+  # secretStoreSelector defines which SecretStore to fetch the ExternalSecret data using selector
+  secretStoreSelector:
+    # Match SecretStore or ClusterSecretStore using label selector
+    # If multiple match, the first match will be used
+    matchLabels:
+      env: prod
+      zone: private
+    kind: SecretStore # or ClusterSecretStore
+
   # RefreshInterval is the amount of time before the values reading again from the SecretStore provider
   # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h" (from time.ParseDuration)
   # May be set to zero to fetch and create it once


### PR DESCRIPTION
Provide the ability to match a SecretStore or a ClusterSecretStore using labels (usual design on K8s).

For example:

```
apiVersion: external-secrets.io/v1alpha1
kind: ExternalSecret
metadata: {...}
spec:
  secretStoreSelector:
    matchLabels:
      env: prod
      zone: private
    kind: SecretStore
{...}
```

I'm looking for feedback before I implement it.