### PR TITLE
fix aws ParamaterStore typo

### DIFF
--- a/docs/snippets/provider-aws-access.md
+++ b/docs/snippets/provider-aws-access.md
@@ -4,7 +4,7 @@
 
 ![Pod Identity Authentication](./pictures/diagrams-provider-aws-auth-pod-identity.png)
 
-Note: If you are using Paramater Store replace `service: SecretsManager` with `service: ParamaterStore` in all examples below.
+Note: If you are using Parameter Store replace `service: SecretsManager` with `service: ParameterStore` in all examples below.
 
 This is basicially a zero-configuration authentication method that inherits the credentials from the runtime environment using the [aws sdk default credential chain](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default).
 


### PR DESCRIPTION
Just a quick fix to have the correct name in the documentation: ParameterStore