### PR TITLE
feat(docs): add proposal process, add bi-weekly meeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ Even though we have active maintainers and people assigned to this project, we k
 
 We welcome and encourage contributions to this project! Please read the [Developer](https://www.external-secrets.io/contributing-devguide/) and [Contribution process](https://www.external-secrets.io/contributing-process/) guides. Also make sure to check the [Code of Conduct](https://www.external-secrets.io/contributing-coc/) and adhere to its guidelines.
 
+## Bi-weekly Development Meeting
+
+We host our development meeting every odd wednesday at [5:30 PM Berlin Time](https://dateful.com/time-zone-converter?t=17:30&tz=Europe/Berlin) on [Jitsi](https://meet.jit.si/SurroundingContentionsImportSubsequently). Meeting notes are recorded on [hackmd](https://hackmd.io/GSGEpTVdRZCP6LDxV3FHJA).
+
+Anyone is welcome to join. Feel free to ask questions, request feedback, raise awareness for an issue or just say hi ;)
+
 ## Security
 
 Please report vulnerabilities by email to contact@external-secrets.io, also see our [security policy](SECURITY.md) for details.

--- a/design/000-template.md
+++ b/design/000-template.md
@@ -1,0 +1,61 @@
+```yaml
+---
+title: My Shiny New Feature
+version: v1alpha1
+authors: you, me
+creation-date: 2020-09-01
+status: draft
+---
+```
+
+# My Shiny New Feature
+
+## Table of Contents
+
+<!-- toc -->
+// autogen please
+<!-- /toc -->
+
+
+## Summary
+Please provide a summary of this proposal.
+
+## Motivation
+What is the motivation of this proposal? Why is it useful and relevant?
+
+### Goals
+What are the goals of this proposal, what's the problem we want to solve?
+
+### Non-Goals
+What are explicit non-goals of this proposal?
+
+## Proposal
+How does the proposal look like?
+
+### User Stories
+How would users use this feature, what are their needs?
+
+### API
+Please describe the API (CRD or other) and show some examples.
+
+### Behavior
+How should the new CRD or feature behave? Are there edge cases?
+
+### Drawbacks
+If we implement this feature, what are drawbacks and disadvantages of this approach?
+
+### Acceptance Criteria
+What does it take to make this feature producation ready? Please take the time to think about:
+* how would you rollout this feature and rollback if it causes harm?
+* Test Roadmap: what kinds of tests do we want to ensure a good user experience?
+* observability: Do users need to get insights into the inner workings of that feature?
+* monitoring: How can users tell whether the feature is working as expected or not?
+              can we provide dashboards, metrics, reasonable SLIs/SLOs
+              or example alerts for this feature?
+* troubleshooting: How would users want to troubleshoot this particular feature?
+                   Think about different failure modes of this feature.
+
+## Alternatives
+What alternatives do we have and what are their pros and cons?
+
+

--- a/design/design-crd-spec.md
+++ b/design/design-crd-spec.md
@@ -4,7 +4,7 @@ title: External Secrets Operator CRD
 version: v1alpha1
 authors: all of us
 creation-date: 2020-09-01
-status: draft
+status: accepted
 ---
 ```
 

--- a/docs/contributing-process.md
+++ b/docs/contributing-process.md
@@ -26,9 +26,22 @@ be merged:
 * PR needs be reviewed and approved
 
 Once these steps are completed the PR will be merged by a code owner.
+We're using the pull request `assignee` feature to track who is responsible
+for the lifecycle of the PR: review, merging, ping on inactivity, close.
+We close pull requests or issues if there is no response from the author for
+a period of time. Feel free to reopen if you want to get back on it.
 
+## Proposal Process
+Before we introduce significant changes to the project we want to gather feedback
+from the community to ensure that we progress in the right direction before we
+develop and release big changes. Significant changes include for example:
+* creating new custom resources
+* proposing breaking changes
+* changing the behavior of the controller significantly
+
+Please create a document in the `design/` directory based on the template `000-template.md`
+and fill in your proposal. Open a pull request in draft mode and request feedback. Once the proposal is accepted and the pull request is merged we can create work packages and proceed with the implementation.
 
 ## Cutting Releases
 
-As of now this project is in an early alpha phase. There is just the main branch
-;)
+The external-secrets project is released on a as-needed basis. Feel free to open a issue to request a release. Details on how to cut a release can be found in the `RELEASE.md` file in the repo.

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,8 +39,8 @@ even opinions matter!
 
 How to get involved:
 
-- Monthly Meeting: we announce our meetings on slack
-  ([agenda](https://hackmd.io/GSGEpTVdRZCP6LDxV3FHJA))
+- Bi-weekly Development Meeting every odd week at [5:30 PM Berlin Time](https://dateful.com/time-zone-converter?t=17:30&tz=Europe/Berlin)
+  ([agenda](https://hackmd.io/GSGEpTVdRZCP6LDxV3FHJA), [jitsi call](https://meet.jit.si/SurroundingContentionsImportSubsequently))
 - [Kubernetes Slack
   #external-secrets](https://kubernetes.slack.com/messages/external-secrets)
 - [Contributing Process](contributing-process.md)

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1956,7 +1956,7 @@ string
 </em>
 </td>
 <td>
-<p>projectID is an access token specific to the secret.</p>
+<p>Tenancy is the tenancy OCID where secret is located.</p>
 </td>
 </tr>
 <tr>
@@ -1967,7 +1967,18 @@ string
 </em>
 </td>
 <td>
-<p>projectID is an access token specific to the secret.</p>
+<p>Region is the region where secret is located.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>vault</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Vault is the vault&rsquo;s OCID of the specific vault where secret is located.</p>
 </td>
 </tr>
 </tbody>
@@ -1996,7 +2007,7 @@ github.com/external-secrets/external-secrets/apis/meta/v1.SecretKeySelector
 </em>
 </td>
 <td>
-<p>The Access Token is used for authentication</p>
+<p>PrivateKey is the user&rsquo;s API Signing Key in PEM format, used for authentication.</p>
 </td>
 </tr>
 <tr>
@@ -2007,7 +2018,7 @@ github.com/external-secrets/external-secrets/apis/meta/v1.SecretKeySelector
 </em>
 </td>
 <td>
-<p>projectID is an access token specific to the secret.</p>
+<p>Fingerprint is the fingerprint of the API private key.</p>
 </td>
 </tr>
 </tbody>
@@ -3194,6 +3205,36 @@ CAProvider
 <td>
 <em>(Optional)</em>
 <p>The provider for the CA bundle to use to validate Vault server certificate.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>readYourWrites</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ReadYourWrites ensures isolated read-after-write semantics by
+providing discovered cluster replication states in each request.
+More information about eventual consistency in Vault can be found here
+<a href="https://www.vaultproject.io/docs/enterprise/consistency">https://www.vaultproject.io/docs/enterprise/consistency</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>forwardInconsistent</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ForwardInconsistent tells Vault to forward read-after-write requests to the Vault
+leader instead of simply retrying within a loop. This can increase performance if
+the option is enabled serverside.
+<a href="https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header">https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header</a></p>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
As discussed in the community meeting i added docs for:
1. proposal process + template
2. bi-weekly development meeting
3. a note about PR-close 

PTAL and add things to the proposal template if something is missing. The template is a stripped version of the KEP template.