### PR TITLE
Promote aws and gcp to beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Multiple people and organizations are joining efforts to create a single Externa
 
 | Provider                                                                 | Stability |                                        Contact |
 | ------------------------------------------------------------------------ | :-------: | ---------------------------------------------: |
-| [AWS SM](https://external-secrets.io/provider-aws-secrets-manager/)      |   alpha   | [ESO Org](https://github.com/external-secrets) |
-| [AWS PS](https://external-secrets.io/provider-aws-parameter-store/)      |   alpha   | [ESO Org](https://github.com/external-secrets) |
+| [AWS SM](https://external-secrets.io/provider-aws-secrets-manager/)      |   beta   | [ESO Org](https://github.com/external-secrets) |
+| [AWS PS](https://external-secrets.io/provider-aws-parameter-store/)      |   beta   | [ESO Org](https://github.com/external-secrets) |
 | [Hashicorp Vault](https://external-secrets.io/provider-hashicorp-vault/) |   stable   | [ESO Org](https://github.com/external-secrets) |
-| [GCP SM](https://external-secrets.io/provider-google-secrets-manager/)   |   alpha   | [ESO Org](https://github.com/external-secrets) |
+| [GCP SM](https://external-secrets.io/provider-google-secrets-manager/)   |   beta   | [ESO Org](https://github.com/external-secrets) |
 
 ### Community maintained:
 


### PR DESCRIPTION
Promote aws and gcp to beta :) 

When we have e2e tests for all auth methods in these providers, a good amount of runs, and we get consensus on a community meeting, we can also upgrade them to stable, as we did for vault. 