### PR TITLE
Update guides-metrics.md

### DIFF
--- a/docs/guides-metrics.md
+++ b/docs/guides-metrics.md
@@ -2,4 +2,4 @@
 
 The External Secrets Operator exposes its Prometheus metrics in the `/metrics` path. To enable it, set the `prometheus.enabled` Helm flag to `true`.
 
-The Operator has the metrics inherited from Kubebuilder plus some custom metrics with the `external_secret` prefix.
+The Operator has the metrics inherited from Kubebuilder plus some custom metrics with the `externalsecret` prefix.


### PR DESCRIPTION
I have installed external-secrets v0.4.4 and figured out that metrics actually have prefix `externalsecret`, not `external_secret`
For example:
* externalsecret_status_condition
* externalsecret_sync_calls_total