### PR TITLE
Enable mounting of custom volumes to deployments

### DIFF
--- a/deploy/charts/external-secrets/templates/cert-controller-deployment.yaml
+++ b/deploy/charts/external-secrets/templates/cert-controller-deployment.yaml
@@ -82,7 +82,7 @@ spec:
           {{- end }}
       {{- if .Values.certController.extraVolumes }}
       volumes:
-      {{ toYaml .Values.certController.extraVolumes | nindent 8 }}
+      {{- toYaml .Values.certController.extraVolumes | nindent 8 }}
       {{- end }}
       {{- with .Values.certController.nodeSelector }}
       nodeSelector:

--- a/deploy/charts/external-secrets/templates/cert-controller-deployment.yaml
+++ b/deploy/charts/external-secrets/templates/cert-controller-deployment.yaml
@@ -76,6 +76,14 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if .Values.certController.extraVolumeMounts }}
+          volumeMounts:
+          {{- toYaml .Values.certController.extraVolumeMounts | nindent 12 }}
+          {{- end }}
+      {{- if .Values.certController.extraVolumes }}
+      volumes:
+      {{ toYaml .Values.certController.extraVolumes | nindent 8 }}
+      {{- end }}
       {{- with .Values.certController.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/charts/external-secrets/templates/deployment.yaml
+++ b/deploy/charts/external-secrets/templates/deployment.yaml
@@ -89,13 +89,13 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if .Values.webhook.extraVolumeMounts }}
+          {{- if .Values.extraVolumeMounts }}
           volumeMounts:
-          {{- toYaml .Values.webhook.extraVolumeMounts | nindent 12 }}
+          {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
           {{- end }}
       {{- if .Values.extraVolumes }}
       volumes:
-      {{ toYaml .Values.extraVolumes | nindent 8 }}
+      {{- toYaml .Values.extraVolumes | nindent 8 }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/deploy/charts/external-secrets/templates/deployment.yaml
+++ b/deploy/charts/external-secrets/templates/deployment.yaml
@@ -89,6 +89,14 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if .Values.webhook.extraVolumeMounts }}
+          volumeMounts:
+          {{- toYaml .Values.webhook.extraVolumeMounts | nindent 12 }}
+          {{- end }}
+      {{- if .Values.extraVolumes }}
+      volumes:
+      {{ toYaml .Values.extraVolumes | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/charts/external-secrets/templates/webhook-deployment.yaml
+++ b/deploy/charts/external-secrets/templates/webhook-deployment.yaml
@@ -91,7 +91,7 @@ spec:
         secret:
           secretName: {{ include "external-secrets.fullname" . }}-webhook
       {{- if .Values.webhook.extraVolumes }}
-      {{ toYaml .Values.webhook.extraVolumes | nindent 8 }}
+      {{- toYaml .Values.webhook.extraVolumes | nindent 8 }}
       {{- end }}
       {{- with .Values.webhook.nodeSelector }}
       nodeSelector:

--- a/deploy/charts/external-secrets/templates/webhook-deployment.yaml
+++ b/deploy/charts/external-secrets/templates/webhook-deployment.yaml
@@ -83,10 +83,16 @@ spec:
           - name: certs
             mountPath: {{ .Values.webhook.certDir }}
             readOnly: true
+          {{- if .Values.webhook.extraVolumeMounts }}
+          {{- toYaml .Values.webhook.extraVolumeMounts | nindent 12 }}
+          {{- end }}
       volumes:
       - name: certs
         secret:
           secretName: {{ include "external-secrets.fullname" . }}-webhook
+      {{- if .Values.webhook.extraVolumes }}
+      {{ toYaml .Values.webhook.extraVolumes | nindent 8 }}
+      {{- end }}
       {{- with .Values.webhook.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -67,6 +67,12 @@ extraEnv: []
 ## -- Map of extra arguments to pass to container.
 extraArgs: {}
 
+## -- Extra volumes to pass to pod.
+extraVolumes: []
+
+## -- Extra volumes to mount to the container.
+extraVolumeMounts: []
+
 # -- Annotations to add to Deployment
 deploymentAnnotations: {}
 
@@ -197,6 +203,12 @@ webhook:
     ## -- Map of extra arguments to pass to container.
   extraArgs: {}
 
+    ## -- Extra volumes to pass to pod.
+  extraVolumes: []
+
+    ## -- Extra volumes to mount to the container.
+  extraVolumeMounts: []
+
     # -- Annotations to add to Secret
   secretAnnotations: {}
 
@@ -287,6 +299,12 @@ certController:
 
     ## -- Map of extra arguments to pass to container.
   extraArgs: {}
+
+    ## -- Extra volumes to pass to pod.
+  extraVolumes: []
+
+    ## -- Extra volumes to mount to the container.
+  extraVolumeMounts: []
 
     # -- Annotations to add to Deployment
   deploymentAnnotations: {}


### PR DESCRIPTION
ESO currently offers no configuration of volumes mounted to the containers. This is a problem for certain secret providers which don't allow configuration of the Certificate Authority (e.g. GitLab https://github.com/external-secrets/external-secrets/issues/1228). In its current form, ESO cannot be used with GitLab in an internet-disconnected environment or in any environment with a custom certificate authority.

This change adds `extraVolumeMounts` and `extraVolumes` to all containers so that users can mount secrets, configMaps or any other volume they may require.

This MR contains no code changes, nor will it cause any breaking changes for existing users.