### PR TITLE
Add support for referencing secrets manager secrets by their VersionId

### DIFF
--- a/pkg/provider/aws/secretsmanager/secretsmanager_test.go
+++ b/pkg/provider/aws/secretsmanager/secretsmanager_test.go
@@ -155,12 +155,21 @@ func TestSecretsManagerGetSecret(t *testing.T) {
 		smtc.expectedSecret = "nestedval"
 	}
 
-	// good case: custom version set
-	setCustomVersion := func(smtc *secretsManagerTestCase) {
+	// good case: custom version stage set
+	setCustomVersionStage := func(smtc *secretsManagerTestCase) {
 		smtc.apiInput.VersionStage = aws.String("1234")
 		smtc.remoteRef.Version = "1234"
 		smtc.apiOutput.SecretString = aws.String("FOOBA!")
 		smtc.expectedSecret = "FOOBA!"
+	}
+
+	// good case: custom version id set
+	setCustomVersionID := func(smtc *secretsManagerTestCase) {
+		smtc.apiInput.VersionStage = nil
+		smtc.apiInput.VersionId = aws.String("1234-5678")
+		smtc.remoteRef.Version = "uuid/1234-5678"
+		smtc.apiOutput.SecretString = aws.String("myvalue")
+		smtc.expectedSecret = "myvalue"
 	}
 
 	successCases := []*secretsManagerTestCase{
@@ -173,7 +182,8 @@ func TestSecretsManagerGetSecret(t *testing.T) {
 		makeValidSecretsManagerTestCaseCustom(setSecretBinaryAndSecretStringToNil),
 		makeValidSecretsManagerTestCaseCustom(setNestedSecretValueJSONParsing),
 		makeValidSecretsManagerTestCaseCustom(setSecretValueWithDot),
-		makeValidSecretsManagerTestCaseCustom(setCustomVersion),
+		makeValidSecretsManagerTestCaseCustom(setCustomVersionStage),
+		makeValidSecretsManagerTestCaseCustom(setCustomVersionID),
 		makeValidSecretsManagerTestCaseCustom(setAPIErr),
 	}
 


### PR DESCRIPTION
Fixes https://github.com/external-secrets/external-secrets/issues/1036

When the `version` field is set on the remoteRef for an ExternalSecret which references an AWS SecretsManager secret, it will only set the `VersionStage` field of the GetSecretValue api call. SecretsManager secrets can also be referenced by their `VersionId`, which is an immutable tag that is generated every time the secret is modified. This allows users to set a version for their secrets manager secrets and know that the secret in the cluster will not change even if the external secret is modified.