### PR TITLE
GCP: allow cluster to be in different project

### DIFF
--- a/apis/externalsecrets/v1alpha1/secretstore_gcpsm_types.go
+++ b/apis/externalsecrets/v1alpha1/secretstore_gcpsm_types.go
@@ -35,7 +35,7 @@ type GCPWorkloadIdentity struct {
 	ServiceAccountRef esmeta.ServiceAccountSelector `json:"serviceAccountRef"`
 	ClusterLocation   string                        `json:"clusterLocation"`
 	ClusterName       string                        `json:"clusterName"`
-	ClusterProjectID  string                        `json:"clusterProjectID"`
+	ClusterProjectID  string                        `json:"clusterProjectID,omitempty"`
 }
 
 // GCPSMProvider Configures a store to sync secrets using the GCP Secret Manager provider.

--- a/apis/externalsecrets/v1alpha1/secretstore_gcpsm_types.go
+++ b/apis/externalsecrets/v1alpha1/secretstore_gcpsm_types.go
@@ -35,6 +35,7 @@ type GCPWorkloadIdentity struct {
 	ServiceAccountRef esmeta.ServiceAccountSelector `json:"serviceAccountRef"`
 	ClusterLocation   string                        `json:"clusterLocation"`
 	ClusterName       string                        `json:"clusterName"`
+	ClusterProjectID  string                        `json:"clusterProjectID"`
 }
 
 // GCPSMProvider Configures a store to sync secrets using the GCP Secret Manager provider.

--- a/apis/externalsecrets/v1beta1/secretstore_gcpsm_types.go
+++ b/apis/externalsecrets/v1beta1/secretstore_gcpsm_types.go
@@ -35,7 +35,7 @@ type GCPWorkloadIdentity struct {
 	ServiceAccountRef esmeta.ServiceAccountSelector `json:"serviceAccountRef"`
 	ClusterLocation   string                        `json:"clusterLocation"`
 	ClusterName       string                        `json:"clusterName"`
-	ClusterProjectID  string                        `json:"clusterProjectID"`
+	ClusterProjectID  string                        `json:"clusterProjectID,omitempty"`
 }
 
 // GCPSMProvider Configures a store to sync secrets using the GCP Secret Manager provider.

--- a/apis/externalsecrets/v1beta1/secretstore_gcpsm_types.go
+++ b/apis/externalsecrets/v1beta1/secretstore_gcpsm_types.go
@@ -35,6 +35,7 @@ type GCPWorkloadIdentity struct {
 	ServiceAccountRef esmeta.ServiceAccountSelector `json:"serviceAccountRef"`
 	ClusterLocation   string                        `json:"clusterLocation"`
 	ClusterName       string                        `json:"clusterName"`
+	ClusterProjectID  string                        `json:"clusterProjectID"`
 }
 
 // GCPSMProvider Configures a store to sync secrets using the GCP Secret Manager provider.

--- a/config/crds/bases/external-secrets.io_clustersecretstores.yaml
+++ b/config/crds/bases/external-secrets.io_clustersecretstores.yaml
@@ -443,6 +443,8 @@ spec:
                                 type: string
                               clusterName:
                                 type: string
+                              clusterProjectID:
+                                type: string
                               serviceAccountRef:
                                 description: A reference to a ServiceAccount resource.
                                 properties:
@@ -462,6 +464,7 @@ spec:
                             required:
                             - clusterLocation
                             - clusterName
+                            - clusterProjectID
                             - serviceAccountRef
                             type: object
                         type: object
@@ -1746,6 +1749,8 @@ spec:
                                 type: string
                               clusterName:
                                 type: string
+                              clusterProjectID:
+                                type: string
                               serviceAccountRef:
                                 description: A reference to a ServiceAccount resource.
                                 properties:
@@ -1765,6 +1770,7 @@ spec:
                             required:
                             - clusterLocation
                             - clusterName
+                            - clusterProjectID
                             - serviceAccountRef
                             type: object
                         type: object

--- a/config/crds/bases/external-secrets.io_clustersecretstores.yaml
+++ b/config/crds/bases/external-secrets.io_clustersecretstores.yaml
@@ -464,7 +464,6 @@ spec:
                             required:
                             - clusterLocation
                             - clusterName
-                            - clusterProjectID
                             - serviceAccountRef
                             type: object
                         type: object

--- a/config/crds/bases/external-secrets.io_clustersecretstores.yaml
+++ b/config/crds/bases/external-secrets.io_clustersecretstores.yaml
@@ -1769,7 +1769,6 @@ spec:
                             required:
                             - clusterLocation
                             - clusterName
