### PR TITLE
feat: add webhook debug mode

### DIFF
--- a/apis/externalsecrets/v1alpha1/conversion_debug.go
+++ b/apis/externalsecrets/v1alpha1/conversion_debug.go
@@ -1,0 +1,41 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var webhookDebug bool
+var conversionLog = ctrl.Log.WithName("conversion")
+
+func EnableWebhookDebug() {
+	webhookDebug = true
+}
+
+func logDebug(context string, resource runtime.Object) {
+	if !webhookDebug {
+		return
+	}
+	bytes, err := json.Marshal(resource)
+	if err != nil {
+		conversionLog.Error(err, fmt.Sprintf("%s: unable to marshal resource", context))
+	}
+	conversionLog.V(1).Info(context, "object", string(bytes))
+}

--- a/apis/externalsecrets/v1alpha1/externalsecret_conversion.go
+++ b/apis/externalsecrets/v1alpha1/externalsecret_conversion.go
@@ -23,6 +23,7 @@ import (
 )
 
 func (alpha *ExternalSecret) ConvertTo(betaRaw conversion.Hub) error {
+	logDebug("v1alpha1/convertTo input", alpha)
 	beta := betaRaw.(*esv1beta1.ExternalSecret)
 	// Actual converted code that needs to be like this
 	v1beta1DataFrom := make([]esv1beta1.ExternalSecretDataFromRemoteRef, 0)
@@ -71,10 +72,12 @@ func (alpha *ExternalSecret) ConvertTo(betaRaw conversion.Hub) error {
 		return err
 	}
 	beta.Status = status
+	logDebug("v1alpha1/convertTo output", beta)
 	return nil
 }
 
 func (alpha *ExternalSecret) ConvertFrom(betaRaw conversion.Hub) error {
+	logDebug("v1alpha1/convertFrom", betaRaw)
 	beta := betaRaw.(*esv1beta1.ExternalSecret)
 	v1alpha1DataFrom := make([]ExternalSecretDataRemoteRef, 0)
 	for _, v1beta1RemoteRef := range beta.Spec.DataFrom {
@@ -125,5 +128,6 @@ func (alpha *ExternalSecret) ConvertFrom(betaRaw conversion.Hub) error {
 		return err
 	}
 	alpha.Status = status
+	logDebug("v1alpha1/convertFrom", alpha)
 	return nil
 }

--- a/apis/externalsecrets/v1alpha1/secretstore_conversion.go
+++ b/apis/externalsecrets/v1alpha1/secretstore_conversion.go
@@ -23,6 +23,7 @@ import (
 )
 
 func (c *SecretStore) ConvertTo(betaRaw conversion.Hub) error {
+	logDebug("v1alpha1/convertTo input", c)
 	beta := betaRaw.(*esv1beta1.SecretStore)
 	tmp := &esv1beta1.SecretStore{}
 	alphajson, err := json.Marshal(c)
@@ -36,10 +37,12 @@ func (c *SecretStore) ConvertTo(betaRaw conversion.Hub) error {
 	beta.Spec = tmp.Spec
 	beta.ObjectMeta = tmp.ObjectMeta
 	beta.Status = tmp.Status
+	logDebug("v1alpha1/convertTo output", beta)
 	return nil
 }
 
 func (c *SecretStore) ConvertFrom(betaRaw conversion.Hub) error {
+	logDebug("v1alpha1/convertFrom input", betaRaw)
 	beta := betaRaw.(*esv1beta1.SecretStore)
 	tmp := &SecretStore{}
 	betajson, err := json.Marshal(beta)
@@ -53,10 +56,12 @@ func (c *SecretStore) ConvertFrom(betaRaw conversion.Hub) error {
 	c.Spec = tmp.Spec
 	c.ObjectMeta = tmp.ObjectMeta
 	c.Status = tmp.Status
+	logDebug("v1alpha1/convertFrom output", betaRaw)
 	return nil
 }
 
 func (c *ClusterSecretStore) ConvertTo(betaRaw conversion.Hub) error {
+	logDebug("v1alpha1/convertTo input", c)
 	beta := betaRaw.(*esv1beta1.ClusterSecretStore)
 	tmp := &esv1beta1.ClusterSecretStore{}
 	alphajson, err := json.Marshal(c)
@@ -70,10 +75,12 @@ func (c *ClusterSecretStore) ConvertTo(betaRaw conversion.Hub) error {
 	beta.Spec = tmp.Spec
 	beta.ObjectMeta = tmp.ObjectMeta
 	beta.Status = tmp.Status
+	logDebug("v1alpha1/convertTo output", beta)
 	return nil
 }
 
 func (c *ClusterSecretStore) ConvertFrom(betaRaw conversion.Hub) error {
+	logDebug("v1alpha1/convertFrom input", betaRaw)
 	beta := betaRaw.(*esv1beta1.ClusterSecretStore)
 	tmp := &ClusterSecretStore{}
 	betajson, err := json.Marshal(beta)
@@ -87,5 +94,6 @@ func (c *ClusterSecretStore) ConvertFrom(betaRaw conversion.Hub) error {
 	c.Spec = tmp.Spec
 	c.ObjectMeta = tmp.ObjectMeta
 	c.Status = tmp.Status
+	logDebug("v1alpha1/convertFrom output", c)
 	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,6 +46,7 @@ var (
 	setupLog                              = ctrl.Log.WithName("setup")
 	dnsName                               string
 	certDir                               string
+	conversionWebhookDebug                bool
 	metricsAddr                           string
 	healthzAddr                           string
 	controllerClass                       string

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -136,6 +136,10 @@ var webhookCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
+		if conversionWebhookDebug {
+			esv1alpha1.EnableWebhookDebug()
+		}
+
 		setupLog.Info("starting manager")
 		if err := mgr.Start(ctx); err != nil {
 			setupLog.Error(err, "problem running manager")
@@ -177,4 +181,5 @@ func init() {
 	webhookCmd.Flags().StringVar(&loglevel, "loglevel", "info", "loglevel to use, one of: debug, info, warn, error, dpanic, panic, fatal")
 	webhookCmd.Flags().DurationVar(&certCheckInterval, "check-interval", 5*time.Minute, "certificate check interval")
 	webhookCmd.Flags().DurationVar(&certLookaheadInterval, "lookahead-interval", crds.LookaheadInterval, "certificate check interval")
+	webhookCmd.Flags().BoolVar(&conversionWebhookDebug, "experimental-conversion-webhook-debug", false, "dumps requests and responses in the conversion webhook")
 }


### PR DESCRIPTION
relates to: https://github.com/external-secrets/external-secrets/issues/1136#issuecomment-1198641866

This PR allows the user to set `--experimental-conversion-webhook-debug=true` together with `--loglevel=debug`. This will log all input and output parameters in the conversion logic (`ConvertFrom` and `ConvertTo`).
These flags can be added through the helm chart with `webhook.extraArgs`.

I didn't add this to the `v1beta1` package as there is no conversion logic, currently.