### PR TITLE
chore/clean-maintainers

### DIFF
--- a/.github/PAUL.yaml
+++ b/.github/PAUL.yaml
@@ -1,19 +1,15 @@
 maintainers:
 - knelasevero
 - gusfcarvalho
-- sebagomez
-- serdarkalayci
-- riccardomc
-- iamcaleberic
-- jonatasbaldin
-- mircea-cosbuc
-- mcavoyk
 - moolen
-- silasbw
-- Flydiverny
-- gabibeyer
-- ricardoptcosta
+- sebagomez
 - rodrmartinez
+# Emeritus Approvers
+- Flydiverny
+- silasbw
+- mcavoyk
+- riccardomc
+- jonatasbaldin
 # Allows for the /label and /remove-label commands
 # usage: /label enhancement
 # usage: /remove-label enhancement


### PR DESCRIPTION
Removing some inactive contributors. Kept some people that were helping in the creation of this project as emeritus approvers.