### PR TITLE
fix: infracost v2 migration

### DIFF
--- a/.github/workflows/e2e-managed.yml
+++ b/.github/workflows/e2e-managed.yml
@@ -149,13 +149,19 @@ jobs:
         api-key: ${{ secrets.INFRACOST_API_KEY }}
 
     - name: Generate Infracost JSON for provider
-      run: infracost breakdown --path terraform/${{github.event.client_payload.slash_command.args.named.provider}}/plan.json --format json --out-file /tmp/infracost.json
+      run: |
+        infracost breakdown \
+          --path terraform/${{github.event.client_payload.slash_command.args.named.provider}}/plan.json \
+          --format json \
+          --out-file /tmp/infracost.json
 
     - name: Post Infracost comment
-      uses: infracost/actions/comment@v2
-      with:
-        path: /tmp/infracost.json
-        behavior: update
+      run: |
+        infracost comment github --path=/tmp/infracost.json \
+          --repo=$GITHUB_REPOSITORY \
+          --github-token=${{ secrets.GITHUB_TOKEN }} \
+          --pull-request=${{ github.event.client_payload.pull_request.number }} \
+          --behavior=update
 
     - name: Apply TF
       run: |-


### PR DESCRIPTION
This PR fixes the infracost v2 issue introduced in https://github.com/external-secrets/external-secrets/pull/1203

see managed action failure: https://github.com/external-secrets/external-secrets/runs/6993607301?check_suite_focus=true 

migration guide: https://www.infracost.io/docs/guides/actions_migration/