### PR TITLE
allow nested json in vault

### DIFF
--- a/pkg/provider/vault/vault.go
+++ b/pkg/provider/vault/vault.go
@@ -18,15 +18,18 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/go-logr/logr"
 	vault "github.com/hashicorp/vault/api"
+	"github.com/tidwall/gjson"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -157,15 +160,50 @@ func (v *client) GetSecret(ctx context.Context, ref esv1alpha1.ExternalSecretDat
 	if err != nil {
 		return nil, err
 	}
-	value, exists := data[ref.Property]
-	if !exists {
+
+	// return raw json if no property is defined
+	if ref.Property == "" {
+		return data, nil
+	}
+
+	val := gjson.Get(string(data), ref.Property)
+	if !val.Exists() {
 		return nil, fmt.Errorf(errSecretKeyFmt, ref.Property)
 	}
-	return value, nil
+	return []byte(val.String()), nil
 }
 
 func (v *client) GetSecretMap(ctx context.Context, ref esv1alpha1.ExternalSecretDataRemoteRef) (map[string][]byte, error) {
-	return v.readSecret(ctx, ref.Key, ref.Version)
+	data, err := v.readSecret(ctx, ref.Key, ref.Version)
+	if err != nil {
+		return nil, err
+	}
+
+	var secretData map[string]interface{}
+	err = json.Unmarshal(data, &secretData)
+	if err != nil {
+		return nil, err
+	}
+	byteMap := make(map[string][]byte, len(secretData))
+	for k, v := range secretData {
+		switch t := v.(type) {
+		case string:
+			byteMap[k] = []byte(t)
+		case []byte:
+			byteMap[k] = t
+		// also covers int and float32 due to json.Marshal
+		case float64:
+			byteMap[k] = []byte(strconv.FormatFloat(t, 'f', -1, 64))
+		case bool:
+			byteMap[k] = []byte(strconv.FormatBool(t))
+		case nil:
+			byteMap[k] = []byte(nil)
+		default:
+			return nil, errors.New(errSecretFormat)
+		}
+	}
+
+	return byteMap, nil
 }
 
 func (v *client) Close(ctx context.Context) error {
@@ -208,7 +246,7 @@ func (v *client) buildPath(path string) string {
 	return returnPath
 }
 
-func (v *client) readSecret(ctx context.Context, path, version string) (map[string][]byte, error) {
+func (v *client) readSecret(ctx context.Context, path, version string) ([]byte, error) {
 	dataPath := v.buildPath(path)
 
 	// path formated according to vault docs for v1 and v2 API
@@ -244,21 +282,8 @@ func (v *client) readSecret(ctx context.Context, path, version string) (map[stri
 		}
 	}
 
-	byteMap := make(map[string][]byte, len(secretData))
-	for k, v := range secretData {
-		switch t := v.(type) {
-		case string:
-			byteMap[k] = []byte(t)
-		case []byte:
-			byteMap[k] = t
-		case nil:
-			byteMap[k] = []byte(nil)
-		default:
-			return nil, errors.New(errSecretFormat)
-		}
-	}
-
-	return byteMap, nil
+	// return json string
+	return json.Marshal(secretData)
 }
 
 func (v *client) newConfig() (*vault.Config, error) {


### PR DESCRIPTION
I would like to get some feedback on my proposal. If accepted i will add more docs and e2e tests for it.
These changes would be forward compatible and would not break current behavior.

supersedes #515, fixes #649

### GetSecret()

Vault KV supports specifying key/value pairs under a certain `path`. You can not create a secret with "just" a value in a `path`. You can also create nested key/value pairs (more on that below).

Our provider reflects that in a sense that you **must** provide a `ref.Property`. The provider returns an error if it's not set.

I propose that we make `ref.Property` optional and return the raw json if it's not set. A user can now use the raw response and post-process it in the template.

Example:

```yaml
spec:
  data:
  - secretKey: foobar # => {"foo":{"bar":"myvalue"}}
    remoteRef:
      key: secret/foo
      # note: no property set

# with this secret
# {
#   "foo": {
#     "bar": "myvalue"
#   }
# }
```

In addition to that i propose to support `gjson` paths to specify nested keys within the vault data. Other providers support that already.

```yaml
spec:
  data:
  - secretKey: foobar # => myvalue
    remoteRef:
      key: secret/foo
      property: foo.bar

# with this secret
# {
#   "foo": {
#     "bar": "myvalue"
#   }
# }
```

### GetSecretMap()

We are in a bit of trouble here. `GetSecretMap()` is expected to return a `map[string][]byte`. Unfortunately vault supports nested key/value pairs - So we can only return the first level of values.

This is unfortunate but it is how it is. I added support for `bool` and `float64` (which includes int and float32 as well). That improves the situation a bit but does not solve the issue.

```yaml
spec:
  dataFrom:
  - key: "secret/foo"
```