### PR TITLE
add create flags to each CRDs resources for a more fine-grained control

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,9 +181,13 @@ helm.generate:
 	done
 # Add helm if statement for controlling the install of CRDs
 	@for i in $(HELM_DIR)/templates/crds/*.yml; do \
-		CRDS_FLAG_NAME="create$$(yq '.spec.names.kind' $$i)" && \
-		cp "$$i" "$$i.bkp" && \
-		echo "{{- if and (.Values.installCRDs) (.Values.crds.$$CRDS_FLAG_NAME) }}" > "$$i" && \
+		export CRDS_FLAG_NAME="create$$(yq '.spec.names.kind' $$i)"; \
+		cp "$$i" "$$i.bkp"; \
+		if [[ "$$CRDS_FLAG_NAME" == *"Cluster"* ]]; then \
+			echo "{{- if and (.Values.installCRDs) (.Values.crds.$$CRDS_FLAG_NAME) }}" > "$$i"; \
+		else \
+			echo "{{- if .Values.installCRDs }}" > "$$i"; \
+		fi; \
 		cat "$$i.bkp" >> "$$i" && \
 		echo "{{- end }}" >> "$$i" && \
 		rm "$$i.bkp" && \

--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -64,9 +64,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | concurrent | int | `1` | Specifies the number of concurrent ExternalSecret Reconciles external-secret executes at a time. |
 | controllerClass | string | `""` | If set external secrets will filter matching Secret Stores with the appropriate controller values. |
 | crds.createClusterExternalSecret | bool | `true` | If true, create CRDs for Cluster External Secret. |
-| crds.createClusterSecretStore | bool | `true` | If true, create CRDs for Secret Store. |
-| crds.createExternalSecret | bool | `true` | If true, create CRDs for External Secret. |
-| crds.createSecretStore | bool | `true` | If true, create CRDs for Secret Store. |
+| crds.createClusterSecretStore | bool | `true` | If true, create CRDs for Cluster Secret Store. |
 | createOperator | bool | `true` | Specifies whether an external secret operator deployment be created. |
 | deploymentAnnotations | object | `{}` | Annotations to add to Deployment |
 | extraArgs | object | `{}` |  |

--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -63,6 +63,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | certController.tolerations | list | `[]` |  |
 | concurrent | int | `1` | Specifies the number of concurrent ExternalSecret Reconciles external-secret executes at a time. |
 | controllerClass | string | `""` | If set external secrets will filter matching Secret Stores with the appropriate controller values. |
+| crds.createClusterExternalSecret | bool | `true` | If true, create CRDs for Cluster External Secret. |
+| crds.createClusterSecretStore | bool | `true` | If true, create CRDs for Secret Store. |
+| crds.createExternalSecret | bool | `true` | If true, create CRDs for External Secret. |
+| crds.createSecretStore | bool | `true` | If true, create CRDs for Secret Store. |
 | createOperator | bool | `true` | Specifies whether an external secret operator deployment be created. |
 | deploymentAnnotations | object | `{}` | Annotations to add to Deployment |
 | extraArgs | object | `{}` |  |

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -12,12 +12,8 @@ installCRDs: true
 crds:
   # -- If true, create CRDs for Cluster External Secret.
   createClusterExternalSecret: true
-  # -- If true, create CRDs for Secret Store.
+  # -- If true, create CRDs for Cluster Secret Store.
   createClusterSecretStore: true
-  # -- If true, create CRDs for External Secret.
-  createExternalSecret: true
-  # -- If true, create CRDs for Secret Store.
-  createSecretStore: true
 
 imagePullSecrets: []
 nameOverride: ""

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -9,6 +9,16 @@ image:
 # -- If set, install and upgrade CRDs through helm chart.
 installCRDs: true
 
+crds:
+  # -- If true, create CRDs for Cluster External Secret.
+  createClusterExternalSecret: true
+  # -- If true, create CRDs for Secret Store.
+  createClusterSecretStore: true
+  # -- If true, create CRDs for External Secret.
+  createExternalSecret: true
+  # -- If true, create CRDs for Secret Store.
+  createSecretStore: true
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
In our use case, we strictly disallow external secrets to be created in the cluster scope.

Add flags to each of the CRDs so that we can skip the creation of all cluster-scoped CRDs during the deployment.

Example:
```helm
{{- if and (.Values.installCRDs) (.Values.crds.createClusterExternalSecret) }}
(...content omitted)
{{- end }}
```