### PR TITLE
Update fakes to implement client for 1Password/connect-sdk-go v1.4.0

### DIFF
--- a/docs/contributing-devguide.md
+++ b/docs/contributing-devguide.md
@@ -44,10 +44,11 @@ make build
 make docker.build IMG=external-secrets:latest
 ```
 
-Run tests and lint the code:
+Run tests and lint the code: *(golangci-lint@1.45.2 is needed.)*
 ```shell
 make test
-make lint
+make lint # OR
+docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.42.1 golangci-lint run
 ```
 
 Build the documentation:

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1552,14 +1552,16 @@ string
 </tr>
 <tr>
 <td>
-<code>version</code></br>
+<code>metadataPolicy</code></br>
 <em>
-string
+<a href="#external-secrets.io/v1beta1.ExternalSecretMetadataPolicy">
+ExternalSecretMetadataPolicy
+</a>
 </em>
 </td>
 <td>
 <em>(Optional)</em>
-<p>Used to select a specific version of the Provider value, if supported</p>
+<p>Policy for fetching tags/labels from provider secrets, possible options are Fetch, None. Defaults to None</p>
 </td>
 </tr>
 <tr>
@@ -1572,6 +1574,18 @@ string
 <td>
 <em>(Optional)</em>
 <p>Used to select a specific property of the Provider value (if a map), if supported</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>version</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Used to select a specific version of the Provider value, if supported</p>
 </td>
 </tr>
 <tr>
@@ -1694,6 +1708,27 @@ ExternalSecretConversionStrategy
 </td>
 </tr>
 </tbody>
+</table>
+<h3 id="external-secrets.io/v1beta1.ExternalSecretMetadataPolicy">ExternalSecretMetadataPolicy
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#external-secrets.io/v1beta1.ExternalSecretDataRemoteRef">ExternalSecretDataRemoteRef</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;Fetch&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;None&#34;</p></td>
+<td></td>
+</tr></tbody>
 </table>
 <h3 id="external-secrets.io/v1beta1.ExternalSecretSpec">ExternalSecretSpec
 </h3>

--- a/pkg/provider/onepassword/fake/fake.go
+++ b/pkg/provider/onepassword/fake/fake.go
@@ -38,21 +38,34 @@ func NewMockClient() *OnePasswordMockClient {
 	}
 }
 
+// GetVaults unused fake.
+func (mockClient *OnePasswordMockClient) GetVaults() ([]onepassword.Vault, error) {
+	return []onepassword.Vault{}, nil
+}
+
+// GetVault unused fake.
+func (mockClient *OnePasswordMockClient) GetVault(uuid string) (*onepassword.Vault, error) {
+	return &onepassword.Vault{}, nil
+}
+
+// GetVaultByUUID unused fake.
+func (mockClient *OnePasswordMockClient) GetVaultByUUID(uuid string) (*onepassword.Vault, error) {
+	return &onepassword.Vault{}, nil
+}
+
+// GetVaultByTitle unused fake.
+func (mockClient *OnePasswordMockClient) GetVaultByTitle(uuid string) (*onepassword.Vault, error) {
+	return &onepassword.Vault{}, nil
+}
+
 // GetVaultsByTitle returns a list of vaults, you must preload.
 func (mockClient *OnePasswordMockClient) GetVaultsByTitle(uuid string) ([]onepassword.Vault, error) {
 	return mockClient.MockVaults[uuid], nil
 }
 
-// GetItemsByTitle returns a list of items, you must preload.
-func (mockClient *OnePasswordMockClient) GetItemsByTitle(itemUUID, vaultUUID string) ([]onepassword.Item, error) {
-	items := []onepassword.Item{}
-	for _, item := range mockClient.MockItems[vaultUUID] {
-		if item.Title == itemUUID {
-			items = append(items, item)
-		}
-	}
-
-	return items, nil
+// GetItems returns []onepassword.Item, you must preload.
+func (mockClient *OnePasswordMockClient) GetItems(vaultUUID string) ([]onepassword.Item, error) {
+	return mockClient.MockItems[vaultUUID], nil
 }
 
 // GetItem returns a *onepassword.Item, you must preload.
@@ -69,9 +82,56 @@ func (mockClient *OnePasswordMockClient) GetItem(itemUUID, vaultUUID string) (*o
 	return &onepassword.Item{}, errors.New("status 400: Invalid Item UUID")
 }
 
-// GetItems returns []onepassword.Item, you must preload.
-func (mockClient *OnePasswordMockClient) GetItems(vaultUUID string) ([]onepassword.Item, error) {
-	return mockClient.MockItems[vaultUUID], nil
+// GetItemByUUID unused fake.
+func (mockClient *OnePasswordMockClient) GetItemByUUID(uuid, vaultQuery string) (*onepassword.Item, error) {
+	return &onepassword.Item{}, nil
+}
+
+// GetItemByTitle unused fake.
+func (mockClient *OnePasswordMockClient) GetItemByTitle(title, vaultUUID string) (*onepassword.Item, error) {
+	return &onepassword.Item{}, nil
+}
+
+// GetItemsByTitle returns a list of items, you must preload.
+func (mockClient *OnePasswordMockClient) GetItemsByTitle(itemUUID, vaultUUID string) ([]onepassword.Item, error) {
+	items := []onepassword.Item{}
+	for _, item := range mockClient.MockItems[vaultUUID] {
+		if item.Title == itemUUID {
+			items = append(items, item)
+		}
+	}
+
+	return items, nil
+}
+
+// CreateItem unused fake.
+func (mockClient *OnePasswordMockClient) CreateItem(item *onepassword.Item, vaultUUID string) (*onepassword.Item, error) {
+	return &onepassword.Item{}, nil
+}
+
+// UpdateItem unused fake.
+func (mockClient *OnePasswordMockClient) UpdateItem(item *onepassword.Item, vaultUUID string) (*onepassword.Item, error) {
+	return &onepassword.Item{}, nil
+}
+
+// DeleteItem unused fake.
+func (mockClient *OnePasswordMockClient) DeleteItem(item *onepassword.Item, vaultUUID string) error {
+	return nil
+}
+
+// DeleteItemByID unused fake.
+func (mockClient *OnePasswordMockClient) DeleteItemByID(itemUUID, vaultQuery string) error {
+	return nil
+}
+
+// GetFiles unused fake.
+func (mockClient *OnePasswordMockClient) GetFiles(itemQuery, vaultQuery string) ([]onepassword.File, error) {
+	return []onepassword.File{}, nil
+}
+
+// GetFile unused fake.
+func (mockClient *OnePasswordMockClient) GetFile(fileUUID, itemUUID, vaultUUID string) (*onepassword.File, error) {
+	return &onepassword.File{}, nil
 }
 
 // GetFileContent returns file data, you must preload.
@@ -84,39 +144,29 @@ func (mockClient *OnePasswordMockClient) GetFileContent(file *onepassword.File) 
 	return value, nil
 }
 
-// GetVaults fake.
-func (mockClient *OnePasswordMockClient) GetVaults() ([]onepassword.Vault, error) {
-	return []onepassword.Vault{}, nil
+// DownloadFile unused fake.
+func (mockClient *OnePasswordMockClient) DownloadFile(file *onepassword.File, targetDirectory string, overwrite bool) (string, error) {
+	return "", nil
 }
 
-// GetVault fake.
-func (mockClient *OnePasswordMockClient) GetVault(uuid string) (*onepassword.Vault, error) {
-	return &onepassword.Vault{}, nil
-}
-
-// GetItemByTitle fake.
-func (mockClient *OnePasswordMockClient) GetItemByTitle(title, vaultUUID string) (*onepassword.Item, error) {
-	return &onepassword.Item{}, nil
-}
-
-// CreateItem fake.
-func (mockClient *OnePasswordMockClient) CreateItem(item *onepassword.Item, vaultUUID string) (*onepassword.Item, error) {
-	return &onepassword.Item{}, nil
-}
-
-// UpdateItem fake.
-func (mockClient *OnePasswordMockClient) UpdateItem(item *onepassword.Item, vaultUUID string) (*onepassword.Item, error) {
-	return &onepassword.Item{}, nil
-}
-
-// DeleteItem fake.
-func (mockClient *OnePasswordMockClient) DeleteItem(item *onepassword.Item, vaultUUID string) error {
+// LoadStructFromItemByUUID unused fake.
+func (mockClient *OnePasswordMockClient) LoadStructFromItemByUUID(config interface{}, itemUUID, vaultQuery string) error {
 	return nil
 }
 
-// GetFile fake.
-func (mockClient *OnePasswordMockClient) GetFile(fileUUID, itemUUID, vaultUUID string) (*onepassword.File, error) {
-	return &onepassword.File{}, nil
+// LoadStructFromItemByTitle unused fake.
+func (mockClient *OnePasswordMockClient) LoadStructFromItemByTitle(config interface{}, itemTitle, vaultQuery string) error {
+	return nil
+}
+
+// LoadStructFromItem unused fake.
+func (mockClient *OnePasswordMockClient) LoadStructFromItem(config interface{}, itemQuery, vaultQuery string) error {
+	return nil
+}
+
+// LoadStructunused fake.
+func (mockClient *OnePasswordMockClient) LoadStruct(config interface{}) error {
+	return nil
 }
 
 // // For rigging test cases


### PR DESCRIPTION
Add mocks for the new methods in the upgraded 1Password/connect-sdk-go client. Also sort the mocks in the same order as the client to make this easier in the future.

Add note to docs about need for specific version of golangci-lint.

Note: not sure why `docs/spec.md` got updated when I ran `make docs`, I didn't change anything that I know of that would've caused this.

