### PR TITLE
fix: use controller-runtime internal backoff retry

### DIFF
--- a/pkg/controllers/externalsecret/externalsecret_controller.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller.go
@@ -247,7 +247,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		conditionSynced := NewExternalSecretCondition(esv1beta1.ExternalSecretReady, v1.ConditionFalse, esv1beta1.ConditionReasonSecretSyncedError, errUpdateSecret)
 		SetExternalSecretCondition(&externalSecret, *conditionSynced)
 		syncCallsError.With(syncCallsMetricLabels).Inc()
-		return ctrl.Result{RequeueAfter: requeueAfter}, nil
+		return ctrl.Result{}, err
 	}
 
 	r.recorder.Event(&externalSecret, v1.EventTypeNormal, esv1beta1.ReasonUpdated, "Updated Secret")


### PR DESCRIPTION
I didn't see a sufficient reason to put a fixed re-queue on error.

Controller Runtime can manage internally exponential retry, so we should let the controller manage that by itself.

I haven't checked the whole method but I'm pretty sure that `return ctrl.Result{RequeueAfter: requeueAfter}, nil` on error is an anti-pattern. Maybe I should also apply this fix on the following lines:
- https://github.com/external-secrets/external-secrets/blob/c00afc9ff7575b37b4e332e214c270fc25bb09ae/pkg/controllers/externalsecret/externalsecret_controller.go#L120
- https://github.com/external-secrets/external-secrets/blob/c00afc9ff7575b37b4e332e214c270fc25bb09ae/pkg/controllers/externalsecret/externalsecret_controller.go#L135
- https://github.com/external-secrets/external-secrets/blob/c00afc9ff7575b37b4e332e214c270fc25bb09ae/pkg/controllers/externalsecret/externalsecret_controller.go#L144

We do not need to update the controller creation because rate-limiting relies on default value (https://github.com/kubernetes-sigs/controller-runtime/blob/16bf3ad036b908d897543c415fcc0bafc5cec711/pkg/controller/controller.go#L117)

related to https://github.com/external-secrets/external-secrets/issues/646