### PR TITLE
Add the ability to support scoped RBAC with a scoped namespace

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,23 +41,24 @@ import (
 )
 
 var (
-	scheme                        = runtime.NewScheme()
-	setupLog                      = ctrl.Log.WithName("setup")
-	dnsName                       string
-	certDir                       string
-	metricsAddr                   string
-	healthzAddr                   string
-	controllerClass               string
-	enableLeaderElection          bool
-	concurrent                    int
-	loglevel                      string
-	namespace                     string
-	enableClusterStoreReconciler  bool
-	storeRequeueInterval          time.Duration
-	serviceName, serviceNamespace string
-	secretName, secretNamespace   string
-	crdRequeueInterval            time.Duration
-	certCheckInterval             time.Duration
+	scheme                                = runtime.NewScheme()
+	setupLog                              = ctrl.Log.WithName("setup")
+	dnsName                               string
+	certDir                               string
+	metricsAddr                           string
+	healthzAddr                           string
+	controllerClass                       string
+	enableLeaderElection                  bool
+	concurrent                            int
+	loglevel                              string
+	namespace                             string
+	enableClusterStoreReconciler          bool
+	enableClusterExternalSecretReconciler bool
+	storeRequeueInterval                  time.Duration
+	serviceName, serviceNamespace         string
+	secretName, secretNamespace           string
+	crdRequeueInterval                    time.Duration
+	certCheckInterval                     time.Duration
 )
 
 const (
@@ -142,16 +143,18 @@ var rootCmd = &cobra.Command{
 			setupLog.Error(err, errCreateController, "controller", "ExternalSecret")
 			os.Exit(1)
 		}
-		if err = (&clusterexternalsecret.Reconciler{
-			Client:          mgr.GetClient(),
-			Log:             ctrl.Log.WithName("controllers").WithName("ClusterExternalSecret"),
-			Scheme:          mgr.GetScheme(),
-			RequeueInterval: time.Hour,
-		}).SetupWithManager(mgr, controller.Options{
-			MaxConcurrentReconciles: concurrent,
-		}); err != nil {
-			setupLog.Error(err, errCreateController, "controller", "ClusterExternalSecret")
-			os.Exit(1)
+		if enableClusterExternalSecretReconciler {
+			if err = (&clusterexternalsecret.Reconciler{
+				Client:          mgr.GetClient(),
+				Log:             ctrl.Log.WithName("controllers").WithName("ClusterExternalSecret"),
+				Scheme:          mgr.GetScheme(),
+				RequeueInterval: time.Hour,
+			}).SetupWithManager(mgr, controller.Options{
+				MaxConcurrentReconciles: concurrent,
+			}); err != nil {
+				setupLog.Error(err, errCreateController, "controller", "ClusterExternalSecret")
+				os.Exit(1)
+			}
 		}
 		setupLog.Info("starting manager")
 		if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
@@ -176,5 +179,6 @@ func init() {
 	rootCmd.Flags().StringVar(&loglevel, "loglevel", "info", "loglevel to use, one of: debug, info, warn, error, dpanic, panic, fatal")
 	rootCmd.Flags().StringVar(&namespace, "namespace", "", "watch external secrets scoped in the provided namespace only. ClusterSecretStore can be used but only work if it doesn't reference resources from other namespaces")
 	rootCmd.Flags().BoolVar(&enableClusterStoreReconciler, "enable-cluster-store-reconciler", true, "Enable cluster store reconciler.")
+	rootCmd.Flags().BoolVar(&enableClusterExternalSecretReconciler, "enable-cluster-external-secret-reconciler", true, "Enable cluster external secret reconciler.")
 	rootCmd.Flags().DurationVar(&storeRequeueInterval, "store-requeue-interval", time.Minute*5, "Time duration between reconciling (Cluster)SecretStores")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -130,11 +130,12 @@ var rootCmd = &cobra.Command{
 			}
 		}
 		if err = (&externalsecret.Reconciler{
-			Client:          mgr.GetClient(),
-			Log:             ctrl.Log.WithName("controllers").WithName("ExternalSecret"),
-			Scheme:          mgr.GetScheme(),
-			ControllerClass: controllerClass,
-			RequeueInterval: time.Hour,
+			Client:                    mgr.GetClient(),
+			Log:                       ctrl.Log.WithName("controllers").WithName("ExternalSecret"),
+			Scheme:                    mgr.GetScheme(),
+			ControllerClass:           controllerClass,
+			RequeueInterval:           time.Hour,
+			ClusterSecretStoreEnabled: enableClusterStoreReconciler,
 		}).SetupWithManager(mgr, controller.Options{
 			MaxConcurrentReconciles: concurrent,
 		}); err != nil {

--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -86,6 +86,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | scopedNamespace | string | `""` | If set external secrets are only reconciled in the provided namespace |
+| scopedRBAC | bool | `false` | If true, disable ClusterSecretStore. If scopedNamespace is provided, create scoped RBAC roles under the scoped namespace. |
 | securityContext | object | `{}` |  |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |

--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -80,13 +80,15 @@ The command removes all the Kubernetes components associated with the chart and 
 | podLabels | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | priorityClassName | string | `""` | Pod priority class name. |
+| processClusterExternalSecret | bool | `true` | if true, the operator will process cluster external secret. Else, it will ignore them. |
+| processClusterStore | bool | `true` | if true, the operator will process cluster store. Else, it will ignore them. |
 | prometheus.enabled | bool | `false` | Specifies whether to expose Service resource for collecting Prometheus metrics |
 | prometheus.service.port | int | `8080` |  |
 | rbac.create | bool | `true` | Specifies whether role and rolebinding resources should be created. |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | scopedNamespace | string | `""` | If set external secrets are only reconciled in the provided namespace |
-| scopedRBAC | bool | `false` | If true, disable ClusterSecretStore. If scopedNamespace is provided, create scoped RBAC roles under the scoped namespace. |
+| scopedRBAC | bool | `false` | Must be used with scopedNamespace. If true, create scoped RBAC roles under the scoped namespace and implicitly disable cluster stores and cluster external secrets |
 | securityContext | object | `{}` |  |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |

--- a/deploy/charts/external-secrets/templates/deployment.yaml
+++ b/deploy/charts/external-secrets/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if or (.Values.leaderElect) (.Values.scopedNamespace) (.Values.scopedRBAC) (.Values.concurrent) (.Values.extraArgs) }}
+          {{- if or (.Values.leaderElect) (.Values.scopedNamespace) (.Values.processClusterStore) (.Values.processClusterExternalSecret) (.Values.concurrent) (.Values.extraArgs) }}
           args:
           {{- if .Values.leaderElect }}
           - --enable-leader-election=true
@@ -52,8 +52,16 @@ spec:
           {{- if .Values.scopedNamespace }}
           - --namespace={{ .Values.scopedNamespace }}
           {{- end }}
-          {{- if .Values.scopedRBAC }}
+          {{- if and .Values.scopedNamespace .Values.scopedRBAC }}
           - --enable-cluster-store-reconciler=false
+          - --enable-cluster-external-secret-reconciler=false
+          {{- else }}
+            {{- if not .Values.processClusterStore }}
+          - --enable-cluster-store-reconciler=false
+            {{- end }}
+            {{- if not .Values.processClusterExternalSecret }}
+          - --enable-cluster-external-secret-reconciler=false
+            {{- end }}
           {{- end }}
           {{- if .Values.controllerClass }}
           - --controller-class={{ .Values.controllerClass }}

--- a/deploy/charts/external-secrets/templates/deployment.yaml
+++ b/deploy/charts/external-secrets/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if or (.Values.leaderElect) (.Values.scopedNamespace) (.Values.concurrent) (.Values.extraArgs) }}
+          {{- if or (.Values.leaderElect) (.Values.scopedNamespace) (.Values.scopedRBAC) (.Values.concurrent) (.Values.extraArgs) }}
           args:
           {{- if .Values.leaderElect }}
           - --enable-leader-election=true
