### PR TITLE
feat(helm): adds new flags to create metrics services for other scrapers

### DIFF
--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -47,6 +47,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | certController.image.repository | string | `"ghcr.io/external-secrets/external-secrets"` |  |
 | certController.image.tag | string | `""` |  |
 | certController.imagePullSecrets | list | `[]` |  |
+| certController.metrics.service.annotations | object | `{}` | Additional service annotations |
+| certController.metrics.service.enabled | bool | `false` | Enable if you use another monitoring tool than Prometheus to scrape the metrics |
+| certController.metrics.service.port | int | `8080` | Metrics service port to scrape |
 | certController.nameOverride | string | `""` |  |
 | certController.nodeSelector | object | `{}` |  |
 | certController.podAnnotations | object | `{}` | Annotations to add to Pod |
@@ -76,6 +79,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | crds.createClusterSecretStore | bool | `true` | If true, create CRDs for Cluster Secret Store. |
 | createOperator | bool | `true` | Specifies whether an external secret operator deployment be created. |
 | deploymentAnnotations | object | `{}` | Annotations to add to Deployment |
+| dnsConfig | object | `{}` | Specifies `dnsOptions` to deployment |
 | extraArgs | object | `{}` |  |
 | extraEnv | list | `[]` |  |
 | extraVolumeMounts | list | `[]` |  |
@@ -87,6 +91,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | imagePullSecrets | list | `[]` |  |
 | installCRDs | bool | `true` | If set, install and upgrade CRDs through helm chart. |
 | leaderElect | bool | `false` | If true, external-secrets will perform leader election between instances to ensure no more than one instance of external-secrets operates at a time. |
