### PR TITLE
Fix template fallback logic to handle TemplateFrom syntax

### DIFF
--- a/pkg/controllers/externalsecret/externalsecret_controller_template.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller_template.go
@@ -67,7 +67,7 @@ func (r *Reconciler) applyTemplate(ctx context.Context, es *esv1beta1.ExternalSe
 
 	// if no data was provided by template fallback
 	// to value from the provider
-	if len(es.Spec.Target.Template.Data) == 0 {
+	if len(es.Spec.Target.Template.Data) == 0 && len(es.Spec.Target.Template.TemplateFrom) == 0 {
 		secret.Data = dataMap
 	}
 	secret.Annotations[esv1beta1.AnnotationDataHash] = utils.ObjectHash(secret.Data)


### PR DESCRIPTION
The External Secrets documentation has the following example:
```yaml
# define your template in a config map
apiVersion: v1
kind: ConfigMap
metadata:
  name: grafana-config-tpl
data:
  config.yaml: |
    datasources:
      - name: Graphite
        type: graphite
        access: proxy
        url: http://localhost:8080
        password: "{{ .password }}"
        user: "{{ .user }}"
---
apiVersion: external-secrets.io/v1alpha1
kind: ExternalSecret
metadata:
  name: my-template-example
spec:
  # ...
  target:
    name: secret-to-be-created
    template:
      engineVersion: v2
      templateFrom:
      - configMap:
          # name of the configmap to pull in
          name: grafana-config-tpl
          # here you define the keys that should be used as template
          items:
          - key: config.yaml
  data:
  - secretKey: user
    remoteRef:
      key: /grafana/user
  - secretKey: password
    remoteRef:
      key: /grafana/password
```
This configuration currently triggers some fallback logic and would result in a non-templated secret with just the key value data because `target.template.data` is empty.

This PR fixes that fallback logic to allow for template definitions like the example that just use templates from ConfigMaps.