### PR TITLE
docs: Adds k8s provider example to ClusterSecretStore

### DIFF
--- a/docs/provider-kubernetes.md
+++ b/docs/provider-kubernetes.md
@@ -197,10 +197,8 @@ spec:
           clientCert:
             name: "tls-secret"
             key: "tls.crt"
-            namespace: "foobar" # only ClusterSecretStore
           clientKey:
             name: "tls-secret"
             key: "tls.key"
-            namespace: "foobar" # only ClusterSecretStore
       remoteNamespace: default
 ```

--- a/docs/provider-kubernetes.md
+++ b/docs/provider-kubernetes.md
@@ -169,7 +169,6 @@ spec:
       auth:
         serviceAccount:
           name: "my-store"
-          namespace: "" # only ClusterSecretStore
       remoteNamespace: default
 ```
 

--- a/docs/snippets/full-cluster-secret-store.yaml
+++ b/docs/snippets/full-cluster-secret-store.yaml
@@ -101,6 +101,19 @@ spec:
             key: secret-access-credentials
             namespace: example
       projectID: myproject
+    # (3): Kubernetes provider
+    kubernetes:
+      server:
+        url:  "https://myapiserver.tld"
+        caProvider: 
+            type: Secret
+            name : my-cluster-secrets
+            namespace: example
+            key: ca.crt
+      auth:
+        serviceAccount:
+          name: "example-sa"
+          namespace: "example"
     # (TODO): add more provider examples here
 
 status:


### PR DESCRIPTION
Solves #850

- Adds kubernetes provider to `ClusterSecretStore` example
- Removes namespace from `SecretStore` example