### PR TITLE
Implements DecodingStrategy. 

### DIFF
--- a/apis/externalsecrets/v1beta1/externalsecret_types.go
+++ b/apis/externalsecrets/v1beta1/externalsecret_types.go
@@ -182,6 +182,11 @@ type ExternalSecretDataRemoteRef struct {
 	// Used to define a conversion Strategy
 	// +kubebuilder:default="Default"
 	ConversionStrategy ExternalSecretConversionStrategy `json:"conversionStrategy,omitempty"`
+
+	// +optional
+	// Used to define a conversion Strategy
+	// +kubebuilder:default="None"
+	DecodingStrategy ExternalSecretDecodingStrategy `json:"decodingStrategy,omitempty"`
 }
 
 type ExternalSecretMetadataPolicy string
@@ -196,6 +201,15 @@ type ExternalSecretConversionStrategy string
 const (
 	ExternalSecretConversionDefault ExternalSecretConversionStrategy = "Default"
 	ExternalSecretConversionUnicode ExternalSecretConversionStrategy = "Unicode"
+)
+
+type ExternalSecretDecodingStrategy string
+
+const (
+	ExternalSecretDecodeAuto      ExternalSecretDecodingStrategy = "Auto"
+	ExternalSecretDecodeBase64    ExternalSecretDecodingStrategy = "Base64"
+	ExternalSecretDecodeBase64URL ExternalSecretDecodingStrategy = "Base64URL"
+	ExternalSecretDecodeNone      ExternalSecretDecodingStrategy = "None"
 )
 
 // +kubebuilder:validation:MinProperties=1
