### PR TITLE
fix(metrics): ensure status_condition metrics reflect the status

### DIFF
--- a/pkg/controllers/externalsecret/metrics.go
+++ b/pkg/controllers/externalsecret/metrics.go
@@ -52,7 +52,6 @@ var (
 // updateExternalSecretCondition updates the ExternalSecret conditions.
 func updateExternalSecretCondition(es *esv1alpha1.ExternalSecret, condition *esv1alpha1.ExternalSecretStatusCondition, value float64) {
 	switch condition.Type {
-
 	case esv1alpha1.ExternalSecretDeleted:
 		// Remove condition=Ready metrics when the object gets deleted.
 		externalSecretCondition.Delete(prometheus.Labels{
@@ -86,6 +85,9 @@ func updateExternalSecretCondition(es *esv1alpha1.ExternalSecret, condition *esv
 				"status":    string(v1.ConditionFalse),
 			}).Set(0)
 		}
+
+	default:
+		break
 	}
 
 	externalSecretCondition.With(prometheus.Labels{

--- a/pkg/controllers/externalsecret/metrics.go
+++ b/pkg/controllers/externalsecret/metrics.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	esv1alpha1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
+	v1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -50,6 +51,43 @@ var (
 
 // updateExternalSecretCondition updates the ExternalSecret conditions.
 func updateExternalSecretCondition(es *esv1alpha1.ExternalSecret, condition *esv1alpha1.ExternalSecretStatusCondition, value float64) {
+	switch condition.Type {
+
+	case esv1alpha1.ExternalSecretDeleted:
+		// Remove condition=Ready metrics when the object gets deleted.
+		externalSecretCondition.Delete(prometheus.Labels{
+			"name":      es.Name,
+			"namespace": es.Namespace,
+			"condition": string(esv1alpha1.ExternalSecretReady),
+			"status":    string(v1.ConditionFalse),
+		})
+		externalSecretCondition.Delete(prometheus.Labels{
+			"name":      es.Name,
+			"namespace": es.Namespace,
+			"condition": string(esv1alpha1.ExternalSecretReady),
+			"status":    string(v1.ConditionTrue),
+		})
+
+	case esv1alpha1.ExternalSecretReady:
+		// Toggle opposite Status to 0
+		switch condition.Status {
+		case v1.ConditionFalse:
+			externalSecretCondition.With(prometheus.Labels{
+				"name":      es.Name,
+				"namespace": es.Namespace,
+				"condition": string(esv1alpha1.ExternalSecretReady),
+				"status":    string(v1.ConditionTrue),
+			}).Set(0)
+		case v1.ConditionTrue:
+			externalSecretCondition.With(prometheus.Labels{
+				"name":      es.Name,
+				"namespace": es.Namespace,
+				"condition": string(esv1alpha1.ExternalSecretReady),
+				"status":    string(v1.ConditionFalse),
+			}).Set(0)
+		}
+	}
+
 	externalSecretCondition.With(prometheus.Labels{
 		"name":      es.Name,
 		"namespace": es.Namespace,

--- a/pkg/controllers/externalsecret/metrics.go
+++ b/pkg/controllers/externalsecret/metrics.go
@@ -16,10 +16,10 @@ package externalsecret
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	esv1alpha1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
-	v1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -68,6 +68,19 @@ func updateExternalSecretCondition(es *esv1alpha1.ExternalSecret, condition *esv
 		})
 
 	case esv1alpha1.ExternalSecretReady:
+		// Remove condition=Deleted metrics when the object gets ready.
+		externalSecretCondition.Delete(prometheus.Labels{
+			"name":      es.Name,
+			"namespace": es.Namespace,
+			"condition": string(esv1alpha1.ExternalSecretDeleted),
+			"status":    string(v1.ConditionFalse),
+		})
+		externalSecretCondition.Delete(prometheus.Labels{
+			"name":      es.Name,
+			"namespace": es.Namespace,
+			"condition": string(esv1alpha1.ExternalSecretDeleted),
+			"status":    string(v1.ConditionTrue),
+		})
 		// Toggle opposite Status to 0
 		switch condition.Status {
 		case v1.ConditionFalse:
@@ -84,6 +97,10 @@ func updateExternalSecretCondition(es *esv1alpha1.ExternalSecret, condition *esv
 				"condition": string(esv1alpha1.ExternalSecretReady),
 				"status":    string(v1.ConditionFalse),
 			}).Set(0)
+		case v1.ConditionUnknown:
+			break
+		default:
+			break
 		}
 
 	default:


### PR DESCRIPTION
ref: #471

This is an initial attempt at tackling #417, I've kept the logic fairly simple in
metrics.go.

It might be better off being implemented elsewhere. (in `SetExternalSecretCondition`
perhaps?)
