### PR TITLE
Fix provisionedNamespaces status field of ClusterExternalSecret keeps getting updated non-stop

### DIFF
--- a/pkg/controllers/clusterexternalsecret/clusterexternalsecret_controller.go
+++ b/pkg/controllers/clusterexternalsecret/clusterexternalsecret_controller.go
@@ -16,6 +16,7 @@ package clusterexternalsecret
 
 import (
 	"context"
+	"sort"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -130,6 +131,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	setFailedNamespaces(&clusterExternalSecret, failedNamespaces)
 
 	if len(provisionedNamespaces) > 0 {
+		sort.Strings(provisionedNamespaces)
 		clusterExternalSecret.Status.ProvisionedNamespaces = provisionedNamespaces
 	}
 


### PR DESCRIPTION
Fix `provisionedNamespaces` field in `Status` of `ClusterExternalSecret` keeps getting updated non-stop.

We've noticed this odd behavior in all of our `ClusterExternalSecret` objects that are replicated to hundreds of other namespaces. The `resourceVersion` keeps jumping a few dozen every second and `provisionedNamespaces` keeps getting reordered despite the items are exactly the same.

We've tested this patch in our cluster and successfully stopped the forever updating.