### PR TITLE
Remove duplicate entry

### DIFF
--- a/docs/snippets/gcpsm-docker-config-externalsecret.yaml
+++ b/docs/snippets/gcpsm-docker-config-externalsecret.yaml
@@ -9,7 +9,6 @@ spec:
     name: example
     kind: SecretStore
   target:
-    name: secret-to-be-created
     template:
       type: kubernetes.io/dockerconfigjson
       data:


### PR DESCRIPTION
Manifest in documentation has a duplicate name entry for the remote reference