### PR TITLE
Update refreshInterval duration format in docs

### DIFF
--- a/docs/provider-kubernetes.md
+++ b/docs/provider-kubernetes.md
@@ -66,7 +66,7 @@ kind: ExternalSecret
 metadata:
   name: example
 spec:
-  refreshInterval: 1h           
+  refreshInterval: 1h0m0s           
   secretStoreRef:
     kind: SecretStore
     name: example               # name of the SecretStore (or kind specified)
@@ -131,7 +131,7 @@ kind: ExternalSecret
 metadata:
   name: example
 spec:
-  refreshInterval: 1h           
+  refreshInterval: 1h0m0s           
   secretStoreRef:
     kind: SecretStore
     name: example               # name of the SecretStore (or kind specified)

--- a/docs/provider-yandex-lockbox.md
+++ b/docs/provider-yandex-lockbox.md
@@ -68,7 +68,7 @@ kind: ExternalSecret
 metadata:
   name: external-secret
 spec:
-  refreshInterval: 1h
+  refreshInterval: 1h0m0s
   secretStoreRef:
     name: secret-store
     kind: SecretStore

--- a/docs/snippets/akeyless-external-secret-json.yaml
+++ b/docs/snippets/akeyless-external-secret-json.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: akeyless-external-secret-example-json
 spec:
-  refreshInterval: 1h
+  refreshInterval: 1h0m0s
 
   secretStoreRef:
     kind: SecretStore

--- a/docs/snippets/akeyless-external-secret.yaml
+++ b/docs/snippets/akeyless-external-secret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: akeyless-external-secret-example
 spec:
-  refreshInterval: 1h
+  refreshInterval: 1h0m0s
 
   secretStoreRef:
     kind: SecretStore

--- a/docs/snippets/aws-anchore-engine-access-credentials-external-secret.yaml
+++ b/docs/snippets/aws-anchore-engine-access-credentials-external-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: anchore-access-credentials
   namespace: ci
 spec:
-  refreshInterval: 1m
+  refreshInterval: 1m0s
   secretStoreRef:
     name: cluster-secrets-store
     kind: ClusterSecretStore

--- a/docs/snippets/aws-jenkins-credential-github-ssh-external-secret.yaml
+++ b/docs/snippets/aws-jenkins-credential-github-ssh-external-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: github-ssh-access
   namespace: ci
 spec:
-  refreshInterval: 1m
+  refreshInterval: 1m0s
   secretStoreRef:
     name: cluster-parameter-store
     kind: ClusterSecretStore

--- a/docs/snippets/aws-jenkins-credential-sonarqube-api-token-external-secret.yaml
+++ b/docs/snippets/aws-jenkins-credential-sonarqube-api-token-external-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: sonarqube-api-token
   namespace: ci
 spec:
-  refreshInterval: 1m
+  refreshInterval: 1m0s
   secretStoreRef:
     name: cluster-secrets-store
     kind: ClusterSecretStore

--- a/docs/snippets/aws-jenkins-credentials-harbor-chart-robot-external-secret.yaml
+++ b/docs/snippets/aws-jenkins-credentials-harbor-chart-robot-external-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: harbor-chart-robot
   namespace: ci
 spec:
-  refreshInterval: 1m
+  refreshInterval: 1m0s
   secretStoreRef:
     name: cluster-secrets-store
     kind: ClusterSecretStore

--- a/docs/snippets/aws-sm-external-secret.yaml
+++ b/docs/snippets/aws-sm-external-secret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: example
 spec:
-  refreshInterval: 1m
+  refreshInterval: 1m0s
   secretStoreRef:
     name: secretstore-sample
     kind: SecretStore

--- a/docs/snippets/azkv-external-secret.yaml
+++ b/docs/snippets/azkv-external-secret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: example-external-secret
 spec:
-  refreshInterval: 1h
+  refreshInterval: 1h0m0s
   secretStoreRef:
     kind: SecretStore
     name: example-secret-store

--- a/docs/snippets/basic-external-secret.yaml
+++ b/docs/snippets/basic-external-secret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: example
 spec:
