### PR TITLE
update cosign installer action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,13 +259,11 @@ jobs:
 
       - name: Install cosign
         if: github.ref == 'refs/heads/main' && env.GHCR_USERNAME != ''
-        uses: sigstore/cosign-installer@main
-        with:
-          cosign-release: 'v1.6.0'
+        uses: sigstore/cosign-installer@v2.4.0
 
       - name: Sign Artifacts to main release channel
         if: github.ref == 'refs/heads/main' && env.GHCR_USERNAME != ''
         run: make docker.sign
         env:
           RELEASE_TAG: main
-          COSIGN_EXPERIMENTAL: 1
+          COSIGN_EXPERIMENTAL: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,9 +126,7 @@ jobs:
 
       - name: Install cosign
         if: env.GHCR_USERNAME != ''
-        uses: sigstore/cosign-installer@main
-        with:
-          cosign-release: 'v1.6.0'
+        uses: sigstore/cosign-installer@v2.4.0
 
       - name: Sign Container Image
         if: env.GHCR_USERNAME != ''
@@ -136,4 +134,4 @@ jobs:
         env:
           RELEASE_TAG: ${{ github.event.inputs.version }}
           SOURCE_TAG: main
-          COSIGN_EXPERIMENTAL: 1
+          COSIGN_EXPERIMENTAL: true


### PR DESCRIPTION
cosign release below v1.8.0 will not work anymore with Fulcio (that generates the ephemeral certificates) which is our case here.

Updating to the latest release cosign installer action and default that to the latest release (v1.9.0)

cc @knelasevero 