### PR TITLE
docs: fix syntax in Kubernetes provider examples

### DIFF
--- a/docs/provider-kubernetes.md
+++ b/docs/provider-kubernetes.md
@@ -40,12 +40,12 @@ spec:
           type: Secret
           name: mydefaulttoken
           key: ca.crt
-        auth:
-          token:
-            bearerToken: 
-              name: mydefaulttoken
-              key: token
-        remoteNamespace: default
+      auth:
+        token:
+          bearerToken: 
+            name: mydefaulttoken
+            key: token
+      remoteNamespace: default
 ```
 3. Create the local secret that will be synced 
               
@@ -109,19 +109,19 @@ metadata:
   name: example
 spec:
   provider:
-      kubernetes: 
-        # If not remoteNamesapce is provided, default     namespace is used
-        remoteNamespace: remote-namespace
-        server: 
-          url: https://remote.kubernetes.api-server.address
-          # Add your encoded base64 to caBundle
-          caBundle: Cg==
-        auth:
-          # Adds referenced bearerToken
-          token:
-            bearerToken:
-              name: cluster-secrets
-              key: bearerToken
+    kubernetes:
+      # If not remoteNamesapce is provided, default     namespace is used
+      remoteNamespace: remote-namespace
+      server:
+        url: https://remote.kubernetes.api-server.address
+        # Add your encoded base64 to caBundle
+        caBundle: Cg==
+      auth:
+        # Adds referenced bearerToken
+        token:
+          bearerToken:
+            name: cluster-secrets
+            key: bearerToken
 ```     
 4. Finally create the ExternalSecret resource
 

--- a/docs/provider-kubernetes.md
+++ b/docs/provider-kubernetes.md
@@ -35,14 +35,14 @@ metadata:
 spec:
   provider:
     kubernetes:
-      server: 
-        caProvider: 
+      server:
+        caProvider:
           type: Secret
           name: mydefaulttoken
           key: ca.crt
       auth:
         token:
-          bearerToken: 
+          bearerToken:
             name: mydefaulttoken
             key: token
       remoteNamespace: default


### PR DESCRIPTION
The indent is incorrect:

```
error: error validating "STDIN": error validating data: [ValidationError(ClusterSecretStore.spec.provider.kubernetes.server): unknown field "auth" in io.external-secrets.v1beta1.ClusterSecretStore.spec.provider.kubernetes.server, ValidationError(ClusterSecretStore.spec.provider.kubernetes): missing required field "auth" in io.external-secrets.v1beta1.ClusterSecretStore.spec.provider.kubernetes]; if you choose to ignore these errors, turn validation off with --validate=false
```