### PR TITLE
chore: force interface validation

### DIFF
--- a/pkg/provider/akeyless/akeyless.go
+++ b/pkg/provider/akeyless/akeyless.go
@@ -31,6 +31,10 @@ const (
 	defaultAPIUrl = "https://api.akeyless.io"
 )
 
+// https://github.com/external-secrets/external-secrets/issues/644
+var _ esv1beta1.SecretsClient = &Akeyless{}
+var _ esv1beta1.Provider = &Provider{}
+
 // Provider satisfies the provider interface.
 type Provider struct{}
 

--- a/pkg/provider/alibaba/kms.go
+++ b/pkg/provider/alibaba/kms.go
@@ -51,6 +51,10 @@ type Client struct {
 	accessKey []byte
 }
 
+// https://github.com/external-secrets/external-secrets/issues/644
+var _ esv1beta1.SecretsClient = &KeyManagementService{}
+var _ esv1beta1.Provider = &KeyManagementService{}
+
 type KeyManagementService struct {
 	Client SMInterface
 }

--- a/pkg/provider/aws/parameterstore/parameterstore.go
+++ b/pkg/provider/aws/parameterstore/parameterstore.go
@@ -31,6 +31,9 @@ import (
 	"github.com/external-secrets/external-secrets/pkg/utils"
 )
 
