### PR TITLE
Implementing Concurrency validation checks

### DIFF
--- a/apis/externalsecrets/v1beta1/provider.go
+++ b/apis/externalsecrets/v1beta1/provider.go
@@ -32,6 +32,8 @@ type Provider interface {
 
 	// ValidateStore checks if the provided store is valid
 	ValidateStore(store GenericStore) error
+	// Checks if provider supports concurrency
+	SupportsConcurrency() bool
 }
 
 // +kubebuilder:object:root=false

--- a/apis/externalsecrets/v1beta1/provider_schema_test.go
+++ b/apis/externalsecrets/v1beta1/provider_schema_test.go
@@ -25,6 +25,10 @@ type PP struct{}
 
 const shouldBeRegistered = "provider should be registered"
 
+func (p *PP) SupportsConcurrency() bool {
+	return true
+}
+
 // New constructs a SecretsManager Provider.
 func (p *PP) NewClient(ctx context.Context, store GenericStore, kube client.Client, namespace string) (SecretsClient, error) {
 	return p, nil

--- a/deploy/charts/external-secrets/templates/cert-controller-service.yaml
+++ b/deploy/charts/external-secrets/templates/cert-controller-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.certController.prometheus.enabled }}
+{{- if and .Values.certController.create .Values.certController.prometheus.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/deploy/charts/external-secrets/templates/cert-controller-serviceaccount.yaml
+++ b/deploy/charts/external-secrets/templates/cert-controller-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.certController.serviceAccount.create -}}
+{{- if and .Values.certController.create .Values.certController.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/deploy/charts/external-secrets/templates/validatingwebhook.yaml
+++ b/deploy/charts/external-secrets/templates/validatingwebhook.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.webhook.create }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -39,3 +40,4 @@ webhooks:
   admissionReviewVersions: ["v1", "v1beta1"]
   sideEffects: None
   timeoutSeconds: 5
+{{- end }}

--- a/deploy/charts/external-secrets/templates/webhook-secret.yaml
+++ b/deploy/charts/external-secrets/templates/webhook-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.webhook.create }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,3 +7,4 @@ metadata:
   labels:
     {{- include "external-secrets-webhook.labels" . | nindent 4 }}
     external-secrets.io/component : webhook
+{{- end }}

--- a/deploy/charts/external-secrets/templates/webhook-service.yaml
+++ b/deploy/charts/external-secrets/templates/webhook-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.webhook.create }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -27,3 +28,4 @@ spec:
   {{- end }}
   selector:
     {{- include "external-secrets-webhook.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/deploy/charts/external-secrets/templates/webhook-serviceaccount.yaml
+++ b/deploy/charts/external-secrets/templates/webhook-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.webhook.serviceAccount.create -}}
+{{- if and .Values.webhook.create .Values.webhook.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/e2e/framework/addon/eso.go
+++ b/e2e/framework/addon/eso.go
@@ -93,6 +93,24 @@ func WithNamespaceScope(namespace string) MutationFunc {
 	}
 }
 
+func WithoutWebhook() MutationFunc {
+	return func(eso *ESO) {
+		eso.HelmChart.Vars = append(eso.HelmChart.Vars, StringTuple{
+			Key:   "webhook.create",
+			Value: "false",
+		})
+	}
+}
+
+func WithoutCertController() MutationFunc {
+	return func(eso *ESO) {
+		eso.HelmChart.Vars = append(eso.HelmChart.Vars, StringTuple{
+			Key:   "certController.create",
+			Value: "false",
+		})
+	}
+}
+
 func WithServiceAccount(saName string) MutationFunc {
 	return func(eso *ESO) {
 		eso.HelmChart.Vars = append(eso.HelmChart.Vars, []StringTuple{

--- a/e2e/suite/aws/parameterstore/parameterstore_managed.go
+++ b/e2e/suite/aws/parameterstore/parameterstore_managed.go
@@ -63,6 +63,8 @@ var _ = Describe("[awsmanaged] with mounted IRSA", Label("aws", "parameterstore"
 			addon.WithServiceAccount(prov.ServiceAccountName),
 			addon.WithReleaseName(f.Namespace.Name),
 			addon.WithNamespace("default"),
+			addon.WithoutWebhook(),
+			addon.WithoutCertController(),
 		))
 	})
 

--- a/e2e/suite/aws/secretsmanager/secretsmanager_managed.go
+++ b/e2e/suite/aws/secretsmanager/secretsmanager_managed.go
@@ -63,6 +63,8 @@ var _ = Describe("[awsmanaged] with mounted IRSA", Label("aws", "secretsmanager"
 			addon.WithServiceAccount(prov.ServiceAccountName),
 			addon.WithReleaseName(f.Namespace.Name),
 			addon.WithNamespace("default"),
+			addon.WithoutWebhook(),
+			addon.WithoutCertController(),
 		))
 	})
 

--- a/e2e/suite/gcp/gcp_managed.go
+++ b/e2e/suite/gcp/gcp_managed.go
@@ -44,6 +44,8 @@ var _ = Describe("[gcpmanaged] with pod identity", Label("gcp", "secretsmanager"
 			addon.WithServiceAccount(prov.ServiceAccountName),
 			addon.WithReleaseName(f.Namespace.Name),
 			addon.WithNamespace("default"),
+			addon.WithoutWebhook(),
+			addon.WithoutCertController(),
 		))
 	})
 
