### PR TITLE
Implement validate for gitlab provider

### DIFF
--- a/pkg/provider/gitlab/fake/fake.go
+++ b/pkg/provider/gitlab/fake/fake.go
@@ -18,14 +18,19 @@ import (
 )
 
 type GitlabMockClient struct {
-	getVariable func(pid interface{}, key string, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectVariable, *gitlab.Response, error)
+	getVariable   func(pid interface{}, key string, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectVariable, *gitlab.Response, error)
+	listVariables func(pid interface{}, options ...gitlab.RequestOptionFunc) ([]*gitlab.ProjectVariable, *gitlab.Response, error)
 }
 
 func (mc *GitlabMockClient) GetVariable(pid interface{}, key string, opt *gitlab.GetProjectVariableOptions, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectVariable, *gitlab.Response, error) {
 	return mc.getVariable(pid, key, nil)
 }
 
-func (mc *GitlabMockClient) WithValue(projectIDinput, keyInput string, output *gitlab.ProjectVariable, err error) {
+func (mc *GitlabMockClient) ListVariables(pid interface{}, opt *gitlab.ListProjectVariablesOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.ProjectVariable, *gitlab.Response, error) {
+	return mc.listVariables(pid)
+}
+
+func (mc *GitlabMockClient) WithValue(projectIDinput, keyInput string, output *gitlab.ProjectVariable, response *gitlab.Response, err error) {
 	if mc != nil {
 		mc.getVariable = func(pid interface{}, key string, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectVariable, *gitlab.Response, error) {
 			// type secretmanagerpb.AccessSecretVersionRequest contains unexported fields
@@ -33,7 +38,11 @@ func (mc *GitlabMockClient) WithValue(projectIDinput, keyInput string, output *g
 			// if !cmp.Equal(paramReq, input, cmpopts.IgnoreUnexported(gitlab.ProjectVariable{})) {
 			// 	return nil, nil, fmt.Errorf("unexpected test argument")
 			// }
-			return output, nil, err
+			return output, response, err
+		}
+
+		mc.listVariables = func(pid interface{}, options ...gitlab.RequestOptionFunc) ([]*gitlab.ProjectVariable, *gitlab.Response, error) {
+			return []*gitlab.ProjectVariable{output}, response, err
 		}
 	}
 }

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -17,8 +17,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
-	"time"
 
 	"github.com/tidwall/gjson"
 	gitlab "github.com/xanzy/go-gitlab"
@@ -38,6 +38,8 @@ const (
 	errInvalidClusterStoreMissingSAKNamespace = "invalid clusterStore missing SAK namespace"
 	errFetchSAKSecret                         = "couldn't find secret on cluster: %w"
 	errMissingSAK                             = "missing credentials while setting auth"
+	errList                                   = "could not verify if the client is valid: %w"
+	errAuth                                   = "client is not allowed to get secrets"
 	errUninitalizedGitlabProvider             = "provider gitlab is not initialized"
 	errJSONSecretUnmarshal                    = "unable to unmarshal secret: %w"
 )
@@ -48,6 +50,7 @@ var _ esv1beta1.Provider = &Gitlab{}
 
 type Client interface {
 	GetVariable(pid interface{}, key string, opt *gitlab.GetProjectVariableOptions, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectVariable, *gitlab.Response, error)
+	ListVariables(pid interface{}, opt *gitlab.ListProjectVariablesOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.ProjectVariable, *gitlab.Response, error)
 }
 
 // Gitlab Provider struct with reference to a GitLab client and a projectID.
@@ -222,11 +225,15 @@ func (g *Gitlab) Close(ctx context.Context) error {
 	return nil
 }
 
+// Validate will use the gitlab client to validate the gitlab provider using the ListVariable call to ensure get permissions without needing a specific key.
 func (g *Gitlab) Validate() error {
-	timeout := 15 * time.Second
-	url := g.url
-
-	return utils.NetworkValidate(url, timeout)
+	_, resp, err := g.client.ListVariables(g.projectID, nil)
+	if err != nil {
+		return fmt.Errorf(errList, err)
+	} else if resp == nil || resp.StatusCode != http.StatusOK {
+		return fmt.Errorf(errAuth)
+	}
+	return nil
 }
 
 func (g *Gitlab) ValidateStore(store esv1beta1.GenericStore) error {


### PR DESCRIPTION
This is my attempt at #889 .  I ended up using the ListVariable call on the project so a key wasn't necessary.  It ignores the results and checks the resp and err to make sure it worked.  Doing tests in KinD showed it working as I would expect (bad token = shows the GET with a 401) but works with a valid token.  Attempted to follow the pattern with the fake, but feedback always appreciated.

Biggest questions I have are:
Are you comfortable using list to validate our permissions?
WIthout knowing the ins/outs of the gitlab API, I may have been heavy handed with my if's to validate.  Would love thoughts/opinions on those lines.