### PR TITLE
adding make lint to make reviewable steps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ FAIL	= (echo ${TIME} ${RED}[FAIL]${CNone} && false)
 # Conformance
 
 # Ensure a PR is ready for review.
-reviewable: generate helm.generate
+reviewable: generate helm.generate lint
 	@go mod tidy
 
 # Ensure branch is clean.


### PR DESCRIPTION
Make reviewable did not check if make lint was passing. Now lint is added to the reviewable script calls