### PR TITLE
Fix documentation for namespace in ClusterSecretStore

### DIFF
--- a/docs/provider-google-secrets-manager.md
+++ b/docs/provider-google-secrets-manager.md
@@ -106,6 +106,8 @@ You can use [GCP Service Account](https://cloud.google.com/iam/docs/service-acco
 {% include 'gcpsm-credentials-secret.yaml' %}
 ```
 
+**NOTE:** In case of a `ClusterSecretStore`, Be sure to provide `namespace` for `SecretAccessKeyRef` with the namespace of the secret that we just created.
+
 #### Update secret store
 Be sure the `gcpsm` provider is listed in the `Kind=SecretStore`
 


### PR DESCRIPTION
I was facing SecretsSyncedError due to namespace being not set in case of a ClusterSecretStore.

Where should i add the NOTE ?