### PR TITLE
fix: add port name to deployment and service

### DIFF
--- a/deploy/charts/external-secrets/templates/deployment.yaml
+++ b/deploy/charts/external-secrets/templates/deployment.yaml
@@ -68,6 +68,7 @@ spec:
           ports:
             - containerPort: {{ .Values.prometheus.service.port }}
               protocol: TCP
+              name: metrics
           {{- with .Values.extraEnv }}
           env:
             {{- toYaml . | nindent 12 }}

--- a/deploy/charts/external-secrets/templates/service.yaml
+++ b/deploy/charts/external-secrets/templates/service.yaml
@@ -13,8 +13,8 @@ spec:
   type: ClusterIP
   ports:
     - port: {{ .Values.prometheus.service.port }}
-      targetPort: {{ .Values.prometheus.service.port }}
       protocol: TCP
+      name: metrics
   selector:
     {{- include "external-secrets.selectorLabels" . | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
based on #673 but also removes the `targetPort` from the `service.yaml` and adds the port name to the `deployment.yaml` 