### PR TITLE
change ExternalSecret example to use SecretStore

### DIFF
--- a/docs/provider-hashicorp-vault.md
+++ b/docs/provider-hashicorp-vault.md
@@ -54,7 +54,7 @@ spec:
   refreshInterval: "15s"
   secretStoreRef:
     name: vault-backend
-    kind: ClusterSecretStore
+    kind: SecretStore
   target:
     name: example-sync
   data:


### PR DESCRIPTION
The basic ExternalSecret example is referencing a ClusterSecretStore
while all of the examples of configuring a provider are a /SecretStore/.
This means that a new user try to cut'n'paste the examples will be
unable to create a working demo without reading the API reference.