### PR TITLE
fix: clarify CAProvider usage in struct annotations

### DIFF
--- a/apis/externalsecrets/v1beta1/secretstore_types.go
+++ b/apis/externalsecrets/v1beta1/secretstore_types.go
@@ -107,6 +107,34 @@ type SecretStoreProvider struct {
 	Senhasegura *SenhaseguraProvider `json:"senhasegura,omitempty"`
 }
 
+type CAProviderType string
+
+const (
+	CAProviderTypeSecret    CAProviderType = "Secret"
+	CAProviderTypeConfigMap CAProviderType = "ConfigMap"
+)
+
+// Used to provide custom certificate authority (CA) certificates
+// for a secret store. The CAProvider points to a Secret or ConfigMap resource
+// that contains a PEM-encoded certificate.
+type CAProvider struct {
+	// The type of provider to use such as "Secret", or "ConfigMap".
+	// +kubebuilder:validation:Enum="Secret";"ConfigMap"
+	Type CAProviderType `json:"type"`
+
+	// The name of the object located at the provider type.
+	Name string `json:"name"`
+
+	// The key where the CA certificate can be found in the Secret or ConfigMap.
+	// +kubebuilder:validation:Optional
+	Key string `json:"key,omitempty"`
+
+	// The namespace the Provider type is in.
+	// Can only be defined when used in a ClusterSecretStore.
+	// +optional
+	Namespace *string `json:"namespace,omitempty"`
+}
+
 type SecretStoreRetrySettings struct {
 	MaxRetries    *int32  `json:"maxRetries,omitempty"`
 	RetryInterval *string `json:"retryInterval,omitempty"`

--- a/apis/externalsecrets/v1beta1/secretstore_vault_types.go
+++ b/apis/externalsecrets/v1beta1/secretstore_vault_types.go
@@ -25,31 +25,6 @@ const (
 	VaultKVStoreV2 VaultKVStoreVersion = "v2"
 )
 
-type CAProviderType string
-
-const (
-	CAProviderTypeSecret    CAProviderType = "Secret"
-	CAProviderTypeConfigMap CAProviderType = "ConfigMap"
-)
-
-// Defines a location to fetch the cert for the vault provider from.
-type CAProvider struct {
-	// The type of provider to use such as "Secret", or "ConfigMap".
-	// +kubebuilder:validation:Enum="Secret";"ConfigMap"
-	Type CAProviderType `json:"type"`
-
-	// The name of the object located at the provider type.
-	Name string `json:"name"`
-
-	// The key the value inside of the provider type to use, only used with "Secret" type
-	// +kubebuilder:validation:Optional
-	Key string `json:"key,omitempty"`
-
-	// The namespace the Provider type is in.
-	// +optional
-	Namespace *string `json:"namespace,omitempty"`
-}
-
 // Configures an store to sync secrets using a HashiCorp Vault
 // KV backend.
 type VaultProvider struct {

--- a/config/crds/bases/external-secrets.io_clustersecretstores.yaml
+++ b/config/crds/bases/external-secrets.io_clustersecretstores.yaml
@@ -2071,8 +2071,8 @@ spec:
                             description: 'see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider'
                             properties:
                               key:
-                                description: The key the value inside of the provider
-                                  type to use, only used with "Secret" type
+                                description: The key where the CA certificate can
+                                  be found in the Secret or ConfigMap.
                                 type: string
                               name:
                                 description: The name of the object located at the
@@ -2080,6 +2080,7 @@ spec:
                                 type: string
                               namespace:
                                 description: The namespace the Provider type is in.
+                                  Can only be defined when used in a ClusterSecretStore.
                                 type: string
                               type:
                                 description: The type of provider to use such as "Secret",
@@ -2604,15 +2605,16 @@ spec:
                           Vault server certificate.
                         properties:
                           key:
-                            description: The key the value inside of the provider
-                              type to use, only used with "Secret" type
+                            description: The key where the CA certificate can be found
+                              in the Secret or ConfigMap.
                             type: string
                           name:
                             description: The name of the object located at the provider
                               type.
                             type: string
                           namespace:
-                            description: The namespace the Provider type is in.
+                            description: The namespace the Provider type is in. Can
+                              only be defined when used in a ClusterSecretStore.
                             type: string
                           type:
                             description: The type of provider to use such as "Secret",

--- a/config/crds/bases/external-secrets.io_secretstores.yaml
+++ b/config/crds/bases/external-secrets.io_secretstores.yaml
@@ -2071,8 +2071,8 @@ spec:
                             description: 'see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider'
                             properties:
                               key:
-                                description: The key the value inside of the provider
-                                  type to use, only used with "Secret" type
+                                description: The key where the CA certificate can
+                                  be found in the Secret or ConfigMap.
                                 type: string
                               name:
                                 description: The name of the object located at the
@@ -2080,6 +2080,7 @@ spec:
                                 type: string
                               namespace:
                                 description: The namespace the Provider type is in.
+                                  Can only be defined when used in a ClusterSecretStore.
                                 type: string
                               type:
                                 description: The type of provider to use such as "Secret",
@@ -2604,15 +2605,16 @@ spec:
                           Vault server certificate.
                         properties:
                           key:
-                            description: The key the value inside of the provider
-                              type to use, only used with "Secret" type
+                            description: The key where the CA certificate can be found
+                              in the Secret or ConfigMap.
                             type: string
                           name:
                             description: The name of the object located at the provider
                               type.
                             type: string
                           namespace:
-                            description: The namespace the Provider type is in.
+                            description: The namespace the Provider type is in. Can
+                              only be defined when used in a ClusterSecretStore.
                             type: string
                           type:
                             description: The type of provider to use such as "Secret",

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -1894,13 +1894,13 @@ spec:
                               description: 'see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider'
                               properties:
                                 key:
-                                  description: The key the value inside of the provider type to use, only used with "Secret" type
+                                  description: The key where the CA certificate can be found in the Secret or ConfigMap.
                                   type: string
                                 name:
                                   description: The name of the object located at the provider type.
                                   type: string
                                 namespace:
-                                  description: The namespace the Provider type is in.
+                                  description: The namespace the Provider type is in. Can only be defined when used in a ClusterSecretStore.
                                   type: string
                                 type:
                                   description: The type of provider to use such as "Secret", or "ConfigMap".
@@ -2266,13 +2266,13 @@ spec:
                           description: The provider for the CA bundle to use to validate Vault server certificate.
                           properties:
                             key:
-                              description: The key the value inside of the provider type to use, only used with "Secret" type
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
                               type: string
                             name:
                               description: The name of the object located at the provider type.
                               type: string
                             namespace:
-                              description: The namespace the Provider type is in.
+                              description: The namespace the Provider type is in. Can only be defined when used in a ClusterSecretStore.
                               type: string
                             type:
                               description: The type of provider to use such as "Secret", or "ConfigMap".
@@ -4594,13 +4594,13 @@ spec:
                               description: 'see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider'
                               properties:
                                 key:
-                                  description: The key the value inside of the provider type to use, only used with "Secret" type
+                                  description: The key where the CA certificate can be found in the Secret or ConfigMap.
                                   type: string
                                 name:
                                   description: The name of the object located at the provider type.
                                   type: string
                                 namespace:
-                                  description: The namespace the Provider type is in.
+                                  description: The namespace the Provider type is in. Can only be defined when used in a ClusterSecretStore.
                                   type: string
                                 type:
                                   description: The type of provider to use such as "Secret", or "ConfigMap".
@@ -4966,13 +4966,13 @@ spec:
                           description: The provider for the CA bundle to use to validate Vault server certificate.
                           properties:
                             key:
-                              description: The key the value inside of the provider type to use, only used with "Secret" type
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
                               type: string
                             name:
                               description: The name of the object located at the provider type.
                               type: string
                             namespace:
-                              description: The namespace the Provider type is in.
+                              description: The namespace the Provider type is in. Can only be defined when used in a ClusterSecretStore.
                               type: string
                             type:
                               description: The type of provider to use such as "Secret", or "ConfigMap".


### PR DESCRIPTION
relates to: #850

This PR fixes the comments around the `CAProvider` type.