### PR TITLE
AWS GetAllSecrets: Trimming root path when a dataFrom.find.path is provided.

### DIFF
--- a/e2e/suite/aws/parameterstore/find_by_name.go
+++ b/e2e/suite/aws/parameterstore/find_by_name.go
@@ -72,11 +72,11 @@ func FindByNameWithPath(f *framework.Framework) (string, func(*framework.TestCas
 		tc.ExpectedSecret = &v1.Secret{
 			Type: v1.SecretTypeOpaque,
 			Data: map[string][]byte{
-				fmt.Sprintf("_%s_two", f.Namespace.Name):   []byte(secretValue),
-				fmt.Sprintf("_%s_three", f.Namespace.Name): []byte(secretValue),
+				"two":   []byte(secretValue),
+				"three": []byte(secretValue),
 			},
 		}
-		pathPrefix := fmt.Sprintf("/%s", f.Namespace.Name)
+		pathPrefix := fmt.Sprintf("/%s/", f.Namespace.Name)
 		tc.ExternalSecret.Spec.DataFrom = []esapi.ExternalSecretDataFromRemoteRef{
 			{
 				Find: &esapi.ExternalSecretFind{

--- a/e2e/suite/aws/parameterstore/find_by_tags.go
+++ b/e2e/suite/aws/parameterstore/find_by_tags.go
@@ -97,8 +97,8 @@ func FindByTagWithPath(f *framework.Framework) (string, func(*framework.TestCase
 		tc.ExpectedSecret = &v1.Secret{
 			Type: v1.SecretTypeOpaque,
 			Data: map[string][]byte{
-				fmt.Sprintf("_foobar_%s_two", f.Namespace.Name):   []byte(secretValue),
-				fmt.Sprintf("_foobar_%s_three", f.Namespace.Name): []byte(secretValue),
+				fmt.Sprintf("_%s_two", f.Namespace.Name):   []byte(secretValue),
+				fmt.Sprintf("_%s_three", f.Namespace.Name): []byte(secretValue),
 			},
 		}
 		tc.ExternalSecret.Spec.DataFrom = []esapi.ExternalSecretDataFromRemoteRef{

--- a/e2e/suite/common/find_by_name.go
+++ b/e2e/suite/common/find_by_name.go
@@ -73,8 +73,8 @@ func FindByNameWithPath(f *framework.Framework) (string, func(*framework.TestCas
 		tc.ExpectedSecret = &v1.Secret{
 			Type: v1.SecretTypeOpaque,
 			Data: map[string][]byte{
-				fmt.Sprintf("%s-two", f.Namespace.Name):   []byte(secretValue),
-				fmt.Sprintf("%s-three", f.Namespace.Name): []byte(secretValue),
+				"-two":   []byte(secretValue),
+				"-three": []byte(secretValue),
 			},
 		}
 		// AWS Secrets Manager is eventually consistent

--- a/e2e/suite/common/find_by_tags.go
+++ b/e2e/suite/common/find_by_tags.go
@@ -99,8 +99,8 @@ func FindByTagWithPath(f *framework.Framework) (string, func(*framework.TestCase
 		tc.ExpectedSecret = &v1.Secret{
 			Type: v1.SecretTypeOpaque,
 			Data: map[string][]byte{
-				fmt.Sprintf("foobar-%s-two", f.Namespace.Name):   []byte(secretValue),
-				fmt.Sprintf("foobar-%s-three", f.Namespace.Name): []byte(secretValue),
+				fmt.Sprintf("-%s-two", f.Namespace.Name):   []byte(secretValue),
+				fmt.Sprintf("-%s-three", f.Namespace.Name): []byte(secretValue),
 			},
 		}
 		// AWS Secrets Manager is eventually consistent


### PR DESCRIPTION
Fixes #915.

Signed-off-by: Gustavo Carvalho <gustavo.carvalho@container-solutions.com>