### PR TITLE
chore: replace alpine by distroless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15.0
+FROM gcr.io/distroless/static
 ARG TARGETOS
 ARG TARGETARCH
 COPY bin/external-secrets-${TARGETOS}-${TARGETARCH} /bin/external-secrets

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -10,7 +10,7 @@ RUN wget -q https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_
     wget -q https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm && \
     chmod +x /usr/local/bin/helm
 
-FROM alpine:3.14.2
+FROM alpine:3.15.0
 RUN apk add -U --no-cache \
     ca-certificates \
     bash \


### PR DESCRIPTION
Bumping alpine of the e2e tests, and replacing main base image with distroless.

We get quite a few CVEs raised almost every week because of alpine packages, we can lower our maintenance considerably by just not having packages in our provided image.

We can use ephemeral containers to debug stuff, and we now have ways to get logs into aggregators and all that.

When we finish the reporter this will also get even easier.

Anyways I think we could already move to distroless, since this project is kinda sensitive when we think about security.