+// https://github.com/external-secrets/external-secrets/issues/644
+var _ esv1beta1.SecretsClient = &ParameterStore{}
+
 // ParameterStore is a provider for AWS ParameterStore.
 type ParameterStore struct {
 	sess   *session.Session

--- a/pkg/provider/aws/provider.go
+++ b/pkg/provider/aws/provider.go
@@ -29,6 +29,9 @@ import (
 	"github.com/external-secrets/external-secrets/pkg/utils"
 )
 
+// https://github.com/external-secrets/external-secrets/issues/644
+var _ esv1beta1.Provider = &Provider{}
+
 // Provider satisfies the provider interface.
 type Provider struct{}
 

--- a/pkg/provider/aws/secretsmanager/secretsmanager.go
+++ b/pkg/provider/aws/secretsmanager/secretsmanager.go
@@ -32,6 +32,9 @@ import (
 	"github.com/external-secrets/external-secrets/pkg/utils"
 )
 
+// https://github.com/external-secrets/external-secrets/issues/644
+var _ esv1beta1.SecretsClient = &SecretsManager{}
+
 // SecretsManager is a provider for AWS SecretsManager.
 type SecretsManager struct {
 	sess   *session.Session

--- a/pkg/provider/azure/keyvault/keyvault.go
+++ b/pkg/provider/azure/keyvault/keyvault.go
@@ -79,6 +79,10 @@ const (
 	errMissingSAAnnotation    = "missing service account annotation: %s"
 )
 
+// https://github.com/external-secrets/external-secrets/issues/644
+var _ esv1beta1.SecretsClient = &Azure{}
+var _ esv1beta1.Provider = &Azure{}
+
 // interface to keyvault.BaseClient.
 type SecretClient interface {
 	GetKey(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string) (result keyvault.KeyBundle, err error)

--- a/pkg/provider/gcp/secretmanager/secretsmanager.go
+++ b/pkg/provider/gcp/secretmanager/secretsmanager.go
@@ -41,9 +41,8 @@ import (
 )
 
 const (
-	CloudPlatformRole = "https://www.googleapis.com/auth/cloud-platform"
-	defaultVersion    = "latest"
-
+	CloudPlatformRole                         = "https://www.googleapis.com/auth/cloud-platform"
+	defaultVersion                            = "latest"
 	errGCPSMStore                             = "received invalid GCPSM SecretStore resource"
 	errUnableGetCredentials                   = "unable to get credentials: %w"
 	errClientClose                            = "unable to close SecretManager client: %w"
@@ -83,6 +82,10 @@ type GoogleSecretManagerClient interface {
  A Mutex was implemented to make sure only one connection can be in place at a time.
 */
 var useMu = sync.Mutex{}
+
+// https://github.com/external-secrets/external-secrets/issues/644
+var _ esv1beta1.SecretsClient = &ProviderGCP{}
+var _ esv1beta1.Provider = &ProviderGCP{}
 
 // ProviderGCP is a provider for GCP Secret Manager.
 type ProviderGCP struct {

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -41,6 +41,10 @@ const (
 	errJSONSecretUnmarshal                    = "unable to unmarshal secret: %w"
 )
 
+// https://github.com/external-secrets/external-secrets/issues/644
+var _ esv1beta1.SecretsClient = &Gitlab{}
+var _ esv1beta1.Provider = &Gitlab{}
+
 type Client interface {
 	GetVariable(pid interface{}, key string, opt *gitlab.GetProjectVariableOptions, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectVariable, *gitlab.Response, error)
 }

--- a/pkg/provider/ibm/provider.go
+++ b/pkg/provider/ibm/provider.go
@@ -47,6 +47,10 @@ const (
 	errJSONSecretUnmarshal                   = "unable to unmarshal secret: %w"
 )
 
+// https://github.com/external-secrets/external-secrets/issues/644
+var _ esv1beta1.SecretsClient = &providerIBM{}
+var _ esv1beta1.Provider = &providerIBM{}
+
 type SecretManagerClient interface {
 	GetSecret(getSecretOptions *sm.GetSecretOptions) (result *sm.GetSecret, response *core.DetailedResponse, err error)
 }

--- a/pkg/provider/kubernetes/kubernetes.go
+++ b/pkg/provider/kubernetes/kubernetes.go
@@ -41,6 +41,10 @@ const (
 	errEmptyKey                            = "key %s found but empty"
 )
 
+// https://github.com/external-secrets/external-secrets/issues/644
+var _ esv1beta1.SecretsClient = &ProviderKubernetes{}
+var _ esv1beta1.Provider = &ProviderKubernetes{}
+
 type KClient interface {
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*corev1.Secret, error)
 }

--- a/pkg/provider/oracle/oracle.go
+++ b/pkg/provider/oracle/oracle.go
@@ -52,6 +52,10 @@ const (
 	errUnexpectedContent                     = "unexpected secret bundle content"
 )
 
+// https://github.com/external-secrets/external-secrets/issues/644
+var _ esv1beta1.SecretsClient = &VaultManagementService{}
+var _ esv1beta1.Provider = &VaultManagementService{}
+
 type VaultManagementService struct {
 	Client VMInterface
 	vault  string

--- a/pkg/provider/vault/vault.go
+++ b/pkg/provider/vault/vault.go
@@ -103,6 +103,10 @@ const (
 	errInvalidTokenRef   = "invalid Auth.TokenSecretRef: %w"
 )
 
+// https://github.com/external-secrets/external-secrets/issues/644
+var _ esv1beta1.SecretsClient = &client{}
+var _ esv1beta1.Provider = &connector{}
+
 type Client interface {
 	NewRequest(method, requestPath string) *vault.Request
 	RawRequestWithContext(ctx context.Context, r *vault.Request) (*vault.Response, error)

--- a/pkg/provider/webhook/webhook.go
+++ b/pkg/provider/webhook/webhook.go
@@ -37,6 +37,10 @@ import (
 	"github.com/external-secrets/external-secrets/pkg/template/v2"
 )
 
+// https://github.com/external-secrets/external-secrets/issues/644
+var _ esv1beta1.SecretsClient = &WebHook{}
+var _ esv1beta1.Provider = &Provider{}
+
 // Provider satisfies the provider interface.
 type Provider struct{}
 

--- a/pkg/provider/yandex/lockbox/lockbox.go
+++ b/pkg/provider/yandex/lockbox/lockbox.go
@@ -45,6 +45,10 @@ type iamTokenKey struct {
 	privateKeyHash   string
 }
 
+// https://github.com/external-secrets/external-secrets/issues/644
+var _ esv1beta1.SecretsClient = &lockboxSecretsClient{}
+var _ esv1beta1.Provider = &lockboxProvider{}
+
 // lockboxProvider is a provider for Yandex Lockbox.
 type lockboxProvider struct {
 	yandexCloudCreator client.YandexCloudCreator


### PR DESCRIPTION
Closes #644

Forces interface validation even if we didn't call it yet. For already implemented (or sufficiently implemented) providers this would not make much of a difference, but it helps a lot when you are developing a new provider, and did not reach the parts where structs are actually being assigned to comply with interfaces. With that said it makes sense to have this at the top of every provider so people implementing new ones can look and know that this is a thing