### PR TITLE
Fixing panic due to no Namespace on ServiceAccountRef

### DIFF
--- a/pkg/provider/aws/auth/auth.go
+++ b/pkg/provider/aws/auth/auth.go
@@ -161,7 +161,7 @@ func sessionFromSecretRef(ctx context.Context, prov *esv1alpha1.AWSProvider, sto
 func sessionFromServiceAccount(ctx context.Context, prov *esv1alpha1.AWSProvider, store esv1alpha1.GenericStore, kube client.Client, namespace string, jwtProvider jwtProviderFactory) (*credentials.Credentials, error) {
 	if store.GetObjectKind().GroupVersionKind().Kind == esv1alpha1.ClusterSecretStoreKind {
 		if prov.Auth.JWTAuth.ServiceAccountRef.Namespace == nil {
-			return nil, fmt.Errorf("ServiceAccountRef has no Namespace field (mandatory for ClusterSecretStore specs)")
+			return nil, fmt.Errorf("serviceAccountRef has no Namespace field (mandatory for ClusterSecretStore specs)")
 		}
 		namespace = *prov.Auth.JWTAuth.ServiceAccountRef.Namespace
 	}

--- a/pkg/provider/aws/auth/auth_test.go
+++ b/pkg/provider/aws/auth/auth_test.go
@@ -434,7 +434,7 @@ func TestNewSession(t *testing.T) {
 					},
 				},
 			},
-			expectErr: "ServiceAccountRef has no Namespace field (mandatory for ClusterSecretStore specs)",
+			expectErr: "serviceAccountRef has no Namespace field (mandatory for ClusterSecretStore specs)",
 		},
 	}
 	for i := range rows {


### PR DESCRIPTION
handles panic due to no namespace setting on SeviceAccountRef for AWSJWTAuth method.

Fixes #419

Signed-off-by: Gustavo Carvalho <gustavo.carvalho@container-solutions.com>