### PR TITLE
Add ability to trim path from secret names

### DIFF
--- a/apis/externalsecrets/v1alpha1/externalsecret_types.go
+++ b/apis/externalsecrets/v1alpha1/externalsecret_types.go
@@ -150,8 +150,9 @@ type ExternalSecretDataRemoteRef struct {
 type ExternalSecretConversionStrategy string
 
 const (
-	ExternalSecretConversionDefault ExternalSecretConversionStrategy = "Default"
-	ExternalSecretConversionUnicode ExternalSecretConversionStrategy = "Unicode"
+	ExternalSecretConversionDefault  ExternalSecretConversionStrategy = "Default"
+	ExternalSecretConversionUnicode  ExternalSecretConversionStrategy = "Unicode"
+	ExternalSecretConversionTrimPath ExternalSecretConversionStrategy = "TrimPath"
 )
 
 // ExternalSecretSpec defines the desired state of ExternalSecret.

--- a/apis/externalsecrets/v1beta1/externalsecret_types.go
+++ b/apis/externalsecrets/v1beta1/externalsecret_types.go
@@ -194,8 +194,9 @@ const (
 type ExternalSecretConversionStrategy string
 
 const (
-	ExternalSecretConversionDefault ExternalSecretConversionStrategy = "Default"
-	ExternalSecretConversionUnicode ExternalSecretConversionStrategy = "Unicode"
+	ExternalSecretConversionDefault  ExternalSecretConversionStrategy = "Default"
+	ExternalSecretConversionUnicode  ExternalSecretConversionStrategy = "Unicode"
+	ExternalSecretConversionTrimPath ExternalSecretConversionStrategy = "TrimPath"
 )
 
 // +kubebuilder:validation:MinProperties=1

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -53,6 +53,9 @@ func ConvertKeys(strategy esv1beta1.ExternalSecretConversionStrategy, in map[str
 }
 
 func convert(strategy esv1beta1.ExternalSecretConversionStrategy, str string) string {
+	if strategy == esv1beta1.ExternalSecretConversionTrimPath {
+		str = str[strings.LastIndex(str, "/")+1:]
+	}
 	rs := []rune(str)
 	newName := make([]string, len(rs))
 	for rk, rv := range rs {
@@ -63,6 +66,8 @@ func convert(strategy esv1beta1.ExternalSecretConversionStrategy, str string) st
 			rv != '_' {
 			switch strategy {
 			case esv1beta1.ExternalSecretConversionDefault:
+				newName[rk] = "_"
+			case esv1beta1.ExternalSecretConversionTrimPath:
 				newName[rk] = "_"
 			case esv1beta1.ExternalSecretConversionUnicode:
 				newName[rk] = fmt.Sprintf("_U%04x_", rv)


### PR DESCRIPTION
This attempts to fix #1067 (and perhaps #975) by introducing a new `conversionStrategy: TrimPath`. Assuming you have the following SSM parameters 

```
/some/ssm/path/KEY1
/some/ssm/path/KEY2
/some/ssm/path/KEY3
```
You can generate a secret without the path i.e.
```
data:
  KEY1: ...
  KEY2: ...
  KEY3: ...
```
 with the following ExternalSecret
```
apiVersion: external-secrets.io/v1beta1
kind: ExternalSecret
metadata:
  name: example
spec:
  refreshInterval: 1h
  secretStoreRef:
    name: secretstore-sample
    kind: SecretStore
  target:
    name: secret-to-be-created
    creationPolicy: Owner
  dataFrom:
  - find:
      path: /some/ssm/path/
      conversionStrategy: TrimPath
      name:
        regexp: '.*'
``` 