### PR TITLE
Adds string replacement usage and test in Template

### DIFF
--- a/docs/snippets/multiline-template-v2-external-secret.yaml
+++ b/docs/snippets/multiline-template-v2-external-secret.yaml
@@ -21,6 +21,8 @@ spec:
             url: http://localhost:8080
             password: "{{ .password }}"
             user: "{{ .user }}"
+        # using replace function to rewrite secret
+        connection: '{{ .dburl | replace "postgres://" "postgresql://" }}'
 
   data:
   - secretKey: user
@@ -29,4 +31,7 @@ spec:
   - secretKey: password
     remoteRef:
       key: /grafana/password
+  - secretKey: dburl
+    remoteRef:
+      key: /database/url
 {% endraw %}

--- a/pkg/template/v2/template_test.go
+++ b/pkg/template/v2/template_test.go
@@ -195,6 +195,18 @@ func TestExecute(t *testing.T) {
 			},
 		},
 		{
+			name: "use replace function",
+			tpl: map[string][]byte{
+				"foo": []byte(`{{ .conn | replace "postgres://" "db+postgresql://"}}`),
+			},
+			data: map[string][]byte{
+				"conn": []byte(`postgres://user:pass@db.host:5432/dbname`),
+			},
+			expetedData: map[string][]byte{
+				"foo": []byte(`db+postgresql://user:pass@db.host:5432/dbname`),
+			},
+		},
+		{
 			name: "multiline template",
 			tpl: map[string][]byte{
 				"cfg": []byte(`


### PR DESCRIPTION
Hi ! 
This is a simple contribution for the Template docs. 
For database URLs, its common to have small differences in protocol naming, and the "replace" function is helpful in these cases.
A few examples: java applications might expect `postgresql://...` while python expects `db+postgresql://` or even `postgresql+psycopg2://`.
 
It also adds a test for this case, but it might be unnecessary (and I can remove it so you chose). 