### PR TITLE
feat: avoid caching secrets/configmaps

### DIFF
--- a/pkg/controllers/externalsecret/externalsecret_controller.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -423,6 +424,6 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, opts controller.Options)
 	return ctrl.NewControllerManagedBy(mgr).
 		WithOptions(opts).
 		For(&esv1alpha1.ExternalSecret{}).
-		Owns(&v1.Secret{}).
+		Owns(&v1.Secret{}, builder.OnlyMetadata).
 		Complete(r)
 }


### PR DESCRIPTION
Fixes #721 

Details are in https://github.com/external-secrets/external-secrets/issues/721#issuecomment-1041515014.

I'm wondering if we should hide that feature behind a feature flag or if it should be enabled by default.

I did some testing with a lot secrets: ~2k `Kind=Secret` with 512k each:
* mem consumption without this patch is ~1GB
* mem consumption with this patch is < 100 MB