-  refreshInterval: 1h
+  refreshInterval: 1h0m0s
   secretStoreRef:
     name: secretstore-sample
     kind: SecretStore

--- a/docs/snippets/fake-provider-es.yaml
+++ b/docs/snippets/fake-provider-es.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: example
 spec:
-  refreshInterval: 1h
+  refreshInterval: 1h0m0s
   secretStoreRef:
     name: fake
     kind: ClusterSecretStore

--- a/docs/snippets/full-cluster-external-secret.yaml
+++ b/docs/snippets/full-cluster-external-secret.yaml
@@ -15,7 +15,7 @@ spec:
 
   # How often the ClusterExternalSecret should reconcile itself
   # This will decide how often to check and make sure that the ExternalSecrets exist in the matching namespaces
-  refreshTime: "1m"
+  refreshTime: "1m0s"
 
   # This is the spec of the ExternalSecrets to be created
   # The content of this was taken from our ExternalSecret example
@@ -24,7 +24,7 @@ spec:
       name: secret-store-name
       kind: SecretStore
 
-    refreshInterval: "1h"
+    refreshInterval: "1h0m0s"
     target:
       name: my-secret
       creationPolicy: 'Merge'

--- a/docs/snippets/full-external-secret.yaml
+++ b/docs/snippets/full-external-secret.yaml
@@ -21,7 +21,7 @@ spec:
   # RefreshInterval is the amount of time before the values reading again from the SecretStore provider
   # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h" (from time.ParseDuration)
   # May be set to zero to fetch and create it once
-  refreshInterval: "1h"
+  refreshInterval: "1h0m0s"
 
   # the target describes the secret that shall be created
   # there can only be one target per ExternalSecret

--- a/docs/snippets/gcpsm-data-from-external-secret.yaml
+++ b/docs/snippets/gcpsm-data-from-external-secret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: example
 spec:
-  refreshInterval: 1h           # rate SecretManager pulls GCPSM
+  refreshInterval: 1h0m0s       # rate SecretManager pulls GCPSM
   secretStoreRef:
     kind: SecretStore
     name: example               # name of the SecretStore (or kind specified)

--- a/docs/snippets/gcpsm-docker-config-externalsecret.yaml
+++ b/docs/snippets/gcpsm-docker-config-externalsecret.yaml
@@ -4,7 +4,7 @@ kind: ExternalSecret
 metadata:
   name: dk-cfg-example
 spec:
-  refreshInterval: 1h
+  refreshInterval: 1h0m0s
   secretStoreRef:
     name: example
     kind: SecretStore

--- a/docs/snippets/gcpsm-external-secret.yaml
+++ b/docs/snippets/gcpsm-external-secret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: example
 spec:
-  refreshInterval: 1h           # rate SecretManager pulls GCPSM
+  refreshInterval: 1h0m0s       # rate SecretManager pulls GCPSM
   secretStoreRef:
     kind: SecretStore
     name: example               # name of the SecretStore (or kind specified)

--- a/docs/snippets/gcpsm-ssh-auth-externalsecret.yaml
+++ b/docs/snippets/gcpsm-ssh-auth-externalsecret.yaml
@@ -4,7 +4,7 @@ kind: ExternalSecret
 metadata:
   name: ssh-auth-example
 spec:
-  refreshInterval: 1h
+  refreshInterval: 1h0m0s
   secretStoreRef:
     name: example
     kind: SecretStore

--- a/docs/snippets/gcpsm-tls-externalsecret.yaml
+++ b/docs/snippets/gcpsm-tls-externalsecret.yaml
@@ -4,7 +4,7 @@ kind: ExternalSecret
 metadata:
   name: template-tls-example
 spec:
-  refreshInterval: 1h
+  refreshInterval: 1h0m0s
   secretStoreRef:
     name: example
     kind: SecretStore

--- a/docs/snippets/getallsecrets-find-by-name.yaml
+++ b/docs/snippets/getallsecrets-find-by-name.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: find-by-tags
 spec:
-  refreshInterval: 1h
+  refreshInterval: 1h0m0s
   secretStoreRef:
     name: secretstore-sample
     kind: SecretStore

