### PR TITLE
Minor change - IBM Cloud SM example - refreshInterval 60m

### DIFF
--- a/docs/snippets/ibm-external-secret.yaml
+++ b/docs/snippets/ibm-external-secret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: external-secret-sample
 spec:
-  refreshInterval: 1m
+  refreshInterval: 60m
   secretStoreRef:
     name: secretstore-sample
     kind: SecretStore


### PR DESCRIPTION
this template is used mostly as is, and the previous `refreshInterval` of `1m` is to high and produces only too much pressure on the API endpoints