### PR TITLE
Add support for PodDisruptionBudget 

### DIFF
--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -51,6 +51,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | certController.podLabels | object | `{}` |  |
 | certController.podSecurityContext | object | `{}` |  |
 | certController.priorityClassName | string | `""` | Pod priority class name. |
+| certController.podDisruptionBudget.enabled | bool | `false` | Enable Pod disruption budget. |
+| certController.podDisruptionBudget.minAvailable | int | `1` | Specifies min available pods. |
+| certController.podDisruptionBudget.maxUnavailable | int | `0` | Specifies max unavailable pods. |
 | certController.prometheus.enabled | bool | `false` | deprecated. will be removed with 0.7.0, use serviceMonitor instead |
 | certController.prometheus.service.port | int | `8080` | deprecated. will be removed with 0.7.0, use serviceMonitor instead |
 | certController.rbac.create | bool | `true` | Specifies whether role and rolebinding resources should be created. |
@@ -86,6 +89,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | podLabels | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | priorityClassName | string | `""` | Pod priority class name. |
+| podDisruptionBudget.enabled | bool | `false` | Enable Pod disruption budget. |
+| podDisruptionBudget.minAvailable | int | `1` | Specifies min available pods. |
+| podDisruptionBudget.maxUnavailable | int | `0` | Specifies max unavailable pods. |
 | processClusterExternalSecret | bool | `true` | if true, the operator will process cluster external secret. Else, it will ignore them. |
 | processClusterStore | bool | `true` | if true, the operator will process cluster store. Else, it will ignore them. |
 | prometheus.enabled | bool | `false` | deprecated. will be removed with 0.7.0, use serviceMonitor instead. |
@@ -125,6 +131,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | webhook.podSecurityContext | object | `{}` |  |
 | webhook.port | int | `10250` | The port the webhook will listen to |
 | webhook.priorityClassName | string | `""` | Pod priority class name. |
+| webhook.podDisruptionBudget.enabled | bool | `false` | Enable Pod disruption budget. |
+| webhook.podDisruptionBudget.minAvailable | int | `1` | Specifies min available pods. |
+| webhook.podDisruptionBudget.maxUnavailable | int | `0` | Specifies max unavailable pods. |
 | webhook.prometheus.enabled | bool | `false` | deprecated. will be removed with 0.7.0, use serviceMonitor instead |
 | webhook.prometheus.service.port | int | `8080` | deprecated. will be removed with 0.7.0, use serviceMonitor instead |
 | webhook.rbac.create | bool | `true` | Specifies whether role and rolebinding resources should be created. |

--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -37,6 +37,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | affinity | object | `{}` |  |
 | certController.affinity | object | `{}` |  |
 | certController.create | bool | `true` | Specifies whether a certificate controller deployment be created. |
+| certController.replicaCount | int | `1` |  |
 | certController.deploymentAnnotations | object | `{}` | Annotations to add to Deployment |
 | certController.extraArgs | object | `{}` |  |
 | certController.extraEnv | list | `[]` |  |

--- a/deploy/charts/external-secrets/templates/cert-controller-deployment.yaml
+++ b/deploy/charts/external-secrets/templates/cert-controller-deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.certController.replicaCount }}
   selector:
     matchLabels:
       {{- include "external-secrets-cert-controller.selectorLabels" . | nindent 6 }}

--- a/deploy/charts/external-secrets/templates/cert-controller-poddisruptionbudget.yaml
+++ b/deploy/charts/external-secrets/templates/cert-controller-poddisruptionbudget.yaml
@@ -15,5 +15,5 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- include "external-secrets-cert-controller.selectorLabels" . | nindent 4 }}
+      {{- include "external-secrets-cert-controller.selectorLabels" . | nindent 6 }}
 {{- end }}

--- a/deploy/charts/external-secrets/templates/cert-controller-poddisruptionbudget.yaml
+++ b/deploy/charts/external-secrets/templates/cert-controller-poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.certController.create .Values.certController.podDisruptionBudget.enabled }}
+{{- if and .Values.certController.create .Values.certController.podDisruptionBudget.enabled }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/deploy/charts/external-secrets/templates/cert-controller-poddisruptionbudget.yaml
+++ b/deploy/charts/external-secrets/templates/cert-controller-poddisruptionbudget.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.certController.create .Values.certController.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "external-secrets.fullname" . }}-cert-controller-pdb
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "external-secrets-cert-controller.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.certController.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.certController.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.certController.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.certController.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "external-secrets-cert-controller.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/deploy/charts/external-secrets/templates/poddisruptionbudget.yaml
+++ b/deploy/charts/external-secrets/templates/poddisruptionbudget.yaml
@@ -15,5 +15,5 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- include "external-secrets.selectorLabels" . | nindent 4 }}
+      {{- include "external-secrets.selectorLabels" . | nindent 6 }}
 {{- end }}