@@ -225,6 +239,11 @@ type ExternalSecretFind struct {
 	// Used to define a conversion Strategy
 	// +kubebuilder:default="Default"
 	ConversionStrategy ExternalSecretConversionStrategy `json:"conversionStrategy,omitempty"`
+
+	// +optional
+	// Used to define a conversion Strategy
+	// +kubebuilder:default="None"
+	DecodingStrategy ExternalSecretDecodingStrategy `json:"decodingStrategy,omitempty"`
 }
 
 type FindName struct {

--- a/config/crds/bases/external-secrets.io_clusterexternalsecrets.yaml
+++ b/config/crds/bases/external-secrets.io_clusterexternalsecrets.yaml
@@ -62,6 +62,10 @@ spec:
                               default: Default
                               description: Used to define a conversion Strategy
                               type: string
+                            decodingStrategy:
+                              default: None
+                              description: Used to define a conversion Strategy
+                              type: string
                             key:
                               description: Key is the key used in the Provider, mandatory
                               type: string
@@ -104,6 +108,10 @@ spec:
                               default: Default
                               description: Used to define a conversion Strategy
                               type: string
+                            decodingStrategy:
+                              default: None
+                              description: Used to define a conversion Strategy
+                              type: string
                             key:
                               description: Key is the key used in the Provider, mandatory
                               type: string
@@ -129,6 +137,10 @@ spec:
                           properties:
                             conversionStrategy:
                               default: Default
+                              description: Used to define a conversion Strategy
+                              type: string
+                            decodingStrategy:
+                              default: None
                               description: Used to define a conversion Strategy
                               type: string
                             name:

--- a/config/crds/bases/external-secrets.io_externalsecrets.yaml
+++ b/config/crds/bases/external-secrets.io_externalsecrets.yaml
@@ -307,6 +307,10 @@ spec:
                           default: Default
                           description: Used to define a conversion Strategy
                           type: string
+                        decodingStrategy:
+                          default: None
+                          description: Used to define a conversion Strategy
+                          type: string
                         key:
                           description: Key is the key used in the Provider, mandatory
                           type: string
@@ -349,6 +353,10 @@ spec:
                           default: Default
                           description: Used to define a conversion Strategy
                           type: string
+                        decodingStrategy:
+                          default: None
+                          description: Used to define a conversion Strategy
+                          type: string
                         key:
                           description: Key is the key used in the Provider, mandatory
                           type: string
@@ -373,6 +381,10 @@ spec:
                       properties:
                         conversionStrategy:
                           default: Default
+                          description: Used to define a conversion Strategy
+                          type: string
+                        decodingStrategy:
+                          default: None
                           description: Used to define a conversion Strategy
                           type: string
                         name:

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -52,6 +52,10 @@ spec:
                                 default: Default
                                 description: Used to define a conversion Strategy
                                 type: string
+                              decodingStrategy:
+                                default: None
+                                description: Used to define a conversion Strategy
+                                type: string
                               key:
                                 description: Key is the key used in the Provider, mandatory
                                 type: string
@@ -87,6 +91,10 @@ spec:
                                 default: Default
                                 description: Used to define a conversion Strategy
                                 type: string
+                              decodingStrategy:
+                                default: None
+                                description: Used to define a conversion Strategy
+                                type: string
                               key:
                                 description: Key is the key used in the Provider, mandatory
                                 type: string
@@ -107,6 +115,10 @@ spec:
                             properties:
                               conversionStrategy:
                                 default: Default
+                                description: Used to define a conversion Strategy
+                                type: string
+                              decodingStrategy:
+                                default: None
                                 description: Used to define a conversion Strategy
                                 type: string
                               name:
@@ -2762,6 +2774,10 @@ spec:
                             default: Default
                             description: Used to define a conversion Strategy
                             type: string
+                          decodingStrategy:
+                            default: None
+                            description: Used to define a conversion Strategy
+                            type: string
                           key:
                             description: Key is the key used in the Provider, mandatory
                             type: string
@@ -2797,6 +2813,10 @@ spec:
                             default: Default
                             description: Used to define a conversion Strategy
                             type: string
+                          decodingStrategy:
+                            default: None
+                            description: Used to define a conversion Strategy
+                            type: string
                           key:
                             description: Key is the key used in the Provider, mandatory
                             type: string
@@ -2817,6 +2837,10 @@ spec:
                         properties:
                           conversionStrategy:
                             default: Default
+                            description: Used to define a conversion Strategy
+                            type: string
+                          decodingStrategy:
+                            default: None
                             description: Used to define a conversion Strategy
                             type: string
                           name:

--- a/docs/guides-decoding-strategy.md
+++ b/docs/guides-decoding-strategy.md
@@ -1,0 +1,50 @@
+# Decoding Strategies
+The External Secrets Operator has the feature to allow multiple decoding strategies during an object generation.
+
+The `decodingStrategy` field allows the user to set the following Decoding Strategies based on their needs. `decodingStrategy` can be placed under `spec.data.remoteRef`, `spec.dataFrom.extract` or `spec.dataFrom.find`. It will configure the decoding strategy for that specific operation, leaving others with the default behavior if not set.
+
+### None (default)
+ESO will not try to decode the secret value.
+
+### Base64
+ESO will try to decode the secret value using [base64](https://datatracker.ietf.org/doc/html/rfc4648#section-4) method. If the decoding fails, an error is produced.
+
+### Base64URL
+ESO will try to decode the secret value using [base64url](https://datatracker.ietf.org/doc/html/rfc4648#section-5) method. If the decoding fails, an error is produced.
+
+### Auto
+ESO will try to decode using Base64/Base64URL strategies. If the decoding fails, ESO will apply decoding strategy None. No error is produced to the user.
+
+## Examples
+
+### Setting Decoding strategy Auto in a DataFrom.Extract
+Given that we have the given secret information:
+```
+{
+    "name": "Gustavo",
+    "surname": "Fring",
+    "address":"aGFwcHkgc3RyZWV0",
+}
+```
+if we apply the following dataFrom:
+```
+spec:
+  dataFrom:
+  - extract:
+      key: my-secret
+      decodingStrategy: Auto
+```
+It will render the following Kubernetes Secret:
+```
+data:
+  name: R3VzdGF2bw==        #Gustavo
+  surname: RnJpbmc=         #Fring
+  address: aGFwcHkgc3RyZWV0 #happy street
+```
+
+## Limitations
+
+At this time, decoding Strategy Auto is only trying to check if the original input is valid to perform Base64 operations. This means that some non-encoded secret values might end up being decoded, producing gibberish. This is the case for numbered values like `123456` or some specially crafted string values such as `happy/street`. 
+
+!!! note 
+    If you are using `decodeStrategy: Auto` and start to see ESO pulling completely wrong secret values into your kubernetes secret, consider changing it to `None` to investigate it.

--- a/docs/snippets/full-external-secret.yaml
+++ b/docs/snippets/full-external-secret.yaml
@@ -74,6 +74,7 @@ spec:
         key: provider-key
         version: provider-key-version
         property: provider-key-property
+        decodingStrategy: None # can be None, Base64, Base64URL or Auto
 
   # Used to fetch all properties from the Provider key
   # If multiple dataFrom are specified, secrets are merged in the specified order
@@ -83,6 +84,7 @@ spec:
       version: provider-key-version
       property: provider-key-property
       conversionStrategy: Default
+      decodingStrategy: Auto
   - find:
       path: path-to-filter
       name:
@@ -90,6 +92,7 @@ spec:
       tags:
         foo: bar
       conversionStrategy: Unicode
+      decodingStrategy: Base64
 
 status:
   # refreshTime is the time and date the external secret was fetched and

--- a/e2e/suites/provider/cases/vault/vault.go
+++ b/e2e/suites/provider/cases/vault/vault.go
@@ -49,6 +49,7 @@ var _ = Describe("[vault]", Label("vault"), func() {
 		framework.Compose(withTokenAuth, f, common.DataPropertyDockerconfigJSON, useTokenAuth),
 		framework.Compose(withTokenAuth, f, common.JSONDataWithoutTargetName, useTokenAuth),
 		framework.Compose(withTokenAuth, f, common.SyncV1Alpha1, useTokenAuth),
+		framework.Compose(withTokenAuth, f, common.DecodingPolicySync, useTokenAuth),
 		// use cert auth
 		framework.Compose(withCertAuth, f, common.FindByName, useCertAuth),
 		framework.Compose(withCertAuth, f, common.JSONDataFromSync, useCertAuth),

--- a/hack/api-docs/mkdocs.yml
+++ b/hack/api-docs/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
     - Common K8S Secret Types: guides-common-k8s-secret-types.md
     - Controller Classes: guides-controller-class.md
     - "Lifecycle: ownership & deletion": guides-ownership-deletion-policy.md
+    - Decoding Strategies: guides-decoding-strategy.md
     - Getting Multiple Secrets: guides-getallsecrets.md
     - Multi Tenancy: guides-multi-tenancy.md
     - Metrics: guides-metrics.md


### PR DESCRIPTION
This is a proposed solution to implement DecodingStrategy, with some strategies available for [base64](https://datatracker.ietf.org/doc/html/rfc4648#section-4) and [base64url](https://datatracker.ietf.org/doc/html/rfc4648#section-5) encoding formats.


Current implementation defaults to `None`, in order to preserve current External Secrets behavior, as some secret values might get misconverted to base64 due to their nature (for instance, numbered values).

Fixes #920

- [x] Functionality itself
- [x] e2e tests
- [x] documentation

Signed-off-by: Gustavo Carvalho <gustavo.carvalho@container-solutions.com>