-                            - clusterProjectID
                             - serviceAccountRef
                             type: object
                         type: object

--- a/config/crds/bases/external-secrets.io_secretstores.yaml
+++ b/config/crds/bases/external-secrets.io_secretstores.yaml
@@ -1772,7 +1772,6 @@ spec:
                             required:
                             - clusterLocation
                             - clusterName
-                            - clusterProjectID
                             - serviceAccountRef
                             type: object
                         type: object

--- a/config/crds/bases/external-secrets.io_secretstores.yaml
+++ b/config/crds/bases/external-secrets.io_secretstores.yaml
@@ -464,7 +464,6 @@ spec:
                             required:
                             - clusterLocation
                             - clusterName
-                            - clusterProjectID
                             - serviceAccountRef
                             type: object
                         type: object

--- a/config/crds/bases/external-secrets.io_secretstores.yaml
+++ b/config/crds/bases/external-secrets.io_secretstores.yaml
@@ -443,6 +443,8 @@ spec:
                                 type: string
                               clusterName:
                                 type: string
+                              clusterProjectID:
+                                type: string
                               serviceAccountRef:
                                 description: A reference to a ServiceAccount resource.
                                 properties:
@@ -462,6 +464,7 @@ spec:
                             required:
                             - clusterLocation
                             - clusterName
+                            - clusterProjectID
                             - serviceAccountRef
                             type: object
                         type: object
@@ -1749,6 +1752,8 @@ spec:
                                 type: string
                               clusterName:
                                 type: string
+                              clusterProjectID:
+                                type: string
                               serviceAccountRef:
                                 description: A reference to a ServiceAccount resource.
                                 properties:
@@ -1768,6 +1773,7 @@ spec:
                             required:
                             - clusterLocation
                             - clusterName
+                            - clusterProjectID
                             - serviceAccountRef
                             type: object
                         type: object

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -351,7 +351,6 @@ spec:
                               required:
                                 - clusterLocation
                                 - clusterName
-                                - clusterProjectID
                                 - serviceAccountRef
                               type: object
                           type: object
@@ -2794,7 +2793,6 @@ spec:
                               required:
                                 - clusterLocation
                                 - clusterName
-                                - clusterProjectID
                                 - serviceAccountRef
                               type: object
                           type: object

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -334,6 +334,8 @@ spec:
                                   type: string
                                 clusterName:
                                   type: string
+                                clusterProjectID:
+                                  type: string
                                 serviceAccountRef:
                                   description: A reference to a ServiceAccount resource.
                                   properties:
@@ -349,6 +351,7 @@ spec:
                               required:
                                 - clusterLocation
                                 - clusterName
+                                - clusterProjectID
                                 - serviceAccountRef
                               type: object
                           type: object
@@ -1295,6 +1298,8 @@ spec:
                                   type: string
                                 clusterName:
                                   type: string
+                                clusterProjectID:
+                                  type: string
                                 serviceAccountRef:
                                   description: A reference to a ServiceAccount resource.
                                   properties:
@@ -1310,6 +1315,7 @@ spec:
                               required:
                                 - clusterLocation
                                 - clusterName
+                                - clusterProjectID
                                 - serviceAccountRef
                               type: object
                           type: object
@@ -2771,6 +2777,8 @@ spec:
                                   type: string
                                 clusterName:
                                   type: string
+                                clusterProjectID:
+                                  type: string
                                 serviceAccountRef:
                                   description: A reference to a ServiceAccount resource.
                                   properties:
@@ -2786,6 +2794,7 @@ spec:
                               required:
                                 - clusterLocation
                                 - clusterName
+                                - clusterProjectID
                                 - serviceAccountRef
                               type: object
                           type: object
@@ -3735,6 +3744,8 @@ spec:
                                   type: string
                                 clusterName:
                                   type: string
+                                clusterProjectID:
+                                  type: string
                                 serviceAccountRef:
                                   description: A reference to a ServiceAccount resource.
                                   properties:
@@ -3750,6 +3761,7 @@ spec:
                               required:
                                 - clusterLocation
                                 - clusterName
+                                - clusterProjectID
                                 - serviceAccountRef
                               type: object
                           type: object

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -1314,7 +1314,6 @@ spec:
                               required:
                                 - clusterLocation
                                 - clusterName
-                                - clusterProjectID
                                 - serviceAccountRef
                               type: object
                           type: object
@@ -3759,7 +3758,6 @@ spec:
                               required:
                                 - clusterLocation
                                 - clusterName
