### PR TITLE
Fix the leak in GCPSM when the secret operator cannot find the secret.

### DIFF
--- a/pkg/provider/gcp/secretmanager/secretsmanager_workload_identity.go
+++ b/pkg/provider/gcp/secretmanager/secretsmanager_workload_identity.go
@@ -62,6 +62,7 @@ type workloadIdentity struct {
 // interface to GCP IAM API.
 type IamClient interface {
 	GenerateAccessToken(ctx context.Context, req *credentialspb.GenerateAccessTokenRequest, opts ...gax.CallOption) (*credentialspb.GenerateAccessTokenResponse, error)
+	Close() error
 }
 
 // interface to securetoken/identitybindingtoken API.
@@ -152,6 +153,10 @@ func (w *workloadIdentity) TokenSource(ctx context.Context, store esv1alpha1.Gen
 	return oauth2.StaticTokenSource(&oauth2.Token{
 		AccessToken: gcpSAResp.GetAccessToken(),
 	}), nil
+}
+
+func (w *workloadIdentity) Close() error {
+	return w.iamClient.Close()
 }
 
 func newIAMClient(ctx context.Context) (IamClient, error) {

--- a/pkg/provider/gcp/secretmanager/secretsmanager_workload_identity_test.go
+++ b/pkg/provider/gcp/secretmanager/secretsmanager_workload_identity_test.go
@@ -357,6 +357,10 @@ func (f *fakeIAMClient) GenerateAccessToken(ctx context.Context, req *credential
 	return f.generateAccessTokenFunc(ctx, req, opts...)
 }
 
+func (f *fakeIAMClient) Close() error {
+	return nil
+}
+
 // fake SA Token Generator.
 type fakeSATokenGen struct {
 	GenerateFunc func(context.Context, string, string, string) (*authv1.TokenRequest, error)


### PR DESCRIPTION
#290 is a great fix!
However, the GCP's IAM client has an internal gRPC connection, so if the fetch secret fails, the goroutine created by the gRPC connection will leak.
Therefore, close the IAM client when the creation of the GCPSM client fails.

I intentionally caused a Permission denied error on a GKE cluster with workload identity and measured the number of goroutines before and after applying this patch.

![image](https://user-images.githubusercontent.com/562795/154059638-1fdddd24-4a03-46a7-a8eb-c3f5240a84d3.png)

![image](https://user-images.githubusercontent.com/562795/154059747-2046af68-f5eb-4ba5-884c-cc504574c4b6.png)