@@ -52,8 +52,7 @@ spec:
           {{- if .Values.scopedNamespace }}
           - --namespace={{ .Values.scopedNamespace }}
           {{- end }}
-          {{- if and .Values.scopedNamespace .Values.scopedRBAC }}
-          # when scoped RBAC is enabled. cluster scoped resources are no longer supported.
+          {{- if .Values.scopedRBAC }}
           - --enable-cluster-store-reconciler=false
           {{- end }}
           {{- if .Values.controllerClass }}

--- a/deploy/charts/external-secrets/templates/deployment.yaml
+++ b/deploy/charts/external-secrets/templates/deployment.yaml
@@ -52,6 +52,10 @@ spec:
           {{- if .Values.scopedNamespace }}
           - --namespace={{ .Values.scopedNamespace }}
           {{- end }}
+          {{- if and .Values.scopedNamespace .Values.scopedRBAC }}
+          # when scoped RBAC is enabled. cluster scoped resources are no longer supported.
+          - --enable-cluster-store-reconciler=false
+          {{- end }}
           {{- if .Values.controllerClass }}
           - --controller-class={{ .Values.controllerClass }}
           {{- end }}

--- a/deploy/charts/external-secrets/templates/rbac.yaml
+++ b/deploy/charts/external-secrets/templates/rbac.yaml
@@ -1,8 +1,15 @@
 {{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if and .Values.scopedNamespace .Values.scopedRBAC }}
