### PR TITLE
Give a name to the Kubernetes port service.

### DIFF
--- a/deploy/charts/external-secrets/templates/service.yaml
+++ b/deploy/charts/external-secrets/templates/service.yaml
@@ -12,7 +12,8 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - port: {{ .Values.prometheus.service.port }}
+    - name: metrics
+      port: {{ .Values.prometheus.service.port }}
       targetPort: {{ .Values.prometheus.service.port }}
       protocol: TCP
   selector:


### PR DESCRIPTION
For make the service clearer and easier to integrate with monitoring applicatios as kube-prometheus