### PR TITLE
fix: re-add provider URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ secret management systems like [AWS Secrets
 Manager](https://aws.amazon.com/secrets-manager/), [HashiCorp
 Vault](https://www.vaultproject.io/), [Google Secrets
 Manager](https://cloud.google.com/secret-manager), [Azure Key
-Vault](https://azure.microsoft.com/en-us/services/key-vault/) and many more. The
+Vault](https://azure.microsoft.com/en-us/services/key-vault/), [Akeyless](https://akeyless.io) and many more. The
 operator reads information from external APIs and automatically injects the
 values into a [Kubernetes
 Secret](https://kubernetes.io/docs/concepts/configuration/secret/).


### PR DESCRIPTION
mentioning Akeyless provider in readme