### PR TITLE
Fix/remove dependabot from e2e trusted

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,7 +35,7 @@ jobs:
   # Branch-based pull request
   integration-trusted:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.author !='dependabot[bot]'
     steps:
 
     - name: Branch based PR checkout

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,7 +8,7 @@ env:
   # Common versions
   GO_VERSION: '1.17'
   GOLANGCI_VERSION: 'v1.33'
-  GINKGO_VERSION: 'v2.1.3'
+  GINKGO_VERSION: 'v2.1.4'
   DOCKER_BUILDX_VERSION: 'v0.4.2'
   KIND_VERSION: 'v0.11.1'
   KIND_IMAGE: 'kindest/node:v1.23.3'

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -46,7 +46,6 @@ until kubectl get secret | grep -q -e ^external-secrets-e2e-token; do \
 done
 
 echo -e "Starting the e2e test pod ${E2E_IMAGE_REGISTRY}:${VERSION}"
-
 kubectl run --rm \
   --attach \
   --restart=Never \


### PR DESCRIPTION
This PR fixes dependabot weird behavior. From this point on, dependabot bumps shall be e2e-tested with ok-to-test