### PR TITLE
fix: gcp service name in singular

### DIFF
--- a/hack/api-docs/mkdocs.yml
+++ b/hack/api-docs/mkdocs.yml
@@ -48,7 +48,7 @@ nav:
     - Azure:
       - Key Vault: provider-azure-key-vault.md
     - Google:
-      - Secrets Manager: provider-google-secrets-manager.md
+      - Secret Manager: provider-google-secrets-manager.md
     - IBM:
       - Secrets Manager: provider-ibm-secrets-manager.md
     - Akeyless: provider-akeyless.md


### PR DESCRIPTION
Both pages had the same name and it was messing up the analytics of the website.