### PR TITLE
Add GetAllSecrets method to the provider interface

### DIFF
--- a/apis/externalsecrets/v1alpha1/externalsecret_types.go
+++ b/apis/externalsecrets/v1alpha1/externalsecret_types.go
@@ -150,6 +150,11 @@ type ExternalSecretSpec struct {
 	// If multiple entries are specified, the Secret keys are merged in the specified order
 	// +optional
 	DataFrom []ExternalSecretDataRemoteRef `json:"dataFrom,omitempty"`
+
+	// DataAll is used to fetch ALL data in the defined Provider
+	// If multiple entries are specified, the Secret keys are merged in the specified order
+	// +optional
+	DataAll []ExternalSecretDataRemoteRef `json:"dataAll,omitempty"`
 }
 
 type ExternalSecretConditionType string

--- a/deploy/crds/external-secrets.io_externalsecrets.yaml
+++ b/deploy/crds/external-secrets.io_externalsecrets.yaml
@@ -102,6 +102,28 @@ spec:
                   - key
                   type: object
                 type: array
+              dataAll:
+                description: DataAll is used to fetch all properties from a specific
+                  Provider Backend If multiple entries are specified, the Secret keys
+                  are merged in the specified order
+                items:
+                  description: ExternalSecretDataRemoteRef defines Provider data location.
+                  properties:
+                    key:
+                      description: Key is the key used in the Provider, mandatory
+                      type: string
+                    property:
+                      description: Used to select a specific property of the Provider
+                        value (if a map), if supported
+                      type: string
+                    version:
+                      description: Used to select a specific version of the Provider
+                        value, if supported
+                      type: string
+                  required:
+                  - key
+                  type: object
+                type: array
               refreshInterval:
                 default: 1h
                 description: RefreshInterval is the amount of time before the values

--- a/pkg/controllers/externalsecret/externalsecret_controller.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller.go
@@ -396,6 +396,15 @@ func (r *Reconciler) getProviderSecretData(ctx context.Context, providerClient p
 		providerData = utils.MergeByteMap(providerData, secretMap)
 	}
 
