### PR TITLE
Adds handling when HashiVault value is still a map[string]interface{}

### DIFF
--- a/pkg/provider/vault/vault.go
+++ b/pkg/provider/vault/vault.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -253,6 +254,12 @@ func (v *client) readSecret(ctx context.Context, path, version string) (map[stri
 			byteMap[k] = t
 		case nil:
 			byteMap[k] = []byte(nil)
+		case map[string]interface{}:
+			jsonData, err := json.Marshal(t)
+			if err != nil {
+				return nil, err
+			}
+			byteMap[k] = jsonData
 		default:
 			return nil, errors.New(errSecretFormat)
 		}


### PR DESCRIPTION
This PR fixes GetSecretMap not handling json values for Vault Provider.


Fixes #649

Signed-off-by: Gustavo Carvalho <gustavo.carvalho@container-solutions.com>