### PR TITLE
Add example of how to handle secretKey values with 'illegal' names in golang templates.

### DIFF
--- a/docs/guides-templating.md
+++ b/docs/guides-templating.md
@@ -71,6 +71,14 @@ NtFUGA95RGN9s+pl6XY0YARPHf5O76ErC1OZtDTR5RdyQfcM+94gYZsexsXl0aQO
 
 You can achieve that by using the `filterPEM` function to extract a specific type of PEM block from that secret. If multiple blocks of that type (here: `CERTIFICATE`) exist then all of them are returned in the order they are specified.
 
+### Handling secretKeys with non-alphanumeric characters
+
+golang templates do not allow keys that contain various names you may wish to use in your secretKey names. For example, you can't use `-` or `.` anywhere in a `secretKey` value, or any `secretKey` value that begins with a number. However, you can work around this using the `index` function:
+
+```yaml
+{% include 'template-v2-handling-secret-keys-with-non-alphanumeric-characters.yaml' %}
+```
+
 ## Helper functions
 
 !!! info inline end

--- a/docs/snippets/template-v2-handling-secret-keys-with-non-alphanumeric-characters.yaml
+++ b/docs/snippets/template-v2-handling-secret-keys-with-non-alphanumeric-characters.yaml
@@ -10,16 +10,23 @@ spec:
     template:
       engineVersion: v2
       data:
-        # Note that Go template errors out if the secretKey value contains 'illegal' characters:
-        # my-certificate.crt: "{{ .my-certificate-base64-encoded.crt | b64dec }}" # ERROR because key contains '-' and '.' characters
-        # my-certificate.crt: "{{ .my-certificate-base64-encoded.crt | b64dec }}" # ERROR because key contains '-' and '.' characters
-        # secretKey: "{{ .37signals_certificate_base64_encoded | b64dec }}"       # ERROR because key starts with a number
-        # Instead, you can use the 'index' function to work around this -- note the single quotes so that you can use double quotes to
+        # Note that Go template errors out if the secretKey value contains
+        # 'illegal' characters:
+        # ERROR because key contains '-' and '.' characters
+        # my-certificate.crt: "{{ .my-certificate-base64-encoded.crt | b64dec }}"
+        # ERROR because key contains '-' and '.' characters
+        # my-private-key.pem: "{{ .my-certificate-base64-encoded.crt | b64dec }}"
+        # ERROR because key starts with a number
+        # secretKey: "{{ .37signals_certificate_base64_encoded | b64dec }}"
+        #
+        # Instead, you can use the 'index' function to work around this.
+        # Note the single quotes so that you can use double quotes to
         # pass the key name to the index function with double quotes
         my-certificate.crt: '{{ index . "my-certificate-base64-encoded.crt" | b64dec }}'
         my-private-key.pem: '{{ index . "my-private-key-base64-encoded.pem" | b64dec }}'
         37signals-certificate.crt: '{{ index . "37signals_certificate_base64_encoded" | b64dec }}'
-        # You can also use the 'index' function in multiline strings - here we concatenate a CA onto the end of a certificate
+        # You can also use the 'index' function in multiline strings.
+        # Here we concatenate a CA onto the end of a certificate
         my-certificate-with-root-ca.crt: |-
           {{ index . "my-certificate-base64-encoded.crt" | b64dec }}{{ index . "root-ca-base64-encoded.crt" | b64dec }}
   data:

--- a/docs/snippets/template-v2-handling-secret-keys-with-non-alphanumeric-characters.yaml
+++ b/docs/snippets/template-v2-handling-secret-keys-with-non-alphanumeric-characters.yaml
@@ -1,0 +1,38 @@
+{% raw %}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: template
+spec:
+  # ...
+  target:
+    name: secret-to-be-created
+    template:
+      engineVersion: v2
+      data:
+        # Note that Go template errors out if the secretKey value contains 'illegal' characters:
+        # my-certificate.crt: "{{ .my-certificate-base64-encoded.crt | b64dec }}" # ERROR because key contains '-' and '.' characters
+        # my-certificate.crt: "{{ .my-certificate-base64-encoded.crt | b64dec }}" # ERROR because key contains '-' and '.' characters
+        # secretKey: "{{ .37signals_certificate_base64_encoded | b64dec }}"       # ERROR because key starts with a number
+        # Instead, you can use the 'index' function to work around this -- note the single quotes so that you can use double quotes to
+        # pass the key name to the index function with double quotes
+        my-certificate.crt: '{{ index . "my-certificate-base64-encoded.crt" | b64dec }}'
+        my-private-key.pem: '{{ index . "my-private-key-base64-encoded.pem" | b64dec }}'
+        37signals-certificate.crt: '{{ index . "37signals_certificate_base64_encoded" | b64dec }}'
+        # You can also use the 'index' function in multiline strings - here we concatenate a CA onto the end of a certificate
+        my-certificate-with-root-ca.crt: |-
+          {{ index . "my-certificate-base64-encoded.crt" | b64dec }}{{ index . "root-ca-base64-encoded.crt" | b64dec }}
+  data:
+  - secretKey: my-certificate-base64-encoded.crt
+    remoteRef:
+      key: my-certificate-base64-encoded.crt
+  - secretKey: my-private-key-base64-encoded.pem
+    remoteRef:
+      key: my-private-key-base64-encoded.pem
+  - secretKey: root-ca-base64-encoded.crt
+    remoteRef:
+      key: root-ca-base64-encoded.crt
+  - secretKey: 37signals_certificate_base64_encoded
+    remoteRef:
+      key: 37signals_certificate_base64_encoded
+{% endraw %}


### PR DESCRIPTION
Definitely the hardest part of my migration from `kubernetes-external-secrets` to ESO was changing all of my secret keys to pass golang template validation. The other aspect was the lack of `isBinary: true` for handling base64 encoded secret values.

This example would have helped me a lot! Hopefully it can help others.