+	for _, allSecretsRef := range externalSecret.Spec.DataAll {
+		secretAll, err := providerClient.GetAllSecrets(ctx, allSecretsRef)
+		if err != nil {
+			return nil, fmt.Errorf(errGetSecretKey, allSecretsRef.Key, externalSecret.Name, err)
+		}
+
+		providerData = utils.MergeByteMap(providerData, secretAll)
+	}
+
 	for _, secretRef := range externalSecret.Spec.Data {
 		secretData, err := providerClient.GetSecret(ctx, secretRef.RemoteRef)
 		if err != nil {

--- a/pkg/provider/akeyless/akeyless.go
+++ b/pkg/provider/akeyless/akeyless.go
@@ -128,6 +128,13 @@ func (a *Akeyless) GetSecret(ctx context.Context, ref esv1alpha1.ExternalSecretD
 	return []byte(value), nil
 }
 
+// Implements store.Client.GetAllSecrets Interface.
+// New version of GetAllSecrets.
+func (a *Akeyless) GetAllSecrets(ctx context.Context, ref esv1alpha1.ExternalSecretDataRemoteRef) (map[string][]byte, error) {
+	// TO be implemented
+	return map[string][]byte{}, nil
+}
+
 // Implements store.Client.GetSecretMap Interface.
 // New version of GetSecretMap.
 func (a *Akeyless) GetSecretMap(ctx context.Context, ref esv1alpha1.ExternalSecretDataRemoteRef) (map[string][]byte, error) {

--- a/pkg/provider/alibaba/kms.go
+++ b/pkg/provider/alibaba/kms.go
@@ -140,6 +140,13 @@ func (kms *KeyManagementService) GetSecret(ctx context.Context, ref esv1alpha1.E
 	return []byte(val.String()), nil
 }
 
+// Implements store.Client.GetAllSecrets Interface.
+// New version of GetAllSecrets.
+func (a *KeyManagementService) GetAllSecrets(ctx context.Context, ref esv1alpha1.ExternalSecretDataRemoteRef) (map[string][]byte, error) {
+	// TO be implemented
+	return map[string][]byte{}, nil
+}
+
 // GetSecretMap returns multiple k/v pairs from the provider.
 func (kms *KeyManagementService) GetSecretMap(ctx context.Context, ref esv1alpha1.ExternalSecretDataRemoteRef) (map[string][]byte, error) {
 	data, err := kms.GetSecret(ctx, ref)

--- a/pkg/provider/aws/parameterstore/parameterstore.go
+++ b/pkg/provider/aws/parameterstore/parameterstore.go
@@ -71,6 +71,13 @@ func (pm *ParameterStore) GetSecret(ctx context.Context, ref esv1alpha1.External
 	return []byte(val.String()), nil
 }
 
+// Implements store.Client.GetAllSecrets Interface.
+// New version of GetAllSecrets.
+func (pm *ParameterStore) GetAllSecrets(ctx context.Context, ref esv1alpha1.ExternalSecretDataRemoteRef) (map[string][]byte, error) {
+	// TO be implemented
+	return map[string][]byte{}, nil
+}
+
 // GetSecretMap returns multiple k/v pairs from the provider.
 func (pm *ParameterStore) GetSecretMap(ctx context.Context, ref esv1alpha1.ExternalSecretDataRemoteRef) (map[string][]byte, error) {
 	log.Info("fetching secret map", "key", ref.Key)

--- a/pkg/provider/aws/secretsmanager/secretsmanager.go
+++ b/pkg/provider/aws/secretsmanager/secretsmanager.go
@@ -123,6 +123,13 @@ func (sm *SecretsManager) GetSecretMap(ctx context.Context, ref esv1alpha1.Exter
 	return secretData, nil
 }
 
+// Implements store.Client.GetAllSecrets Interface.
+// New version of GetAllSecrets.
+func (sm *SecretsManager) GetAllSecrets(ctx context.Context, ref esv1alpha1.ExternalSecretDataRemoteRef) (map[string][]byte, error) {
+	// TO be implemented
+	return map[string][]byte{}, nil
+}
+
 func (sm *SecretsManager) Close(ctx context.Context) error {
 	return nil
 }

--- a/pkg/provider/fake/fake.go
+++ b/pkg/provider/fake/fake.go
@@ -70,6 +70,13 @@ func (v *Client) WithGetSecret(secData []byte, err error) *Client {
 	return v
 }
 
+// Implements store.Client.GetAllSecrets Interface.
+// New version of GetAllSecrets.
+func (v *Client) GetAllSecrets(ctx context.Context, ref esv1alpha1.ExternalSecretDataRemoteRef) (map[string][]byte, error) {
+	// TO be implemented
+	return map[string][]byte{}, nil
+}
+
 // GetSecretMap imeplements the provider.Provider interface.
 func (v *Client) GetSecretMap(ctx context.Context, ref esv1alpha1.ExternalSecretDataRemoteRef) (map[string][]byte, error) {
 	return v.GetSecretMapFn(ctx, ref)

--- a/pkg/provider/gcp/secretmanager/secretsmanager.go
+++ b/pkg/provider/gcp/secretmanager/secretsmanager.go
@@ -186,6 +186,13 @@ func (sm *ProviderGCP) GetSecret(ctx context.Context, ref esv1alpha1.ExternalSec
 	return []byte(val.String()), nil
 }
 
+// Implements store.Client.GetAllSecrets Interface.
+// New version of GetAllSecrets.
+func (sm *ProviderGCP) GetAllSecrets(ctx context.Context, ref esv1alpha1.ExternalSecretDataRemoteRef) (map[string][]byte, error) {
+	// TO be implemented
+	return map[string][]byte{}, nil
+}
+
 // GetSecretMap returns multiple k/v pairs from the provider.
 func (sm *ProviderGCP) GetSecretMap(ctx context.Context, ref esv1alpha1.ExternalSecretDataRemoteRef) (map[string][]byte, error) {
 	if sm.SecretManagerClient == nil || sm.projectID == "" {

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -185,6 +185,13 @@ func (g *Gitlab) GetSecret(ctx context.Context, ref esv1alpha1.ExternalSecretDat
 	return []byte(val.String()), nil
 }
 
+// Implements store.Client.GetAllSecrets Interface.
+// New version of GetAllSecrets.
+func (g *Gitlab) GetAllSecrets(ctx context.Context, ref esv1alpha1.ExternalSecretDataRemoteRef) (map[string][]byte, error) {
+	// TO be implemented
+	return map[string][]byte{}, nil
+}
+
 func (g *Gitlab) GetSecretMap(ctx context.Context, ref esv1alpha1.ExternalSecretDataRemoteRef) (map[string][]byte, error) {
 	// Gets a secret as normal, expecting secret value to be a json object
 	data, err := g.GetSecret(ctx, ref)

--- a/pkg/provider/ibm/provider.go
+++ b/pkg/provider/ibm/provider.go
@@ -92,6 +92,13 @@ func (c *client) setAuth(ctx context.Context) error {
 	return nil
 }
 
+// Implements store.Client.GetAllSecrets Interface.
+// New version of GetAllSecrets.
+func (ibm *providerIBM) GetAllSecrets(ctx context.Context, ref esv1alpha1.ExternalSecretDataRemoteRef) (map[string][]byte, error) {
+	// TO be implemented
+	return map[string][]byte{}, nil
+}
+
 func (ibm *providerIBM) GetSecret(ctx context.Context, ref esv1alpha1.ExternalSecretDataRemoteRef) ([]byte, error) {
 	if utils.IsNil(ibm.IBMClient) {
 		return nil, fmt.Errorf(errUninitalizedIBMProvider)

--- a/pkg/provider/oracle/oracle.go
+++ b/pkg/provider/oracle/oracle.go
@@ -154,6 +154,13 @@ func (vms *VaultManagementService) GetSecret(ctx context.Context, ref esv1alpha1
 	return []byte(val.String()), nil
 }
 
+// Implements store.Client.GetAllSecrets Interface.
+// New version of GetAllSecrets.
+func (vms *VaultManagementService) GetAllSecrets(ctx context.Context, ref esv1alpha1.ExternalSecretDataRemoteRef) (map[string][]byte, error) {
+	// TO be implemented
+	return map[string][]byte{}, nil
+}
+
 func (vms *VaultManagementService) GetSecretMap(ctx context.Context, ref esv1alpha1.ExternalSecretDataRemoteRef) (map[string][]byte, error) {
 	data, err := vms.GetSecret(ctx, ref)
 	if err != nil {

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -35,5 +35,9 @@ type SecretsClient interface {
 
 	// GetSecretMap returns multiple k/v pairs from the provider
 	GetSecretMap(ctx context.Context, ref esv1alpha1.ExternalSecretDataRemoteRef) (map[string][]byte, error)
+
+	// GetSecretMap returns all k/v pairs from the provider
+	GetAllSecrets(ctx context.Context, ref esv1alpha1.ExternalSecretDataRemoteRef) (map[string][]byte, error)
+
 	Close(ctx context.Context) error
 }

--- a/pkg/provider/schema/schema_test.go
+++ b/pkg/provider/schema/schema_test.go
@@ -43,6 +43,13 @@ func (p *PP) GetSecretMap(ctx context.Context, ref esv1alpha1.ExternalSecretData
 	return map[string][]byte{}, nil
 }
 
+// Implements store.Client.GetAllSecrets Interface.
+// New version of GetAllSecrets.
+func (p *PP) GetAllSecrets(ctx context.Context, ref esv1alpha1.ExternalSecretDataRemoteRef) (map[string][]byte, error) {
+	// TO be implemented
+	return map[string][]byte{}, nil
+}
+
 func (p *PP) Close(ctx context.Context) error {
 	return nil
 }

--- a/pkg/provider/vault/vault.go
+++ b/pkg/provider/vault/vault.go
@@ -162,6 +162,13 @@ func (v *client) GetSecretMap(ctx context.Context, ref esv1alpha1.ExternalSecret
 	return v.readSecret(ctx, ref.Key, ref.Version)
 }
 
+// Implements store.Client.GetAllSecrets Interface.
+// New version of GetAllSecrets.
+func (v *client) GetAllSecrets(ctx context.Context, ref esv1alpha1.ExternalSecretDataRemoteRef) (map[string][]byte, error) {
+	// TO be implemented
+	return map[string][]byte{}, nil
+}
+
 func (v *client) Close(ctx context.Context) error {
 	// Revoke the token if we have one set and it wasn't sourced from a TokenSecretRef
 	if v.client.Token() != "" && v.store.Auth.TokenSecretRef == nil {

--- a/pkg/provider/yandex/lockbox/lockbox.go
+++ b/pkg/provider/yandex/lockbox/lockbox.go
@@ -227,6 +227,13 @@ func (c *lockboxSecretsClient) GetSecret(ctx context.Context, ref esv1alpha1.Ext
 	return getValueAsBinary(entry)
 }
 
+// Implements store.Client.GetAllSecrets Interface.
+// New version of GetAllSecrets.
+func (c *lockboxSecretsClient) GetAllSecrets(ctx context.Context, ref esv1alpha1.ExternalSecretDataRemoteRef) (map[string][]byte, error) {
+	// TO be implemented
+	return map[string][]byte{}, nil
+}
+
 // GetSecretMap returns multiple k/v pairs from the provider.
 func (c *lockboxSecretsClient) GetSecretMap(ctx context.Context, ref esv1alpha1.ExternalSecretDataRemoteRef) (map[string][]byte, error) {
 	entries, err := c.lockboxClient.GetPayloadEntries(ctx, c.iamToken, ref.Key, ref.Version)


### PR DESCRIPTION
Following the discussions [470](https://github.com/external-secrets/external-secrets/discussions/470) , [436](https://github.com/external-secrets/external-secrets/discussions/436) , and the raised issue [498](https://github.com/external-secrets/external-secrets/issues/498). I am raising this PR to introduce a new Property DataAll which returns ALL secrets in the secret provider which can be differentiated from DataFrom which returns all secrets aggregated in json formar under the SAME property in a specific secret provider. 