@@ -78,6 +80,8 @@ var _ = Describe("[gcpmanaged] with service account", Label("gcp", "secretsmanag
 			addon.WithControllerClass(f.BaseName),
 			addon.WithReleaseName(f.Namespace.Name),
 			addon.WithNamespace(f.Namespace.Name),
+			addon.WithoutWebhook(),
+			addon.WithoutCertController(),
 		))
 	})
 

--- a/pkg/controllers/externalsecret/externalsecret_controller.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller.go
@@ -148,6 +148,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 	secretClient, err := storeProvider.NewClient(ctx, store, r.Client, req.Namespace)
 	if err != nil {
+		if !storeProvider.SupportsConcurrency() {
+			r.RdyMu.Unlock()
+		}
 		log.Error(err, errStoreClient)
 		conditionSynced := NewExternalSecretCondition(esv1beta1.ExternalSecretReady, v1.ConditionFalse, esv1beta1.ConditionReasonSecretSyncedError, errStoreClient)
 		SetExternalSecretCondition(&externalSecret, *conditionSynced)

--- a/pkg/controllers/externalsecret/externalsecret_controller.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller.go
@@ -17,6 +17,7 @@ package externalsecret
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -79,6 +80,7 @@ type Reconciler struct {
 	ControllerClass string
 	RequeueInterval time.Duration
 	recorder        record.EventRecorder
+	RdyMu           *sync.Mutex
 }
 
 // Reconcile implements the main reconciliation loop
@@ -141,7 +143,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		syncCallsError.With(syncCallsMetricLabels).Inc()
 		return ctrl.Result{RequeueAfter: requeueAfter}, nil
 	}
-
+	if !storeProvider.SupportsConcurrency() {
+		r.RdyMu.Lock()
+	}
 	secretClient, err := storeProvider.NewClient(ctx, store, r.Client, req.Namespace)
 	if err != nil {
 		log.Error(err, errStoreClient)
@@ -156,6 +160,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		err = secretClient.Close(ctx)
 		if err != nil {
 			log.Error(err, errCloseStoreClient)
+		}
+		if !storeProvider.SupportsConcurrency() {
+			r.RdyMu.Unlock()
 		}
 	}()
 

--- a/pkg/controllers/secretstore/clustersecretstore_controller.go
+++ b/pkg/controllers/secretstore/clustersecretstore_controller.go
@@ -16,6 +16,7 @@ package secretstore
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -39,6 +40,7 @@ type ClusterStoreReconciler struct {
 	ControllerClass string
 	RequeueInterval time.Duration
 	recorder        record.EventRecorder
+	RdyMu           *sync.Mutex
 }
 
 func (r *ClusterStoreReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -52,7 +54,7 @@ func (r *ClusterStoreReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, err
 	}
 
-	return reconcile(ctx, req, &css, r.Client, log, r.ControllerClass, r.recorder, r.RequeueInterval)
+	return reconcile(ctx, req, &css, r.Client, log, r.ControllerClass, r.recorder, r.RequeueInterval, r.RdyMu)
 }
 
 // SetupWithManager returns a new controller builder that will be started by the provided Manager.

