### PR TITLE
Add annotation to Deployment

### DIFF
--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -35,6 +35,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
+| deploymentAnnotations | object | `{}` | Annotations to add to Deployment |
 | extraArgs | object | `{}` |  |
 | extraEnv | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
@@ -46,7 +47,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | leaderElect | bool | `false` | If true, external-secrets will perform leader election between instances to ensure no more than one instance of external-secrets operates at a time. |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
-| podAnnotations | object | `{}` |  |
+| podAnnotations | object | `{}` | Annotations to add to Pod |
 | podLabels | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | priorityClassName | string | `""` | Pod priority class name. |

--- a/deploy/charts/external-secrets/templates/deployment.yaml
+++ b/deploy/charts/external-secrets/templates/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "external-secrets.labels" . | nindent 4 }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -40,7 +40,12 @@ extraEnv: []
 ## -- Map of extra arguments to pass to container.
 extraArgs: {}
 
+# -- Annotations to add to Deployment
+deploymentAnnotations: {}
+
+# -- Annotations to add to Pod
 podAnnotations: {}
+
 podLabels: {}
 
 podSecurityContext: {}


### PR DESCRIPTION
Allow adding annotations to Deployment via Helm values.

This enable using some third-party tools which rely on adding annotations on `Deployment`,`Statefulset`,`Daemonset`. For example, adding annotations to external-secrets Deployment allow [stakater-reloader](https://github.com/stakater/Reloader) to restart(and reload) deployment upon `ConfigMap` or `Secret` modifications.

