### PR TITLE
add ClusterSecretStore AWS IRSA example setting docs

### DIFF
--- a/docs/snippets/full-cluster-secret-store.yaml
+++ b/docs/snippets/full-cluster-secret-store.yaml
@@ -22,9 +22,9 @@ spec:
       role: iam-role
       # AWS Region to be used for the provider
       region: eu-central-1
-      # Auth defines the information necessary to authenticate against AWS by
-      # getting the accessKeyID and secretAccessKey from an already created Kubernetes Secret
+      # Auth defines the information necessary to authenticate against AWS
       auth:
+        # Getting the accessKeyID and secretAccessKey from an already created Kubernetes Secret
         secretRef:
           accessKeyID:
             name: awssm-secret
@@ -32,6 +32,12 @@ spec:
           secretAccessKey:
             name: awssm-secret
             key: secret-access-key
+        # IAM roles for service accounts
+        # https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html
+        jwt:
+          serviceAccountRef:
+            name: my-serviceaccount
+            namespace: sa-namespace
 
     vault:
       server: "https://vault.acme.org"


### PR DESCRIPTION
There is no example for AWS IRSA in ClusterSecretStore doc.

https://external-secrets.io/api-clustersecretstore/

SecretStore IRSA setting doesn't need `namespace`, but ClusterSecretStore require it. It may become a pitfall.

https://github.com/external-secrets/external-secrets/blob/05a8f1739673a7ddade89cdefcd52ec70db2aa25/pkg/provider/aws/auth/auth.go#L163-L165