### PR TITLE
Replace vaults with secrets package to retrieve secrets

### DIFF
--- a/pkg/provider/oracle/fake/fake.go
+++ b/pkg/provider/oracle/fake/fake.go
@@ -16,20 +16,20 @@ package fake
 import (
 	"context"
 
-	vault "github.com/oracle/oci-go-sdk/v45/vault"
+	secrets "github.com/oracle/oci-go-sdk/v45/secrets"
 )
 
 type OracleMockClient struct {
-	getSecret func(ctx context.Context, request vault.GetSecretRequest) (response vault.GetSecretResponse, err error)
+	getSecret func(ctx context.Context, request secrets.GetSecretBundleRequest) (response secrets.GetSecretBundleResponse, err error)
 }
 
-func (mc *OracleMockClient) GetSecret(ctx context.Context, request vault.GetSecretRequest) (response vault.GetSecretResponse, err error) {
+func (mc *OracleMockClient) GetSecretBundle(ctx context.Context, request secrets.GetSecretBundleRequest) (response secrets.GetSecretBundleResponse, err error) {
 	return mc.getSecret(ctx, request)
 }
 
-func (mc *OracleMockClient) WithValue(input vault.GetSecretRequest, output vault.GetSecretResponse, err error) {
+func (mc *OracleMockClient) WithValue(input secrets.GetSecretBundleRequest, output secrets.GetSecretBundleResponse, err error) {
 	if mc != nil {
-		mc.getSecret = func(ctx context.Context, paramReq vault.GetSecretRequest) (vault.GetSecretResponse, error) {
+		mc.getSecret = func(ctx context.Context, paramReq secrets.GetSecretBundleRequest) (secrets.GetSecretBundleResponse, error) {
 			return output, err
 		}
 	}

--- a/pkg/provider/oracle/oracle.go
+++ b/pkg/provider/oracle/oracle.go
@@ -140,9 +140,15 @@ func (vms *VaultManagementService) GetSecret(ctx context.Context, ref esv1alpha1
 	if !ok {
 		return nil, fmt.Errorf(errUnexpectedContent)
 	}
+
 	payload, err := base64.StdEncoding.DecodeString(*bt.Content)
+
+	if err != nil {
+		return nil, err
+	}
+
 	if ref.Property == "" {
-		return []byte(payload), nil
+		return payload, nil
 	}
 
 	val := gjson.Get(string(payload), ref.Property)

--- a/pkg/provider/oracle/oracle.go
+++ b/pkg/provider/oracle/oracle.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 
 	"github.com/oracle/oci-go-sdk/v45/common"
-	vault "github.com/oracle/oci-go-sdk/v45/vault"
+	secrets "github.com/oracle/oci-go-sdk/v45/secrets"
 	"github.com/tidwall/gjson"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -47,6 +47,7 @@ const (
 	errMissingFingerprint                    = "missing Fingerprint"
 	errJSONSecretUnmarshal                   = "unable to unmarshal secret: %w"
 	errMissingKey                            = "missing Key in secret: %s"
+	errUnexpectedContent                     = "unexpected secret bundle content"
 	errInvalidSecret                         = "invalid secret received. no secret string nor binary for key: %s"
 )
 
@@ -67,7 +68,7 @@ type VaultManagementService struct {
 }
 
 type VMInterface interface {
-	GetSecret(ctx context.Context, request vault.GetSecretRequest) (response vault.GetSecretResponse, err error)
+	GetSecretBundle(ctx context.Context, request secrets.GetSecretBundleRequest) (response secrets.GetSecretBundleResponse, err error)
 }
 
 func (c *client) setAuth(ctx context.Context) error {
@@ -126,27 +127,26 @@ func (vms *VaultManagementService) GetSecret(ctx context.Context, ref esv1alpha1
 	if utils.IsNil(vms.Client) {
 		return nil, fmt.Errorf(errUninitalizedOracleProvider)
 	}
-	vmsRequest := vault.GetSecretRequest{
+	sec, err := vms.Client.GetSecretBundle(ctx, secrets.GetSecretBundleRequest{
 		SecretId: &ref.Key,
-	}
-	secretOut, err := vms.Client.GetSecret(context.Background(), vmsRequest)
+		Stage:    secrets.GetSecretBundleStageEnum(ref.Version),
+	})
+
 	if err != nil {
 		return nil, util.SanitizeErr(err)
 	}
+	// TODO: should bt.Content be base64 decoded??
+	bt, ok := sec.SecretBundleContent.(secrets.Base64SecretBundleContentDetails)
+	if !ok {
+		return nil, fmt.Errorf(errUnexpectedContent)
+	}
+	payload := *bt.Content
 	if ref.Property == "" {
-		if *secretOut.SecretName != "" {
-			return []byte(*secretOut.SecretName), nil
-		}
-		return nil, fmt.Errorf(errInvalidSecret, ref.Key)
-	}
-	var payload *string
-	if secretOut.SecretName != nil {
-		payload = secretOut.SecretName
+		return []byte(payload), nil
 	}
 
-	payloadval := *payload
+	val := gjson.Get(payload, ref.Property)
 
-	val := gjson.Get(payloadval, ref.Property)
 	if !val.Exists() {
 		return nil, fmt.Errorf(errMissingKey, ref.Key)
 	}
@@ -194,11 +194,11 @@ func (vms *VaultManagementService) NewClient(ctx context.Context, store esv1alph
 
 	configurationProvider := common.NewRawConfigurationProvider(oracleTenancy, oracleUser, oracleRegion, oracleFingerprint, oraclePrivateKey, nil)
 
-	vaultManagementService, err := vault.NewVaultsClientWithConfigurationProvider(configurationProvider)
+	secretManagementService, err := secrets.NewSecretsClientWithConfigurationProvider(configurationProvider)
 	if err != nil {
 		return nil, fmt.Errorf(errOracleClient, err)
 	}
-	vms.Client = vaultManagementService
+	vms.Client = secretManagementService
 	return vms, nil
 }
 

--- a/pkg/provider/oracle/oracle.go
+++ b/pkg/provider/oracle/oracle.go
@@ -13,6 +13,7 @@ package oracle
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 
@@ -139,12 +140,12 @@ func (vms *VaultManagementService) GetSecret(ctx context.Context, ref esv1alpha1
 	if !ok {
 		return nil, fmt.Errorf(errUnexpectedContent)
 	}
-	payload := *bt.Content
+	payload, err := base64.StdEncoding.DecodeString(*bt.Content)
 	if ref.Property == "" {
 		return []byte(payload), nil
 	}
 
-	val := gjson.Get(payload, ref.Property)
+	val := gjson.Get(string(payload), ref.Property)
 
 	if !val.Exists() {
 		return nil, fmt.Errorf(errMissingKey, ref.Key)

--- a/pkg/provider/oracle/oracle.go
+++ b/pkg/provider/oracle/oracle.go
@@ -48,7 +48,6 @@ const (
 	errJSONSecretUnmarshal                   = "unable to unmarshal secret: %w"
 	errMissingKey                            = "missing Key in secret: %s"
 	errUnexpectedContent                     = "unexpected secret bundle content"
-	errInvalidSecret                         = "invalid secret received. no secret string nor binary for key: %s"
 )
 
 type client struct {

--- a/pkg/provider/oracle/oracle_test.go
+++ b/pkg/provider/oracle/oracle_test.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"testing"
 
-	vault "github.com/oracle/oci-go-sdk/v45/vault"
+	secrets "github.com/oracle/oci-go-sdk/v45/secrets"
 	utilpointer "k8s.io/utils/pointer"
 
 	esv1alpha1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
@@ -27,8 +27,8 @@ import (
 
 type vaultTestCase struct {
 	mockClient     *fakeoracle.OracleMockClient
-	apiInput       *vault.GetSecretRequest
-	apiOutput      *vault.GetSecretResponse
+	apiInput       *secrets.GetSecretBundleRequest
+	apiOutput      *secrets.GetSecretBundleResponse
 	ref            *esv1alpha1.ExternalSecretDataRemoteRef
 	apiErr         error
 	expectError    string
@@ -59,16 +59,16 @@ func makeValidRef() *esv1alpha1.ExternalSecretDataRemoteRef {
 	}
 }
 
-func makeValidAPIInput() *vault.GetSecretRequest {
-	return &vault.GetSecretRequest{
+func makeValidAPIInput() *secrets.GetSecretBundleRequest {
+	return &secrets.GetSecretBundleRequest{
 		SecretId: utilpointer.StringPtr("test-secret"),
 	}
 }
 
-func makeValidAPIOutput() *vault.GetSecretResponse {
-	return &vault.GetSecretResponse{
-		Etag:   utilpointer.StringPtr("test-name"),
-		Secret: vault.Secret{},
+func makeValidAPIOutput() *secrets.GetSecretBundleResponse {
+	return &secrets.GetSecretBundleResponse{
+		Etag:         utilpointer.StringPtr("test-name"),
+		SecretBundle: secrets.SecretBundle{},
 	}
 }
 
@@ -98,12 +98,11 @@ func TestOracleVaultGetSecret(t *testing.T) {
 	// good case: default version is set
 	// key is passed in, output is sent back
 	setSecretString := func(smtc *vaultTestCase) {
-		smtc.apiOutput = &vault.GetSecretResponse{
+		smtc.apiOutput = &secrets.GetSecretBundleResponse{
 			Etag: utilpointer.StringPtr("test-name"),
-			Secret: vault.Secret{
-				CompartmentId: utilpointer.StringPtr("test-compartment-id"),
-				Id:            utilpointer.StringPtr("test-id"),
-				SecretName:    utilpointer.StringPtr("changedvalue"),
+			SecretBundle: secrets.SecretBundle{
+				SecretId:            ,
+				SecretBundleContent: ,
 			},
 		}
 		smtc.expectedSecret = secretValue

--- a/pkg/provider/oracle/oracle_test.go
+++ b/pkg/provider/oracle/oracle_test.go
@@ -101,8 +101,11 @@ func TestOracleVaultGetSecret(t *testing.T) {
 		smtc.apiOutput = &secrets.GetSecretBundleResponse{
 			Etag: utilpointer.StringPtr("test-name"),
 			SecretBundle: secrets.SecretBundle{
-				SecretId:            ,
-				SecretBundleContent: ,
+				SecretId: utilpointer.StringPtr("test-id"),
+				VersionNumber: utilpointer.Int64(1),
+				SecretBundleContent: secrets.Base64SecretBundleContentDetails{
+					Content: utilpointer.StringPtr(secretValue),
+				},
 			},
 		}
 		smtc.expectedSecret = secretValue

--- a/pkg/provider/oracle/oracle_test.go
+++ b/pkg/provider/oracle/oracle_test.go
@@ -13,6 +13,7 @@ package oracle
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"reflect"
 	"strings"
@@ -104,7 +105,7 @@ func TestOracleVaultGetSecret(t *testing.T) {
 				SecretId:      utilpointer.StringPtr("test-id"),
 				VersionNumber: utilpointer.Int64(1),
 				SecretBundleContent: secrets.Base64SecretBundleContentDetails{
-					Content: utilpointer.StringPtr(secretValue),
+					Content: utilpointer.StringPtr(base64.StdEncoding.EncodeToString([]byte(secretValue))),
 				},
 			},
 		}
@@ -135,7 +136,7 @@ func TestGetSecretMap(t *testing.T) {
 	// good case: default version & deserialization
 	setDeserialization := func(smtc *vaultTestCase) {
 		smtc.apiOutput.SecretBundleContent = secrets.Base64SecretBundleContentDetails{
-			Content: utilpointer.StringPtr(`{"foo":"bar"}`),
+			Content: utilpointer.StringPtr(base64.StdEncoding.EncodeToString([]byte(`{"foo":"bar"}`))),
 		}
 		smtc.expectedData["foo"] = []byte("bar")
 	}
@@ -143,7 +144,7 @@ func TestGetSecretMap(t *testing.T) {
 	// bad case: invalid json
 	setInvalidJSON := func(smtc *vaultTestCase) {
 		smtc.apiOutput.SecretBundleContent = secrets.Base64SecretBundleContentDetails{
-			Content: utilpointer.StringPtr(`-----------------`),
+			Content: utilpointer.StringPtr(base64.StdEncoding.EncodeToString([]byte(`-----------------`))),
 		}
 		smtc.expectError = "unable to unmarshal secret"
 	}

--- a/pkg/provider/oracle/oracle_test.go
+++ b/pkg/provider/oracle/oracle_test.go
@@ -101,7 +101,7 @@ func TestOracleVaultGetSecret(t *testing.T) {
 		smtc.apiOutput = &secrets.GetSecretBundleResponse{
 			Etag: utilpointer.StringPtr("test-name"),
 			SecretBundle: secrets.SecretBundle{
-				SecretId: utilpointer.StringPtr("test-id"),
+				SecretId:      utilpointer.StringPtr("test-id"),
 				VersionNumber: utilpointer.Int64(1),
 				SecretBundleContent: secrets.Base64SecretBundleContentDetails{
 					Content: utilpointer.StringPtr(secretValue),
@@ -134,13 +134,17 @@ func TestOracleVaultGetSecret(t *testing.T) {
 func TestGetSecretMap(t *testing.T) {
 	// good case: default version & deserialization
 	setDeserialization := func(smtc *vaultTestCase) {
-		smtc.apiOutput.SecretName = utilpointer.StringPtr(`{"foo":"bar"}`)
+		smtc.apiOutput.SecretBundleContent = secrets.Base64SecretBundleContentDetails{
+			Content: utilpointer.StringPtr(`{"foo":"bar"}`),
+		}
 		smtc.expectedData["foo"] = []byte("bar")
 	}
 
 	// bad case: invalid json
 	setInvalidJSON := func(smtc *vaultTestCase) {
-		smtc.apiOutput.SecretName = utilpointer.StringPtr(`-----------------`)
+		smtc.apiOutput.SecretBundleContent = secrets.Base64SecretBundleContentDetails{
+			Content: utilpointer.StringPtr(`-----------------`),
+		}
 		smtc.expectError = "unable to unmarshal secret"
 	}
 


### PR DESCRIPTION
Proposes a fix for issue #504.

Replaces the OCI `vaults` package for `secrets` to retrieve the secrets using `secrets.GetSecretBundle()`.

I couldn't create an OCI account so I was unable to test and check the payload.