+kind: Role
+{{- else }}
 kind: ClusterRole
+{{- end }}
 metadata:
   name: {{ include "external-secrets.fullname" . }}-controller
+  {{- if and .Values.scopedNamespace .Values.scopedRBAC }}
+  namespace: {{ .Values.scopedNamespace | quote }}
+  {{- end }}
   labels:
     {{- include "external-secrets.labels" . | nindent 4 }}
 rules:
@@ -86,9 +93,16 @@ rules:
     - "update"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if and .Values.scopedNamespace .Values.scopedRBAC }}
+kind: Role
+{{- else }}
 kind: ClusterRole
+{{- end }}
 metadata:
   name: {{ include "external-secrets.fullname" . }}-view
+  {{- if and .Values.scopedNamespace .Values.scopedRBAC }}
+  namespace: {{ .Values.scopedNamespace | quote }}
+  {{- end }}
   labels:
     {{- include "external-secrets.labels" . | nindent 4 }}
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -107,9 +121,16 @@ rules:
       - "list"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if and .Values.scopedNamespace .Values.scopedRBAC }}
+kind: Role
+{{- else }}
 kind: ClusterRole
+{{- end }}
 metadata:
   name: {{ include "external-secrets.fullname" . }}-edit
+  {{- if and .Values.scopedNamespace .Values.scopedRBAC }}
+  namespace: {{ .Values.scopedNamespace | quote }}
+  {{- end }}
   labels:
     {{- include "external-secrets.labels" . | nindent 4 }}
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -129,14 +150,25 @@ rules:
       - "update"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if and .Values.scopedNamespace .Values.scopedRBAC }}
+kind: RoleBinding
+{{- else }}
 kind: ClusterRoleBinding
+{{- end }}
 metadata:
   name: {{ include "external-secrets.fullname" . }}-controller
