### PR TITLE
feature: gives the possibility to add extra labels to the serviceAcco…

### DIFF
--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -63,6 +63,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | certController.securityContext | object | `{}` |  |
 | certController.serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
 | certController.serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
+| certController.serviceAccount.extraLabels | object | `{}` | Extra Labels to add to the service account. |
 | certController.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. |
 | certController.serviceMonitor.additionalLabels | object | `{}` | Additional labels |
 | certController.serviceMonitor.enabled | bool | `false` | Specifies whether to create a ServiceMonitor resource for collecting Prometheus metrics |
@@ -105,6 +106,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | securityContext | object | `{}` |  |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
+| serviceAccount.extraLabels | object | `{}` | Extra Labels to add to the service account. |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. |
 | serviceMonitor.additionalLabels | object | `{}` | Additional labels |
 | serviceMonitor.enabled | bool | `false` | Specifies whether to create a ServiceMonitor resource for collecting Prometheus metrics |
@@ -145,6 +147,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | webhook.securityContext | object | `{}` |  |
 | webhook.serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
 | webhook.serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
+| webhook.serviceAccount.extraLabels | object | `{}` | Extra Labels to add to the service account. |
 | webhook.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. |
 | webhook.serviceMonitor.additionalLabels | object | `{}` | Additional labels |
 | webhook.serviceMonitor.enabled | bool | `false` | Specifies whether to create a ServiceMonitor resource for collecting Prometheus metrics |

--- a/deploy/charts/external-secrets/templates/cert-controller-serviceaccount.yaml
+++ b/deploy/charts/external-secrets/templates/cert-controller-serviceaccount.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "external-secrets-cert-controller.labels" . | nindent 4 }}
+    {{- with .Values.certController.serviceAccount.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.certController.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/deploy/charts/external-secrets/templates/serviceaccount.yaml
+++ b/deploy/charts/external-secrets/templates/serviceaccount.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "external-secrets.labels" . | nindent 4 }}
+    {{- with .Values.serviceAccount.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/deploy/charts/external-secrets/templates/webhook-serviceaccount.yaml
+++ b/deploy/charts/external-secrets/templates/webhook-serviceaccount.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "external-secrets-webhook.labels" . | nindent 4 }}
+    {{- with .Values.webhook.serviceAccount.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.webhook.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -53,6 +53,8 @@ serviceAccount:
   create: true
   # -- Annotations to add to the service account.
   annotations: {}
+  # -- Extra Labels to add to the service account.
+  extraLabels: {}
   # -- The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template.
   name: ""
@@ -163,6 +165,8 @@ webhook:
     create: true
     # -- Annotations to add to the service account.
     annotations: {}
+    # -- Extra Labels to add to the service account.
+    extraLabels: {}
     # -- The name of the service account to use.
     # If not set and create is true, a name is generated using the fullname template.
     name: ""
@@ -259,6 +263,8 @@ certController:
     create: true
     # -- Annotations to add to the service account.
     annotations: {}
+    # -- Extra Labels to add to the service account.
+    extraLabels: {}
     # -- The name of the service account to use.
     # If not set and create is true, a name is generated using the fullname template.
     name: ""


### PR DESCRIPTION
Fixes https://github.com/external-secrets/external-secrets/issues/1355

With this change, users of the Helm chart will have the possibility to add extra labels to the service accounts.
As explained in the issue, this is needed for users on AKS using Azure Workload Identity authentication.

Defaults to none.

Signed-off-by: cebidhem <cebidhem@pm.me>