### PR TITLE
fix(templateFrom): Fix template.templateFrom missing from 

### DIFF
--- a/pkg/controllers/externalsecret/externalsecret_controller_template.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller_template.go
@@ -67,7 +67,7 @@ func (r *Reconciler) applyTemplate(ctx context.Context, es *esv1alpha1.ExternalS
 
 	// if no data was provided by template fallback
 	// to value from the provider
-	if len(es.Spec.Target.Template.Data) == 0 {
+	if len(es.Spec.Target.Template.Data) == 0 && len(es.Spec.Target.Template.TemplateFrom) == 0 {
 		secret.Data = dataMap
 	}
 	secret.Annotations[esv1alpha1.AnnotationDataHash] = utils.ObjectHash(secret.Data)


### PR DESCRIPTION
# What?

While #645 fixed orphan secretes it did not take in to account templateFrom entries.

# How?

Try the following:

```yaml
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: bar
  namespace: foo
data:
  config.yaml: |
    webhook_configs:
      - url: "{{ .webhook }}"
    foo:
      bar: yes
---
apiVersion: external-secrets.io/v1alpha1
kind: ExternalSecret
metadata:
  name: bar
  namespace: foo
spec:
  secretStoreRef:
    name: hashicorp-vault
    kind: ClusterSecretStore
  refreshInterval: "10s"
  target:
    template:
      engineVersion: v2
      templateFrom:
      - configMap:
          name: bar
          items:
          - key: config.yaml
  data:
    - secretKey: webhook
      remoteRef:
        key: path/to/property
        property: key
```

Expected value of Secrete/bar:
```yaml
kind: Secret
apiVersion: v1
metadata:
  name: bar
  namespace: foo
type: Opaque
data:
  config.yml: |
    webhook_configs:
      - url: "XXXXXX"
    foo:
      bar: yes
```

Instead you get:
```yaml
kind: Secret
apiVersion: v1
metadata:
  name: bar
  namespace: foo
type: Opaque
data:
  webhook: XXXXXX
```









