### PR TITLE
OCI Vault: Get secret by name from a specific Vault

### DIFF
--- a/apis/externalsecrets/v1alpha1/secretstore_oracle_types.go
+++ b/apis/externalsecrets/v1alpha1/secretstore_oracle_types.go
@@ -30,6 +30,9 @@ type OracleProvider struct {
 
 	// Region is the region where secret is located.
 	Region string `json:"region,omitempty"`
+
+	// Vault is the vault's OCID of the specific vault where secret is located.
+	Vault string `json:"vault,omitempty"`
 }
 
 type OracleAuth struct {

--- a/apis/externalsecrets/v1alpha1/secretstore_oracle_types.go
+++ b/apis/externalsecrets/v1alpha1/secretstore_oracle_types.go
@@ -25,10 +25,10 @@ type OracleProvider struct {
 	// User is an access OCID specific to the account.
 	User string `json:"user,omitempty"`
 
-	// projectID is an access token specific to the secret.
+	// Tenancy is the tenancy OCID where secret is located.
 	Tenancy string `json:"tenancy,omitempty"`
 
-	// projectID is an access token specific to the secret.
+	// Region is the region where secret is located.
 	Region string `json:"region,omitempty"`
 }
 
@@ -38,9 +38,9 @@ type OracleAuth struct {
 }
 
 type OracleSecretRef struct {
-	// The Access Token is used for authentication
+	// PrivateKey is the user's API Signing Key in PEM format, used for authentication.
 	PrivateKey esmeta.SecretKeySelector `json:"privatekey,omitempty"`
 
-	// projectID is an access token specific to the secret.
+	// Fingerprint is the fingerprint of the API private key.
 	Fingerprint esmeta.SecretKeySelector `json:"fingerprint,omitempty"`
 }

--- a/deploy/crds/external-secrets.io_clustersecretstores.yaml
+++ b/deploy/crds/external-secrets.io_clustersecretstores.yaml
@@ -541,8 +541,8 @@ spec:
                             description: SecretRef to pass through sensitive information.
                             properties:
                               fingerprint:
-                                description: projectID is an access token specific
-                                  to the secret.
+                                description: Fingerprint is the fingerprint of the
+                                  API private key.
                                 properties:
                                   key:
                                     description: The key of the entry in the Secret
@@ -562,7 +562,8 @@ spec:
                                     type: string
                                 type: object
                               privatekey:
-                                description: The Access Token is used for authentication
+                                description: PrivateKey is the user's API Signing
+                                  Key in PEM format, used for authentication.
                                 properties:
                                   key:
                                     description: The key of the entry in the Secret
@@ -586,12 +587,10 @@ spec:
                         - secretRef
                         type: object
                       region:
-                        description: projectID is an access token specific to the
-                          secret.
+                        description: Region is the region where secret is located.
                         type: string
                       tenancy:
-                        description: projectID is an access token specific to the
-                          secret.
+                        description: Tenancy is the tenancy OCID where secret is located.
                         type: string
                       user:
                         description: User is an access OCID specific to the account.

--- a/deploy/crds/external-secrets.io_clustersecretstores.yaml
+++ b/deploy/crds/external-secrets.io_clustersecretstores.yaml
@@ -595,6 +595,10 @@ spec:
                       user:
                         description: User is an access OCID specific to the account.
                         type: string
+                      vault:
+                        description: Vault is the vault's OCID of the specific vault
+                          where secret is located.
+                        type: string
                     required:
                     - auth
                     type: object

--- a/deploy/crds/external-secrets.io_secretstores.yaml
+++ b/deploy/crds/external-secrets.io_secretstores.yaml
@@ -541,8 +541,8 @@ spec:
                             description: SecretRef to pass through sensitive information.
                             properties:
                               fingerprint:
-                                description: projectID is an access token specific
-                                  to the secret.
+                                description: Fingerprint is the fingerprint of the
+                                  API private key.
                                 properties:
                                   key:
                                     description: The key of the entry in the Secret
@@ -562,7 +562,8 @@ spec:
                                     type: string
                                 type: object
                               privatekey:
-                                description: The Access Token is used for authentication
+                                description: PrivateKey is the user's API Signing
+                                  Key in PEM format, used for authentication.
                                 properties:
                                   key:
                                     description: The key of the entry in the Secret
@@ -586,12 +587,10 @@ spec:
                         - secretRef
                         type: object
                       region:
-                        description: projectID is an access token specific to the
-                          secret.
+                        description: Region is the region where secret is located.
                         type: string
                       tenancy:
-                        description: projectID is an access token specific to the
-                          secret.
+                        description: Tenancy is the tenancy OCID where secret is located.
                         type: string
                       user:
                         description: User is an access OCID specific to the account.

--- a/deploy/crds/external-secrets.io_secretstores.yaml
+++ b/deploy/crds/external-secrets.io_secretstores.yaml
@@ -595,6 +595,10 @@ spec:
                       user:
                         description: User is an access OCID specific to the account.
                         type: string
+                      vault:
+                        description: Vault is the vault's OCID of the specific vault
+                          where secret is located.
+                        type: string
                     required:
                     - auth
                     type: object

--- a/docs/provider-oracle-vault.md
+++ b/docs/provider-oracle-vault.md
@@ -32,7 +32,7 @@ This will automatically generate a fingerprint.
 ![API-key-details](./pictures/screenshot_API_key.png)
 
 ### Update secret store
-Be sure the `oracle` provider is listed in the `Kind=SecretStore`
+Be sure the `oracle` provider is listed in the `Kind=SecretStore`.
 
 ```yaml
 {% include 'oracle-secret-store.yaml' %}

--- a/docs/snippets/oracle-external-secret.yaml
+++ b/docs/snippets/oracle-external-secret.yaml
@@ -10,7 +10,5 @@ spec:
   target:
     name: secret-to-be-created # Name for the secret on the cluster
     creationPolicy: Owner
-  data:
-  - secretKey: 
-    remoteRef:
-      key: 
+  dataFrom:
+    - key: the-secret-name

--- a/docs/snippets/oracle-secret-store.yaml
+++ b/docs/snippets/oracle-secret-store.yaml
@@ -5,9 +5,10 @@ metadata:
 spec:
   provider:
     oracle: #Needs to match value in secretstore_types.go
-      user: 
-      tenancy: 
-      region: 
+      vault: # The vault OCID
+      user:
+      tenancy:
+      region:
       auth:
         secretRef:
           privatekey:

--- a/pkg/provider/oracle/fake/fake.go
+++ b/pkg/provider/oracle/fake/fake.go
@@ -20,16 +20,16 @@ import (
 )
 
 type OracleMockClient struct {
-	getSecret func(ctx context.Context, request secrets.GetSecretBundleRequest) (response secrets.GetSecretBundleResponse, err error)
+	getSecret func(ctx context.Context, request secrets.GetSecretBundleByNameRequest) (response secrets.GetSecretBundleByNameResponse, err error)
 }
 
-func (mc *OracleMockClient) GetSecretBundle(ctx context.Context, request secrets.GetSecretBundleRequest) (response secrets.GetSecretBundleResponse, err error) {
+func (mc *OracleMockClient) GetSecretBundleByName(ctx context.Context, request secrets.GetSecretBundleByNameRequest) (response secrets.GetSecretBundleByNameResponse, err error) {
 	return mc.getSecret(ctx, request)
 }
 
-func (mc *OracleMockClient) WithValue(input secrets.GetSecretBundleRequest, output secrets.GetSecretBundleResponse, err error) {
+func (mc *OracleMockClient) WithValue(input secrets.GetSecretBundleByNameRequest, output secrets.GetSecretBundleByNameResponse, err error) {
 	if mc != nil {
-		mc.getSecret = func(ctx context.Context, paramReq secrets.GetSecretBundleRequest) (secrets.GetSecretBundleResponse, error) {
+		mc.getSecret = func(ctx context.Context, paramReq secrets.GetSecretBundleByNameRequest) (secrets.GetSecretBundleByNameResponse, error) {
 			return output, err
 		}
 	}

--- a/pkg/provider/oracle/oracle_test.go
+++ b/pkg/provider/oracle/oracle_test.go
@@ -28,8 +28,8 @@ import (
 
 type vaultTestCase struct {
 	mockClient     *fakeoracle.OracleMockClient
-	apiInput       *secrets.GetSecretBundleRequest
-	apiOutput      *secrets.GetSecretBundleResponse
+	apiInput       *secrets.GetSecretBundleByNameRequest
+	apiOutput      *secrets.GetSecretBundleByNameResponse
 	ref            *esv1alpha1.ExternalSecretDataRemoteRef
 	apiErr         error
 	expectError    string
@@ -60,15 +60,15 @@ func makeValidRef() *esv1alpha1.ExternalSecretDataRemoteRef {
 	}
 }
 
-func makeValidAPIInput() *secrets.GetSecretBundleRequest {
-	return &secrets.GetSecretBundleRequest{
-		SecretId: utilpointer.StringPtr("test-secret"),
+func makeValidAPIInput() *secrets.GetSecretBundleByNameRequest {
+	return &secrets.GetSecretBundleByNameRequest{
+		SecretName: utilpointer.StringPtr("test-secret"),
+		VaultId: utilpointer.StringPtr("test-vault"),
 	}
 }
 
-func makeValidAPIOutput() *secrets.GetSecretBundleResponse {
-	return &secrets.GetSecretBundleResponse{
-		Etag:         utilpointer.StringPtr("test-name"),
+func makeValidAPIOutput() *secrets.GetSecretBundleByNameResponse {
+	return &secrets.GetSecretBundleByNameResponse{
 		SecretBundle: secrets.SecretBundle{},
 	}
 }
@@ -99,8 +99,7 @@ func TestOracleVaultGetSecret(t *testing.T) {
 	// good case: default version is set
 	// key is passed in, output is sent back
 	setSecretString := func(smtc *vaultTestCase) {
-		smtc.apiOutput = &secrets.GetSecretBundleResponse{
-			Etag: utilpointer.StringPtr("test-name"),
+		smtc.apiOutput = &secrets.GetSecretBundleByNameResponse{
 			SecretBundle: secrets.SecretBundle{
 				SecretId:      utilpointer.StringPtr("test-id"),
 				VersionNumber: utilpointer.Int64(1),

--- a/pkg/provider/oracle/oracle_test.go
+++ b/pkg/provider/oracle/oracle_test.go
@@ -63,7 +63,7 @@ func makeValidRef() *esv1alpha1.ExternalSecretDataRemoteRef {
 func makeValidAPIInput() *secrets.GetSecretBundleByNameRequest {
 	return &secrets.GetSecretBundleByNameRequest{
 		SecretName: utilpointer.StringPtr("test-secret"),
-		VaultId: utilpointer.StringPtr("test-vault"),
+		VaultId:    utilpointer.StringPtr("test-vault"),
 	}
 }
 


### PR DESCRIPTION
Following to https://github.com/external-secrets/external-secrets/issues/587
add Vault ID field to the SecretStore, then use the ExternalSecret's key as a secret name in the provided Vault.