### PR TITLE
Updating path name for kubernetes auth in Vault provider

### DIFF
--- a/apis/externalsecrets/v1alpha1/secretstore_vault_types.go
+++ b/apis/externalsecrets/v1alpha1/secretstore_vault_types.go
@@ -164,7 +164,7 @@ type VaultKubernetesAuth struct {
 	// Path where the Kubernetes authentication backend is mounted in Vault, e.g:
 	// "kubernetes"
 	// +kubebuilder:default=kubernetes
-	Path string `json:"mountPath"`
+	Path string `json:"path"`
 
 	// Optional service account field containing the name of a kubernetes ServiceAccount.
 	// If the service account is specified, the service account secret token JWT will be used

--- a/deploy/crds/external-secrets.io_clustersecretstores.yaml
+++ b/deploy/crds/external-secrets.io_clustersecretstores.yaml
@@ -746,7 +746,7 @@ spec:
                               the ServiceAccount token stored in the named Secret
                               resource to the Vault server.
                             properties:
-                              mountPath:
+                              path:
                                 default: kubernetes
                                 description: 'Path where the Kubernetes authentication
                                   backend is mounted in Vault, e.g: "kubernetes"'
@@ -802,7 +802,7 @@ spec:
                                 - name
                                 type: object
                             required:
-                            - mountPath
+                            - path
                             - role
                             type: object
                           ldap:

--- a/deploy/crds/external-secrets.io_secretstores.yaml
+++ b/deploy/crds/external-secrets.io_secretstores.yaml
@@ -746,7 +746,7 @@ spec:
                               the ServiceAccount token stored in the named Secret
                               resource to the Vault server.
                             properties:
-                              mountPath:
+                              path:
                                 default: kubernetes
                                 description: 'Path where the Kubernetes authentication
                                   backend is mounted in Vault, e.g: "kubernetes"'
@@ -802,7 +802,7 @@ spec:
                                 - name
                                 type: object
                             required:
-                            - mountPath
+                            - path
                             - role
                             type: object
                           ldap:

--- a/docs/snippets/vault-kubernetes-store.yaml
+++ b/docs/snippets/vault-kubernetes-store.yaml
@@ -15,7 +15,7 @@ spec:
         # https://www.vaultproject.io/docs/auth/kubernetes
         kubernetes:
           # Path where the Kubernetes authentication backend is mounted in Vault
-          mountPath: "kubernetes"
+          path: "kubernetes"
           # A required field containing the Vault Role to assume.
           role: "demo"
           # Optional service account field containing the name


### PR DESCRIPTION
This PR standardizes Vault Provider auth calls. 

Before this PR, Kubernetes Mount Path was being built on 'mountPath', where all other authentication methods such as AppRole, JWT, etc, are using 'path'.


This PR introduces a breaking change.


Signed-off-by: Gustavo Carvalho <gustavo.carvalho@container-solutions.com>