### PR TITLE
Fix keys for secretRef in CRD ClusterSecretStore

### DIFF
--- a/docs/snippets/full-cluster-secret-store.yaml
+++ b/docs/snippets/full-cluster-secret-store.yaml
@@ -26,10 +26,10 @@ spec:
       auth:
         # Getting the accessKeyID and secretAccessKey from an already created Kubernetes Secret
         secretRef:
-          accessKeyID:
+          accessKeyIDSecretRef:
             name: awssm-secret
             key: access-key
-          secretAccessKey:
+          secretAccessKeySecretRef:
             name: awssm-secret
             key: secret-access-key
         # IAM roles for service accounts


### PR DESCRIPTION
While testing I have found that the documentation was referencing to wrong key names:

`provider.aws.auth.secretRef.accessKeyIDSecretRef`
`provider.aws.auth.secretRef.secretAccessKeySecretRef`