### PR TITLE
feat: (helm chart) enable annotations for webhook secret

### DIFF
--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -115,13 +115,14 @@ The command removes all the Kubernetes components associated with the chart and 
 | webhook.podAnnotations | object | `{}` | Annotations to add to Pod |
 | webhook.podLabels | object | `{}` |  |
 | webhook.podSecurityContext | object | `{}` |  |
-| webhook.port | int | `443` | The port the webhook will listen to |
+| webhook.port | int | `10250` | The port the webhook will listen to |
 | webhook.priorityClassName | string | `""` | Pod priority class name. |
 | webhook.prometheus.enabled | bool | `false` | Specifies whether to expose Service resource for collecting Prometheus metrics |
 | webhook.prometheus.service.port | int | `8080` |  |
 | webhook.rbac.create | bool | `true` | Specifies whether role and rolebinding resources should be created. |
 | webhook.replicaCount | int | `1` |  |
 | webhook.resources | object | `{}` |  |
+| webhook.secretAnnotations | object | `{}` | Annotations to add to Secret |
 | webhook.securityContext | object | `{}` |  |
 | webhook.serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
 | webhook.serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |

--- a/deploy/charts/external-secrets/templates/webhook-secret.yaml
+++ b/deploy/charts/external-secrets/templates/webhook-secret.yaml
@@ -7,4 +7,8 @@ metadata:
   labels:
     {{- include "external-secrets-webhook.labels" . | nindent 4 }}
     external-secrets.io/component : webhook
+  {{- with .Values.webhook.secretAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -156,6 +156,9 @@ webhook:
     ## -- Map of extra arguments to pass to container.
   extraArgs: {}
 
+    # -- Annotations to add to Secret
+  secretAnnotations: {}
+
     # -- Annotations to add to Deployment
   deploymentAnnotations: {}
 


### PR DESCRIPTION
Implements https://github.com/external-secrets/external-secrets/issues/1002

This would allow a user to define annotations for the webhook secret in `values.yaml`