### PR TITLE
docs: add Azure KV PKCS12 example (#1358)

### DIFF
--- a/docs/snippets/azkv-pkcs12-cert-external-secret.yaml
+++ b/docs/snippets/azkv-pkcs12-cert-external-secret.yaml
@@ -1,0 +1,24 @@
+{% raw %}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: mycert
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kv-mycert
+  target:
+    template:
+      type: kubernetes.io/tls
+      engineVersion: v2
+      data:
+        tls.crt: "{{ .mycert | b64dec | pkcs12cert }}"
+        tls.key: "{{ .mycert | b64dec | pkcs12key }}"
+  data:
+  - secretKey: mycert
+    remoteRef:
+      # Azure Key Vault certificates must be fetched as secret/cert-name
+      key: secret/mycert
+
+{% endraw %}


### PR DESCRIPTION
This PR address the changes discussed in #1358 related to a clear example to sync Azure Key Vault certificates.