### PR TITLE
Add Path Parameter to LDAP and JWT/OIDC Hashicorp Vault Auth

### DIFF
--- a/apis/externalsecrets/v1alpha1/secretstore_vault_types.go
+++ b/apis/externalsecrets/v1alpha1/secretstore_vault_types.go
@@ -191,6 +191,11 @@ type VaultLdapAuth struct {
 // VaultJwtAuth authenticates with Vault using the JWT/OIDC authentication
 // method, with the role name and token stored in a Kubernetes Secret resource.
 type VaultJwtAuth struct {
+	// Path where the JWT authentication backend is mounted
+	// in Vault, e.g: "jwt"
+	// +kubebuilder:default=jwt
+	Path string `json:"path"`
+
 	// Role is a JWT role to authenticate using the JWT/OIDC Vault
 	// authentication method
 	// +optional

--- a/apis/externalsecrets/v1alpha1/secretstore_vault_types.go
+++ b/apis/externalsecrets/v1alpha1/secretstore_vault_types.go
@@ -177,7 +177,7 @@ type VaultLdapAuth struct {
 	// in Vault, e.g: "ldap"
 	// +kubebuilder:default=ldap
 	Path string `json:"path"`
-	
+
 	// Username is a LDAP user name used to authenticate using the LDAP Vault
 	// authentication method
 	Username string `json:"username"`

--- a/apis/externalsecrets/v1alpha1/secretstore_vault_types.go
+++ b/apis/externalsecrets/v1alpha1/secretstore_vault_types.go
@@ -173,6 +173,11 @@ type VaultKubernetesAuth struct {
 // VaultLdapAuth authenticates with Vault using the LDAP authentication method,
 // with the username and password stored in a Kubernetes Secret resource.
 type VaultLdapAuth struct {
+	// Path where the LDAP authentication backend is mounted
+	// in Vault, e.g: "ldap"
+	// +kubebuilder:default=ldap
+	Path string `json:"path"`
+	
 	// Username is a LDAP user name used to authenticate using the LDAP Vault
 	// authentication method
 	Username string `json:"username"`

--- a/deploy/crds/external-secrets.io_clustersecretstores.yaml
+++ b/deploy/crds/external-secrets.io_clustersecretstores.yaml
@@ -800,6 +800,11 @@ spec:
                               username/password pair using the LDAP authentication
                               method
                             properties:
+                              path:
+                                default: ldap
+                                description: 'Path where the LDAP authentication backend
+                                  is mounted in Vault, e.g: "ldap"'
+                                type: string
                               secretRef:
                                 description: SecretRef to a key in a Secret resource
                                   containing password for the LDAP user used to authenticate
@@ -828,6 +833,7 @@ spec:
                                   method
                                 type: string
                             required:
+                            - path
                             - username
                             type: object
                           tokenSecretRef:

--- a/deploy/crds/external-secrets.io_clustersecretstores.yaml
+++ b/deploy/crds/external-secrets.io_clustersecretstores.yaml
@@ -704,6 +704,11 @@ spec:
                             description: Jwt authenticates with Vault by passing role
                               and JWT token using the JWT/OIDC authentication method
                             properties:
+                              path:
+                                default: jwt
+                                description: 'Path where the JWT authentication backend
+                                  is mounted in Vault, e.g: "jwt"'
+                                type: string
                               role:
                                 description: Role is a JWT role to authenticate using
                                   the JWT/OIDC Vault authentication method
@@ -730,6 +735,8 @@ spec:
                                       the referent.
                                     type: string
                                 type: object
+                            required:
+                            - path
                             type: object
                           kubernetes:
                             description: Kubernetes authenticates with Vault by passing

--- a/deploy/crds/external-secrets.io_secretstores.yaml
+++ b/deploy/crds/external-secrets.io_secretstores.yaml
@@ -800,6 +800,11 @@ spec:
                               username/password pair using the LDAP authentication
                               method
                             properties:
+                              path:
+                                default: ldap
+                                description: 'Path where the LDAP authentication backend
+                                  is mounted in Vault, e.g: "ldap"'
+                                type: string
                               secretRef:
                                 description: SecretRef to a key in a Secret resource
                                   containing password for the LDAP user used to authenticate
@@ -828,6 +833,7 @@ spec:
                                   method
                                 type: string
                             required:
+                            - path
                             - username
                             type: object
                           tokenSecretRef:

--- a/deploy/crds/external-secrets.io_secretstores.yaml
+++ b/deploy/crds/external-secrets.io_secretstores.yaml
@@ -704,6 +704,11 @@ spec:
                             description: Jwt authenticates with Vault by passing role
                               and JWT token using the JWT/OIDC authentication method
                             properties:
+                              path:
+                                default: jwt
+                                description: 'Path where the JWT authentication backend
+                                  is mounted in Vault, e.g: "jwt"'
+                                type: string
                               role:
                                 description: Role is a JWT role to authenticate using
                                   the JWT/OIDC Vault authentication method
@@ -730,6 +735,8 @@ spec:
                                       the referent.
                                     type: string
                                 type: object
+                            required:
+                            - path
                             type: object
                           kubernetes:
                             description: Kubernetes authenticates with Vault by passing

--- a/docs/provider-hashicorp-vault.md
+++ b/docs/provider-hashicorp-vault.md
@@ -77,10 +77,12 @@ Vault supports only simple key/value pairs - nested objects are not supported. H
 
 ### Authentication
 
-We support three different modes for authentication:
+We support five different modes for authentication:
 [token-based](https://www.vaultproject.io/docs/auth/token),
-[appRole](https://www.vaultproject.io/docs/auth/approle) and
-[kubernetes-native](https://www.vaultproject.io/docs/auth/kubernetes), each one comes with it's own
+[appRole](https://www.vaultproject.io/docs/auth/approle),
+[kubernetes-native](https://www.vaultproject.io/docs/auth/kubernetes),
+[ldap](https://www.vaultproject.io/docs/auth/ldap) and
+[jwt/odic](https://www.vaultproject.io/docs/auth/jwt), each one comes with it's own
 trade-offs. Depending on the authentication method you need to adapt your environment.
 
 #### Token-based authentication

--- a/docs/snippets/vault-jwt-store.yaml
+++ b/docs/snippets/vault-jwt-store.yaml
@@ -13,6 +13,8 @@ spec:
         # VaultJwt authenticates with Vault using the JWT/OIDC auth mechanism
         # https://www.vaultproject.io/docs/auth/jwt
         jwt:
+          # Path where the JWT authentication backend is mounted
+          path: "jwt"
           # JWT role configured in a Vault server, optional.
           role: "vault-jwt-role"
           secretRef:

--- a/docs/snippets/vault-ldap-store.yaml
+++ b/docs/snippets/vault-ldap-store.yaml
@@ -13,7 +13,7 @@ spec:
         # VaultLdap authenticates with Vault using the LDAP auth mechanism
         # https://www.vaultproject.io/docs/auth/ldap
         ldap:
-        # Path where the LDAP authentication backend is mounted
+          # Path where the LDAP authentication backend is mounted
           path: "ldap"
           # LDAP username
           username: "username"

--- a/docs/snippets/vault-ldap-store.yaml
+++ b/docs/snippets/vault-ldap-store.yaml
@@ -13,6 +13,8 @@ spec:
         # VaultLdap authenticates with Vault using the LDAP auth mechanism
         # https://www.vaultproject.io/docs/auth/ldap
         ldap:
+        # Path where the LDAP authentication backend is mounted
+          path: "ldap"
           # LDAP username
           username: "username"
           secretRef:

--- a/e2e/framework/addon/vault.go
+++ b/e2e/framework/addon/vault.go
@@ -57,6 +57,7 @@ type Vault struct {
 	JWTPrivKey         []byte
 	JWTToken           string
 	JWTRole            string
+	JWTPath            string
 	KubernetesAuthPath string
 	KubernetesAuthRole string
 
@@ -160,6 +161,7 @@ func (l *Vault) initVault() error {
 	l.JWTPrivKey = jwtPrivkey
 	l.JWTPubkey = jwtPubkey
 	l.JWTToken = jwtToken
+	l.JWTPath = "myjwt"                                // see configure-vault.sh
 	l.JWTRole = "external-secrets-operator"            // see configure-vault.sh
 	l.KubernetesAuthPath = "mykubernetes"              // see configure-vault.sh
 	l.KubernetesAuthRole = "external-secrets-operator" // see configure-vault.sh

--- a/e2e/k8s/vault-config/configure-vault.sh
+++ b/e2e/k8s/vault-config/configure-vault.sh
@@ -51,17 +51,17 @@ vault write auth/myapprole/role/eso-e2e-role \
     secret_id_num_uses=40
 
 # ------------------
-#   App Role AUTH
+#   JWT AUTH
 #   https://www.vaultproject.io/docs/auth/jwt
 # ------------------
-vault auth enable jwt
+vault auth enable -path=myjwt jwt
 
-vault write auth/jwt/config \
+vault write auth/myjwt/config \
    jwt_validation_pubkeys=@/etc/vault-config/jwt-pubkey.pem \
    bound_issuer="example.iss" \
    default_role="external-secrets-operator"
 
-vault write auth/jwt/role/external-secrets-operator \
+vault write auth/myjwt/role/external-secrets-operator \
     role_type="jwt" \
     bound_subject="vault@example" \
     bound_audiences="vault.client" \

--- a/e2e/suite/vault/provider.go
+++ b/e2e/suite/vault/provider.go
@@ -242,6 +242,7 @@ func (s vaultProvider) CreateJWTStore(v *addon.Vault, ns string) {
 	secretStore := makeStore(jwtProviderName, ns, v)
 	secretStore.Spec.Provider.Vault.Auth = esv1alpha1.VaultAuth{
 		Jwt: &esv1alpha1.VaultJwtAuth{
+			Path: v.JWTPath,
 			Role: v.JWTRole,
 			SecretRef: esmeta.SecretKeySelector{
 				Name: "jwt-provider",

--- a/pkg/provider/vault/vault.go
+++ b/pkg/provider/vault/vault.go
@@ -633,7 +633,7 @@ func (v *client) requestTokenWithLdapAuth(ctx context.Context, client Client, ld
 	parameters := map[string]string{
 		"password": password,
 	}
-	url := strings.Join([]string{"/v1", "auth", "ldap", "login", username}, "/")
+	url := strings.Join([]string{"/v1", "auth", ldapAuth.Path, "login", username}, "/")
 	request := client.NewRequest("POST", url)
 
 	err = request.SetJSONBody(parameters)

--- a/pkg/provider/vault/vault.go
+++ b/pkg/provider/vault/vault.go
@@ -673,7 +673,7 @@ func (v *client) requestTokenWithJwtAuth(ctx context.Context, client Client, jwt
 		"role": role,
 		"jwt":  jwt,
 	}
-	url := strings.Join([]string{"/v1", "auth", "jwt", "login"}, "/")
+	url := strings.Join([]string{"/v1", "auth", jwtAuth.Path, "login"}, "/")
 	request := client.NewRequest("POST", url)
 
 	err = request.SetJSONBody(parameters)


### PR DESCRIPTION
Proposes a fix for issue #540 

The code is based on the same workflow as https://external-secrets.io/provider-hashicorp-vault/#approle-authentication-example

It extends the ask to also include the same fix for the JWT/OIDC authentication method.

Further details on how Hashicorp Vault uses this path can be found on the issue referenced above.