### PR TITLE
chore: update k8s / envtest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,7 @@ env:
   # Common versions
   GO_VERSION: '1.17'
   GOLANGCI_VERSION: 'v1.42.1'
-  # list of available versions: https://storage.googleapis.com/kubebuilder-tools
-  # TODO: 1.21.2 does not shut down properly with controller-runtime 0.9.2
-  KUBEBUILDER_TOOLS_VERSION: '1.20.2'
+  KUBERNETES_VERSION: '1.23.x'
   DOCKER_BUILDX_VERSION: 'v0.4.2'
 
   # Common users. We can't run a step 'if secrets.GHCR_USERNAME != ""' but we can run
@@ -164,22 +162,22 @@ jobs:
           key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-pkg-
 
-      - name: Add envtest binaries
-        run:  |
-          curl -sSLo envtest-bins.tar.gz "https://storage.googleapis.com/kubebuilder-tools/kubebuilder-tools-${{env.KUBEBUILDER_TOOLS_VERSION}}-linux-amd64.tar.gz"
-          sudo mkdir -p /usr/local/kubebuilder
-          sudo tar -C /usr/local/kubebuilder --strip-components=1 -zvxf envtest-bins.tar.gz
+      - name: Add setup-envtest
+        run: |
+          go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+          setup-envtest use ${{env.KUBERNETES_VERSION}} -p env --os $(go env GOOS) --arch $(go env GOARCH)
 
       - name: Cache envtest binaries
         uses: actions/cache@v2.1.7
         with:
-          path: /usr/local/kubebuilder
-          key: ${{ runner.os }}-kubebuilder-${{env.KUBEBUILDER_TOOLS_VERSION}}
+          path: /home/runner/.local/share/kubebuilder-envtest/
+          key: ${{ runner.os }}-kubebuilder-${{env.KUBERNETES_VERSION}}
           restore-keys: ${{ runner.os }}-kubebuilder-
 
       - name: Run Unit Tests
         run: |
           export KUBEBUILDER_ATTACH_CONTROL_PLANE_OUTPUT=true
+          source <(setup-envtest use ${{env.KUBERNETES_VERSION}} -p env --os $(go env GOOS) --arch $(go env GOARCH))
           make test
 
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,6 +9,8 @@ env:
   GO_VERSION: '1.17'
   GOLANGCI_VERSION: 'v1.33'
   DOCKER_BUILDX_VERSION: 'v0.4.2'
+  KIND_VERSION: 'v0.11.1'
+  KIND_IMAGE: 'kindest/node:v1.23.3'
 
   # Common users. We can't run a step 'if secrets.GHCR_USERNAME != ""' but we can run
   # a step 'if env.GHCR_USERNAME' != ""', so we copy these to succinctly test whether
@@ -71,9 +73,9 @@ jobs:
     - name: Setup kind
       uses: engineerd/setup-kind@v0.5.0
       with:
-        version: "v0.11.1"
+        version: ${{env.KIND_VERSION}}
         wait: 10m
-        node_image: kindest/node:v1.20.7
+        node_image: ${{env.KIND_IMAGE}}
         name: external-secrets
 
     - name: Setup Docker Buildx
@@ -134,9 +136,9 @@ jobs:
     - name: Setup kind
       uses: engineerd/setup-kind@v0.5.0
       with:
-        version: "v0.11.1"
+        version: ${{env.KIND_VERSION}}
         wait: 10m
-        node_image: kindest/node:v1.20.7
+        node_image: ${{env.KIND_IMAGE}}
         name: external-secrets
 
     - name: Setup Docker Buildx

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -2,7 +2,7 @@ MAKEFLAGS   += --warn-undefined-variables
 SHELL       := /bin/bash
 .SHELLFLAGS := -euo pipefail -c
 
-KIND_IMG       = "kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6"
+KIND_IMG       = "kindest/node:v1.23.3@sha256:0df8215895129c0d3221cda19847d1296c4f29ec93487339149333bd9d899e5a"
 BUILD_ARGS     ?=
 
 export E2E_IMAGE_REGISTRY ?= ghcr.io/external-secrets/external-secrets-e2e

--- a/pkg/controllers/externalsecret/suite_test.go
+++ b/pkg/controllers/externalsecret/suite_test.go
@@ -15,6 +15,7 @@ limitations under the License.
 package externalsecret
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 	"time"
@@ -40,6 +41,7 @@ import (
 var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
+var cancel context.CancelFunc
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -55,6 +57,9 @@ var _ = BeforeSuite(func() {
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "deploy", "crds")},
 	}
+
+	var ctx context.Context
+	ctx, cancel = context.WithCancel(context.Background())
 
 	var err error
 	cfg, err = testEnv.Start()
@@ -87,12 +92,13 @@ var _ = BeforeSuite(func() {
 
 	go func() {
 		defer GinkgoRecover()
-		Expect(k8sManager.Start(ctrl.SetupSignalHandler())).ToNot(HaveOccurred())
+		Expect(k8sManager.Start(ctx)).ToNot(HaveOccurred())
 	}()
 })
 
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
+	cancel() // stop manager
 	err := testEnv.Stop()
 	Expect(err).ToNot(HaveOccurred())
 })


### PR DESCRIPTION
* use setup-envtest
* kubebuilder/envtest: use v1.23.3
* fix envtest issue `timeout waiting for process kube-apiserver to stop` for 1.21+