--- a/pkg/controllers/secretstore/common.go
+++ b/pkg/controllers/secretstore/common.go
@@ -90,6 +90,9 @@ func validateStore(ctx context.Context, namespace string, store esapi.GenericSto
 	}
 	cl, err := storeProvider.NewClient(ctx, store, client, namespace)
 	if err != nil {
+		if !storeProvider.SupportsConcurrency() {
+			mu.Unlock()
+		}
 		cond := NewSecretStoreCondition(esapi.SecretStoreReady, v1.ConditionFalse, esapi.ReasonInvalidProviderConfig, errUnableCreateClient)
 		SetExternalSecretCondition(store, *cond)
 		recorder.Event(store, v1.EventTypeWarning, esapi.ReasonInvalidProviderConfig, err.Error())

--- a/pkg/controllers/secretstore/secretstore_controller.go
+++ b/pkg/controllers/secretstore/secretstore_controller.go
@@ -16,6 +16,7 @@ package secretstore
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -39,6 +40,7 @@ type StoreReconciler struct {
 	recorder        record.EventRecorder
 	RequeueInterval time.Duration
 	ControllerClass string
+	RdyMu           *sync.Mutex
 }
 
 func (r *StoreReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -52,7 +54,7 @@ func (r *StoreReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return ctrl.Result{}, err
 	}
 
-	return reconcile(ctx, req, &ss, r.Client, log, r.ControllerClass, r.recorder, r.RequeueInterval)
+	return reconcile(ctx, req, &ss, r.Client, log, r.ControllerClass, r.recorder, r.RequeueInterval, r.RdyMu)
 }
 
 // SetupWithManager returns a new controller builder that will be started by the provided Manager.

--- a/pkg/provider/akeyless/akeyless.go
+++ b/pkg/provider/akeyless/akeyless.go
@@ -58,6 +58,9 @@ func init() {
 		Akeyless: &esv1beta1.AkeylessProvider{},
 	})
 }
