### PR TITLE
Added log for first secret reconciliation after errors

### DIFF
--- a/pkg/controllers/externalsecret/externalsecret_controller.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller.go
@@ -238,11 +238,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	conditionSynced := NewExternalSecretCondition(esv1alpha1.ExternalSecretReady, v1.ConditionTrue, esv1alpha1.ConditionReasonSecretSynced, "Secret was synced")
+	currCond := GetExternalSecretCondition(externalSecret.Status, esv1alpha1.ExternalSecretReady)
 	SetExternalSecretCondition(&externalSecret, *conditionSynced)
 	externalSecret.Status.RefreshTime = metav1.NewTime(time.Now())
 	externalSecret.Status.SyncedResourceVersion = getResourceVersion(externalSecret)
 	syncCallsTotal.With(syncCallsMetricLabels).Inc()
-	log.V(1).Info("reconciled secret")
+	if currCond == nil || currCond.Status != conditionSynced.Status {
+		log.Info("reconciled secret")
+	} else {
+		log.V(1).Info("reconciled secret")
+	}
 
 	return ctrl.Result{
 		RequeueAfter: refreshInt,

--- a/pkg/controllers/externalsecret/externalsecret_controller.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller.go
@@ -244,9 +244,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	externalSecret.Status.SyncedResourceVersion = getResourceVersion(externalSecret)
 	syncCallsTotal.With(syncCallsMetricLabels).Inc()
 	if currCond == nil || currCond.Status != conditionSynced.Status {
-		log.Info("reconciled secret")
+		log.Info("reconciled secret") // Log once if on success in any verbosity
 	} else {
-		log.V(1).Info("reconciled secret")
+		log.V(1).Info("reconciled secret") // Log all reconciliation cycles if higher verbosity applied
 	}
 
 	return ctrl.Result{


### PR DESCRIPTION
This commit implements logging for first successful reconciliation after an error or externalSecret creation.

Fixes #444
