### PR TITLE
add support for Azure USGovCloud|GermanCloud|ChinaCloud

### DIFF
--- a/apis/externalsecrets/v1beta1/secretstore_azurekv_types.go
+++ b/apis/externalsecrets/v1beta1/secretstore_azurekv_types.go
@@ -34,6 +34,20 @@ const (
 	AzureWorkloadIdentity AzureAuthType = "WorkloadIdentity"
 )
 
+// AzureEnvironmentType specifies the Azure cloud environment endpoints to use for
+// connecting and authenticating with Azure. By default it points to the public cloud AAD endpoint.
+// The following endpoints are available, also see here: https://github.com/Azure/go-autorest/blob/main/autorest/azure/environments.go#L152
+// PublicCloud, USGovernmentCloud, ChinaCloud, GermanCloud
+// +kubebuilder:validation:Enum=PublicCloud;USGovernmentCloud;ChinaCloud;GermanCloud
+type AzureEnvironmentType string
+
+const (
+	AzureEnvironmentPublicCloud       AzureEnvironmentType = "PublicCloud"
+	AzureEnvironmentUSGovernmentCloud AzureEnvironmentType = "USGovernmentCloud"
+	AzureEnvironmentChinaCloud        AzureEnvironmentType = "ChinaCloud"
+	AzureEnvironmentGermanCloud       AzureEnvironmentType = "GermanCloud"
+)
+
 // Configures an store to sync secrets using Azure KV.
 type AzureKVProvider struct {
 	// Auth type defines how to authenticate to the keyvault service.
@@ -50,6 +64,13 @@ type AzureKVProvider struct {
 	// TenantID configures the Azure Tenant to send requests to. Required for ServicePrincipal auth type.
 	// +optional
 	TenantID *string `json:"tenantId,omitempty"`
+
+	// EnvironmentType specifies the Azure cloud environment endpoints to use for
+	// connecting and authenticating with Azure. By default it points to the public cloud AAD endpoint.
+	// The following endpoints are available, also see here: https://github.com/Azure/go-autorest/blob/main/autorest/azure/environments.go#L152
+	// PublicCloud, USGovernmentCloud, ChinaCloud, GermanCloud
+	// +kubebuilder:default=PublicCloud
+	EnvironmentType AzureEnvironmentType `json:"environmentType,omitempty"`
 
 	// Auth configures how the operator authenticates with Azure. Required for ServicePrincipal auth type.
 	// +optional

--- a/config/crds/bases/external-secrets.io_clustersecretstores.yaml
+++ b/config/crds/bases/external-secrets.io_clustersecretstores.yaml
@@ -1734,6 +1734,19 @@ spec:
                         - ManagedIdentity
                         - WorkloadIdentity
                         type: string
+                      environmentType:
+                        default: PublicCloud
+                        description: 'EnvironmentType specifies the Azure cloud environment
+                          endpoints to use for connecting and authenticating with
+                          Azure. By default it points to the public cloud AAD endpoint.
+                          The following endpoints are available, also see here: https://github.com/Azure/go-autorest/blob/main/autorest/azure/environments.go#L152
+                          PublicCloud, USGovernmentCloud, ChinaCloud, GermanCloud'
+                        enum:
+                        - PublicCloud
+                        - USGovernmentCloud
+                        - ChinaCloud
+                        - GermanCloud
+                        type: string
                       identityId:
                         description: If multiple Managed Identity is assigned to the
                           pod, you can select the one to be used

--- a/config/crds/bases/external-secrets.io_secretstores.yaml
+++ b/config/crds/bases/external-secrets.io_secretstores.yaml
@@ -1734,6 +1734,19 @@ spec:
                         - ManagedIdentity
                         - WorkloadIdentity
                         type: string
+                      environmentType:
+                        default: PublicCloud
+                        description: 'EnvironmentType specifies the Azure cloud environment
+                          endpoints to use for connecting and authenticating with
+                          Azure. By default it points to the public cloud AAD endpoint.
+                          The following endpoints are available, also see here: https://github.com/Azure/go-autorest/blob/main/autorest/azure/environments.go#L152
+                          PublicCloud, USGovernmentCloud, ChinaCloud, GermanCloud'
+                        enum:
+                        - PublicCloud
+                        - USGovernmentCloud
+                        - ChinaCloud
+                        - GermanCloud
+                        type: string
                       identityId:
                         description: If multiple Managed Identity is assigned to the
                           pod, you can select the one to be used

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -1654,6 +1654,15 @@ spec:
                             - ManagedIdentity
                             - WorkloadIdentity
                           type: string
+                        environmentType:
+                          default: PublicCloud
+                          description: 'EnvironmentType specifies the Azure cloud environment endpoints to use for connecting and authenticating with Azure. By default it points to the public cloud AAD endpoint. The following endpoints are available, also see here: https://github.com/Azure/go-autorest/blob/main/autorest/azure/environments.go#L152 PublicCloud, USGovernmentCloud, ChinaCloud, GermanCloud'
+                          enum:
+                            - PublicCloud
+                            - USGovernmentCloud
+                            - ChinaCloud
+                            - GermanCloud
+                          type: string
                         identityId:
                           description: If multiple Managed Identity is assigned to the pod, you can select the one to be used
                           type: string
@@ -4373,6 +4382,15 @@ spec:
                             - ServicePrincipal
                             - ManagedIdentity
                             - WorkloadIdentity
+                          type: string
+                        environmentType:
+                          default: PublicCloud
+                          description: 'EnvironmentType specifies the Azure cloud environment endpoints to use for connecting and authenticating with Azure. By default it points to the public cloud AAD endpoint. The following endpoints are available, also see here: https://github.com/Azure/go-autorest/blob/main/autorest/azure/environments.go#L152 PublicCloud, USGovernmentCloud, ChinaCloud, GermanCloud'
+                          enum:
+                            - PublicCloud
+                            - USGovernmentCloud
+                            - ChinaCloud
+                            - GermanCloud
                           type: string
                         identityId:
                           description: If multiple Managed Identity is assigned to the pod, you can select the one to be used

--- a/docs/provider-azure-key-vault.md
+++ b/docs/provider-azure-key-vault.md
@@ -11,6 +11,20 @@ We support Service Principals, Managed Identity and Workload Identity authentica
 
 To use Managed Identity authentication, you should use [aad-pod-identity](https://azure.github.io/aad-pod-identity/docs/) to assign the identity to external-secrets operator. To add the selector to external-secrets operator, use `podLabels` in your values.yaml in case of Helm installation of external-secrets.
 
+We support connecting to different cloud flavours azure supports: `PublicCloud`, `USGovernmentCloud`, `ChinaCloud` and `GermanCloud`. You have to specify the `environmentType` and point to the correct cloud flavour. This defaults to `PublicCloud`.
+
+```
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: azure-backend
+spec:
+  provider:
+    azurekv:
+      # PublicCloud, USGovernmentCloud, ChinaCloud, GermanCloud
+      environmentType: PublicCloud # default
+```
+
 Minimum required permissions are `Get` over secret and certificate permissions. This can be done by adding a Key Vault access policy:
 
 ```sh

--- a/pkg/provider/azure/keyvault/keyvault_auth_test.go
+++ b/pkg/provider/azure/keyvault/keyvault_auth_test.go
@@ -193,7 +193,7 @@ func TestGetAuthorizorForWorkloadIdentity(t *testing.T) {
 				kubeClient: awsauthfake.NewCreateTokenMock(saToken),
 				provider:   store.Spec.Provider.AzureKV,
 			}
-			tokenProvider := func(ctx context.Context, token, clientID, tenantID string) (adal.OAuthTokenProvider, error) {
+			tokenProvider := func(ctx context.Context, token, clientID, tenantID, aadEndpoint, kvResource string) (adal.OAuthTokenProvider, error) {
 				tassert.Equal(t, token, saToken)
 				tassert.Equal(t, clientID, clientID)
 				tassert.Equal(t, tenantID, tenantID)


### PR DESCRIPTION
This PR adds the ability to define a `environmentType` (cloud flavour). This is needed to supply slightly different configuration to the Azure sdk based on the environment type which should be used.
In particular ActiveDirectoryEndpoint and AzureKV Resource URL should be changed with each environment.

Fixes #1467