+  {{- if and .Values.scopedNamespace .Values.scopedRBAC }}
+  namespace: {{ .Values.scopedNamespace | quote }}
+  {{- end }}
   labels:
     {{- include "external-secrets.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
+  {{- if and .Values.scopedNamespace .Values.scopedRBAC }}
+  kind: Role
+  {{- else }}
   kind: ClusterRole
+  {{- end }}
   name: {{ include "external-secrets.fullname" . }}-controller
 subjects:
   - name: {{ include "external-secrets.serviceAccountName" . }}

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -28,6 +28,10 @@ scopedNamespace: ""
 # -- Specifies whether an external secret operator deployment be created.
 createOperator: true
 
+# -- If true, disable ClusterSecretStore.
+# If scopedNamespace is provided, create scoped RBAC roles under the scoped namespace.
+scopedRBAC: false
+
 # -- Specifies the number of concurrent ExternalSecret Reconciles external-secret executes at
 # a time.
 concurrent: 1

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -25,12 +25,18 @@ controllerClass: ""
 # provided namespace
 scopedNamespace: ""
 
+# -- Must be used with scopedNamespace. If true, create scoped RBAC roles under the scoped namespace
+# and implicitly disable cluster stores and cluster external secrets
+scopedRBAC: false
+
+# -- if true, the operator will process cluster external secret. Else, it will ignore them.
+processClusterExternalSecret: true
+
+# -- if true, the operator will process cluster store. Else, it will ignore them.
+processClusterStore: true
+
 # -- Specifies whether an external secret operator deployment be created.
 createOperator: true
-
-# -- If true, disable ClusterSecretStore.
-# If scopedNamespace is provided, create scoped RBAC roles under the scoped namespace.
-scopedRBAC: false
 
 # -- Specifies the number of concurrent ExternalSecret Reconciles external-secret executes at
 # a time.

--- a/pkg/controllers/externalsecret/externalsecret_controller.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller.go
@@ -74,11 +74,12 @@ const (
 // Reconciler reconciles a ExternalSecret object.
 type Reconciler struct {
 	client.Client
-	Log             logr.Logger
-	Scheme          *runtime.Scheme
-	ControllerClass string
-	RequeueInterval time.Duration
-	recorder        record.EventRecorder
+	Log                       logr.Logger
+	Scheme                    *runtime.Scheme
+	ControllerClass           string
+	RequeueInterval           time.Duration
+	ClusterSecretStoreEnabled bool
+	recorder                  record.EventRecorder
 }
 
 // Reconcile implements the main reconciliation loop
@@ -105,6 +106,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	} else if err != nil {
 		log.Error(err, errGetES)
 		syncCallsError.With(syncCallsMetricLabels).Inc()
+		return ctrl.Result{}, nil
+	}
+
+	if !r.ClusterSecretStoreEnabled && externalSecret.Spec.SecretStoreRef.Kind == esv1beta1.ClusterSecretStoreKind {
+		log.Info("skipping cluster secret store as it is disabled")
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/controllers/externalsecret/externalsecret_controller.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller.go
@@ -109,7 +109,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, nil
 	}
 
-	if !r.ClusterSecretStoreEnabled && externalSecret.Spec.SecretStoreRef.Kind == esv1beta1.ClusterSecretStoreKind {
+	if shouldSkipClusterSecretStore(r, externalSecret) {
 		log.Info("skipping cluster secret store as it is disabled")
 		return ctrl.Result{}, nil
 	}
@@ -324,6 +324,10 @@ func hashMeta(m metav1.ObjectMeta) string {
 		annotations: m.Annotations,
 		labels:      m.Labels,
 	})
+}
+
+func shouldSkipClusterSecretStore(r *Reconciler, es esv1beta1.ExternalSecret) bool {
+	return !r.ClusterSecretStoreEnabled && es.Spec.SecretStoreRef.Kind == esv1beta1.ClusterSecretStoreKind
 }
 
 func shouldRefresh(es esv1beta1.ExternalSecret) bool {


### PR DESCRIPTION
First of all thanks for this amazing project!

I created this PR first and am looking for some helps on this PR before I go too far off so any assistance is greatly appreciated.

I have an issue building using the `main` branch as it is very different from the `v0.4.4` tag.
This PR is built on top of v0.4.4 and modified based on the changes in the `main` branch.

**Summary**
This PR is a follow-up on the [scopedNamesapce](https://github.com/external-secrets/external-secrets/pull/320) and is addressing the [comment](https://github.com/external-secrets/external-secrets/pull/320#issuecomment-904420147) for scoped RBAC roles.

The current implementation of `scopedNamespace` is using Cluster roles to access Kube API.

There are two major security concerns:
1. The operator can access ExternalSecret outside the scoped namespace
2. The operator can alter and read Kube resources such as `secrets` outside the scoped namespace

To address these, we need to scope the RBAC within the scoped namespace by creating Roles instead of ClusterRoles.

This PR adds a new option in the chart called `scopedRBAC` which must be used alongside `scopedNamespace`.

When `scopedRBAC` is `true`, it will create RBAC roles under the scoped namespace.

This will limit access to the Kube API within the scoped namespace.

However, there is a side-effect of such scoped RBAC that `ClusterSecretStore` cannot be supported because it is a cluster scoped resource.
