### PR TITLE
:memo: update references to select "main" instead of "master"

### DIFF
--- a/deploy/charts/external-secrets/README.md.gotmpl
+++ b/deploy/charts/external-secrets/README.md.gotmpl
@@ -1,4 +1,3 @@
-{{- $valuesYAML := "https://github.com/external-secrets/external-secrets/blob/main/deploy/charts/external-secrets/values.yaml" -}}
 {{- $chartRepo := "https://charts.external-secrets.io" -}}
 {{- $org := "external-secrets" -}}
 # External Secrets

--- a/deploy/charts/external-secrets/README.md.gotmpl
+++ b/deploy/charts/external-secrets/README.md.gotmpl
@@ -1,4 +1,4 @@
-{{- $valuesYAML := "https://github.com/external-secrets/external-secrets/blob/master/deploy/charts/external-secrets/values.yaml" -}}
+{{- $valuesYAML := "https://github.com/external-secrets/external-secrets/blob/main/deploy/charts/external-secrets/values.yaml" -}}
 {{- $chartRepo := "https://charts.external-secrets.io" -}}
 {{- $org := "external-secrets" -}}
 # External Secrets

--- a/hack/api-docs/mkdocs.yml
+++ b/hack/api-docs/mkdocs.yml
@@ -3,6 +3,7 @@ repo_url: https://github.com/external-secrets/external-secrets
 repo_name: External Secrets Operator
 site_dir: ../../site
 docs_dir: ../../docs
+edit_uri: ./edit/main/docs/
 remote_branch: gh-pages
 theme:
   name: material


### PR DESCRIPTION
This will make it so when you click the little pencil on the material site, it will direct you to the right path to edit the file. Also updated the valuesYaml default to point to main, since master doesn't exist anymore.