+| metrics.service.annotations | object | `{}` | Additional service annotations |
+| metrics.service.enabled | bool | `false` | Enable if you use another monitoring tool than Prometheus to scrape the metrics |
+| metrics.service.port | int | `8080` | Metrics service port to scrape |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` | Annotations to add to Pod |
@@ -130,6 +137,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | webhook.image.tag | string | `""` | The image tag to use. The default is the chart appVersion. |
 | webhook.imagePullSecrets | list | `[]` |  |
 | webhook.lookaheadInterval | string | `""` | Specifices the lookaheadInterval for certificate validity |
+| webhook.metrics.service.annotations | object | `{}` | Additional service annotations |
+| webhook.metrics.service.enabled | bool | `false` | Enable if you use another monitoring tool than Prometheus to scrape the metrics |
+| webhook.metrics.service.port | int | `8080` | Metrics service port to scrape |
 | webhook.nameOverride | string | `""` |  |
 | webhook.nodeSelector | object | `{}` |  |
 | webhook.podAnnotations | object | `{}` | Annotations to add to Pod |

--- a/deploy/charts/external-secrets/templates/cert-controller-service.yaml
+++ b/deploy/charts/external-secrets/templates/cert-controller-service.yaml
@@ -1,18 +1,29 @@
-{{- if and .Values.certController.create .Values.certController.prometheus.enabled }}
+{{- if or (and .Values.certController.create .Values.certController.prometheus.enabled) (and .Values.certController.create .Values.certController.metrics.service.enabled) }}
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "external-secrets.fullname" . }}-cert-controller-metrics
   labels:
     {{- include "external-secrets.labels" . | nindent 4 }}
+  {{- if .Values.certController.prometheus.enabled }}
   annotations:
     prometheus.io/path: "/metrics"
     prometheus.io/scrape: "true"
     prometheus.io/port: {{ .Values.certController.prometheus.service.port | quote }}
+  {{- else }}
+  {{- with .Values.metrics.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
 spec:
   type: ClusterIP
   ports:
+  {{- if .Values.certController.prometheus.enabled }}
   - port: {{ .Values.certController.prometheus.service.port }}
+  {{- else }}
+  - port: {{ .Values.certController.metrics.service.port }}
+  {{- end }}
     protocol: TCP
     name: metrics
   selector:

--- a/deploy/charts/external-secrets/templates/service.yaml
+++ b/deploy/charts/external-secrets/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.prometheus.enabled }}
+{{- if or .Values.prometheus.enabled .Values.metrics.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -6,14 +6,25 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "external-secrets.labels" . | nindent 4 }}
+  {{- if .Values.prometheus.enabled }}
   annotations:
     prometheus.io/path: "/metrics"
     prometheus.io/scrape: "true"
     prometheus.io/port: {{ .Values.prometheus.service.port | quote }}
+  {{- else }}
+  {{- with .Values.metrics.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
 spec:
   type: ClusterIP
   ports:
+    {{- if .Values.prometheus.enabled }}
     - port: {{ .Values.prometheus.service.port }}
+    {{- else }}
+    - port: {{ .Values.metrics.service.port }}
+    {{- end }}
       protocol: TCP
       name: metrics
   selector:

--- a/deploy/charts/external-secrets/templates/webhook-service.yaml
+++ b/deploy/charts/external-secrets/templates/webhook-service.yaml
@@ -26,7 +26,7 @@ spec:
     protocol: TCP
     name: webhook
   {{- if or .Values.webhook.prometheus.enabled .Values.webhook.metrics.service.enabled }}
-  {{- if or .Values.webhook.prometheus.enabled }}
+  {{- if .Values.webhook.prometheus.enabled }}
   - port: {{ .Values.webhook.prometheus.service.port }}
     targetPort: {{ .Values.webhook.prometheus.service.port }}
   {{- else }}

--- a/deploy/charts/external-secrets/templates/webhook-service.yaml
+++ b/deploy/charts/external-secrets/templates/webhook-service.yaml
@@ -12,6 +12,11 @@ metadata:
     prometheus.io/path: "/metrics"
     prometheus.io/scrape: "true"
     prometheus.io/port: {{ .Values.prometheus.service.port | quote }}
+  {{- else }}
+  {{- with .Values.metrics.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
 spec:
   type: ClusterIP
@@ -20,9 +25,14 @@ spec:
     targetPort: {{ .Values.webhook.port }}
     protocol: TCP
     name: webhook
-  {{- if .Values.webhook.prometheus.enabled}}
-  - port: {{ .Values.webhook.prometheus.service.port}}
-    targetPort: {{ .Values.webhook.prometheus.service.port}}
+  {{- if or .Values.webhook.prometheus.enabled .Values.webhook.metrics.service.enabled }}
+  {{- if or .Values.webhook.prometheus.enabled }}
+  - port: {{ .Values.webhook.prometheus.service.port }}
+    targetPort: {{ .Values.webhook.prometheus.service.port }}
+  {{- else }}
+  - port: {{ .Values.webhook.metrics.service.port }}
+    targetPort: {{ .Values.webhook.metrics.service.port }}
+  {{- end }}
     protocol: TCP
     name: metrics
   {{- end }}

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -119,6 +119,17 @@ serviceMonitor:
   # -- Timeout if metrics can't be retrieved in given time interval
   scrapeTimeout: 25s
 
+metrics:
+  service:
+    # -- Enable if you use another monitoring tool than Prometheus to scrape the metrics
+    enabled: false
+
+    # -- Metrics service port to scrape
+    port: 8080
+
+    # -- Additional service annotations
+    annotations: {}
+
 nodeSelector: {}
 
 tolerations: []
@@ -203,6 +214,17 @@ webhook:
 
     # -- Timeout if metrics can't be retrieved in given time interval
     scrapeTimeout: 25s
+
+  metrics:
+    service:
+      # -- Enable if you use another monitoring tool than Prometheus to scrape the metrics
+      enabled: false
+
+      # -- Metrics service port to scrape
+      port: 8080
+
+      # -- Additional service annotations
+      annotations: {}
 
     ## -- Extra environment variables to add to container.
   extraEnv: []
@@ -302,6 +324,17 @@ certController:
 
     # -- Timeout if metrics can't be retrieved in given time interval
     scrapeTimeout: 25s
+
+  metrics:
+    service:
+      # -- Enable if you use another monitoring tool than Prometheus to scrape the metrics
+      enabled: false
+
+      # -- Metrics service port to scrape
+      port: 8080
+
+      # -- Additional service annotations
+      annotations: {}
 
     ## -- Extra environment variables to add to container.
   extraEnv: []

--- a/docs/guides-metrics.md
+++ b/docs/guides-metrics.md
@@ -2,6 +2,8 @@
 
 The External Secrets Operator exposes its Prometheus metrics in the `/metrics` path. To enable it, set the `serviceMonitor.enabled` Helm flag to `true`. In addition you can also set `webhook.serviceMonitor.enabled=true` and `certController.serviceMonitor.enabled=true` to create `ServiceMonitor` resources for the other components.
 
+If you are using a different monitoring tool that also needs a `/metrics` endpoint, you can set the `metrics.service.enabled` Helm flag to `true`. In addition you can also set `webhook.metrics.service.enabled` and `certController.metrics.service.enabled` to scrape the other components.
+
 The Operator has the metrics inherited from Kubebuilder plus some custom metrics with the `externalsecret` prefix.
 
 ## External Secret Metrics

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1602,7 +1602,47 @@ ExternalSecretConversionStrategy
 <p>Used to define a conversion Strategy</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>decodingStrategy</code></br>
+<em>
+<a href="#external-secrets.io/v1beta1.ExternalSecretDecodingStrategy">
+ExternalSecretDecodingStrategy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Used to define a conversion Strategy</p>
+</td>
+</tr>
 </tbody>
+</table>
+<h3 id="external-secrets.io/v1beta1.ExternalSecretDecodingStrategy">ExternalSecretDecodingStrategy
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#external-secrets.io/v1beta1.ExternalSecretDataRemoteRef">ExternalSecretDataRemoteRef</a>, 
+<a href="#external-secrets.io/v1beta1.ExternalSecretFind">ExternalSecretFind</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;Auto&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;Base64&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;Base64URL&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;None&#34;</p></td>
+<td></td>
+</tr></tbody>
 </table>
 <h3 id="external-secrets.io/v1beta1.ExternalSecretDeletionPolicy">ExternalSecretDeletionPolicy
 (<code>string</code> alias)</p></h3>
@@ -1699,6 +1739,20 @@ map[string]string
 <em>
 <a href="#external-secrets.io/v1beta1.ExternalSecretConversionStrategy">
 ExternalSecretConversionStrategy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Used to define a conversion Strategy</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>decodingStrategy</code></br>
+<em>
+<a href="#external-secrets.io/v1beta1.ExternalSecretDecodingStrategy">
+ExternalSecretDecodingStrategy
 </a>
 </em>
 </td>


### PR DESCRIPTION
Signed-off-by: cebidhem <cebidhem@pm.me>

Fixes https://github.com/external-secrets/external-secrets/issues/1329

This adds new flags to create metrics services for users that don't use Prometheus as a metrics scraper.
Targets are `external-secrets`, `webhook` and `certController`.

Metrics guide has been updated, the docs and the Helm README updated. Looking at the changes, seems like some docs have not been generated in previous commits, hence why they ended up in this :) 

I've run several test scenario using `helm template`.

Let me know if something is missing.