--- a/deploy/charts/external-secrets/templates/poddisruptionbudget.yaml
+++ b/deploy/charts/external-secrets/templates/poddisruptionbudget.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "external-secrets.fullname" . }}-pdb
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "external-secrets.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/deploy/charts/external-secrets/templates/webhook-poddisruptionbudget.yaml
+++ b/deploy/charts/external-secrets/templates/webhook-poddisruptionbudget.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ include "external-secrets.fullname" . }}-pdb
+  name: {{ include "external-secrets.fullname" . }}-webhook-pdb
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "external-secrets-webhook.labels" . | nindent 4 }}

--- a/deploy/charts/external-secrets/templates/webhook-poddisruptionbudget.yaml
+++ b/deploy/charts/external-secrets/templates/webhook-poddisruptionbudget.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.webhook.create .Values.webhook.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "external-secrets.fullname" . }}-pdb
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "external-secrets-webhook.labels" . | nindent 4 }}
+    external-secrets.io/component : webhook
+spec:
+  {{- if .Values.webhook.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.webhook.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.webhook.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.webhook.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "external-secrets-webhook.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/deploy/charts/external-secrets/templates/webhook-poddisruptionbudget.yaml
+++ b/deploy/charts/external-secrets/templates/webhook-poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.webhook.create .Values.webhook.podDisruptionBudget.enabled }}
+{{- if and .Values.webhook.create .Values.webhook.podDisruptionBudget.enabled }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/deploy/charts/external-secrets/templates/webhook-poddisruptionbudget.yaml
+++ b/deploy/charts/external-secrets/templates/webhook-poddisruptionbudget.yaml
@@ -16,5 +16,5 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- include "external-secrets-webhook.selectorLabels" . | nindent 4 }}
+      {{- include "external-secrets-webhook.selectorLabels" . | nindent 6 }}
 {{- end }}

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -120,6 +120,12 @@ affinity: {}
 # -- Pod priority class name.
 priorityClassName: ""
 
+# -- Pod disruption budget - for more details see https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+podDisruptionBudget:
+  enabled: false 
+  minAvailable: 1
+  # maxUnavailable: 1
+
 webhook:
   # -- Specifies whether a webhook deployment be created.
   create: true
@@ -160,6 +166,11 @@ webhook:
     # -- Pod priority class name.
   priorityClassName: ""
 
+  # -- Pod disruption budget - for more details see https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+  podDisruptionBudget:
+    enabled: false 
+    minAvailable: 1
+    # maxUnavailable: 1
   prometheus:
     # -- deprecated. will be removed with 0.7.0, use serviceMonitor instead
     enabled: false
@@ -243,6 +254,12 @@ certController:
 
     # -- Pod priority class name.
   priorityClassName: ""
+
+  # -- Pod disruption budget - for more details see https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+  podDisruptionBudget:
+    enabled: false 
+    minAvailable: 1
+    # maxUnavailable: 1
 
   prometheus:
     # -- deprecated. will be removed with 0.7.0, use serviceMonitor instead

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -228,6 +228,7 @@ certController:
   # -- Specifies whether a certificate controller deployment be created.
   create: true
   requeueInterval: "5m"
+  replicaCount: 1
   image:
     repository: ghcr.io/external-secrets/external-secrets
     pullPolicy: IfNotPresent

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -122,7 +122,7 @@ priorityClassName: ""
 
 # -- Pod disruption budget - for more details see https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
 podDisruptionBudget:
-  enabled: false 
+  enabled: false
   minAvailable: 1
   # maxUnavailable: 1
 
@@ -168,7 +168,7 @@ webhook:
 
   # -- Pod disruption budget - for more details see https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
   podDisruptionBudget:
-    enabled: false 
+    enabled: false
     minAvailable: 1
     # maxUnavailable: 1
   prometheus:
@@ -257,7 +257,7 @@ certController:
 
   # -- Pod disruption budget - for more details see https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
   podDisruptionBudget:
-    enabled: false 
+    enabled: false
     minAvailable: 1
     # maxUnavailable: 1
 


### PR DESCRIPTION
Add support to PodDisruptionBudget to increase HA of ExternalSecrets deployments.

What is the added value?
Achieve HA for ExternalSecrets deployments

Give us examples of the outcome

Add pdb to certController
Add pdb to webhook
Add pdb to operator


A fix to the issue reported in https://github.com/external-secrets/external-secrets/issues/1162