### PR TITLE
fix: force ownership when merging secrets

### DIFF
--- a/pkg/controllers/externalsecret/externalsecret_controller.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller.go
@@ -279,10 +279,9 @@ func patchSecret(ctx context.Context, c client.Client, scheme *runtime.Scheme, s
 	if !unversioned && len(gvks) == 1 {
 		secret.SetGroupVersionKind(gvks[0])
 	}
-	// we might get into a conflict here if we are not the manager of that particular field
-	// we do not resolve the conflict and return an error instead
-	// see: https://kubernetes.io/docs/reference/using-api/server-side-apply/#conflicts
-	err = c.Patch(ctx, secret, client.Apply, client.FieldOwner("external-secrets"))
+	// we're not able to resolve conflicts so we force ownership
+	// see: https://kubernetes.io/docs/reference/using-api/server-side-apply/#using-server-side-apply-in-a-controller
+	err = c.Patch(ctx, secret, client.Apply, client.FieldOwner("external-secrets"), client.ForceOwnership)
 	if err != nil {
 		return fmt.Errorf(errPolicyMergePatch, secret.Name, err)
 	}


### PR DESCRIPTION
fixes #583 

It seems like there is an issue when mixing operation=Update and operation=Apply; It's best described here: https://github.com/kubernetes/kubernetes/issues/80916#issuecomment-525049458 - it looks like we can't do server-side apply with client-side applied resources.

IMO we should force ownership of the fields we care about.

[docs](https://kubernetes.io/docs/reference/using-api/server-side-apply/#using-server-side-apply-in-a-controller) say:
> It is strongly recommended for controllers to always "force" conflicts, since they might not be able to resolve or act on these conflicts. 



