### PR TITLE
Update docs from v1alpha to v1beta1, fix typos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,11 +177,11 @@ helm.build: helm.generate ## Build helm chart
 helm.generate:
 # Split the generated bundle yaml file to inject control flags
 	@for i in $(BUNDLE_DIR)/*.yaml; do \
-		yq -Ns '"$(HELM_DIR)/templates/crds/" + .spec.names.singular' "$$i"; \
+		yq e -Ns '"$(HELM_DIR)/templates/crds/" + .spec.names.singular' "$$i"; \
 	done
 # Add helm if statement for controlling the install of CRDs
 	@for i in $(HELM_DIR)/templates/crds/*.yml; do \
-		export CRDS_FLAG_NAME="create$$(yq '.spec.names.kind' $$i)"; \
+		export CRDS_FLAG_NAME="create$$(yq e '.spec.names.kind' $$i)"; \
 		cp "$$i" "$$i.bkp"; \
 		if [[ "$$CRDS_FLAG_NAME" == *"Cluster"* ]]; then \
 			echo "{{- if and (.Values.installCRDs) (.Values.crds.$$CRDS_FLAG_NAME) }}" > "$$i"; \

--- a/docs/contributing-devguide.md
+++ b/docs/contributing-devguide.md
@@ -110,14 +110,14 @@ documentation. See `/docs` for the source code and `/hack/api-docs` for the buil
 When writing documentation it is advised to run the mkdocs server with livereload:
 
 ```shell
-make serve-docs
+make docs.serve
 ```
 
 Run the following command to run a complete build. The rendered assets are available under `/site`.
 
 ```shell
 make docs
-make serve-docs
+make docs.serve
 ```
 
 Open `http://localhost:8000` in your browser.

--- a/docs/contributing-devguide.md
+++ b/docs/contributing-devguide.md
@@ -8,6 +8,8 @@ git clone https://github.com/external-secrets/external-secrets.git
 cd external-secrets
 ```
 
+_Note: many of the `make` commands use [yq](https://github.com/mikefarah/yq), version 4.2X.X or higher._
+
 If you want to run controller tests you also need to install kubebuilder's `envtest`.
 
 The recommended way to do so is to install [setup-envtest](https://pkg.go.dev/sigs.k8s.io/controller-runtime/tools/setup-envtest)

--- a/docs/contributing-process.md
+++ b/docs/contributing-process.md
@@ -61,7 +61,7 @@ There's another suite of e2e tests that integrate with managed Kuberentes offeri
 They create real infrastructure at a cloud provider and deploy the controller
 into that environment.
 This is necessary to test the authentication integration
-([GCP Worklaod Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity),
+([GCP Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity),
 [EKS IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)...).
 
 These tests are time intensive (~20-45min) and must be triggered manually by

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1,20 +1,20 @@
 <p>Packages:</p>
 <ul>
 <li>
-<a href="#external-secrets.io%2fv1alpha1">external-secrets.io/v1alpha1</a>
+<a href="#external-secrets.io%2fv1beta1">external-secrets.io/v1beta1</a>
 </li>
 </ul>
-<h2 id="external-secrets.io/v1alpha1">external-secrets.io/v1alpha1</h2>
+<h2 id="external-secrets.io/v1beta1">external-secrets.io/v1beta1</h2>
 <p>
-<p>Package v1alpha1 contains resources for external-secrets</p>
+<p>Package v1beta1 contains resources for external-secrets</p>
 </p>
 Resource Types:
 <ul></ul>
-<h3 id="external-secrets.io/v1alpha1.AWSAuth">AWSAuth
+<h3 id="external-secrets.io/v1beta1.AWSAuth">AWSAuth
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.AWSProvider">AWSProvider</a>)
+<a href="#external-secrets.io/v1beta1.AWSProvider">AWSProvider</a>)
 </p>
 <p>
 <p>AWSAuth tells the controller how to do authentication with aws.
@@ -33,7 +33,7 @@ if none is specified the controller will load credentials using the aws sdk defa
 <td>
 <code>secretRef</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.AWSAuthSecretRef">
+<a href="#external-secrets.io/v1beta1.AWSAuthSecretRef">
 AWSAuthSecretRef
 </a>
 </em>
@@ -46,7 +46,7 @@ AWSAuthSecretRef
 <td>
 <code>jwt</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.AWSJWTAuth">
+<a href="#external-secrets.io/v1beta1.AWSJWTAuth">
 AWSJWTAuth
 </a>
 </em>
@@ -57,11 +57,11 @@ AWSJWTAuth
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.AWSAuthSecretRef">AWSAuthSecretRef
+<h3 id="external-secrets.io/v1beta1.AWSAuthSecretRef">AWSAuthSecretRef
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.AWSAuth">AWSAuth</a>)
+<a href="#external-secrets.io/v1beta1.AWSAuth">AWSAuth</a>)
 </p>
 <p>
 <p>AWSAuthSecretRef holds secret references for AWS credentials
@@ -99,11 +99,11 @@ github.com/external-secrets/external-secrets/apis/meta/v1.SecretKeySelector
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.AWSJWTAuth">AWSJWTAuth
+<h3 id="external-secrets.io/v1beta1.AWSJWTAuth">AWSJWTAuth
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.AWSAuth">AWSAuth</a>)
+<a href="#external-secrets.io/v1beta1.AWSAuth">AWSAuth</a>)
 </p>
 <p>
 <p>Authenticate against AWS using service account tokens.</p>
@@ -128,11 +128,11 @@ github.com/external-secrets/external-secrets/apis/meta/v1.ServiceAccountSelector
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.AWSProvider">AWSProvider
+<h3 id="external-secrets.io/v1beta1.AWSProvider">AWSProvider
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.SecretStoreProvider">SecretStoreProvider</a>)
+<a href="#external-secrets.io/v1beta1.SecretStoreProvider">SecretStoreProvider</a>)
 </p>
 <p>
 <p>AWSProvider configures a store to sync secrets with AWS.</p>
@@ -149,7 +149,7 @@ github.com/external-secrets/external-secrets/apis/meta/v1.ServiceAccountSelector
 <td>
 <code>service</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.AWSServiceType">
+<a href="#external-secrets.io/v1beta1.AWSServiceType">
 AWSServiceType
 </a>
 </em>
@@ -162,7 +162,7 @@ AWSServiceType
 <td>
 <code>auth</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.AWSAuth">
+<a href="#external-secrets.io/v1beta1.AWSAuth">
 AWSAuth
 </a>
 </em>
@@ -199,11 +199,11 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.AWSServiceType">AWSServiceType
+<h3 id="external-secrets.io/v1beta1.AWSServiceType">AWSServiceType
 (<code>string</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.AWSProvider">AWSProvider</a>)
+<a href="#external-secrets.io/v1beta1.AWSProvider">AWSProvider</a>)
 </p>
 <p>
 <p>AWSServiceType is a enum that defines the service/API that is used to fetch the secrets.</p>
@@ -225,11 +225,11 @@ see: <a href="https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.
 </td>
 </tr></tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.AkeylessAuth">AkeylessAuth
+<h3 id="external-secrets.io/v1beta1.AkeylessAuth">AkeylessAuth
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.AkeylessProvider">AkeylessProvider</a>)
+<a href="#external-secrets.io/v1beta1.AkeylessProvider">AkeylessProvider</a>)
 </p>
 <p>
 </p>
@@ -245,7 +245,7 @@ see: <a href="https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.
 <td>
 <code>secretRef</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.AkeylessAuthSecretRef">
+<a href="#external-secrets.io/v1beta1.AkeylessAuthSecretRef">
 AkeylessAuthSecretRef
 </a>
 </em>
@@ -255,11 +255,11 @@ AkeylessAuthSecretRef
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.AkeylessAuthSecretRef">AkeylessAuthSecretRef
+<h3 id="external-secrets.io/v1beta1.AkeylessAuthSecretRef">AkeylessAuthSecretRef
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.AkeylessAuth">AkeylessAuth</a>)
+<a href="#external-secrets.io/v1beta1.AkeylessAuth">AkeylessAuth</a>)
 </p>
 <p>
 <p>AkeylessAuthSecretRef
@@ -306,11 +306,11 @@ github.com/external-secrets/external-secrets/apis/meta/v1.SecretKeySelector
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.AkeylessProvider">AkeylessProvider
+<h3 id="external-secrets.io/v1beta1.AkeylessProvider">AkeylessProvider
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.SecretStoreProvider">SecretStoreProvider</a>)
+<a href="#external-secrets.io/v1beta1.SecretStoreProvider">SecretStoreProvider</a>)
 </p>
 <p>
 <p>AkeylessProvider Configures an store to sync secrets using Akeyless KV.</p>
@@ -338,7 +338,7 @@ string
 <td>
 <code>authSecretRef</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.AkeylessAuth">
+<a href="#external-secrets.io/v1beta1.AkeylessAuth">
 AkeylessAuth
 </a>
 </em>
@@ -349,11 +349,11 @@ AkeylessAuth
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.AlibabaAuth">AlibabaAuth
+<h3 id="external-secrets.io/v1beta1.AlibabaAuth">AlibabaAuth
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.AlibabaProvider">AlibabaProvider</a>)
+<a href="#external-secrets.io/v1beta1.AlibabaProvider">AlibabaProvider</a>)
 </p>
 <p>
 <p>AlibabaAuth contains a secretRef for credentials.</p>
@@ -370,7 +370,7 @@ AkeylessAuth
 <td>
 <code>secretRef</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.AlibabaAuthSecretRef">
+<a href="#external-secrets.io/v1beta1.AlibabaAuthSecretRef">
 AlibabaAuthSecretRef
 </a>
 </em>
@@ -380,11 +380,11 @@ AlibabaAuthSecretRef
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.AlibabaAuthSecretRef">AlibabaAuthSecretRef
+<h3 id="external-secrets.io/v1beta1.AlibabaAuthSecretRef">AlibabaAuthSecretRef
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.AlibabaAuth">AlibabaAuth</a>)
+<a href="#external-secrets.io/v1beta1.AlibabaAuth">AlibabaAuth</a>)
 </p>
 <p>
 <p>AlibabaAuthSecretRef holds secret references for Alibaba credentials.</p>
@@ -421,11 +421,11 @@ github.com/external-secrets/external-secrets/apis/meta/v1.SecretKeySelector
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.AlibabaProvider">AlibabaProvider
+<h3 id="external-secrets.io/v1beta1.AlibabaProvider">AlibabaProvider
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.SecretStoreProvider">SecretStoreProvider</a>)
+<a href="#external-secrets.io/v1beta1.SecretStoreProvider">SecretStoreProvider</a>)
 </p>
 <p>
 <p>AlibabaProvider configures a store to sync secrets using the Alibaba Secret Manager provider.</p>
@@ -442,7 +442,7 @@ github.com/external-secrets/external-secrets/apis/meta/v1.SecretKeySelector
 <td>
 <code>auth</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.AlibabaAuth">
+<a href="#external-secrets.io/v1beta1.AlibabaAuth">
 AlibabaAuth
 </a>
 </em>
@@ -474,11 +474,11 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.AzureAuthType">AzureAuthType
+<h3 id="external-secrets.io/v1beta1.AzureAuthType">AzureAuthType
 (<code>string</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.AzureKVProvider">AzureKVProvider</a>)
+<a href="#external-secrets.io/v1beta1.AzureKVProvider">AzureKVProvider</a>)
 </p>
 <p>
 <p>AuthType describes how to authenticate to the Azure Keyvault
@@ -504,11 +504,11 @@ is ServicePrincipal.</p>
 </td>
 </tr></tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.AzureKVAuth">AzureKVAuth
+<h3 id="external-secrets.io/v1beta1.AzureKVAuth">AzureKVAuth
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.AzureKVProvider">AzureKVProvider</a>)
+<a href="#external-secrets.io/v1beta1.AzureKVProvider">AzureKVProvider</a>)
 </p>
 <p>
 <p>Configuration used to authenticate with Azure.</p>
@@ -547,11 +547,11 @@ github.com/external-secrets/external-secrets/apis/meta/v1.SecretKeySelector
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.AzureKVProvider">AzureKVProvider
+<h3 id="external-secrets.io/v1beta1.AzureKVProvider">AzureKVProvider
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.SecretStoreProvider">SecretStoreProvider</a>)
+<a href="#external-secrets.io/v1beta1.SecretStoreProvider">SecretStoreProvider</a>)
 </p>
 <p>
 <p>Configures an store to sync secrets using Azure KV.</p>
@@ -568,7 +568,7 @@ github.com/external-secrets/external-secrets/apis/meta/v1.SecretKeySelector
 <td>
 <code>authType</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.AzureAuthType">
+<a href="#external-secrets.io/v1beta1.AzureAuthType">
 AzureAuthType
 </a>
 </em>
@@ -608,7 +608,7 @@ string
 <td>
 <code>authSecretRef</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.AzureKVAuth">
+<a href="#external-secrets.io/v1beta1.AzureKVAuth">
 AzureKVAuth
 </a>
 </em>
@@ -645,12 +645,12 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.CAProvider">CAProvider
+<h3 id="external-secrets.io/v1beta1.CAProvider">CAProvider
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.KubernetesServer">KubernetesServer</a>, 
-<a href="#external-secrets.io/v1alpha1.VaultProvider">VaultProvider</a>)
+<a href="#external-secrets.io/v1beta1.KubernetesServer">KubernetesServer</a>, 
+<a href="#external-secrets.io/v1beta1.VaultProvider">VaultProvider</a>)
 </p>
 <p>
 <p>Defines a location to fetch the cert for the vault provider from.</p>
@@ -667,7 +667,7 @@ string
 <td>
 <code>type</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.CAProviderType">
+<a href="#external-secrets.io/v1beta1.CAProviderType">
 CAProviderType
 </a>
 </em>
@@ -712,11 +712,11 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.CAProviderType">CAProviderType
+<h3 id="external-secrets.io/v1beta1.CAProviderType">CAProviderType
 (<code>string</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.CAProvider">CAProvider</a>)
+<a href="#external-secrets.io/v1beta1.CAProvider">CAProvider</a>)
 </p>
 <p>
 </p>
@@ -733,11 +733,11 @@ string
 <td></td>
 </tr></tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.CertAuth">CertAuth
+<h3 id="external-secrets.io/v1beta1.CertAuth">CertAuth
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.KubernetesAuth">KubernetesAuth</a>)
+<a href="#external-secrets.io/v1beta1.KubernetesAuth">KubernetesAuth</a>)
 </p>
 <p>
 </p>
@@ -771,7 +771,361 @@ github.com/external-secrets/external-secrets/apis/meta/v1.SecretKeySelector
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.ClusterSecretStore">ClusterSecretStore
+<h3 id="external-secrets.io/v1beta1.ClusterExternalSecret">ClusterExternalSecret
+</h3>
+<p>
+<p>ClusterExternalSecret is the Schema for the clusterexternalsecrets API.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#external-secrets.io/v1beta1.ClusterExternalSecretSpec">
+ClusterExternalSecretSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>externalSecretSpec</code></br>
+<em>
+<a href="#external-secrets.io/v1beta1.ExternalSecretSpec">
+ExternalSecretSpec
+</a>
+</em>
+</td>
+<td>
+<p>The spec for the ExternalSecrets to be created</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>externalSecretName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The name of the external secrets to be created defaults to the name of the ClusterExternalSecret</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>namespaceSelector</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta">
+Kubernetes meta/v1.LabelSelector
+</a>
+</em>
+</td>
+<td>
+<p>The labels to select by to find the Namespaces to create the ExternalSecrets in.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>refreshTime</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#duration-v1-meta">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<p>The time in which the controller should reconcile it&rsquo;s objects and recheck namespaces for labels.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#external-secrets.io/v1beta1.ClusterExternalSecretStatus">
+ClusterExternalSecretStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="external-secrets.io/v1beta1.ClusterExternalSecretConditionType">ClusterExternalSecretConditionType
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#external-secrets.io/v1beta1.ClusterExternalSecretStatusCondition">ClusterExternalSecretStatusCondition</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;NotReady&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;PartiallyReady&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;Ready&#34;</p></td>
+<td></td>
+</tr></tbody>
+</table>
+<h3 id="external-secrets.io/v1beta1.ClusterExternalSecretNamespaceFailure">ClusterExternalSecretNamespaceFailure
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#external-secrets.io/v1beta1.ClusterExternalSecretStatus">ClusterExternalSecretStatus</a>)
+</p>
+<p>
+<p>ClusterExternalSecretNamespaceFailure represents a failed namespace deployment and it&rsquo;s reason.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>namespace</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Namespace is the namespace that failed when trying to apply an ExternalSecret</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reason</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Reason is why the ExternalSecret failed to apply to the namespace</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="external-secrets.io/v1beta1.ClusterExternalSecretSpec">ClusterExternalSecretSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#external-secrets.io/v1beta1.ClusterExternalSecret">ClusterExternalSecret</a>)
+</p>
+<p>
+<p>ClusterExternalSecretSpec defines the desired state of ClusterExternalSecret.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>externalSecretSpec</code></br>
+<em>
+<a href="#external-secrets.io/v1beta1.ExternalSecretSpec">
+ExternalSecretSpec
+</a>
+</em>
+</td>
+<td>
+<p>The spec for the ExternalSecrets to be created</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>externalSecretName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The name of the external secrets to be created defaults to the name of the ClusterExternalSecret</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>namespaceSelector</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta">
+Kubernetes meta/v1.LabelSelector
+</a>
+</em>
+</td>
+<td>
+<p>The labels to select by to find the Namespaces to create the ExternalSecrets in.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>refreshTime</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#duration-v1-meta">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<p>The time in which the controller should reconcile it&rsquo;s objects and recheck namespaces for labels.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="external-secrets.io/v1beta1.ClusterExternalSecretStatus">ClusterExternalSecretStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#external-secrets.io/v1beta1.ClusterExternalSecret">ClusterExternalSecret</a>)
+</p>
+<p>
+<p>ClusterExternalSecretStatus defines the observed state of ClusterExternalSecret.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>failedNamespaces</code></br>
+<em>
+<a href="#external-secrets.io/v1beta1.ClusterExternalSecretNamespaceFailure">
+[]ClusterExternalSecretNamespaceFailure
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Failed namespaces are the namespaces that failed to apply an ExternalSecret</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>provisionedNamespaces</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ProvisionedNamespaces are the namespaces where the ClusterExternalSecret has secrets</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>conditions</code></br>
+<em>
+<a href="#external-secrets.io/v1beta1.ClusterExternalSecretStatusCondition">
+[]ClusterExternalSecretStatusCondition
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="external-secrets.io/v1beta1.ClusterExternalSecretStatusCondition">ClusterExternalSecretStatusCondition
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#external-secrets.io/v1beta1.ClusterExternalSecretStatus">ClusterExternalSecretStatus</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>type</code></br>
+<em>
+<a href="#external-secrets.io/v1beta1.ClusterExternalSecretConditionType">
+ClusterExternalSecretConditionType
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
+Kubernetes core/v1.ConditionStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>message</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="external-secrets.io/v1beta1.ClusterSecretStore">ClusterSecretStore
 </h3>
 <p>
 <p>ClusterSecretStore represents a secure external location for storing secrets, which can be referenced as part of <code>storeRef</code> fields.</p>
@@ -802,7 +1156,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.SecretStoreSpec">
+<a href="#external-secrets.io/v1beta1.SecretStoreSpec">
 SecretStoreSpec
 </a>
 </em>
@@ -828,7 +1182,7 @@ The KES controller is instantiated with a specific controller name and filters E
 <td>
 <code>provider</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.SecretStoreProvider">
+<a href="#external-secrets.io/v1beta1.SecretStoreProvider">
 SecretStoreProvider
 </a>
 </em>
@@ -841,7 +1195,7 @@ SecretStoreProvider
 <td>
 <code>retrySettings</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.SecretStoreRetrySettings">
+<a href="#external-secrets.io/v1beta1.SecretStoreRetrySettings">
 SecretStoreRetrySettings
 </a>
 </em>
@@ -851,6 +1205,18 @@ SecretStoreRetrySettings
 <p>Used to configure http retries if failed</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>refreshInterval</code></br>
+<em>
+int
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Used to configure store refresh interval in seconds. Empty or 0 will default to the controller config.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -858,7 +1224,7 @@ SecretStoreRetrySettings
 <td>
 <code>status</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.SecretStoreStatus">
+<a href="#external-secrets.io/v1beta1.SecretStoreStatus">
 SecretStoreStatus
 </a>
 </em>
@@ -868,7 +1234,7 @@ SecretStoreStatus
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.ExternalSecret">ExternalSecret
+<h3 id="external-secrets.io/v1beta1.ExternalSecret">ExternalSecret
 </h3>
 <p>
 <p>ExternalSecret is the Schema for the external-secrets API.</p>
@@ -899,7 +1265,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.ExternalSecretSpec">
+<a href="#external-secrets.io/v1beta1.ExternalSecretSpec">
 ExternalSecretSpec
 </a>
 </em>
@@ -912,7 +1278,7 @@ ExternalSecretSpec
 <td>
 <code>secretStoreRef</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.SecretStoreRef">
+<a href="#external-secrets.io/v1beta1.SecretStoreRef">
 SecretStoreRef
 </a>
 </em>
@@ -924,7 +1290,7 @@ SecretStoreRef
 <td>
 <code>target</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.ExternalSecretTarget">
+<a href="#external-secrets.io/v1beta1.ExternalSecretTarget">
 ExternalSecretTarget
 </a>
 </em>
@@ -951,7 +1317,7 @@ May be set to zero to fetch and create it once. Defaults to 1h.</p>
 <td>
 <code>data</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.ExternalSecretData">
+<a href="#external-secrets.io/v1beta1.ExternalSecretData">
 []ExternalSecretData
 </a>
 </em>
@@ -965,8 +1331,8 @@ May be set to zero to fetch and create it once. Defaults to 1h.</p>
 <td>
 <code>dataFrom</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.ExternalSecretDataRemoteRef">
-[]ExternalSecretDataRemoteRef
+<a href="#external-secrets.io/v1beta1.ExternalSecretDataFromRemoteRef">
+[]ExternalSecretDataFromRemoteRef
 </a>
 </em>
 </td>
@@ -983,7 +1349,7 @@ If multiple entries are specified, the Secret keys are merged in the specified o
 <td>
 <code>status</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.ExternalSecretStatus">
+<a href="#external-secrets.io/v1beta1.ExternalSecretStatus">
 ExternalSecretStatus
 </a>
 </em>
@@ -993,11 +1359,11 @@ ExternalSecretStatus
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.ExternalSecretConditionType">ExternalSecretConditionType
+<h3 id="external-secrets.io/v1beta1.ExternalSecretConditionType">ExternalSecretConditionType
 (<code>string</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.ExternalSecretStatusCondition">ExternalSecretStatusCondition</a>)
+<a href="#external-secrets.io/v1beta1.ExternalSecretStatusCondition">ExternalSecretStatusCondition</a>)
 </p>
 <p>
 </p>
@@ -1014,11 +1380,12 @@ ExternalSecretStatus
 <td></td>
 </tr></tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.ExternalSecretConversionStrategy">ExternalSecretConversionStrategy
+<h3 id="external-secrets.io/v1beta1.ExternalSecretConversionStrategy">ExternalSecretConversionStrategy
 (<code>string</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.ExternalSecretDataRemoteRef">ExternalSecretDataRemoteRef</a>)
+<a href="#external-secrets.io/v1beta1.ExternalSecretDataRemoteRef">ExternalSecretDataRemoteRef</a>, 
+<a href="#external-secrets.io/v1beta1.ExternalSecretFind">ExternalSecretFind</a>)
 </p>
 <p>
 </p>
@@ -1035,11 +1402,11 @@ ExternalSecretStatus
 <td></td>
 </tr></tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.ExternalSecretCreationPolicy">ExternalSecretCreationPolicy
+<h3 id="external-secrets.io/v1beta1.ExternalSecretCreationPolicy">ExternalSecretCreationPolicy
 (<code>string</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.ExternalSecretTarget">ExternalSecretTarget</a>)
+<a href="#external-secrets.io/v1beta1.ExternalSecretTarget">ExternalSecretTarget</a>)
 </p>
 <p>
 <p>ExternalSecretCreationPolicy defines rules on how to create the resulting Secret.</p>
@@ -1057,16 +1424,20 @@ ExternalSecretStatus
 </tr><tr><td><p>&#34;None&#34;</p></td>
 <td><p>None does not create a Secret (future use with injector).</p>
 </td>
+</tr><tr><td><p>&#34;Orphan&#34;</p></td>
+<td><p>Orphan creates the Secret and does not set the ownerReference.
+I.e. it will be orphaned after the deletion of the ExternalSecret.</p>
+</td>
 </tr><tr><td><p>&#34;Owner&#34;</p></td>
 <td><p>Owner creates the Secret and sets .metadata.ownerReferences to the ExternalSecret resource.</p>
 </td>
 </tr></tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.ExternalSecretData">ExternalSecretData
+<h3 id="external-secrets.io/v1beta1.ExternalSecretData">ExternalSecretData
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.ExternalSecretSpec">ExternalSecretSpec</a>)
+<a href="#external-secrets.io/v1beta1.ExternalSecretSpec">ExternalSecretSpec</a>)
 </p>
 <p>
 <p>ExternalSecretData defines the connection between the Kubernetes Secret key (spec.data.<key>) and the Provider data.</p>
@@ -1093,7 +1464,7 @@ string
 <td>
 <code>remoteRef</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.ExternalSecretDataRemoteRef">
+<a href="#external-secrets.io/v1beta1.ExternalSecretDataRemoteRef">
 ExternalSecretDataRemoteRef
 </a>
 </em>
@@ -1103,12 +1474,58 @@ ExternalSecretDataRemoteRef
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.ExternalSecretDataRemoteRef">ExternalSecretDataRemoteRef
+<h3 id="external-secrets.io/v1beta1.ExternalSecretDataFromRemoteRef">ExternalSecretDataFromRemoteRef
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.ExternalSecretData">ExternalSecretData</a>, 
-<a href="#external-secrets.io/v1alpha1.ExternalSecretSpec">ExternalSecretSpec</a>)
+<a href="#external-secrets.io/v1beta1.ExternalSecretSpec">ExternalSecretSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>extract</code></br>
+<em>
+<a href="#external-secrets.io/v1beta1.ExternalSecretDataRemoteRef">
+ExternalSecretDataRemoteRef
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Used to extract multiple key/value pairs from one secret</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>find</code></br>
+<em>
+<a href="#external-secrets.io/v1beta1.ExternalSecretFind">
+ExternalSecretFind
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Used to find secrets based on tags or regular expressions</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="external-secrets.io/v1beta1.ExternalSecretDataRemoteRef">ExternalSecretDataRemoteRef
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#external-secrets.io/v1beta1.ExternalSecretData">ExternalSecretData</a>, 
+<a href="#external-secrets.io/v1beta1.ExternalSecretDataFromRemoteRef">ExternalSecretDataFromRemoteRef</a>)
 </p>
 <p>
 <p>ExternalSecretDataRemoteRef defines Provider data location.</p>
@@ -1160,7 +1577,7 @@ string
 <td>
 <code>conversionStrategy</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.ExternalSecretConversionStrategy">
+<a href="#external-secrets.io/v1beta1.ExternalSecretConversionStrategy">
 ExternalSecretConversionStrategy
 </a>
 </em>
@@ -1172,11 +1589,117 @@ ExternalSecretConversionStrategy
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.ExternalSecretSpec">ExternalSecretSpec
+<h3 id="external-secrets.io/v1beta1.ExternalSecretDeletionPolicy">ExternalSecretDeletionPolicy
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#external-secrets.io/v1beta1.ExternalSecretTarget">ExternalSecretTarget</a>)
+</p>
+<p>
+<p>ExternalSecretDeletionPolicy defines rules on how to delete the resulting Secret.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;Delete&#34;</p></td>
+<td><p>Delete deletes the secret if all provider secrets are deleted.
+If a secret gets deleted on the provider side and is not accessible
+anymore this is not considered an error and the ExternalSecret
+does not go into SecretSyncedError status.</p>
+</td>
+</tr><tr><td><p>&#34;Merge&#34;</p></td>
+<td><p>Merge removes keys in the secret, but not the secret itself.
+If a secret gets deleted on the provider side and is not accessible
+anymore this is not considered an error and the ExternalSecret
+does not go into SecretSyncedError status.</p>
+</td>
+</tr><tr><td><p>&#34;Retain&#34;</p></td>
+<td><p>Retain will retain the secret if all provider secrets have been deleted.
+If a provider secret does not exist the ExternalSecret gets into the
+SecretSyncedError status.</p>
+</td>
+</tr></tbody>
+</table>
+<h3 id="external-secrets.io/v1beta1.ExternalSecretFind">ExternalSecretFind
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.ExternalSecret">ExternalSecret</a>)
+<a href="#external-secrets.io/v1beta1.ExternalSecretDataFromRemoteRef">ExternalSecretDataFromRemoteRef</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>path</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>A root path to start the find operations.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>name</code></br>
+<em>
+<a href="#external-secrets.io/v1beta1.FindName">
+FindName
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Finds secrets based on the name.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tags</code></br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Find secrets based on tags.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>conversionStrategy</code></br>
+<em>
+<a href="#external-secrets.io/v1beta1.ExternalSecretConversionStrategy">
+ExternalSecretConversionStrategy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Used to define a conversion Strategy</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="external-secrets.io/v1beta1.ExternalSecretSpec">ExternalSecretSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#external-secrets.io/v1beta1.ClusterExternalSecretSpec">ClusterExternalSecretSpec</a>, 
+<a href="#external-secrets.io/v1beta1.ExternalSecret">ExternalSecret</a>)
 </p>
 <p>
 <p>ExternalSecretSpec defines the desired state of ExternalSecret.</p>
@@ -1193,7 +1716,7 @@ ExternalSecretConversionStrategy
 <td>
 <code>secretStoreRef</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.SecretStoreRef">
+<a href="#external-secrets.io/v1beta1.SecretStoreRef">
 SecretStoreRef
 </a>
 </em>
@@ -1205,7 +1728,7 @@ SecretStoreRef
 <td>
 <code>target</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.ExternalSecretTarget">
+<a href="#external-secrets.io/v1beta1.ExternalSecretTarget">
 ExternalSecretTarget
 </a>
 </em>
@@ -1232,7 +1755,7 @@ May be set to zero to fetch and create it once. Defaults to 1h.</p>
 <td>
 <code>data</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.ExternalSecretData">
+<a href="#external-secrets.io/v1beta1.ExternalSecretData">
 []ExternalSecretData
 </a>
 </em>
@@ -1246,8 +1769,8 @@ May be set to zero to fetch and create it once. Defaults to 1h.</p>
 <td>
 <code>dataFrom</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.ExternalSecretDataRemoteRef">
-[]ExternalSecretDataRemoteRef
+<a href="#external-secrets.io/v1beta1.ExternalSecretDataFromRemoteRef">
+[]ExternalSecretDataFromRemoteRef
 </a>
 </em>
 </td>
@@ -1259,11 +1782,11 @@ If multiple entries are specified, the Secret keys are merged in the specified o
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.ExternalSecretStatus">ExternalSecretStatus
+<h3 id="external-secrets.io/v1beta1.ExternalSecretStatus">ExternalSecretStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.ExternalSecret">ExternalSecret</a>)
+<a href="#external-secrets.io/v1beta1.ExternalSecret">ExternalSecret</a>)
 </p>
 <p>
 </p>
@@ -1304,7 +1827,7 @@ string
 <td>
 <code>conditions</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.ExternalSecretStatusCondition">
+<a href="#external-secrets.io/v1beta1.ExternalSecretStatusCondition">
 []ExternalSecretStatusCondition
 </a>
 </em>
@@ -1315,11 +1838,11 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.ExternalSecretStatusCondition">ExternalSecretStatusCondition
+<h3 id="external-secrets.io/v1beta1.ExternalSecretStatusCondition">ExternalSecretStatusCondition
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.ExternalSecretStatus">ExternalSecretStatus</a>)
+<a href="#external-secrets.io/v1beta1.ExternalSecretStatus">ExternalSecretStatus</a>)
 </p>
 <p>
 </p>
@@ -1335,7 +1858,7 @@ string
 <td>
 <code>type</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.ExternalSecretConditionType">
+<a href="#external-secrets.io/v1beta1.ExternalSecretConditionType">
 ExternalSecretConditionType
 </a>
 </em>
@@ -1392,11 +1915,11 @@ Kubernetes meta/v1.Time
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.ExternalSecretTarget">ExternalSecretTarget
+<h3 id="external-secrets.io/v1beta1.ExternalSecretTarget">ExternalSecretTarget
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.ExternalSecretSpec">ExternalSecretSpec</a>)
+<a href="#external-secrets.io/v1beta1.ExternalSecretSpec">ExternalSecretSpec</a>)
 </p>
 <p>
 <p>ExternalSecretTarget defines the Kubernetes Secret to be created
@@ -1428,7 +1951,7 @@ Defaults to the .metadata.name of the ExternalSecret resource</p>
 <td>
 <code>creationPolicy</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.ExternalSecretCreationPolicy">
+<a href="#external-secrets.io/v1beta1.ExternalSecretCreationPolicy">
 ExternalSecretCreationPolicy
 </a>
 </em>
@@ -1441,9 +1964,24 @@ Defaults to &lsquo;Owner&rsquo;</p>
 </tr>
 <tr>
 <td>
+<code>deletionPolicy</code></br>
+<em>
+<a href="#external-secrets.io/v1beta1.ExternalSecretDeletionPolicy">
+ExternalSecretDeletionPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeletionPolicy defines rules on how to delete the resulting Secret
+Defaults to &lsquo;Retain&rsquo;</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>template</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.ExternalSecretTemplate">
+<a href="#external-secrets.io/v1beta1.ExternalSecretTemplate">
 ExternalSecretTemplate
 </a>
 </em>
@@ -1467,11 +2005,11 @@ bool
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.ExternalSecretTemplate">ExternalSecretTemplate
+<h3 id="external-secrets.io/v1beta1.ExternalSecretTemplate">ExternalSecretTemplate
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.ExternalSecretTarget">ExternalSecretTarget</a>)
+<a href="#external-secrets.io/v1beta1.ExternalSecretTarget">ExternalSecretTarget</a>)
 </p>
 <p>
 <p>ExternalSecretTemplate defines a blueprint for the created Secret resource.
@@ -1502,22 +2040,19 @@ Kubernetes core/v1.SecretType
 <td>
 <code>engineVersion</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.TemplateEngineVersion">
+<a href="#external-secrets.io/v1beta1.TemplateEngineVersion">
 TemplateEngineVersion
 </a>
 </em>
 </td>
 <td>
-<p>EngineVersion specifies the template engine version
-that should be used to compile/execute the
-template specified in .data and .templateFrom[].</p>
 </td>
 </tr>
 <tr>
 <td>
 <code>metadata</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.ExternalSecretTemplateMetadata">
+<a href="#external-secrets.io/v1beta1.ExternalSecretTemplateMetadata">
 ExternalSecretTemplateMetadata
 </a>
 </em>
@@ -1541,7 +2076,7 @@ map[string]string
 <td>
 <code>templateFrom</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.TemplateFrom">
+<a href="#external-secrets.io/v1beta1.TemplateFrom">
 []TemplateFrom
 </a>
 </em>
@@ -1552,11 +2087,11 @@ map[string]string
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.ExternalSecretTemplateMetadata">ExternalSecretTemplateMetadata
+<h3 id="external-secrets.io/v1beta1.ExternalSecretTemplateMetadata">ExternalSecretTemplateMetadata
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.ExternalSecretTemplate">ExternalSecretTemplate</a>)
+<a href="#external-secrets.io/v1beta1.ExternalSecretTemplate">ExternalSecretTemplate</a>)
 </p>
 <p>
 <p>ExternalSecretTemplateMetadata defines metadata fields for the Secret blueprint.</p>
@@ -1593,11 +2128,15 @@ map[string]string
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.FakeProvider">FakeProvider
+<h3 id="external-secrets.io/v1beta1.ExternalSecretValidator">ExternalSecretValidator
+</h3>
+<p>
+</p>
+<h3 id="external-secrets.io/v1beta1.FakeProvider">FakeProvider
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.SecretStoreProvider">SecretStoreProvider</a>)
+<a href="#external-secrets.io/v1beta1.SecretStoreProvider">SecretStoreProvider</a>)
 </p>
 <p>
 <p>FakeProvider configures a fake provider that returns static values.</p>
@@ -1614,7 +2153,7 @@ map[string]string
 <td>
 <code>data</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.FakeProviderData">
+<a href="#external-secrets.io/v1beta1.FakeProviderData">
 []FakeProviderData
 </a>
 </em>
@@ -1624,11 +2163,11 @@ map[string]string
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.FakeProviderData">FakeProviderData
+<h3 id="external-secrets.io/v1beta1.FakeProviderData">FakeProviderData
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.FakeProvider">FakeProvider</a>)
+<a href="#external-secrets.io/v1beta1.FakeProvider">FakeProvider</a>)
 </p>
 <p>
 </p>
@@ -1682,11 +2221,41 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.GCPSMAuth">GCPSMAuth
+<h3 id="external-secrets.io/v1beta1.FindName">FindName
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.GCPSMProvider">GCPSMProvider</a>)
+<a href="#external-secrets.io/v1beta1.ExternalSecretFind">ExternalSecretFind</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>regexp</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Finds secrets base</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="external-secrets.io/v1beta1.GCPSMAuth">GCPSMAuth
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#external-secrets.io/v1beta1.GCPSMProvider">GCPSMProvider</a>)
 </p>
 <p>
 </p>
@@ -1702,7 +2271,7 @@ string
 <td>
 <code>secretRef</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.GCPSMAuthSecretRef">
+<a href="#external-secrets.io/v1beta1.GCPSMAuthSecretRef">
 GCPSMAuthSecretRef
 </a>
 </em>
@@ -1715,7 +2284,7 @@ GCPSMAuthSecretRef
 <td>
 <code>workloadIdentity</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.GCPWorkloadIdentity">
+<a href="#external-secrets.io/v1beta1.GCPWorkloadIdentity">
 GCPWorkloadIdentity
 </a>
 </em>
@@ -1726,11 +2295,11 @@ GCPWorkloadIdentity
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.GCPSMAuthSecretRef">GCPSMAuthSecretRef
+<h3 id="external-secrets.io/v1beta1.GCPSMAuthSecretRef">GCPSMAuthSecretRef
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.GCPSMAuth">GCPSMAuth</a>)
+<a href="#external-secrets.io/v1beta1.GCPSMAuth">GCPSMAuth</a>)
 </p>
 <p>
 </p>
@@ -1756,11 +2325,11 @@ github.com/external-secrets/external-secrets/apis/meta/v1.SecretKeySelector
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.GCPSMProvider">GCPSMProvider
+<h3 id="external-secrets.io/v1beta1.GCPSMProvider">GCPSMProvider
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.SecretStoreProvider">SecretStoreProvider</a>)
+<a href="#external-secrets.io/v1beta1.SecretStoreProvider">SecretStoreProvider</a>)
 </p>
 <p>
 <p>GCPSMProvider Configures a store to sync secrets using the GCP Secret Manager provider.</p>
@@ -1777,7 +2346,7 @@ github.com/external-secrets/external-secrets/apis/meta/v1.SecretKeySelector
 <td>
 <code>auth</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.GCPSMAuth">
+<a href="#external-secrets.io/v1beta1.GCPSMAuth">
 GCPSMAuth
 </a>
 </em>
@@ -1800,11 +2369,11 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.GCPWorkloadIdentity">GCPWorkloadIdentity
+<h3 id="external-secrets.io/v1beta1.GCPWorkloadIdentity">GCPWorkloadIdentity
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.GCPSMAuth">GCPSMAuth</a>)
+<a href="#external-secrets.io/v1beta1.GCPSMAuth">GCPSMAuth</a>)
 </p>
 <p>
 </p>
@@ -1858,17 +2427,21 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.GenericStore">GenericStore
+<h3 id="external-secrets.io/v1beta1.GenericStore">GenericStore
 </h3>
 <p>
 <p>GenericStore is a common interface for interacting with ClusterSecretStore
 or a namespaced SecretStore.</p>
 </p>
-<h3 id="external-secrets.io/v1alpha1.GitlabAuth">GitlabAuth
+<h3 id="external-secrets.io/v1beta1.GenericStoreValidator">GenericStoreValidator
+</h3>
+<p>
+</p>
+<h3 id="external-secrets.io/v1beta1.GitlabAuth">GitlabAuth
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.GitlabProvider">GitlabProvider</a>)
+<a href="#external-secrets.io/v1beta1.GitlabProvider">GitlabProvider</a>)
 </p>
 <p>
 </p>
@@ -1884,7 +2457,7 @@ or a namespaced SecretStore.</p>
 <td>
 <code>SecretRef</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.GitlabSecretRef">
+<a href="#external-secrets.io/v1beta1.GitlabSecretRef">
 GitlabSecretRef
 </a>
 </em>
@@ -1894,11 +2467,11 @@ GitlabSecretRef
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.GitlabProvider">GitlabProvider
+<h3 id="external-secrets.io/v1beta1.GitlabProvider">GitlabProvider
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.SecretStoreProvider">SecretStoreProvider</a>)
+<a href="#external-secrets.io/v1beta1.SecretStoreProvider">SecretStoreProvider</a>)
 </p>
 <p>
 <p>Configures a store to sync secrets with a GitLab instance.</p>
@@ -1926,7 +2499,7 @@ string
 <td>
 <code>auth</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.GitlabAuth">
+<a href="#external-secrets.io/v1beta1.GitlabAuth">
 GitlabAuth
 </a>
 </em>
@@ -1948,11 +2521,11 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.GitlabSecretRef">GitlabSecretRef
+<h3 id="external-secrets.io/v1beta1.GitlabSecretRef">GitlabSecretRef
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.GitlabAuth">GitlabAuth</a>)
+<a href="#external-secrets.io/v1beta1.GitlabAuth">GitlabAuth</a>)
 </p>
 <p>
 </p>
@@ -1977,11 +2550,11 @@ github.com/external-secrets/external-secrets/apis/meta/v1.SecretKeySelector
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.IBMAuth">IBMAuth
+<h3 id="external-secrets.io/v1beta1.IBMAuth">IBMAuth
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.IBMProvider">IBMProvider</a>)
+<a href="#external-secrets.io/v1beta1.IBMProvider">IBMProvider</a>)
 </p>
 <p>
 </p>
@@ -1997,7 +2570,7 @@ github.com/external-secrets/external-secrets/apis/meta/v1.SecretKeySelector
 <td>
 <code>secretRef</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.IBMAuthSecretRef">
+<a href="#external-secrets.io/v1beta1.IBMAuthSecretRef">
 IBMAuthSecretRef
 </a>
 </em>
@@ -2007,11 +2580,11 @@ IBMAuthSecretRef
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.IBMAuthSecretRef">IBMAuthSecretRef
+<h3 id="external-secrets.io/v1beta1.IBMAuthSecretRef">IBMAuthSecretRef
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.IBMAuth">IBMAuth</a>)
+<a href="#external-secrets.io/v1beta1.IBMAuth">IBMAuth</a>)
 </p>
 <p>
 </p>
@@ -2037,11 +2610,11 @@ github.com/external-secrets/external-secrets/apis/meta/v1.SecretKeySelector
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.IBMProvider">IBMProvider
+<h3 id="external-secrets.io/v1beta1.IBMProvider">IBMProvider
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.SecretStoreProvider">SecretStoreProvider</a>)
+<a href="#external-secrets.io/v1beta1.SecretStoreProvider">SecretStoreProvider</a>)
 </p>
 <p>
 <p>Configures an store to sync secrets using a IBM Cloud Secrets Manager
@@ -2059,7 +2632,7 @@ backend.</p>
 <td>
 <code>auth</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.IBMAuth">
+<a href="#external-secrets.io/v1beta1.IBMAuth">
 IBMAuth
 </a>
 </em>
@@ -2081,11 +2654,11 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.KubernetesAuth">KubernetesAuth
+<h3 id="external-secrets.io/v1beta1.KubernetesAuth">KubernetesAuth
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.KubernetesProvider">KubernetesProvider</a>)
+<a href="#external-secrets.io/v1beta1.KubernetesProvider">KubernetesProvider</a>)
 </p>
 <p>
 </p>
@@ -2101,7 +2674,7 @@ string
 <td>
 <code>cert</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.CertAuth">
+<a href="#external-secrets.io/v1beta1.CertAuth">
 CertAuth
 </a>
 </em>
@@ -2115,7 +2688,7 @@ CertAuth
 <td>
 <code>token</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.TokenAuth">
+<a href="#external-secrets.io/v1beta1.TokenAuth">
 TokenAuth
 </a>
 </em>
@@ -2129,7 +2702,7 @@ TokenAuth
 <td>
 <code>serviceAccount</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.ServiceAccountAuth">
+<a href="#external-secrets.io/v1beta1.ServiceAccountAuth">
 ServiceAccountAuth
 </a>
 </em>
@@ -2141,11 +2714,11 @@ ServiceAccountAuth
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.KubernetesProvider">KubernetesProvider
+<h3 id="external-secrets.io/v1beta1.KubernetesProvider">KubernetesProvider
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.SecretStoreProvider">SecretStoreProvider</a>)
+<a href="#external-secrets.io/v1beta1.SecretStoreProvider">SecretStoreProvider</a>)
 </p>
 <p>
 <p>Configures a store to sync secrets with a Kubernetes instance.</p>
@@ -2162,7 +2735,7 @@ ServiceAccountAuth
 <td>
 <code>server</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.KubernetesServer">
+<a href="#external-secrets.io/v1beta1.KubernetesServer">
 KubernetesServer
 </a>
 </em>
@@ -2175,7 +2748,7 @@ KubernetesServer
 <td>
 <code>auth</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.KubernetesAuth">
+<a href="#external-secrets.io/v1beta1.KubernetesAuth">
 KubernetesAuth
 </a>
 </em>
@@ -2198,11 +2771,11 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.KubernetesServer">KubernetesServer
+<h3 id="external-secrets.io/v1beta1.KubernetesServer">KubernetesServer
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.KubernetesProvider">KubernetesProvider</a>)
+<a href="#external-secrets.io/v1beta1.KubernetesProvider">KubernetesProvider</a>)
 </p>
 <p>
 </p>
@@ -2242,7 +2815,7 @@ string
 <td>
 <code>caProvider</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.CAProvider">
+<a href="#external-secrets.io/v1beta1.CAProvider">
 CAProvider
 </a>
 </em>
@@ -2254,11 +2827,17 @@ CAProvider
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.OracleAuth">OracleAuth
+<h3 id="external-secrets.io/v1beta1.NoSecretError">NoSecretError
+</h3>
+<p>
+<p>NoSecretError shall be returned when a GetSecret can not find the
+desired secret. This is used for deletionPolicy.</p>
+</p>
+<h3 id="external-secrets.io/v1beta1.OracleAuth">OracleAuth
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.OracleProvider">OracleProvider</a>)
+<a href="#external-secrets.io/v1beta1.OracleProvider">OracleProvider</a>)
 </p>
 <p>
 </p>
@@ -2296,7 +2875,7 @@ string
 <td>
 <code>secretRef</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.OracleSecretRef">
+<a href="#external-secrets.io/v1beta1.OracleSecretRef">
 OracleSecretRef
 </a>
 </em>
@@ -2307,11 +2886,11 @@ OracleSecretRef
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.OracleProvider">OracleProvider
+<h3 id="external-secrets.io/v1beta1.OracleProvider">OracleProvider
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.SecretStoreProvider">SecretStoreProvider</a>)
+<a href="#external-secrets.io/v1beta1.SecretStoreProvider">SecretStoreProvider</a>)
 </p>
 <p>
 <p>Configures an store to sync secrets using a Oracle Vault
@@ -2351,7 +2930,7 @@ string
 <td>
 <code>auth</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.OracleAuth">
+<a href="#external-secrets.io/v1beta1.OracleAuth">
 OracleAuth
 </a>
 </em>
@@ -2364,11 +2943,11 @@ If empty, use the instance principal, otherwise the user credentials specified i
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.OracleSecretRef">OracleSecretRef
+<h3 id="external-secrets.io/v1beta1.OracleSecretRef">OracleSecretRef
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.OracleAuth">OracleAuth</a>)
+<a href="#external-secrets.io/v1beta1.OracleAuth">OracleAuth</a>)
 </p>
 <p>
 </p>
@@ -2404,7 +2983,12 @@ github.com/external-secrets/external-secrets/apis/meta/v1.SecretKeySelector
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.SecretStore">SecretStore
+<h3 id="external-secrets.io/v1beta1.Provider">Provider
+</h3>
+<p>
+<p>Provider is a common interface for interacting with secret backends.</p>
+</p>
+<h3 id="external-secrets.io/v1beta1.SecretStore">SecretStore
 </h3>
 <p>
 <p>SecretStore represents a secure external location for storing secrets, which can be referenced as part of <code>storeRef</code> fields.</p>
@@ -2435,7 +3019,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.SecretStoreSpec">
+<a href="#external-secrets.io/v1beta1.SecretStoreSpec">
 SecretStoreSpec
 </a>
 </em>
@@ -2461,7 +3045,7 @@ The KES controller is instantiated with a specific controller name and filters E
 <td>
 <code>provider</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.SecretStoreProvider">
+<a href="#external-secrets.io/v1beta1.SecretStoreProvider">
 SecretStoreProvider
 </a>
 </em>
@@ -2474,7 +3058,7 @@ SecretStoreProvider
 <td>
 <code>retrySettings</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.SecretStoreRetrySettings">
+<a href="#external-secrets.io/v1beta1.SecretStoreRetrySettings">
 SecretStoreRetrySettings
 </a>
 </em>
@@ -2484,6 +3068,18 @@ SecretStoreRetrySettings
 <p>Used to configure http retries if failed</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>refreshInterval</code></br>
+<em>
+int
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Used to configure store refresh interval in seconds. Empty or 0 will default to the controller config.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -2491,7 +3087,7 @@ SecretStoreRetrySettings
 <td>
 <code>status</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.SecretStoreStatus">
+<a href="#external-secrets.io/v1beta1.SecretStoreStatus">
 SecretStoreStatus
 </a>
 </em>
@@ -2501,11 +3097,11 @@ SecretStoreStatus
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.SecretStoreConditionType">SecretStoreConditionType
+<h3 id="external-secrets.io/v1beta1.SecretStoreConditionType">SecretStoreConditionType
 (<code>string</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.SecretStoreStatusCondition">SecretStoreStatusCondition</a>)
+<a href="#external-secrets.io/v1beta1.SecretStoreStatusCondition">SecretStoreStatusCondition</a>)
 </p>
 <p>
 </p>
@@ -2520,11 +3116,11 @@ SecretStoreStatus
 <td></td>
 </tr></tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.SecretStoreProvider">SecretStoreProvider
+<h3 id="external-secrets.io/v1beta1.SecretStoreProvider">SecretStoreProvider
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.SecretStoreSpec">SecretStoreSpec</a>)
+<a href="#external-secrets.io/v1beta1.SecretStoreSpec">SecretStoreSpec</a>)
 </p>
 <p>
 <p>SecretStoreProvider contains the provider-specific configration.</p>
@@ -2541,7 +3137,7 @@ SecretStoreStatus
 <td>
 <code>aws</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.AWSProvider">
+<a href="#external-secrets.io/v1beta1.AWSProvider">
 AWSProvider
 </a>
 </em>
@@ -2555,7 +3151,7 @@ AWSProvider
 <td>
 <code>azurekv</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.AzureKVProvider">
+<a href="#external-secrets.io/v1beta1.AzureKVProvider">
 AzureKVProvider
 </a>
 </em>
@@ -2569,7 +3165,7 @@ AzureKVProvider
 <td>
 <code>akeyless</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.AkeylessProvider">
+<a href="#external-secrets.io/v1beta1.AkeylessProvider">
 AkeylessProvider
 </a>
 </em>
@@ -2583,7 +3179,7 @@ AkeylessProvider
 <td>
 <code>vault</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.VaultProvider">
+<a href="#external-secrets.io/v1beta1.VaultProvider">
 VaultProvider
 </a>
 </em>
@@ -2597,7 +3193,7 @@ VaultProvider
 <td>
 <code>gcpsm</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.GCPSMProvider">
+<a href="#external-secrets.io/v1beta1.GCPSMProvider">
 GCPSMProvider
 </a>
 </em>
@@ -2611,7 +3207,7 @@ GCPSMProvider
 <td>
 <code>oracle</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.OracleProvider">
+<a href="#external-secrets.io/v1beta1.OracleProvider">
 OracleProvider
 </a>
 </em>
@@ -2625,7 +3221,7 @@ OracleProvider
 <td>
 <code>ibm</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.IBMProvider">
+<a href="#external-secrets.io/v1beta1.IBMProvider">
 IBMProvider
 </a>
 </em>
@@ -2639,7 +3235,7 @@ IBMProvider
 <td>
 <code>yandexlockbox</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.YandexLockboxProvider">
+<a href="#external-secrets.io/v1beta1.YandexLockboxProvider">
 YandexLockboxProvider
 </a>
 </em>
@@ -2653,7 +3249,7 @@ YandexLockboxProvider
 <td>
 <code>gitlab</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.GitlabProvider">
+<a href="#external-secrets.io/v1beta1.GitlabProvider">
 GitlabProvider
 </a>
 </em>
@@ -2667,7 +3263,7 @@ GitlabProvider
 <td>
 <code>alibaba</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.AlibabaProvider">
+<a href="#external-secrets.io/v1beta1.AlibabaProvider">
 AlibabaProvider
 </a>
 </em>
@@ -2681,7 +3277,7 @@ AlibabaProvider
 <td>
 <code>webhook</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.WebhookProvider">
+<a href="#external-secrets.io/v1beta1.WebhookProvider">
 WebhookProvider
 </a>
 </em>
@@ -2695,7 +3291,7 @@ WebhookProvider
 <td>
 <code>kubernetes</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.KubernetesProvider">
+<a href="#external-secrets.io/v1beta1.KubernetesProvider">
 KubernetesProvider
 </a>
 </em>
@@ -2709,7 +3305,7 @@ KubernetesProvider
 <td>
 <code>fake</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.FakeProvider">
+<a href="#external-secrets.io/v1beta1.FakeProvider">
 FakeProvider
 </a>
 </em>
@@ -2721,11 +3317,11 @@ FakeProvider
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.SecretStoreRef">SecretStoreRef
+<h3 id="external-secrets.io/v1beta1.SecretStoreRef">SecretStoreRef
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.ExternalSecretSpec">ExternalSecretSpec</a>)
+<a href="#external-secrets.io/v1beta1.ExternalSecretSpec">ExternalSecretSpec</a>)
 </p>
 <p>
 <p>SecretStoreRef defines which SecretStore to fetch the ExternalSecret data.</p>
@@ -2764,11 +3360,11 @@ Defaults to <code>SecretStore</code></p>
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.SecretStoreRetrySettings">SecretStoreRetrySettings
+<h3 id="external-secrets.io/v1beta1.SecretStoreRetrySettings">SecretStoreRetrySettings
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.SecretStoreSpec">SecretStoreSpec</a>)
+<a href="#external-secrets.io/v1beta1.SecretStoreSpec">SecretStoreSpec</a>)
 </p>
 <p>
 </p>
@@ -2802,12 +3398,12 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.SecretStoreSpec">SecretStoreSpec
+<h3 id="external-secrets.io/v1beta1.SecretStoreSpec">SecretStoreSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.ClusterSecretStore">ClusterSecretStore</a>, 
-<a href="#external-secrets.io/v1alpha1.SecretStore">SecretStore</a>)
+<a href="#external-secrets.io/v1beta1.ClusterSecretStore">ClusterSecretStore</a>, 
+<a href="#external-secrets.io/v1beta1.SecretStore">SecretStore</a>)
 </p>
 <p>
 <p>SecretStoreSpec defines the desired state of SecretStore.</p>
@@ -2837,7 +3433,7 @@ The KES controller is instantiated with a specific controller name and filters E
 <td>
 <code>provider</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.SecretStoreProvider">
+<a href="#external-secrets.io/v1beta1.SecretStoreProvider">
 SecretStoreProvider
 </a>
 </em>
@@ -2850,7 +3446,7 @@ SecretStoreProvider
 <td>
 <code>retrySettings</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.SecretStoreRetrySettings">
+<a href="#external-secrets.io/v1beta1.SecretStoreRetrySettings">
 SecretStoreRetrySettings
 </a>
 </em>
@@ -2860,14 +3456,26 @@ SecretStoreRetrySettings
 <p>Used to configure http retries if failed</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>refreshInterval</code></br>
+<em>
+int
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Used to configure store refresh interval in seconds. Empty or 0 will default to the controller config.</p>
+</td>
+</tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.SecretStoreStatus">SecretStoreStatus
+<h3 id="external-secrets.io/v1beta1.SecretStoreStatus">SecretStoreStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.ClusterSecretStore">ClusterSecretStore</a>, 
-<a href="#external-secrets.io/v1alpha1.SecretStore">SecretStore</a>)
+<a href="#external-secrets.io/v1beta1.ClusterSecretStore">ClusterSecretStore</a>, 
+<a href="#external-secrets.io/v1beta1.SecretStore">SecretStore</a>)
 </p>
 <p>
 <p>SecretStoreStatus defines the observed state of the SecretStore.</p>
@@ -2884,7 +3492,7 @@ SecretStoreRetrySettings
 <td>
 <code>conditions</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.SecretStoreStatusCondition">
+<a href="#external-secrets.io/v1beta1.SecretStoreStatusCondition">
 []SecretStoreStatusCondition
 </a>
 </em>
@@ -2895,11 +3503,11 @@ SecretStoreRetrySettings
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.SecretStoreStatusCondition">SecretStoreStatusCondition
+<h3 id="external-secrets.io/v1beta1.SecretStoreStatusCondition">SecretStoreStatusCondition
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.SecretStoreStatus">SecretStoreStatus</a>)
+<a href="#external-secrets.io/v1beta1.SecretStoreStatus">SecretStoreStatus</a>)
 </p>
 <p>
 </p>
@@ -2915,7 +3523,7 @@ SecretStoreRetrySettings
 <td>
 <code>type</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.SecretStoreConditionType">
+<a href="#external-secrets.io/v1beta1.SecretStoreConditionType">
 SecretStoreConditionType
 </a>
 </em>
@@ -2972,11 +3580,16 @@ Kubernetes meta/v1.Time
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.ServiceAccountAuth">ServiceAccountAuth
+<h3 id="external-secrets.io/v1beta1.SecretsClient">SecretsClient
+</h3>
+<p>
+<p>SecretsClient provides access to secrets.</p>
+</p>
+<h3 id="external-secrets.io/v1beta1.ServiceAccountAuth">ServiceAccountAuth
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.KubernetesAuth">KubernetesAuth</a>)
+<a href="#external-secrets.io/v1beta1.KubernetesAuth">KubernetesAuth</a>)
 </p>
 <p>
 </p>
@@ -3000,11 +3613,11 @@ github.com/external-secrets/external-secrets/apis/meta/v1.ServiceAccountSelector
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.TemplateEngineVersion">TemplateEngineVersion
+<h3 id="external-secrets.io/v1beta1.TemplateEngineVersion">TemplateEngineVersion
 (<code>string</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.ExternalSecretTemplate">ExternalSecretTemplate</a>)
+<a href="#external-secrets.io/v1beta1.ExternalSecretTemplate">ExternalSecretTemplate</a>)
 </p>
 <p>
 </p>
@@ -3021,11 +3634,11 @@ github.com/external-secrets/external-secrets/apis/meta/v1.ServiceAccountSelector
 <td></td>
 </tr></tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.TemplateFrom">TemplateFrom
+<h3 id="external-secrets.io/v1beta1.TemplateFrom">TemplateFrom
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.ExternalSecretTemplate">ExternalSecretTemplate</a>)
+<a href="#external-secrets.io/v1beta1.ExternalSecretTemplate">ExternalSecretTemplate</a>)
 </p>
 <p>
 </p>
@@ -3041,7 +3654,7 @@ github.com/external-secrets/external-secrets/apis/meta/v1.ServiceAccountSelector
 <td>
 <code>configMap</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.TemplateRef">
+<a href="#external-secrets.io/v1beta1.TemplateRef">
 TemplateRef
 </a>
 </em>
@@ -3053,7 +3666,7 @@ TemplateRef
 <td>
 <code>secret</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.TemplateRef">
+<a href="#external-secrets.io/v1beta1.TemplateRef">
 TemplateRef
 </a>
 </em>
@@ -3063,11 +3676,11 @@ TemplateRef
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.TemplateRef">TemplateRef
+<h3 id="external-secrets.io/v1beta1.TemplateRef">TemplateRef
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.TemplateFrom">TemplateFrom</a>)
+<a href="#external-secrets.io/v1beta1.TemplateFrom">TemplateFrom</a>)
 </p>
 <p>
 </p>
@@ -3093,7 +3706,7 @@ string
 <td>
 <code>items</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.TemplateRefItem">
+<a href="#external-secrets.io/v1beta1.TemplateRefItem">
 []TemplateRefItem
 </a>
 </em>
@@ -3103,11 +3716,11 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.TemplateRefItem">TemplateRefItem
+<h3 id="external-secrets.io/v1beta1.TemplateRefItem">TemplateRefItem
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.TemplateRef">TemplateRef</a>)
+<a href="#external-secrets.io/v1beta1.TemplateRef">TemplateRef</a>)
 </p>
 <p>
 </p>
@@ -3131,11 +3744,11 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.TokenAuth">TokenAuth
+<h3 id="external-secrets.io/v1beta1.TokenAuth">TokenAuth
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.KubernetesAuth">KubernetesAuth</a>)
+<a href="#external-secrets.io/v1beta1.KubernetesAuth">KubernetesAuth</a>)
 </p>
 <p>
 </p>
@@ -3159,11 +3772,30 @@ github.com/external-secrets/external-secrets/apis/meta/v1.SecretKeySelector
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.VaultAppRole">VaultAppRole
+<h3 id="external-secrets.io/v1beta1.ValidationResult">ValidationResult
+(<code>byte</code> alias)</p></h3>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>2</p></td>
+<td></td>
+</tr><tr><td><p>0</p></td>
+<td></td>
+</tr><tr><td><p>1</p></td>
+<td></td>
+</tr></tbody>
+</table>
+<h3 id="external-secrets.io/v1beta1.VaultAppRole">VaultAppRole
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.VaultAuth">VaultAuth</a>)
+<a href="#external-secrets.io/v1beta1.VaultAuth">VaultAuth</a>)
 </p>
 <p>
 <p>VaultAppRole authenticates with Vault using the App Role auth mechanism,
@@ -3217,11 +3849,11 @@ resource is used as the app role secret.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.VaultAuth">VaultAuth
+<h3 id="external-secrets.io/v1beta1.VaultAuth">VaultAuth
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.VaultProvider">VaultProvider</a>)
+<a href="#external-secrets.io/v1beta1.VaultProvider">VaultProvider</a>)
 </p>
 <p>
 <p>VaultAuth is the configuration used to authenticate with a Vault server.
@@ -3252,7 +3884,7 @@ github.com/external-secrets/external-secrets/apis/meta/v1.SecretKeySelector
 <td>
 <code>appRole</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.VaultAppRole">
+<a href="#external-secrets.io/v1beta1.VaultAppRole">
 VaultAppRole
 </a>
 </em>
@@ -3267,7 +3899,7 @@ with the role and secret stored in a Kubernetes Secret resource.</p>
 <td>
 <code>kubernetes</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.VaultKubernetesAuth">
+<a href="#external-secrets.io/v1beta1.VaultKubernetesAuth">
 VaultKubernetesAuth
 </a>
 </em>
@@ -3282,7 +3914,7 @@ token stored in the named Secret resource to the Vault server.</p>
 <td>
 <code>ldap</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.VaultLdapAuth">
+<a href="#external-secrets.io/v1beta1.VaultLdapAuth">
 VaultLdapAuth
 </a>
 </em>
@@ -3297,7 +3929,7 @@ the LDAP authentication method</p>
 <td>
 <code>jwt</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.VaultJwtAuth">
+<a href="#external-secrets.io/v1beta1.VaultJwtAuth">
 VaultJwtAuth
 </a>
 </em>
@@ -3312,7 +3944,7 @@ JWT/OIDC authentication method</p>
 <td>
 <code>cert</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.VaultCertAuth">
+<a href="#external-secrets.io/v1beta1.VaultCertAuth">
 VaultCertAuth
 </a>
 </em>
@@ -3325,11 +3957,11 @@ Cert authentication method</p>
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.VaultCertAuth">VaultCertAuth
+<h3 id="external-secrets.io/v1beta1.VaultCertAuth">VaultCertAuth
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.VaultAuth">VaultAuth</a>)
+<a href="#external-secrets.io/v1beta1.VaultAuth">VaultAuth</a>)
 </p>
 <p>
 <p>VaultJwtAuth authenticates with Vault using the JWT/OIDC authentication
@@ -3370,15 +4002,16 @@ authenticate with Vault using the Cert authentication method</p>
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.VaultJwtAuth">VaultJwtAuth
+<h3 id="external-secrets.io/v1beta1.VaultJwtAuth">VaultJwtAuth
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.VaultAuth">VaultAuth</a>)
+<a href="#external-secrets.io/v1beta1.VaultAuth">VaultAuth</a>)
 </p>
 <p>
 <p>VaultJwtAuth authenticates with Vault using the JWT/OIDC authentication
-method, with the role name and token stored in a Kubernetes Secret resource.</p>
+method, with the role name and a token stored in a Kubernetes Secret resource or
+a Kubernetes service account token retrieved via <code>TokenRequest</code>.</p>
 </p>
 <table>
 <thead>
@@ -3421,17 +4054,33 @@ github.com/external-secrets/external-secrets/apis/meta/v1.SecretKeySelector
 </em>
 </td>
 <td>
-<p>SecretRef to a key in a Secret resource containing JWT token to
-authenticate with Vault using the JWT/OIDC authentication method</p>
+<em>(Optional)</em>
+<p>Optional SecretRef that refers to a key in a Secret resource containing JWT token to
+authenticate with Vault using the JWT/OIDC authentication method.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>kubernetesServiceAccountToken</code></br>
+<em>
+<a href="#external-secrets.io/v1beta1.VaultKubernetesServiceAccountTokenAuth">
+VaultKubernetesServiceAccountTokenAuth
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Optional ServiceAccountToken specifies the Kubernetes service account for which to request
+a token for with the <code>TokenRequest</code> API.</p>
 </td>
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.VaultKVStoreVersion">VaultKVStoreVersion
+<h3 id="external-secrets.io/v1beta1.VaultKVStoreVersion">VaultKVStoreVersion
 (<code>string</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.VaultProvider">VaultProvider</a>)
+<a href="#external-secrets.io/v1beta1.VaultProvider">VaultProvider</a>)
 </p>
 <p>
 </p>
@@ -3448,11 +4097,11 @@ authenticate with Vault using the JWT/OIDC authentication method</p>
 <td></td>
 </tr></tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.VaultKubernetesAuth">VaultKubernetesAuth
+<h3 id="external-secrets.io/v1beta1.VaultKubernetesAuth">VaultKubernetesAuth
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.VaultAuth">VaultAuth</a>)
+<a href="#external-secrets.io/v1beta1.VaultAuth">VaultAuth</a>)
 </p>
 <p>
 <p>Authenticate against Vault using a Kubernetes ServiceAccount token stored in
@@ -3522,11 +4171,71 @@ Kubernetes ServiceAccount with a set of Vault policies.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.VaultLdapAuth">VaultLdapAuth
+<h3 id="external-secrets.io/v1beta1.VaultKubernetesServiceAccountTokenAuth">VaultKubernetesServiceAccountTokenAuth
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.VaultAuth">VaultAuth</a>)
+<a href="#external-secrets.io/v1beta1.VaultJwtAuth">VaultJwtAuth</a>)
+</p>
+<p>
+<p>VaultKubernetesServiceAccountTokenAuth authenticates with Vault using a temporary
+Kubernetes service account token retrieved by the <code>TokenRequest</code> API.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>serviceAccountRef</code></br>
+<em>
+github.com/external-secrets/external-secrets/apis/meta/v1.ServiceAccountSelector
+</em>
+</td>
+<td>
+<p>Service account field containing the name of a kubernetes ServiceAccount.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>audiences</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Optional audiences field that will be used to request a temporary Kubernetes service
+account token for the service account referenced by <code>serviceAccountRef</code>.
+Defaults to a single audience <code>vault</code> it not specified.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>expirationSeconds</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Optional expiration time in seconds that will be used to request a temporary
+Kubernetes service account token for the service account referenced by
+<code>serviceAccountRef</code>.
+Defaults to 10 minutes.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="external-secrets.io/v1beta1.VaultLdapAuth">VaultLdapAuth
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#external-secrets.io/v1beta1.VaultAuth">VaultAuth</a>)
 </p>
 <p>
 <p>VaultLdapAuth authenticates with Vault using the LDAP authentication method,
@@ -3579,11 +4288,11 @@ method</p>
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.VaultProvider">VaultProvider
+<h3 id="external-secrets.io/v1beta1.VaultProvider">VaultProvider
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.SecretStoreProvider">SecretStoreProvider</a>)
+<a href="#external-secrets.io/v1beta1.SecretStoreProvider">SecretStoreProvider</a>)
 </p>
 <p>
 <p>Configures an store to sync secrets using a HashiCorp Vault
@@ -3601,7 +4310,7 @@ KV backend.</p>
 <td>
 <code>auth</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.VaultAuth">
+<a href="#external-secrets.io/v1beta1.VaultAuth">
 VaultAuth
 </a>
 </em>
@@ -3640,7 +4349,7 @@ if not present in specified path.</p>
 <td>
 <code>version</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.VaultKVStoreVersion">
+<a href="#external-secrets.io/v1beta1.VaultKVStoreVersion">
 VaultKVStoreVersion
 </a>
 </em>
@@ -3683,7 +4392,7 @@ are used to validate the TLS connection.</p>
 <td>
 <code>caProvider</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.CAProvider">
+<a href="#external-secrets.io/v1beta1.CAProvider">
 CAProvider
 </a>
 </em>
@@ -3725,11 +4434,11 @@ the option is enabled serverside.
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.WebhookCAProvider">WebhookCAProvider
+<h3 id="external-secrets.io/v1beta1.WebhookCAProvider">WebhookCAProvider
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.WebhookProvider">WebhookProvider</a>)
+<a href="#external-secrets.io/v1beta1.WebhookProvider">WebhookProvider</a>)
 </p>
 <p>
 <p>Defines a location to fetch the cert for the webhook provider from.</p>
@@ -3746,7 +4455,7 @@ the option is enabled serverside.
 <td>
 <code>type</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.WebhookCAProviderType">
+<a href="#external-secrets.io/v1beta1.WebhookCAProviderType">
 WebhookCAProviderType
 </a>
 </em>
@@ -3791,11 +4500,11 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.WebhookCAProviderType">WebhookCAProviderType
+<h3 id="external-secrets.io/v1beta1.WebhookCAProviderType">WebhookCAProviderType
 (<code>string</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.WebhookCAProvider">WebhookCAProvider</a>)
+<a href="#external-secrets.io/v1beta1.WebhookCAProvider">WebhookCAProvider</a>)
 </p>
 <p>
 </p>
@@ -3812,11 +4521,11 @@ string
 <td></td>
 </tr></tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.WebhookProvider">WebhookProvider
+<h3 id="external-secrets.io/v1beta1.WebhookProvider">WebhookProvider
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.SecretStoreProvider">SecretStoreProvider</a>)
+<a href="#external-secrets.io/v1beta1.SecretStoreProvider">SecretStoreProvider</a>)
 </p>
 <p>
 <p>AkeylessProvider Configures an store to sync secrets using Akeyless KV.</p>
@@ -3893,7 +4602,7 @@ Kubernetes meta/v1.Duration
 <td>
 <code>result</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.WebhookResult">
+<a href="#external-secrets.io/v1beta1.WebhookResult">
 WebhookResult
 </a>
 </em>
@@ -3906,7 +4615,7 @@ WebhookResult
 <td>
 <code>secrets</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.WebhookSecret">
+<a href="#external-secrets.io/v1beta1.WebhookSecret">
 []WebhookSecret
 </a>
 </em>
@@ -3936,7 +4645,7 @@ are used to validate the TLS connection.</p>
 <td>
 <code>caProvider</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.WebhookCAProvider">
+<a href="#external-secrets.io/v1beta1.WebhookCAProvider">
 WebhookCAProvider
 </a>
 </em>
@@ -3948,11 +4657,11 @@ WebhookCAProvider
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.WebhookResult">WebhookResult
+<h3 id="external-secrets.io/v1beta1.WebhookResult">WebhookResult
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.WebhookProvider">WebhookProvider</a>)
+<a href="#external-secrets.io/v1beta1.WebhookProvider">WebhookProvider</a>)
 </p>
 <p>
 </p>
@@ -3978,11 +4687,11 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.WebhookSecret">WebhookSecret
+<h3 id="external-secrets.io/v1beta1.WebhookSecret">WebhookSecret
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.WebhookProvider">WebhookProvider</a>)
+<a href="#external-secrets.io/v1beta1.WebhookProvider">WebhookProvider</a>)
 </p>
 <p>
 </p>
@@ -4018,11 +4727,11 @@ github.com/external-secrets/external-secrets/apis/meta/v1.SecretKeySelector
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.YandexLockboxAuth">YandexLockboxAuth
+<h3 id="external-secrets.io/v1beta1.YandexLockboxAuth">YandexLockboxAuth
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.YandexLockboxProvider">YandexLockboxProvider</a>)
+<a href="#external-secrets.io/v1beta1.YandexLockboxProvider">YandexLockboxProvider</a>)
 </p>
 <p>
 </p>
@@ -4048,11 +4757,11 @@ github.com/external-secrets/external-secrets/apis/meta/v1.SecretKeySelector
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.YandexLockboxCAProvider">YandexLockboxCAProvider
+<h3 id="external-secrets.io/v1beta1.YandexLockboxCAProvider">YandexLockboxCAProvider
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.YandexLockboxProvider">YandexLockboxProvider</a>)
+<a href="#external-secrets.io/v1beta1.YandexLockboxProvider">YandexLockboxProvider</a>)
 </p>
 <p>
 </p>
@@ -4076,11 +4785,11 @@ github.com/external-secrets/external-secrets/apis/meta/v1.SecretKeySelector
 </tr>
 </tbody>
 </table>
-<h3 id="external-secrets.io/v1alpha1.YandexLockboxProvider">YandexLockboxProvider
+<h3 id="external-secrets.io/v1beta1.YandexLockboxProvider">YandexLockboxProvider
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#external-secrets.io/v1alpha1.SecretStoreProvider">SecretStoreProvider</a>)
+<a href="#external-secrets.io/v1beta1.SecretStoreProvider">SecretStoreProvider</a>)
 </p>
 <p>
 <p>YandexLockboxProvider Configures a store to sync secrets using the Yandex Lockbox provider.</p>
@@ -4109,7 +4818,7 @@ string
 <td>
 <code>auth</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.YandexLockboxAuth">
+<a href="#external-secrets.io/v1beta1.YandexLockboxAuth">
 YandexLockboxAuth
 </a>
 </em>
@@ -4122,7 +4831,7 @@ YandexLockboxAuth
 <td>
 <code>caProvider</code></br>
 <em>
-<a href="#external-secrets.io/v1alpha1.YandexLockboxCAProvider">
+<a href="#external-secrets.io/v1beta1.YandexLockboxCAProvider">
 YandexLockboxCAProvider
 </a>
 </em>

--- a/e2e/suite/akeyless/provider.go
+++ b/e2e/suite/akeyless/provider.go
@@ -19,7 +19,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -223,7 +223,7 @@ func readK8SServiceAccountJWT() (string, error) {
 	}
 	defer data.Close()
 
-	contentBytes, err := ioutil.ReadAll(data)
+	contentBytes, err := io.ReadAll(data)
 	if err != nil {
 		return "", err
 	}

--- a/hack/api-docs/generate.sh
+++ b/hack/api-docs/generate.sh
@@ -49,5 +49,5 @@ fi
 
 gendoc::build
 gendoc::exec \
-    -api-dir github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1 \
+    -api-dir github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1 \
     -out-file "$1"

--- a/pkg/provider/azure/keyvault/keyvault_auth_test.go
+++ b/pkg/provider/azure/keyvault/keyvault_auth_test.go
@@ -340,7 +340,7 @@ func TestAuth(t *testing.T) {
 }
 
 func getTokenFromAuthorizer(t *testing.T, authorizer autorest.Authorizer) string {
-	rq, _ := http.NewRequest("POST", "http://example.com", nil)
+	rq, _ := http.NewRequest("POST", "http://example.com", http.NoBody)
 	_, err := authorizer.WithAuthorization()(
 		autorest.PreparerFunc(func(r *http.Request) (*http.Request, error) {
 			return rq, nil


### PR DESCRIPTION
This doesn't have it's own issue, but these bugs were run across while working on https://github.com/external-secrets/external-secrets/issues/36 / https://github.com/external-secrets/external-secrets/pull/1006. I thought a separate PR made sense.

It seems like a mistake that the docs still point to the v1alpha1 API, this fixes that. Also fixes to make `make lint`/`make fmt` pass.