-                                - clusterProjectID
                                 - serviceAccountRef
                               type: object
                           type: object

--- a/docs/snippets/gcpsm-wi-secret-store.yaml
+++ b/docs/snippets/gcpsm-wi-secret-store.yaml
@@ -12,6 +12,8 @@ spec:
           clusterLocation: europe-central2
           # name of the GKE cluster
           clusterName: example-workload-identity
+          # projectID of the cluster (if omitted defaults to spec.provider.gcpsm.projectID)
+          clusterProjectID: my-cluster-project
           # reference the sa from above
           serviceAccountRef:
             name: team-a

--- a/pkg/provider/gcp/secretmanager/secretsmanager_workload_identity.go
+++ b/pkg/provider/gcp/secretmanager/secretsmanager_workload_identity.go
@@ -115,7 +115,7 @@ func (w *workloadIdentity) TokenSource(ctx context.Context, store esv1beta1.Gene
 		saKey.Namespace = *wi.ServiceAccountRef.Namespace
 	}
 
-	clusterProjectID, err := clusterProjectID(store)
+	clusterProjectID, err := clusterProjectID(spec)
 	if err != nil {
 		return nil, err
 	}
@@ -263,8 +263,7 @@ func (g *gcpIDBindTokenGenerator) Generate(ctx context.Context, client *http.Cli
 	return idBindToken, nil
 }
 
