### PR TITLE
GCP: Adds checks to see if a key name exists before trying to load a nested value

### DIFF
--- a/pkg/provider/gcp/secretmanager/secretsmanager_test.go
+++ b/pkg/provider/gcp/secretmanager/secretsmanager_test.go
@@ -109,6 +109,25 @@ func TestSecretManagerGetSecret(t *testing.T) {
 		smtc.apiOutput.Payload.Data = []byte("testtesttest")
 		smtc.expectedSecret = "testtesttest"
 	}
+	// good case: with a dot in the key name
+	setDotRef := func(smtc *secretManagerTestCase) {
+		smtc.ref = &esv1beta1.ExternalSecretDataRemoteRef{
+			Key:      "/baz",
+			Version:  "default",
+			Property: "name.json",
+		}
+		smtc.apiInput.Name = "projects/default/secrets//baz/versions/default"
+		smtc.apiOutput.Payload.Data = []byte(
+			`{
+			"name.json": "Tom",
+			"friends": [
+				{"first": "Dale", "last": "Murphy"},
+				{"first": "Roger", "last": "Craig"},
+				{"first": "Jane", "last": "Murphy"}
+			]
+        }`)
+		smtc.expectedSecret = "Tom"
+	}
 
 	// good case: ref with
 	setCustomRef := func(smtc *secretManagerTestCase) {
@@ -144,6 +163,7 @@ func TestSecretManagerGetSecret(t *testing.T) {
 		makeValidSecretManagerTestCaseCustom(setCustomVersion),
 		makeValidSecretManagerTestCaseCustom(setAPIErr),
 		makeValidSecretManagerTestCaseCustom(setCustomRef),
+		makeValidSecretManagerTestCaseCustom(setDotRef),
 		makeValidSecretManagerTestCaseCustom(setNilMockClient),
 	}
 


### PR DESCRIPTION
Fixes #941

Signed-off-by: Gustavo Carvalho <gustavo.carvalho@container-solutions.com>