### PR TITLE
Fix case in Gitlab description

### DIFF
--- a/apis/externalsecrets/v1alpha1/secretstore_types.go
+++ b/apis/externalsecrets/v1alpha1/secretstore_types.go
@@ -70,7 +70,7 @@ type SecretStoreProvider struct {
 	// +optional
 	YandexLockbox *YandexLockboxProvider `json:"yandexlockbox,omitempty"`
 
-	// GItlab configures this store to sync secrets using Gitlab Variables provider
+	// Gitlab configures this store to sync secrets using Gitlab Variables provider
 	// +optional
 	Gitlab *GitlabProvider `json:"gitlab,omitempty"`
 

--- a/apis/externalsecrets/v1beta1/secretstore_types.go
+++ b/apis/externalsecrets/v1beta1/secretstore_types.go
@@ -74,7 +74,7 @@ type SecretStoreProvider struct {
 	// +optional
 	YandexLockbox *YandexLockboxProvider `json:"yandexlockbox,omitempty"`
 
-	// GItlab configures this store to sync secrets using Gitlab Variables provider
+	// Gitlab configures this store to sync secrets using Gitlab Variables provider
 	// +optional
 	Gitlab *GitlabProvider `json:"gitlab,omitempty"`
 

--- a/config/crds/bases/external-secrets.io_clustersecretstores.yaml
+++ b/config/crds/bases/external-secrets.io_clustersecretstores.yaml
@@ -487,7 +487,7 @@ spec:
                         type: string
                     type: object
                   gitlab:
-                    description: GItlab configures this store to sync secrets using
+                    description: Gitlab configures this store to sync secrets using
                       Gitlab Variables provider
                     properties:
                       auth:
@@ -1848,7 +1848,7 @@ spec:
                         type: string
                     type: object
                   gitlab:
-                    description: GItlab configures this store to sync secrets using
+                    description: Gitlab configures this store to sync secrets using
                       Gitlab Variables provider
                     properties:
                       auth:

--- a/config/crds/bases/external-secrets.io_secretstores.yaml
+++ b/config/crds/bases/external-secrets.io_secretstores.yaml
@@ -487,7 +487,7 @@ spec:
                         type: string
                     type: object
                   gitlab:
-                    description: GItlab configures this store to sync secrets using
+                    description: Gitlab configures this store to sync secrets using
                       Gitlab Variables provider
                     properties:
                       auth:
@@ -1851,7 +1851,7 @@ spec:
                         type: string
                     type: object
                   gitlab:
-                    description: GItlab configures this store to sync secrets using
+                    description: Gitlab configures this store to sync secrets using
                       Gitlab Variables provider
                     properties:
                       auth:

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -702,7 +702,7 @@ spec:
                           type: string
                       type: object
                     gitlab:
-                      description: GItlab configures this store to sync secrets using Gitlab Variables provider
+                      description: Gitlab configures this store to sync secrets using Gitlab Variables provider
                       properties:
                         auth:
                           description: Auth configures how secret-manager authenticates with a GitLab instance.
@@ -1702,7 +1702,7 @@ spec:
                           type: string
                       type: object
                     gitlab:
-                      description: GItlab configures this store to sync secrets using Gitlab Variables provider
+                      description: Gitlab configures this store to sync secrets using Gitlab Variables provider
                       properties:
                         auth:
                           description: Auth configures how secret-manager authenticates with a GitLab instance.
@@ -3253,7 +3253,7 @@ spec:
                           type: string
                       type: object
                     gitlab:
-                      description: GItlab configures this store to sync secrets using Gitlab Variables provider
+                      description: Gitlab configures this store to sync secrets using Gitlab Variables provider
                       properties:
                         auth:
                           description: Auth configures how secret-manager authenticates with a GitLab instance.
@@ -4256,7 +4256,7 @@ spec:
                           type: string
                       type: object
                     gitlab:
-                      description: GItlab configures this store to sync secrets using Gitlab Variables provider
+                      description: Gitlab configures this store to sync secrets using Gitlab Variables provider
                       properties:
                         auth:
                           description: Auth configures how secret-manager authenticates with a GitLab instance.


### PR DESCRIPTION
Fix the case in `GItlab`.