### PR TITLE
Update README.md - promote vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Multiple people and organizations are joining efforts to create a single Externa
 | ------------------------------------------------------------------------ | :-------: | ---------------------------------------------: |
 | [AWS SM](https://external-secrets.io/provider-aws-secrets-manager/)      |   alpha   | [ESO Org](https://github.com/external-secrets) |
 | [AWS PS](https://external-secrets.io/provider-aws-parameter-store/)      |   alpha   | [ESO Org](https://github.com/external-secrets) |
-| [Hashicorp Vault](https://external-secrets.io/provider-hashicorp-vault/) |   alpha   | [ESO Org](https://github.com/external-secrets) |
+| [Hashicorp Vault](https://external-secrets.io/provider-hashicorp-vault/) |   stable   | [ESO Org](https://github.com/external-secrets) |
 | [GCP SM](https://external-secrets.io/provider-google-secrets-manager/)   |   alpha   | [ESO Org](https://github.com/external-secrets) |
 
 ### Community maintained:


### PR DESCRIPTION
Vault is the most used provider right now, with people reporting that they are using it with hundreds of secrets and no problems. Also, Vault is the only one that enabled us to write extensive e2e testing since we can just spin vault up in CI. I want to promote it to stable to ease people's minds :smile: but let me know if you think beta would be more appropriate.