### PR TITLE
Adds ValidateStore for some providers

### DIFF
--- a/pkg/provider/fake/fake.go
+++ b/pkg/provider/fake/fake.go
@@ -27,6 +27,8 @@ var (
 	errNotFound            = fmt.Errorf("secret value not found")
 	errMissingStore        = fmt.Errorf("missing store provider")
 	errMissingFakeProvider = fmt.Errorf("missing store provider fake")
+	errMissingKeyField     = "key must be set in data %v"
+	errMissingValueField   = "at least one of value or valueMap must be set in data %v"
 )
 
 type Provider struct {
@@ -98,6 +100,18 @@ func (p *Provider) Validate() error {
 }
 
 func (p *Provider) ValidateStore(store esv1beta1.GenericStore) error {
+	prov := store.GetSpec().Provider.Fake
+	if prov == nil {
+		return nil
+	}
+	for pos, data := range prov.Data {
+		if data.Key == "" {
+			return fmt.Errorf(errMissingKeyField, pos)
+		}
+		if data.Value == "" && data.ValueMap == nil {
+			return fmt.Errorf(errMissingValueField, pos)
+		}
+	}
 	return nil
 }
 

--- a/pkg/provider/ibm/provider.go
+++ b/pkg/provider/ibm/provider.go
@@ -332,6 +332,12 @@ func (ibm *providerIBM) ValidateStore(store esv1beta1.GenericStore) error {
 	if err != nil {
 		return err
 	}
+	if secretRef.Name == "" {
+		return fmt.Errorf("secretAPIKey.name cannot be empty")
+	}
+	if secretRef.Key == "" {
+		return fmt.Errorf("secretAPIKey.key cannot be empty")
+	}
 	return nil
 }
 

--- a/pkg/provider/ibm/provider.go
+++ b/pkg/provider/ibm/provider.go
@@ -322,6 +322,16 @@ func (ibm *providerIBM) Validate() error {
 }
 
 func (ibm *providerIBM) ValidateStore(store esv1beta1.GenericStore) error {
+	storeSpec := store.GetSpec()
+	ibmSpec := storeSpec.Provider.IBM
+	if ibmSpec.ServiceURL == nil {
+		return fmt.Errorf("serviceURL is required")
+	}
+	secretRef := ibmSpec.Auth.SecretRef.SecretAPIKey
+	err := utils.ValidateSecretSelector(store, secretRef)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/provider/ibm/provider_test.go
+++ b/pkg/provider/ibm/provider_test.go
@@ -136,7 +136,7 @@ func TestValidateStore(t *testing.T) {
 	err = p.ValidateStore(store)
 	if err == nil {
 		t.Errorf(errExpectedErr)
-	} else if err.Error() != "secret name is required" {
+	} else if err.Error() != "secretAPIKey.name cannot be empty" {
 		t.Errorf("KeySelector test failed: expected secret name is required, got %v", err)
 	}
 	store.Spec.Provider.IBM.Auth.SecretRef.SecretAPIKey.Name = "foo"

--- a/pkg/provider/ibm/provider_test.go
+++ b/pkg/provider/ibm/provider_test.go
@@ -32,6 +32,10 @@ import (
 	fakesm "github.com/external-secrets/external-secrets/pkg/provider/ibm/fake"
 )
 
+const (
+	errExpectedErr = "wanted error got nil"
+)
+
 type secretManagerTestCase struct {
 	mockClient     *fakesm.IBMMockClient
 	apiInput       *sm.GetSecretOptions
@@ -109,6 +113,42 @@ var setAPIErr = func(smtc *secretManagerTestCase) {
 var setNilMockClient = func(smtc *secretManagerTestCase) {
 	smtc.mockClient = nil
 	smtc.expectError = errUninitalizedIBMProvider
+}
+
+// simple tests for Validate Store.
+func TestValidateStore(t *testing.T) {
+	p := providerIBM{}
+	store := &esv1beta1.SecretStore{
+		Spec: esv1beta1.SecretStoreSpec{
+			Provider: &esv1beta1.SecretStoreProvider{
+				IBM: &esv1beta1.IBMProvider{},
+			},
+		},
+	}
+	err := p.ValidateStore(store)
+	if err == nil {
+		t.Errorf(errExpectedErr)
+	} else if err.Error() != "serviceURL is required" {
+		t.Errorf("service URL test failed")
+	}
+	url := "my-url"
+	store.Spec.Provider.IBM.ServiceURL = &url
+	err = p.ValidateStore(store)
+	if err == nil {
+		t.Errorf(errExpectedErr)
+	} else if err.Error() != "secret name is required" {
+		t.Errorf("KeySelector test failed: expected secret name is required, got %v", err)
+	}
+	store.Spec.Provider.IBM.Auth.SecretRef.SecretAPIKey.Name = "foo"
+	store.Spec.Provider.IBM.Auth.SecretRef.SecretAPIKey.Key = "bar"
+	ns := "ns-one"
+	store.Spec.Provider.IBM.Auth.SecretRef.SecretAPIKey.Namespace = &ns
+	err = p.ValidateStore(store)
+	if err == nil {
+		t.Errorf(errExpectedErr)
+	} else if err.Error() != "namespace not allowed with namespaced SecretStore" {
+		t.Errorf("KeySelector test failed: expected namespace not allowed, got %v", err)
+	}
 }
 
 // test the sm<->gcp interface

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -110,6 +110,12 @@ func ErrorContains(out error, want string) bool {
 // We MUST NOT check the name or key property here. It MAY be defaulted by the provider.
 func ValidateSecretSelector(store esv1beta1.GenericStore, ref esmeta.SecretKeySelector) error {
 	clusterScope := store.GetObjectKind().GroupVersionKind().Kind == esv1beta1.ClusterSecretStoreKind
+	if ref.Name == "" {
+		return fmt.Errorf("secret name is required")
+	}
+	if ref.Key == "" {
+		return fmt.Errorf("secret key is required")
+	}
 	if clusterScope && ref.Namespace == nil {
 		return fmt.Errorf("cluster scope requires namespace")
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -110,12 +110,6 @@ func ErrorContains(out error, want string) bool {
 // We MUST NOT check the name or key property here. It MAY be defaulted by the provider.
 func ValidateSecretSelector(store esv1beta1.GenericStore, ref esmeta.SecretKeySelector) error {
 	clusterScope := store.GetObjectKind().GroupVersionKind().Kind == esv1beta1.ClusterSecretStoreKind
-	if ref.Name == "" {
-		return fmt.Errorf("secret name is required")
-	}
-	if ref.Key == "" {
-		return fmt.Errorf("secret key is required")
-	}
 	if clusterScope && ref.Namespace == nil {
 		return fmt.Errorf("cluster scope requires namespace")
 	}


### PR DESCRIPTION
This PR adds ValidateStore calls for the following providers.
It was also added a change to `utils.ValidateSecretSelector` in order to make sure `Name` and `Key` values are never empty.

* Fake
* IBM

Fixes #860 
Fixes #858 