--- a/docs/snippets/getallsecrets-find-by-tags.yaml
+++ b/docs/snippets/getallsecrets-find-by-tags.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: find-by-tags
 spec:
-  refreshInterval: 1h
+  refreshInterval: 1h0m0s
   secretStoreRef:
     name: secretstore-sample
     kind: SecretStore

--- a/docs/snippets/gitlab-external-secret-json.yaml
+++ b/docs/snippets/gitlab-external-secret-json.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: gitlab-external-secret-example
 spec:
-  refreshInterval: 1h
+  refreshInterval: 1h0m0s
 
   secretStoreRef:
     kind: SecretStore

--- a/docs/snippets/gitlab-external-secret.yaml
+++ b/docs/snippets/gitlab-external-secret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: gitlab-external-secret-example
 spec:
-  refreshInterval: 1h
+  refreshInterval: 1h0m0s
 
   secretStoreRef:
     kind: SecretStore

--- a/docs/snippets/ibm-external-secret.yaml
+++ b/docs/snippets/ibm-external-secret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: external-secret-sample
 spec:
-  refreshInterval: 60m
+  refreshInterval: 60m0s
   secretStoreRef:
     name: secretstore-sample
     kind: SecretStore

--- a/docs/snippets/multiline-template-v1-external-secret.yaml
+++ b/docs/snippets/multiline-template-v1-external-secret.yaml
@@ -4,7 +4,7 @@ kind: ExternalSecret
 metadata:
   name: template
 spec:
-  refreshInterval: 1h
+  refreshInterval: 1h0m0s
   secretStoreRef:
     name: secretstore-sample
     kind: SecretStore

--- a/docs/snippets/oracle-external-secret.yaml
+++ b/docs/snippets/oracle-external-secret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: example
 spec:
-  refreshInterval: 0.03m
+  refreshInterval: 0.03m0s
   secretStoreRef:
     kind: SecretStore
     name: example # Must match SecretStore on the cluster

--- a/docs/snippets/pkcs12-template-v1-external-secret.yaml
+++ b/docs/snippets/pkcs12-template-v1-external-secret.yaml
@@ -4,7 +4,7 @@ kind: ExternalSecret
 metadata:
   name: template
 spec:
-  refreshInterval: 1h
+  refreshInterval: 1h0m0s
   secretStoreRef:
     name: secretstore-sample
     kind: SecretStore

--- a/docs/snippets/vault-anchore-engine-access-credentials-external-secret.yaml
+++ b/docs/snippets/vault-anchore-engine-access-credentials-external-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: anchore-access-credentials
   namespace: security
 spec:
-  refreshInterval: 1m
+  refreshInterval: 1m0s
   secretStoreRef:
     name: vault-backend
     kind: ClusterSecretStore

--- a/docs/snippets/vault-jenkins-credential-github-ssh-access-external-secret.yaml
+++ b/docs/snippets/vault-jenkins-credential-github-ssh-access-external-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: github-ssh-access
   namespace: ci
 spec:
-  refreshInterval: 1m
+  refreshInterval: 1m0s
   secretStoreRef:
     name: vault-backend
     kind: ClusterSecretStore

--- a/docs/snippets/vault-jenkins-credential-harbor-chart-robot-external-secret.yaml
+++ b/docs/snippets/vault-jenkins-credential-harbor-chart-robot-external-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: harbor-chart-robot
   namespace: ci
 spec:
-  refreshInterval: 1m
+  refreshInterval: 1m0s
   secretStoreRef:
     name: vault-backend
     kind: ClusterSecretStore

--- a/docs/snippets/vault-jenkins-credential-sonarqube-api-token-external-secret.yaml
+++ b/docs/snippets/vault-jenkins-credential-sonarqube-api-token-external-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: sonarqube-api-token
   namespace: ci
 spec:
-  refreshInterval: 1m
+  refreshInterval: 1m0s
   secretStoreRef:
     name: vault-backend
     kind: ClusterSecretStore


### PR DESCRIPTION
After upgrading external-secrets to v0.5.0+, the old duration format suggested by the doc caused ArgoCD to keep thinking the format is out of sync, which leads to resyncing the resource over and over again.

This PR updates the duration format in doc, so users won't hit this issue again.