+func (p *Provider) SupportsConcurrency() bool {
+	return true
+}
 
 // NewClient constructs a new secrets client based on the provided store.
 func (p *Provider) NewClient(ctx context.Context, store esv1beta1.GenericStore, kube client.Client, namespace string) (esv1beta1.SecretsClient, error) {

--- a/pkg/provider/alibaba/kms.go
+++ b/pkg/provider/alibaba/kms.go
@@ -162,6 +162,10 @@ func (kms *KeyManagementService) GetSecretMap(ctx context.Context, ref esv1beta1
 	return secretData, nil
 }
 
+func (kms *KeyManagementService) SupportsConcurrency() bool {
+	return true
+}
+
 // NewClient constructs a new secrets client based on the provided store.
 func (kms *KeyManagementService) NewClient(ctx context.Context, store esv1beta1.GenericStore, kube kclient.Client, namespace string) (esv1beta1.SecretsClient, error) {
 	storeSpec := store.GetSpec()

--- a/pkg/provider/aws/provider.go
+++ b/pkg/provider/aws/provider.go
@@ -38,6 +38,10 @@ const (
 	errRegionNotFound         = "region not found: %s"
 )
 
+func (p *Provider) SupportsConcurrency() bool {
+	return true
+}
+
 // NewClient constructs a new secrets client based on the provided store.
 func (p *Provider) NewClient(ctx context.Context, store esv1beta1.GenericStore, kube client.Client, namespace string) (esv1beta1.SecretsClient, error) {
 	return newClient(ctx, store, kube, namespace, awsauth.DefaultSTSProvider)

--- a/pkg/provider/azure/keyvault/keyvault.go
+++ b/pkg/provider/azure/keyvault/keyvault.go
@@ -82,6 +82,10 @@ func init() {
 	})
 }
 
+func (a *Azure) SupportsConcurrency() bool {
+	return true
+}
+
 // NewClient constructs a new secrets client based on the provided store.
 func (a *Azure) NewClient(ctx context.Context, store esv1beta1.GenericStore, kube client.Client, namespace string) (esv1beta1.SecretsClient, error) {
 	return newClient(ctx, store, kube, namespace)

--- a/pkg/provider/fake/fake.go
+++ b/pkg/provider/fake/fake.go
@@ -33,6 +33,10 @@ type Provider struct {
 	config *esv1beta1.FakeProvider
 }
 
+func (p *Provider) SupportsConcurrency() bool {
+	return true
+}
+
 func (p *Provider) NewClient(ctx context.Context, store esv1beta1.GenericStore, kube client.Client, namespace string) (esv1beta1.SecretsClient, error) {
 	cfg, err := getProvider(store)
 	if err != nil {

--- a/pkg/provider/gcp/secretmanager/secretsmanager.go
+++ b/pkg/provider/gcp/secretmanager/secretsmanager.go
@@ -136,6 +136,10 @@ func serviceAccountTokenSource(ctx context.Context, store esv1beta1.GenericStore
 	return config.TokenSource(ctx), nil
 }
 
+func (sm *ProviderGCP) SupportsConcurrency() bool {
+	return false
+}
+
 // NewClient constructs a GCP Provider.
 func (sm *ProviderGCP) NewClient(ctx context.Context, store esv1beta1.GenericStore, kube kclient.Client, namespace string) (esv1beta1.SecretsClient, error) {
 	storeSpec := store.GetSpec()

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -105,6 +105,10 @@ func NewGitlabProvider() *Gitlab {
 	return &Gitlab{}
 }
 
+func (g *Gitlab) SupportsConcurrency() bool {
+	return true
+}
+
 // Method on Gitlab Provider to set up client with credentials and populate projectID.
 func (g *Gitlab) NewClient(ctx context.Context, store esv1beta1.GenericStore, kube kclient.Client, namespace string) (esv1beta1.SecretsClient, error) {
 	storeSpec := store.GetSpec()

--- a/pkg/provider/ibm/provider.go
+++ b/pkg/provider/ibm/provider.go
@@ -325,6 +325,10 @@ func (ibm *providerIBM) ValidateStore(store esv1beta1.GenericStore) error {
 	return nil
 }
 
+func (ibm *providerIBM) SupportsConcurrency() bool {
+	return true
+}
+
 func (ibm *providerIBM) NewClient(ctx context.Context, store esv1beta1.GenericStore, kube kclient.Client, namespace string) (esv1beta1.SecretsClient, error) {
 	storeSpec := store.GetSpec()
 	ibmSpec := storeSpec.Provider.IBM

--- a/pkg/provider/kubernetes/kubernetes.go
+++ b/pkg/provider/kubernetes/kubernetes.go
@@ -68,6 +68,10 @@ func init() {
 	})
 }
 
+func (k *ProviderKubernetes) SupportsConcurrency() bool {
+	return true
+}
+
 // NewClient constructs a Kubernetes Provider.
 func (k *ProviderKubernetes) NewClient(ctx context.Context, store esv1beta1.GenericStore, kube kclient.Client, namespace string) (esv1beta1.SecretsClient, error) {
 	storeSpec := store.GetSpec()

--- a/pkg/provider/oracle/oracle.go
+++ b/pkg/provider/oracle/oracle.go
@@ -121,6 +121,10 @@ func (vms *VaultManagementService) GetSecretMap(ctx context.Context, ref esv1bet
 	return secretData, nil
 }
 
+func (vms *VaultManagementService) SupportsConcurrency() bool {
+	return true
+}
+
 // NewClient constructs a new secrets client based on the provided store.
 func (vms *VaultManagementService) NewClient(ctx context.Context, store esv1beta1.GenericStore, kube kclient.Client, namespace string) (esv1beta1.SecretsClient, error) {
 	storeSpec := store.GetSpec()

--- a/pkg/provider/testing/fake/fake.go
+++ b/pkg/provider/testing/fake/fake.go
@@ -116,6 +116,9 @@ func (v *Client) WithNew(f func(context.Context, esv1beta1.GenericStore, client.
 	v.NewFn = f
 	return v
 }
+func (v *Client) SupportsConcurrency() bool {
+	return true
+}
 
 // NewClient returns a new fake provider.
 func (v *Client) NewClient(ctx context.Context, store esv1beta1.GenericStore, kube client.Client, namespace string) (esv1beta1.SecretsClient, error) {

--- a/pkg/provider/vault/vault.go
+++ b/pkg/provider/vault/vault.go
@@ -130,6 +130,10 @@ type connector struct {
 	newVaultClient func(c *vault.Config) (Client, error)
 }
 
+func (c *connector) SupportsConcurrency() bool {
+	return true
+}
+
 func (c *connector) NewClient(ctx context.Context, store esv1beta1.GenericStore, kube kclient.Client, namespace string) (esv1beta1.SecretsClient, error) {
 	storeSpec := store.GetSpec()
 	if storeSpec == nil || storeSpec.Provider == nil || storeSpec.Provider.Vault == nil {

--- a/pkg/provider/webhook/webhook.go
+++ b/pkg/provider/webhook/webhook.go
@@ -54,6 +54,10 @@ func init() {
 	})
 }
 
+func (p *Provider) SupportsConcurrency() bool {
+	return true
+}
+
 func (p *Provider) NewClient(ctx context.Context, store esv1beta1.GenericStore, kube client.Client, namespace string) (esv1beta1.SecretsClient, error) {
 	whClient := &WebHook{
 		kube:      kube,

--- a/pkg/provider/yandex/lockbox/lockbox.go
+++ b/pkg/provider/yandex/lockbox/lockbox.go
@@ -63,6 +63,10 @@ func newLockboxProvider(yandexCloudCreator client.YandexCloudCreator) *lockboxPr
 	}
 }
 
+func (p *lockboxProvider) SupportsConcurrency() bool {
+	return true
+}
+
 // NewClient constructs a Yandex Lockbox Provider.
 func (p *lockboxProvider) NewClient(ctx context.Context, store esv1beta1.GenericStore, kube kclient.Client, namespace string) (esv1beta1.SecretsClient, error) {
 	storeSpec := store.GetSpec()


### PR DESCRIPTION
Implementing Concurrency validation checks for providers that do not support it (like GCP SM)
For reference on a similar implementation that didn't work entirely see #841

Fixes #818
Fixes #834

Signed-off-by: Gustavo Carvalho <gustavo.carvalho@container-solutions.com>