### PR TITLE
golangci-lint install and version update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 env:
   # Common versions
   GO_VERSION: '1.16'
-  GOLANGCI_VERSION: 'v1.33'
+  GOLANGCI_VERSION: 'v1.42.1'
   # list of available versions: https://storage.googleapis.com/kubebuilder-tools
   # TODO: 1.21.2 does not shut down properly with controller-runtime 0.9.2
   KUBEBUILDER_TOOLS_VERSION: '1.20.2'
@@ -123,7 +123,7 @@ jobs:
       # Check DIff also runs Reviewable which needs golangci-lint installed
       - name: Check Diff
         run: |
-          wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.33.0
+          wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.42.1
           export PATH=$PATH:./bin
           make check-diff
 

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -32,14 +32,10 @@ linters-settings:
     min-complexity: 16
   goheader:
     template-path: ./hack/boilerplate.go.txt
-  golint:
-    min-confidence: 0
   govet:
     check-shadowing: false
   lll:
     line-length: 300
-  maligned:
-    suggest-new: true
   misspell:
     locale: US
 
@@ -62,7 +58,6 @@ linters:
     - gocritic
     - godot
     - gofmt
-    - golint
     - goprintffuncname
     - gosec
     - gosimple
@@ -70,13 +65,12 @@ linters:
     - ineffassign
     - interfacer
     - lll
-    - maligned
     - misspell
     - nakedret
     - nolintlint
     - prealloc
+    - revive
     - rowserrcheck
-    - scopelint
     - sqlclosecheck
     - staticcheck
     - structcheck
@@ -102,7 +96,6 @@ issues:
         - errcheck
         - dupl
         - gosec
-        - scopelint
         - unparam
         - lll
 

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ lint.check: ## Check install of golanci-lint
 lint.install: ## Install golangci-lint to the go bin dir
 	@if ! golangci-lint --version > /dev/null 2>&1; then \
 		echo "Installing golangci-lint"; \
-		curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(GOBIN) v1.33.0; \
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOBIN) v1.42.1; \
 	fi
 
 lint: lint.check ## Run golangci-lint

--- a/e2e/framework/addon/vault.go
+++ b/e2e/framework/addon/vault.go
@@ -286,6 +286,7 @@ func (l *Vault) Setup(cfg *Config) error {
 	return l.chart.Setup(cfg)
 }
 
+// nolint:gocritic
 func genVaultCertificates(namespace string) ([]byte, []byte, []byte, []byte, []byte, []byte, error) {
 	// gen server ca + certs
 	serverRootCert, serverRootPem, serverRootKey, err := genCARoot()

--- a/pkg/provider/register/register.go
+++ b/pkg/provider/register/register.go
@@ -15,7 +15,7 @@ limitations under the License.
 package register
 
 // packages imported here are registered to the controller schema.
-// nolint:golint
+// nolint:revive
 import (
 	_ "github.com/external-secrets/external-secrets/pkg/provider/alibaba"
 	_ "github.com/external-secrets/external-secrets/pkg/provider/aws"


### PR DESCRIPTION
- Update golangci-lint to 1.42.1
- Fix install make target with new shell script URL
- Replace deprecated lints with suggested alternatives
- Mute one new lint on an e2e test function

Closes #453