### PR TITLE
fix: handle empty conversionStrategy

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -69,6 +69,9 @@ func Decode(strategy esv1beta1.ExternalSecretDecodingStrategy, in []byte) ([]byt
 		return out, nil
 	case esv1beta1.ExternalSecretDecodeNone:
 		return in, nil
+	// default when stored version is v1alpha1
+	case "":
+		return in, nil
 	case esv1beta1.ExternalSecretDecodeAuto:
 		out, err := Decode(esv1beta1.ExternalSecretDecodeBase64, in)
 		if err != nil {


### PR DESCRIPTION
There is an issue when stored version is v1alpha1: the conversion webhook does not set the specified default but instead leaves it a empty string (it's just doing a json.Marshal/Unmarshal).

This is just a hotfix that ensures the correct default behavior is used (instead, it would error out). We probably should investigate if we can use the defaulter in the conversion webhook.