### PR TITLE
Check v1beta1RemoteRef.Extract for nil

### DIFF
--- a/apis/externalsecrets/v1alpha1/externalsecret_conversion.go
+++ b/apis/externalsecrets/v1alpha1/externalsecret_conversion.go
@@ -78,13 +78,15 @@ func (alpha *ExternalSecret) ConvertFrom(betaRaw conversion.Hub) error {
 	beta := betaRaw.(*esv1beta1.ExternalSecret)
 	v1alpha1DataFrom := make([]ExternalSecretDataRemoteRef, 0)
 	for _, v1beta1RemoteRef := range beta.Spec.DataFrom {
-		if v1beta1RemoteRef.Extract.Key != "" {
-			v1alpha1RemoteRef := ExternalSecretDataRemoteRef{
-				Key:      v1beta1RemoteRef.Extract.Key,
-				Property: v1beta1RemoteRef.Extract.Property,
-				Version:  v1beta1RemoteRef.Extract.Version,
+		if v1beta1RemoteRef.Extract != nil {
+			if v1beta1RemoteRef.Extract.Key != "" {
+				v1alpha1RemoteRef := ExternalSecretDataRemoteRef{
+					Key:      v1beta1RemoteRef.Extract.Key,
+					Property: v1beta1RemoteRef.Extract.Property,
+					Version:  v1beta1RemoteRef.Extract.Version,
+				}
+				v1alpha1DataFrom = append(v1alpha1DataFrom, v1alpha1RemoteRef)
 			}
-			v1alpha1DataFrom = append(v1alpha1DataFrom, v1alpha1RemoteRef)
 		}
 	}
 	alpha.Spec.DataFrom = v1alpha1DataFrom


### PR DESCRIPTION
Unless I'm mistaken the type ExternalSecretDataFromRemoteRef makes the `Extract` field optional. We're running into an issue in our deployment where we have an externalsecret using a `Find` and not an `Extract` which seems to cause some issue referencing memory "runtime error: invalid memory address or nil pointer dereference"

sample externalsecret spec to reproduce (running v0.5.2 as well as v0.5.5)

```
spec:
  dataFrom:
  - find:
      conversionStrategy: Default
      name:
        regexp: /some/path/in/aws-ssm/prod/.*$
  refreshInterval: 1h
  secretStoreRef:
    kind: ClusterSecretStore
    name: secretstorename
  target:
    creationPolicy: Owner
    deletionPolicy: Retain
    name: alertmanager-values
    template:
      engineVersion: v2
      metadata: {}
```