### PR TITLE
Adding way to use nested data structure for hashicorp vault

### DIFF
--- a/apis/externalsecrets/v1alpha1/secretstore_vault_types.go
+++ b/apis/externalsecrets/v1alpha1/secretstore_vault_types.go
@@ -21,7 +21,7 @@ import (
 type VaultParser string
 
 const (
-	VaultParserKv     VaultParser = "kv"
+	VaultParserKv     VaultParser = "key-value"
 	VaultParserString VaultParser = "string"
 )
 
@@ -80,10 +80,10 @@ type VaultProvider struct {
 	Version VaultKVStoreVersion `json:"version"`
 
 	// Parser defines how backend data is interpreted by engine.
-	// Parser defaults to "vk".
+	// Parser defaults to "key-value".
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:Enum="kv";"string"
-	// +kubebuilder:default:="kv"
+	// +kubebuilder:validation:Enum="key-value";"string"
+	// +kubebuilder:default:="key-value"
 	Parser VaultParser `json:"parser,omitempty"`
 
 	// Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows

--- a/apis/externalsecrets/v1alpha1/secretstore_vault_types.go
+++ b/apis/externalsecrets/v1alpha1/secretstore_vault_types.go
@@ -18,6 +18,13 @@ import (
 	esmeta "github.com/external-secrets/external-secrets/apis/meta/v1"
 )
 
+type VaultParser string
+
+const (
+	VaultParserKv     VaultParser = "kv"
+	VaultParserString VaultParser = "string"
+)
+
 type VaultKVStoreVersion string
 
 const (
@@ -71,6 +78,13 @@ type VaultProvider struct {
 	// +kubebuilder:validation:Enum="v1";"v2"
 	// +kubebuilder:default:="v2"
 	Version VaultKVStoreVersion `json:"version"`
+
+	// Parser defines how backend data is interpreted by engine.
+	// Parser defaults to "vk".
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum="kv";"string"
+	// +kubebuilder:default:="kv"
+	Parser VaultParser `json:"parser,omitempty"`
 
 	// Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows
 	// Vault environments to support Secure Multi-tenancy. e.g: "ns1".

--- a/deploy/crds/external-secrets.io_clustersecretstores.yaml
+++ b/deploy/crds/external-secrets.io_clustersecretstores.yaml
@@ -855,11 +855,11 @@ spec:
                           More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
                         type: string
                       parser:
-                        default: kv
+                        default: key-value
                         description: Parser defines how backend data is interpreted
-                          by engine. Parser defaults to "vk".
+                          by engine. Parser defaults to "key-value".
                         enum:
-                        - kv
+                        - key-value
                         - string
                         type: string
                       path:

--- a/deploy/crds/external-secrets.io_clustersecretstores.yaml
+++ b/deploy/crds/external-secrets.io_clustersecretstores.yaml
@@ -854,6 +854,14 @@ spec:
                           environments to support Secure Multi-tenancy. e.g: "ns1".
                           More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
                         type: string
+                      parser:
+                        default: kv
+                        description: Parser defines how backend data is interpreted
+                          by engine. Parser defaults to "vk".
+                        enum:
+                        - kv
+                        - string
+                        type: string
                       path:
                         description: 'Path is the mount path of the Vault KV backend
                           endpoint, e.g: "secret". The v2 KV secret engine version

--- a/deploy/crds/external-secrets.io_secretstores.yaml
+++ b/deploy/crds/external-secrets.io_secretstores.yaml
@@ -855,11 +855,11 @@ spec:
                           More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
                         type: string
                       parser:
-                        default: kv
+                        default: key-value
                         description: Parser defines how backend data is interpreted
-                          by engine. Parser defaults to "vk".
+                          by engine. Parser defaults to "key-value".
                         enum:
-                        - kv
+                        - key-value
                         - string
                         type: string
                       path:

--- a/deploy/crds/external-secrets.io_secretstores.yaml
+++ b/deploy/crds/external-secrets.io_secretstores.yaml
@@ -854,6 +854,14 @@ spec:
                           environments to support Secure Multi-tenancy. e.g: "ns1".
                           More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
                         type: string
+                      parser:
+                        default: kv
+                        description: Parser defines how backend data is interpreted
+                          by engine. Parser defaults to "vk".
+                        enum:
+                        - kv
+                        - string
+                        type: string
                       path:
                         description: 'Path is the mount path of the Vault KV backend
                           endpoint, e.g: "secret". The v2 KV secret engine version

--- a/docs/provider-hashicorp-vault.md
+++ b/docs/provider-hashicorp-vault.md
@@ -153,3 +153,27 @@ spec:
       version: "v2"
       parser: "string"
 ```
+
+And then you can access contents using .data
+This example just dumps all aaa/bbb properties as json file
+
+```yaml
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: vault-backend
+spec:
+  dataFrom:
+    - key: aaa/bbb
+  refreshInterval: 600s
+  secretStoreRef:
+    kind: SecretStore
+    name: vault-backend
+  target:
+    creationPolicy: Owner
+    name: test-1
+    template:
+      data:
+        config.json: |
+          {{ .data | toString }}
+```

--- a/docs/provider-hashicorp-vault.md
+++ b/docs/provider-hashicorp-vault.md
@@ -135,3 +135,21 @@ or `Kind=ClusterSecretStore` resource.
 ```yaml
 {% include 'vault-jwt-store.yaml' %}
 ```
+
+#### Nested data structures
+
+If there is need to store complex values in vault you can use string parser and post process string with template engine if needed
+
+```yaml
+apiVersion: external-secrets.io/v1alpha1
+kind: SecretStore
+metadata:
+  name: vault-backend
+spec:
+  provider:
+    vault:
+      server: "http://my.vault.server:8200"
+      path: "secret"
+      version: "v2"
+      parser: "string"
+```

--- a/docs/provider-hashicorp-vault.md
+++ b/docs/provider-hashicorp-vault.md
@@ -177,3 +177,32 @@ spec:
         config.json: |
           {{ .data | toString }}
 ```
+
+Example for parsing json structure/remapping
+
+Path aaa/bbb properties:
+
+```json
+{"auth":{"key":"123","secret":"abc"}}
+```
+
+```yaml
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: vault-backend
+spec:
+  dataFrom:
+    - key: aaa/bbb
+  refreshInterval: 600s
+  secretStoreRef:
+    kind: SecretStore
+    name: vault-backend
+  target:
+    creationPolicy: Owner
+    name: test-1
+    template:
+      data:
+        config.cfg: |
+          key = {{ $a := .data | fromJSON }}{{ $a.auth.key }}
+```

--- a/e2e/suite/vault/provider.go
+++ b/e2e/suite/vault/provider.go
@@ -104,6 +104,7 @@ func makeStore(name, ns string, v *addon.Vault) *esv1alpha1.SecretStore {
 			Provider: &esv1alpha1.SecretStoreProvider{
 				Vault: &esv1alpha1.VaultProvider{
 					Version:  esv1alpha1.VaultKVStoreV2,
+					Parser:   esv1alpha1.VaultParserKv,
 					Path:     "secret",
 					Server:   v.VaultURL,
 					CABundle: v.VaultServerCA,
@@ -216,6 +217,7 @@ func (s vaultProvider) CreateV1Store(v *addon.Vault, ns string) {
 	Expect(err).ToNot(HaveOccurred())
 	secretStore := makeStore(kvv1ProviderName, ns, v)
 	secretStore.Spec.Provider.Vault.Version = esv1alpha1.VaultKVStoreV1
+	secretStore.Spec.Provider.Vault.Parser = esv1alpha1.VaultParserKv
 	secretStore.Spec.Provider.Vault.Path = "secret_v1"
 	secretStore.Spec.Provider.Vault.Auth = esv1alpha1.VaultAuth{
 		TokenSecretRef: &esmeta.SecretKeySelector{

--- a/pkg/provider/vault/vault.go
+++ b/pkg/provider/vault/vault.go
@@ -76,6 +76,8 @@ const (
 	errVaultRevokeToken = "error while revoking token: %w"
 
 	errUnknownCAProvider = "unknown caProvider type given"
+
+	stringParserDataPath = "data"
 )
 
 type Client interface {
@@ -154,6 +156,9 @@ func (v *client) GetSecret(ctx context.Context, ref esv1alpha1.ExternalSecretDat
 	if err != nil {
 		return nil, err
 	}
+	if ref.Property == "" && v.store.Parser == esv1alpha1.VaultParserKv {
+		return data[stringParserDataPath], nil
+	}
 	value, exists := data[ref.Property]
 	if !exists {
 		return nil, fmt.Errorf(errSecretKeyFmt, ref.Property)
@@ -223,7 +228,7 @@ func (v *client) readSecret(ctx context.Context, path, version string) (map[stri
 	switch v.store.Parser {
 	case esv1alpha1.VaultParserString:
 		byteMap := make(map[string][]byte, 1)
-		byteMap["data"], err = json.Marshal(secretData)
+		byteMap[stringParserDataPath], err = json.Marshal(secretData)
 		if err != nil {
 			return nil, errors.New(errSecretParserV2)
 		}

--- a/pkg/provider/vault/vault_test.go
+++ b/pkg/provider/vault/vault_test.go
@@ -52,6 +52,7 @@ func makeValidSecretStoreWithVersion(v esv1alpha1.VaultKVStoreVersion) *esv1alph
 				Vault: &esv1alpha1.VaultProvider{
 					Server:  "vault.example.com",
 					Path:    "secret",
+					Parser:  esv1alpha1.VaultParserKv,
 					Version: v,
 					Auth: esv1alpha1.VaultAuth{
 						Kubernetes: &esv1alpha1.VaultKubernetesAuth{
@@ -89,6 +90,7 @@ func makeValidSecretStoreWithCerts() *esv1alpha1.SecretStore {
 				Vault: &esv1alpha1.VaultProvider{
 					Server:  "vault.example.com",
 					Path:    "secret",
+					Parser:  esv1alpha1.VaultParserKv,
 					Version: esv1alpha1.VaultKVStoreV2,
 					Auth: esv1alpha1.VaultAuth{
 						Cert: &esv1alpha1.VaultCertAuth{


### PR DESCRIPTION
I think many users just go and use vault agent instead because of this missing feature. It is not complete support but it is possible now to have store where you can parse values using go templates of just dump json to file.

See added examples in modified documentation it explains this change