### PR TITLE
feat: add LF footer copytight

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -653,7 +653,9 @@ string
 <a href="#external-secrets.io/v1beta1.VaultProvider">VaultProvider</a>)
 </p>
 <p>
-<p>Defines a location to fetch the cert for the vault provider from.</p>
+<p>Used to provide custom certificate authority (CA) certificates
+for a secret store. The CAProvider points to a Secret or ConfigMap resource
+that contains a PEM-encoded certificate.</p>
 </p>
 <table>
 <thead>
@@ -695,7 +697,7 @@ string
 </em>
 </td>
 <td>
-<p>The key the value inside of the provider type to use, only used with &ldquo;Secret&rdquo; type</p>
+<p>The key where the CA certificate can be found in the Secret or ConfigMap.</p>
 </td>
 </tr>
 <tr>
@@ -707,7 +709,8 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>The namespace the Provider type is in.</p>
+<p>The namespace the Provider type is in.
+Can only be defined when used in a ClusterSecretStore.</p>
 </td>
 </tr>
 </tbody>

--- a/hack/api-docs/mkdocs.yml
+++ b/hack/api-docs/mkdocs.yml
@@ -19,6 +19,11 @@ plugins:
       lang: en
   - macros:
       include_dir: docs/snippets
+copyright: |
+  &copy; 2022 The external-secrets Authors.<br/>
+  &copy; 2022 The Linux Foundation. All rights reserved.<br/><br/>
+  The Linux Foundation has registered trademarks and uses trademarks.<br/>
+  For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage/">Trademark Usage page</a>.
 extra:
   version:
     provider: mike


### PR DESCRIPTION
Working towards: https://github.com/external-secrets/external-secrets/issues/1395

This PR adds the LF footer as per [website guidelines](https://github.com/cncf/foundation/blob/master/website-guidelines.md).

![eso-lf-footer](https://user-images.githubusercontent.com/1709030/182242919-0fd71d29-bbae-4ae7-bd53-0375e4820256.png)

