### PR TITLE
Remove cred dependency if you wanna run less tests

### DIFF
--- a/e2e/suite/alibaba/alibaba.go
+++ b/e2e/suite/alibaba/alibaba.go
@@ -31,7 +31,11 @@ var _ = Describe("[alibaba] ", func() {
 	accessKeyID := os.Getenv("ACCESS_KEY_ID")
 	accessKeySecret := os.Getenv("ACCESS_KEY_SECRET")
 	regionID := os.Getenv("REGION_ID")
-	prov := newAlibabaProvider(f, accessKeyID, accessKeySecret, regionID)
+	prov := &alibabaProvider{}
+
+	if accessKeyID != "" && accessKeySecret != "" && regionID != "" {
+		prov = newAlibabaProvider(f, accessKeyID, accessKeySecret, regionID)
+	}
 
 	DescribeTable("sync secrets", framework.TableFunc(f, prov),
 		Entry(common.SimpleDataSync(f)),

--- a/e2e/suite/azure/azure.go
+++ b/e2e/suite/azure/azure.go
@@ -30,7 +30,11 @@ var _ = Describe("[azure] ", func() {
 	tenantID := os.Getenv("TENANT_ID")
 	clientID := os.Getenv("AZURE_CLIENT_ID")
 	clientSecret := os.Getenv("AZURE_CLIENT_SECRET")
-	prov := newazureProvider(f, clientID, clientSecret, tenantID, vaultURL)
+	prov := &azureProvider{}
+
+	if vaultURL != "" && tenantID != "" && clientID != "" && clientSecret != "" {
+		prov = newazureProvider(f, clientID, clientSecret, tenantID, vaultURL)
+	}
 
 	DescribeTable("sync secrets", framework.TableFunc(f, prov),
 		Entry(common.SimpleDataSync(f)),

--- a/e2e/suite/gcp/gcp.go
+++ b/e2e/suite/gcp/gcp.go
@@ -36,7 +36,11 @@ var _ = Describe("[gcp] ", func() {
 	f := framework.New("eso-gcp")
 	credentials := os.Getenv("GCP_SM_SA_JSON")
 	projectID := os.Getenv("GCP_PROJECT_ID")
-	prov := newgcpProvider(f, credentials, projectID)
+	prov := &gcpProvider{}
+
+	if credentials != "" && projectID != "" {
+		prov = newgcpProvider(f, credentials, projectID)
+	}
 
 	// P12Cert case creates a secret with a p12 cert containing a privkey and cert bundled together.
 	// It uses templating to generate a k8s secret of type tls with pem values

--- a/e2e/suite/gitlab/gitlab.go
+++ b/e2e/suite/gitlab/gitlab.go
@@ -33,7 +33,12 @@ var _ = Describe("[gitlab] ", func() {
 	f := framework.New("esogitlab")
 	credentials := os.Getenv("GITLAB_TOKEN")
 	projectID := os.Getenv("GITLAB_PROJECT_ID")
-	prov := newGitlabProvider(f, credentials, projectID)
+
+	prov := &gitlabProvider{}
+
+	if credentials != "" && projectID != "" {
+		prov = newGitlabProvider(f, credentials, projectID)
+	}
 
 	DescribeTable("sync secrets", framework.TableFunc(f, prov),
 		Entry(common.SimpleDataSync(f)),


### PR DESCRIPTION
Remove cred dependency if you wanna run less tests, so we don't have to export all creds if we want to run tests for only one of the providers