### PR TITLE
Adding status information to kubectl get css

### DIFF
--- a/apis/externalsecrets/v1alpha1/secretstore_types.go
+++ b/apis/externalsecrets/v1alpha1/secretstore_types.go
@@ -151,6 +151,7 @@ type SecretStoreList struct {
 
 // ClusterSecretStore represents a secure external location for storing secrets, which can be referenced as part of `storeRef` fields.
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].reason`
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster,categories={externalsecrets},shortName=css
 type ClusterSecretStore struct {

--- a/deploy/crds/external-secrets.io_clustersecretstores.yaml
+++ b/deploy/crds/external-secrets.io_clustersecretstores.yaml
@@ -22,6 +22,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: AGE
       type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Status
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
Our reporter show status for SecretStores:
```
kubectl get secretstores
NAME            AGE   STATUS
azure-backend   13s   InvalidProviderConfig
```
But not for ClusterSecretStores:
```
kubectl get clustersecretstores                     
NAME            AGE
azure-backend   5m
```
This PR fixes this issue by adding appropriate kubebuilder tags to `ClusterSecretStore` object.

Signed-off-by: Gustavo Carvalho <gustavo.carvalho@container-solutions.com>