### PR TITLE
fix: gen-docs version update

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+env:
+  # Common versions
+  GO_VERSION: '1.17'
+
 jobs:
   deploy:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
deploy docs job fails on main, it seems to use a old go version 1.15.x