-func clusterProjectID(store esv1beta1.GenericStore) (string, error) {
-	spec := store.GetSpec()
+func clusterProjectID(spec *esv1beta1.SecretStoreSpec) (string, error) {
 	if spec.Provider.GCPSM.Auth.WorkloadIdentity.ClusterProjectID != "" {
 		return spec.Provider.GCPSM.Auth.WorkloadIdentity.ClusterProjectID, nil
 	} else if spec.Provider.GCPSM.ProjectID != "" {

--- a/pkg/provider/gcp/secretmanager/secretsmanager_workload_identity_test.go
+++ b/pkg/provider/gcp/secretmanager/secretsmanager_workload_identity_test.go
@@ -160,10 +160,10 @@ func TestWorkloadIdentity(t *testing.T) {
 }
 
 func TestClusterProjectID(t *testing.T) {
-	clusterID, err := clusterProjectID(defaultStore())
+	clusterID, err := clusterProjectID(esv1beta1.GenericStore.GetSpec(defaultStore()))
 	assert.Nil(t, err)
 	assert.Equal(t, clusterID, "1234")
-	externalClusterID, err := clusterProjectID(defaultExternalStore())
+	externalClusterID, err := clusterProjectID(esv1beta1.GenericStore.GetSpec(defaultExternalStore()))
 	assert.Nil(t, err)
 	assert.Equal(t, externalClusterID, "5678")
 }

--- a/pkg/provider/gcp/secretmanager/secretsmanager_workload_identity_test.go
+++ b/pkg/provider/gcp/secretmanager/secretsmanager_workload_identity_test.go
@@ -44,6 +44,7 @@ type workloadIdentityTest struct {
 	genAccessToken func(context.Context, *credentialspb.GenerateAccessTokenRequest, ...gax.CallOption) (*credentialspb.GenerateAccessTokenResponse, error)
 	genIDBindToken func(ctx context.Context, client *http.Client, k8sToken, idPool, idProvider string) (*oauth2.Token, error)
 	genSAToken     func(c context.Context, s1, s2, s3 string) (*authv1.TokenRequest, error)
+	genClusterID   func(context.Context, *esv1beta1.SecretStore) (*oauth2.Token, error)
 	store          esv1beta1.GenericStore
 	kubeObjects    []client.Object
 }
@@ -266,6 +267,11 @@ func defaultTestCase(name string) *workloadIdentityTest {
 				Status: authv1.TokenRequestStatus{
 					Token: defaultSAToken,
 				},
+			}, nil
+		},
+		genClusterID: func(context.Context, *esv1beta1.SecretStore) (*oauth2.Token, error) {
+			return &oauth2.Token{
+				AccessToken: defaultGenAccessToken,
 			}, nil
 		},
 		kubeObjects: []client.Object{

--- a/pkg/provider/gcp/secretmanager/secretsmanager_workload_identity_test.go
+++ b/pkg/provider/gcp/secretmanager/secretsmanager_workload_identity_test.go
@@ -160,6 +160,15 @@ func TestWorkloadIdentity(t *testing.T) {
 	}
 }
 
+func TestClusterProjectID(t *testing.T) {
+	clusterID, err := clusterProjectID(defaultStore())
+	assert.Nil(t, err)
+	assert.Equal(t, clusterID, "1234")
+	externalClusterID, err := clusterProjectID(defaultExternalStore())
+	assert.Nil(t, err)
+	assert.Equal(t, externalClusterID, "5678")
+}
+
 func TestSATokenGen(t *testing.T) {
 	corev1 := &fakeK8sV1{}
 	g := &k8sSATokenGenerator{
@@ -298,6 +307,16 @@ func defaultStore() *esv1beta1.SecretStore {
 	}
 }
 
+func defaultExternalStore() *esv1beta1.SecretStore {
+	return &esv1beta1.SecretStore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foobar",
+			Namespace: "default",
+		},
+		Spec: defaultExternalStoreSpec(),
+	}
+}
+
 func defaultClusterStore() *esv1beta1.ClusterSecretStore {
 	return &esv1beta1.ClusterSecretStore{
 		TypeMeta: metav1.TypeMeta{
@@ -321,6 +340,26 @@ func defaultStoreSpec() esv1beta1.SecretStoreSpec {
 						},
 						ClusterLocation: "example",
 						ClusterName:     "foobar",
+					},
+				},
+				ProjectID: "1234",
+			},
+		},
+	}
+}
+
+func defaultExternalStoreSpec() esv1beta1.SecretStoreSpec {
+	return esv1beta1.SecretStoreSpec{
+		Provider: &esv1beta1.SecretStoreProvider{
+			GCPSM: &esv1beta1.GCPSMProvider{
+				Auth: esv1beta1.GCPSMAuth{
+					WorkloadIdentity: &esv1beta1.GCPWorkloadIdentity{
+						ServiceAccountRef: esmeta.ServiceAccountSelector{
+							Name: "example",
+						},
+						ClusterLocation:  "example",
+						ClusterName:      "foobar",
+						ClusterProjectID: "5678",
 					},
 				},
 				ProjectID: "1234",

--- a/pkg/provider/gcp/secretmanager/secretsmanager_workload_identity_test.go
+++ b/pkg/provider/gcp/secretmanager/secretsmanager_workload_identity_test.go
@@ -160,10 +160,10 @@ func TestWorkloadIdentity(t *testing.T) {
 }
 
 func TestClusterProjectID(t *testing.T) {
-	clusterID, err := clusterProjectID(esv1beta1.GenericStore.GetSpec(defaultStore()))
+	clusterID, err := clusterProjectID(defaultStore().GetSpec())
 	assert.Nil(t, err)
 	assert.Equal(t, clusterID, "1234")
-	externalClusterID, err := clusterProjectID(esv1beta1.GenericStore.GetSpec(defaultExternalStore()))
+	externalClusterID, err := clusterProjectID(defaultExternalStore().GetSpec())
 	assert.Nil(t, err)
 	assert.Equal(t, externalClusterID, "5678")
 }

--- a/pkg/provider/gcp/secretmanager/secretsmanager_workload_identity_test.go
+++ b/pkg/provider/gcp/secretmanager/secretsmanager_workload_identity_test.go
@@ -44,7 +44,6 @@ type workloadIdentityTest struct {
 	genAccessToken func(context.Context, *credentialspb.GenerateAccessTokenRequest, ...gax.CallOption) (*credentialspb.GenerateAccessTokenResponse, error)
 	genIDBindToken func(ctx context.Context, client *http.Client, k8sToken, idPool, idProvider string) (*oauth2.Token, error)
 	genSAToken     func(c context.Context, s1, s2, s3 string) (*authv1.TokenRequest, error)
-	genClusterID   func(context.Context, *esv1beta1.SecretStore) (*oauth2.Token, error)
 	store          esv1beta1.GenericStore
 	kubeObjects    []client.Object
 }
@@ -276,11 +275,6 @@ func defaultTestCase(name string) *workloadIdentityTest {
 				Status: authv1.TokenRequestStatus{
 					Token: defaultSAToken,
 				},
-			}, nil
-		},
-		genClusterID: func(context.Context, *esv1beta1.SecretStore) (*oauth2.Token, error) {
-			return &oauth2.Token{
-				AccessToken: defaultGenAccessToken,
 			}, nil
 		},
 		kubeObjects: []client.Object{


### PR DESCRIPTION
Fixes #772 

Initial proposal of begin able to have your GKE cluster in a different project that where the GCPSM is. I did not yet update any docs or tests. Input / help is welcome

Intend for now is to be backward compatible so this feature can be released without any blockers