### PR TITLE
Add PrometheusRule "external-secrets-ready"

### DIFF
--- a/deploy/charts/external-secrets/templates/prometheus-rules/ready-state.yml
+++ b/deploy/charts/external-secrets/templates/prometheus-rules/ready-state.yml
@@ -1,0 +1,18 @@
+{{- if and .Values.serviceMonitor.enabled .Values.serviceMonitor.prometheusRules.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: external-secrets-ready
+spec:
+  groups:
+    - name: external-secrets
+      rules:
+        - alert: ExternalSecretReady
+          annotations:
+            description: 'ExternalSecret "{{`{{ $labels.name }}`}}" is not ready.'
+            summary: ExternalSecret is not ready
+          expr: externalsecret_status_condition{status="True"} == 0
+          for: 5m
+          labels:
+            severity: critical
+{{- end }}

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -111,6 +111,10 @@ serviceMonitor:
   # -- Timeout if metrics can't be retrieved in given time interval
   scrapeTimeout: 25s
 
+  prometheusRules:
+    # -- Specify whether to create PrometheusRules
+    enabled: true
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
This PR adds a PrometheusRule "external-secrets-ready". This Rule validates if there are any ExternalSecrets that do have value `0` for `status="True"`.

Was wondering what the reasons was for adding two metrics: One with `status="True"` and one with `status="False"` as they both reflect the exact opposite of each other: 
https://github.com/external-secrets/external-secrets/blob/01b495ceea89d0617df7ddcc5103d14d3edceb69/pkg/controllers/externalsecret/metrics.go#L84-L99
<img width="770" alt="Bildschirmfoto 2022-05-23 um 13 03 51" src="https://user-images.githubusercontent.com/927904/169805766-793aa954-7d25-4ddc-9378-32dfbd17b783.png">

