### PR TITLE
Anchore engine and Jenkins Credentials plugin guides and snippets

### DIFF
--- a/docs/guides-anchore-engine-credentials.md
+++ b/docs/guides-anchore-engine-credentials.md
@@ -1,6 +1,6 @@
 # Getting started
 
-Anchore engine is one of the best of breed security scanning used for scanning docker images, filesystems and with Harbor allowing a complete solution to container scanning at build time, nightly and with the admission controller the prevention of unscanned images from being deployed into kubernetes clusters.
+Anchore Engine is an open-source project that provides a centralized service for inspection, analysis, and certification of container images. With Kubernetes, it also brings nice features like preventing unscanned images from being deployed into your clusters
 
 ## Installing with Helm
 

--- a/docs/guides-anchore-engine-credentials.md
+++ b/docs/guides-anchore-engine-credentials.md
@@ -1,0 +1,31 @@
+# Getting started
+
+Anchore engine is one of the best of breed security scanning used for scanning docker images, filesystems and with Harbor allowing a complete solution to container scanning at build time, nightly and with the admission controller the prevention of unscanned images from being deployed into kubernetes clusters.
+
+## Installing with Helm
+
+There are several parts of the installation that require credentials these being :-
+
+ANCHORE_ADMIN_USERNAME
+ANCHORE_ADMIN_PASSWORD
+ANCHORE_DB_PASSWORD
+db-url
+db-user
+postgres-password
+
+
+Creating the following external secret ensure the credentials are drawn from the backend provider of choice example for Hashicorp Vault and AWS Secrets Manager providers
+
+#### Hashicorp Vault
+
+``` yaml
+{% include 'vault-anchore-engine-access-credentials-external-secret.yaml' %}
+```
+
+
+#### AWS Secrets Manager
+
+``` yaml
+{% include 'aws-anchore-engine-access-credentials-external-secret.yaml' %}
+```
+

--- a/docs/guides-anchore-engine-credentials.md
+++ b/docs/guides-anchore-engine-credentials.md
@@ -14,7 +14,7 @@ db-user
 postgres-password
 
 
-Creating the following external secret ensure the credentials are drawn from the backend provider of choice example for Hashicorp Vault and AWS Secrets Manager providers
+Creating the following external secret ensure the credentials are drawn from the backend provider of choice. The example shown here works with Hashicorp Vault and AWS Secrets Manager providers.
 
 #### Hashicorp Vault
 

--- a/docs/guides-jenkins-kubernetes-credentials.md
+++ b/docs/guides-jenkins-kubernetes-credentials.md
@@ -1,0 +1,71 @@
+# Getting started
+
+Jenkins is one of the most popular automation servers for continous integration, automation, scheduling jobs and for generic pipelining. It has an extensive set of plugins that extend or provide additional functionality including the kubernetes secrets plugin. This plugin takes kubernetes secrets and creates Jenkins credentials from them removing the need for manual entry of secrets, local storage and manual secret rotation.
+
+## Examples
+
+The Jenkins credentials plugin uses labels and annotations on a kubernetes secret to create a Jenkins credential, here's an example of one
+
+```yaml
+
+Secret YAML HERE
+
+```
+
+The different types of Jenkins credentials that can be created are SecretText, privateSSHKey, UsernamePassword.
+
+
+### SecretText
+
+Here are some examples of SecretText with the Hashicorp Vault and AWS External Secrets providers:
+
+
+#### Hashicorp Vault
+
+``` yaml
+{% include 'vault-jenkins-credential-sonarqube-api-token-external-secret.yaml' %}
+```
+
+#### AWS Secrets Manager
+
+``` yaml
+{% include 'aws-jenkins-credential-sonarqube-api-token-external-secret.yaml' %}
+```
+
+
+### UsernamePassword
+
+Here are some examples of UsernamePassword credentials with the Hashicorp Vault and AWS External Secrets providers:
+
+
+#### Hashicorp Vault
+
+``` yaml
+{% include 'vault-jenkins-credential-harbor-chart-robot-external-secret.yaml' %}
+```
+
+#### AWS Secrets Manager
+
+``` yaml
+{% include 'aws-jenkins-credential-harbor-chart-robot-external-secret.yaml' %}
+```
+
+
+
+### basicSSHUserPrivateKey
+
+Here are some examples of basicSSHUserPrivateKey credentials with the Hashicorp Vault and AWS External Secrets providers:
+
+
+#### Hashicorp Vault
+
+``` yaml
+{% include 'vault-jenkins-credential-github-ssh-access-external-secret.yaml' %}
+```
+
+#### AWS Secrets Manager
+
+``` yaml
+{% include 'aws-jenkins-credential-github-ssh-external-secret.yaml' %}
+```
+

