### PR TITLE
fix: webhook test race

### DIFF
--- a/pkg/provider/webhook/webhook_test.go
+++ b/pkg/provider/webhook/webhook_test.go
@@ -298,7 +298,9 @@ func testGetSecret(tc testCase, t *testing.T, client provider.SecretsClient) {
 		Key:     tc.Args.Key,
 		Version: tc.Args.Version,
 	}
-	secret, err := client.GetSecret(context.Background(), testRef)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	secret, err := client.GetSecret(ctx, testRef)
 	errStr := ""
 	if err != nil {
 		errStr = err.Error()


### PR DESCRIPTION
webhook unit tests fail sometimes with

```
webhook_test.go:307: error timeout: unexpected error: 
'failed to call endpoint: Get "http://127.0.0.1:43551/api/getsecret?id=testkey&version=1": 
dial tcp 127.0.0.1:43551: i/o timeout 
(Client.Timeout exceeded while awaiting headers)' (expected 'context deadline exceeded')
```

This can be reproduced like this:
```
go test -race -failfast -count=2000 -v ./pkg/provider/webhook
```

This PR fixes this issue by using a context *with* timeout (seems weird, but [this](https://cs.opensource.google/go/go/+/refs/tags/go1.17.6:src/net/http/client.go;l=354;drc=refs%2Ftags%2Fgo1.17.6) is the reason). 