### PR TITLE
Support common idiom for GCP SM

### DIFF
--- a/pkg/provider/gcp/secretmanager/secretsmanager.go
+++ b/pkg/provider/gcp/secretmanager/secretsmanager.go
@@ -197,7 +197,7 @@ func (sm *ProviderGCP) GetSecretMap(ctx context.Context, ref esv1alpha1.External
 		return nil, err
 	}
 
-	kv := make(map[string]string)
+	kv := make(map[string]json.RawMessage)
 	err = json.Unmarshal(data, &kv)
 	if err != nil {
 		return nil, fmt.Errorf(errJSONSecretUnmarshal, err)
@@ -205,7 +205,13 @@ func (sm *ProviderGCP) GetSecretMap(ctx context.Context, ref esv1alpha1.External
 
 	secretData := make(map[string][]byte)
 	for k, v := range kv {
-		secretData[k] = []byte(v)
+		var strVal string
+		err = json.Unmarshal(v, &strVal)
+		if err == nil {
+			secretData[k] = []byte(strVal)
+		} else {
+			secretData[k] = v
+		}
 	}
 
 	return secretData, nil

--- a/pkg/provider/gcp/secretmanager/secretsmanager_test.go
+++ b/pkg/provider/gcp/secretmanager/secretsmanager_test.go
@@ -172,11 +172,19 @@ func TestGetSecretMap(t *testing.T) {
 		smtc.expectError = "unable to unmarshal secret"
 	}
 
+	// good case: deserialize nested json as []byte, if it's a string, decode the string
+	setNestedJSON := func(smtc *secretManagerTestCase) {
+		smtc.apiOutput.Payload.Data = []byte(`{"foo":{"bar":"baz"}, "qux": "qu\"z"}`)
+		smtc.expectedData["foo"] = []byte(`{"bar":"baz"}`)
+		smtc.expectedData["qux"] = []byte("qu\"z")
+	}
+
 	successCases := []*secretManagerTestCase{
 		makeValidSecretManagerTestCaseCustom(setDeserialization),
 		makeValidSecretManagerTestCaseCustom(setAPIErr),
 		makeValidSecretManagerTestCaseCustom(setNilMockClient),
 		makeValidSecretManagerTestCaseCustom(setInvalidJSON),
+		makeValidSecretManagerTestCaseCustom(setNestedJSON),
 	}
 
 	sm := ProviderGCP{}


### PR DESCRIPTION
Common idiom for GCP SM is like:
```json
{
    "name": {
        "client_id": "<client_id>",
        "client_secret": "<client_secret>",
    }
}
```
Using DataFrom, the current GCP SM will fail to unmarshal cause it's expecting
```json
{
    "name": "{\"client_id\": \"<client_id>\", \"client_secret\": \"<client_secret>\"}",
}
```
which is much more annoying to work with.  By tweaking the implementation to
try to decode to a string, but if that fails, use the raw `[]byte` of the value
we get the best of both worlds.