### PR TITLE
Create a kustomization for CRDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ test.e2e: generate ## Run e2e tests
 	@$(OK) go test unit-tests
 
 .PHONY: build
-build: $(addprefix build-,$(ARCH)) ## Build binary 
+build: $(addprefix build-,$(ARCH)) ## Build binary
 
 .PHONY: build-%
 build-%: generate ## Build binary for the specified arch
@@ -126,12 +126,14 @@ fmt: lint.check ## Ensure consistent code style
 generate: ## Generate code and crds
 	@go run sigs.k8s.io/controller-tools/cmd/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
 	@go run sigs.k8s.io/controller-tools/cmd/controller-gen $(CRD_OPTIONS) paths="./..." output:crd:artifacts:config=$(CRD_DIR)
+	@mv $(CRD_DIR)/kustomization.yaml $(CRD_DIR)/kustomization.yaml.bak
 # Remove extra header lines in generated CRDs
 	@for i in $(CRD_DIR)/*.yaml; do \
   		tail -n +3 <"$$i" >"$$i.bkp" && \
   		cp "$$i.bkp" "$$i" && \
   		rm "$$i.bkp"; \
   	done
+	@mv $(CRD_DIR)/kustomization.yaml.bak $(CRD_DIR)/kustomization.yaml
 	@$(OK) Finished generating deepcopy and crds
 
 # ====================================================================================

--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,7 @@ helm.build: helm.generate ## Build helm chart
 
 helm.generate: helm.docs ## Copy crds to helm chart directory
 	@cp $(CRD_DIR)/*.yaml $(HELM_DIR)/templates/crds/
+	@rm $(HELM_DIR)/templates/crds/kustomization.yaml
 # Add helm if statement for controlling the install of CRDs
 	@for i in $(HELM_DIR)/templates/crds/*.yaml; do \
 		cp "$$i" "$$i.bkp" && \

--- a/deploy/crds/kustomization.yaml
+++ b/deploy/crds/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- external-secrets.io_clustersecretstores.yaml
+- external-secrets.io_externalsecrets.yaml
+- external-secrets.io_secretstores.yaml


### PR DESCRIPTION
Need:
Add a Kustomization to allow remote installation of CRDs using Kustomize

Reason:
When you are working with FluxCD, you could deploy External Secrets deploying a HelmRelease and HelmRepository. The problem is that if you deploy de ClusterSecretStore just after it, and the FluxCD HelmController not deployed de CRDs of External Secrets yet, every process will fail because your CRDs are not deployed on Kubernetes.

The approach is using a kustomization.yaml to deploy everything as follows
```
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization

resources:
- helm-repositories.yaml
- helm-release.yaml
- clusterSecretStore.yaml
```

The proposal is to add a kustomization inside External Secrets to allow the deployment of the CRDs before everything and in that way, avoid having a race condition between FluxCD deploying External Secrets and the resources that need it be deployed, as follows:
```
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization

# Install CRDs
- github.com/external-secrets/external-secrets/deploy//crds?ref=main

resources:
- helm-repositories.yaml
- helm-release.yaml
- clusterSecretStore.yaml
```
