### PR TITLE
Implements single Client as the default GCP SecretManager approach

### DIFF
--- a/pkg/controllers/secretstore/common.go
+++ b/pkg/controllers/secretstore/common.go
@@ -91,7 +91,9 @@ func validateStore(ctx context.Context, namespace string, store esapi.GenericSto
 		recorder.Event(store, v1.EventTypeWarning, esapi.ReasonInvalidProviderConfig, err.Error())
 		return fmt.Errorf(errStoreClient, err)
 	}
-
+	defer func() {
+		cl.Close(ctx)
+	}()
 	err = cl.Validate()
 	if err != nil {
 		cond := NewSecretStoreCondition(esapi.SecretStoreReady, v1.ConditionFalse, esapi.ReasonValidationFailed, errUnableValidateStore)


### PR DESCRIPTION
Partially covers #818
 Fixes #834 

Some comments around this fix:

The issues are around the fact that apparently GCP SM does not expects multiple clients running at the same time. 

Also, the main memory leak comes from the fact that SecretStore reconciles were not calling the Close method.

The main idea of the fix is to make sure we only have one instance of GCPSM and GCPWI clients, and never close them. Closing doesn't have to do with memory per se, but with some random error messages that appear if a given ES or SS gets reconciled in parallel.


Signed-off-by: Gustavo Carvalho <gustavo.carvalho@container-solutions.com>