--- a/docs/guides-jenkins-kubernetes-credentials.md
+++ b/docs/guides-jenkins-kubernetes-credentials.md
@@ -1,16 +1,10 @@
 # Getting started
 
-Jenkins is one of the most popular automation servers for continous integration, automation, scheduling jobs and for generic pipelining. It has an extensive set of plugins that extend or provide additional functionality including the kubernetes secrets plugin. This plugin takes kubernetes secrets and creates Jenkins credentials from them removing the need for manual entry of secrets, local storage and manual secret rotation.
+Jenkins is one of the most popular automation servers for continous integration, automation, scheduling jobs and for generic pipelining. It has an extensive set of plugins that extend or provide additional functionality including the [kubernetes credentials plugin](https://github.com/jenkinsci/kubernetes-credentials-provider-plugin). This plugin takes kubernetes secrets and creates Jenkins credentials from them removing the need for manual entry of secrets, local storage and manual secret rotation.
 
 ## Examples
 
-The Jenkins credentials plugin uses labels and annotations on a kubernetes secret to create a Jenkins credential, here's an example of one
-
-```yaml
-
-Secret YAML HERE
-
-```
+The Jenkins credentials plugin uses labels and annotations on a kubernetes secret to create a Jenkins credential.
 
 The different types of Jenkins credentials that can be created are SecretText, privateSSHKey, UsernamePassword.
 

--- a/docs/snippets/aws-anchore-engine-access-credentials-external-secret.yaml
+++ b/docs/snippets/aws-anchore-engine-access-credentials-external-secret.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: anchore-access-credentials
+  namespace: ci
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: cluster-secrets-store
+    kind: ClusterSecretStore
+  target:
+    name: anchore-access-credentials
+  dataFrom:
+  - key: service/anchore-engine/engineAccess

--- a/docs/snippets/aws-jenkins-credential-github-ssh-external-secret.yaml
+++ b/docs/snippets/aws-jenkins-credential-github-ssh-external-secret.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: github-ssh-access
+  namespace: ci
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: cluster-parameter-store
+    kind: ClusterSecretStore
+  target:
+    name: github-ssh-access
+    template:
+      metadata:
+        labels:
+          "jenkins.io/credentials-type": "basicSSHUserPrivateKey"
+        annotations:
+          "jenkins.io/credentials-description": "github-ssh-access key"
+  data:
+    - secretKey: username
+      remoteRef:
+        key: /service/github/sshUserPrivateKeyUserName
+    - secretKey: privateKey
+      remoteRef:
+        key: /service/github/sshUserPrivateKey
+

--- a/docs/snippets/aws-jenkins-credential-sonarqube-api-token-external-secret.yaml
+++ b/docs/snippets/aws-jenkins-credential-sonarqube-api-token-external-secret.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: sonarqube-api-token
+  namespace: ci
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: cluster-secrets-store
+    kind: ClusterSecretStore
+  target:
+    name: sonarqube-api-token
+    template:
+      metadata:
+        labels:
+          "jenkins.io/credentials-type": "secretText"
+        annotations:
+          "jenkins.io/credentials-description": "Sonar API token"
+  data:
+    - secretKey: text
+      remoteRef:
+        key: service/sonarqube/apiToken

--- a/docs/snippets/aws-jenkins-credentials-harbor-chart-robot-external-secret.yaml
+++ b/docs/snippets/aws-jenkins-credentials-harbor-chart-robot-external-secret.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: harbor-chart-robot
+  namespace: ci   
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: cluster-secrets-store
+    kind: ClusterSecretStore
+  target:
+    name: harbor-chart-robot
+    template:
+      metadata:
+        labels:
+          "jenkins.io/credentials-type": "usernamePassword"
+        annotations:
+          "jenkins.io/credentials-description": "harbor chart robot access"
+  data:
+    - secretKey: password
+      remoteRef:
+        key: service/harbor/chartRobot
+        property: password
+    - secretKey: username
+      remoteRef:
+        key: service/harbor/chartRobot
+        property: username

--- a/docs/snippets/vault-anchore-engine-access-credentials-external-secret.yaml
+++ b/docs/snippets/vault-anchore-engine-access-credentials-external-secret.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: anchore-access-credentials
+  namespace: security
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: anchore-access-credentials
+    template:
+
+      data:
+        ANCHORE_ADMIN_USERNAME: >-
+          {{ printf "{{ .username | toString }}" }}
+        ANCHORE_ADMIN_PASSWORD: >-
+          {{ printf "{{ .password | toString }}" }}
+        ANCHORE_DB_PASSWORD: >-
+          {{ printf "{{ .dbPassword | toString }}" }}
+        db-url: >-
+          {{ printf "{{ .dbUrl | toString }}" }}
+        db-user: >-
+          {{ printf "{{ .dbUser | toString }}" }}
+        postgres-password: >-
+          {{ printf "{{ .postgresPassword | toString }}" }}
+
+  data:
+    - secretKey: password
+      remoteRef:
+        key: anchore-engine
+        property: ANCHORE_ADMIN_PASSWORD
+    - secretKey: username
+      remoteRef:
+        key: anchore-engine
+        property: ANCHORE_ADMIN_USERNAME
+    - secretKey: dbPassword
+      remoteRef:
+        key: anchore-engine
+        property: ANCHORE_DB_PASSWORD
+    - secretKey: dbUrl
+      remoteRef:
+        key: anchore-engine
+        property: db-url
+    - secretKey: dbUser
+      remoteRef:
+        key: anchore-engine
+        property: db-user
+    - secretKey: postgresPassword
+      remoteRef:
+        key: anchore-engine
+        property: postgres-password

--- a/docs/snippets/vault-docker-config-external-secret.yaml
+++ b/docs/snippets/vault-docker-config-external-secret.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: image-registry-credentials
+  namespace: example
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: image-registry-credentials
+    template:
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: >-
+          "{{ .dockerconfig | toString }}"
+  data:
+    - secretKey: dockerconfig
+      remoteRef:
+        key: my-kv
+        property: image-registry-credentials

--- a/docs/snippets/vault-jenkins-credential-github-ssh-access-external-secret.yaml
+++ b/docs/snippets/vault-jenkins-credential-github-ssh-access-external-secret.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: github-ssh-access
+  namespace: ci
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: github-ssh-access
+    template:
+      metadata:
+        labels:
+          "jenkins.io/credentials-type": "basicSSHUserPrivateKey"
+        annotations:
+          "jenkins.io/credentials-description": "github-ssh-access key"
+      data:
+        username: >-
+          {{ printf "{{ .username | toString }}" }}
+        privateKey: >-
+          {{ printf "{{ .privateKey | toString }}" }}
+  data:
+    - secretKey: username
+      remoteRef:
+        key: my-kv
+        property: github-ssh-access-username
+    - secretKey: privateKey
+      remoteRef:
+        key: my-kv
+        property: github-ssh-access-private-key

--- a/docs/snippets/vault-jenkins-credential-harbor-chart-robot-external-secret.yaml
+++ b/docs/snippets/vault-jenkins-credential-harbor-chart-robot-external-secret.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: harbor-chart-robot
+  namespace: ci
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: harbor-chart-robot
+    template:
+      metadata:
+        labels:
+          "jenkins.io/credentials-type": "usernamePassword"
+        annotations:
+          "jenkins.io/credentials-description": "harbor chart robot"
+      data:
+        username: >-
+          {{ printf "{{ .username | toString }}" }}
+        password: >-
+          {{ printf "{{ .password | toString }}" }}
+  data:
+    - secretKey: username
+      remoteRef:
+        key: my-kv
+        property: harbor-chart-robot-username
+    - secretKey: password
+      remoteRef:
+        key: my-kv
+        property: harbor-chart-robot-token

--- a/docs/snippets/vault-jenkins-credential-sonarqube-api-token-external-secret.yaml
+++ b/docs/snippets/vault-jenkins-credential-sonarqube-api-token-external-secret.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: sonarqube-api-token
+  namespace: ci
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: sonarqube-api-token
+    template:
+      metadata:
+        labels:
+          "jenkins.io/credentials-type": "secretText"
+        annotations:
+          "jenkins.io/credentials-description": "sonarqube api token"
+      data:
+        text: >-
+          {{ printf "{{ .password | toString }}" }}
+  data:
+    - secretKey: password
+      remoteRef:
+        key: jenkins-credentials
+        property: sonarqube-api-token


### PR DESCRIPTION
Some additional snippets and guides for Jenkins credentials plugin and Anchore engine using AWS and Hashicorp vault secrets backends.