### PR TITLE
fix: remove convertKeys from aws providers

### DIFF
--- a/pkg/provider/aws/parameterstore/parameterstore.go
+++ b/pkg/provider/aws/parameterstore/parameterstore.go
@@ -29,7 +29,6 @@ import (
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 	"github.com/external-secrets/external-secrets/pkg/find"
 	"github.com/external-secrets/external-secrets/pkg/provider/aws/util"
-	"github.com/external-secrets/external-secrets/pkg/utils"
 )
 
 // https://github.com/external-secrets/external-secrets/issues/644
@@ -109,7 +108,7 @@ func (pm *ParameterStore) findByName(ref esv1beta1.ExternalSecretFind) (map[stri
 		}
 	}
 
-	return utils.ConvertKeys(ref.ConversionStrategy, data)
+	return data, nil
 }
 
 func (pm *ParameterStore) findByTags(ref esv1beta1.ExternalSecretFind) (map[string][]byte, error) {
@@ -152,7 +151,7 @@ func (pm *ParameterStore) findByTags(ref esv1beta1.ExternalSecretFind) (map[stri
 		}
 	}
 
-	return utils.ConvertKeys(ref.ConversionStrategy, data)
+	return data, nil
 }
 
 func (pm *ParameterStore) fetchAndSet(data map[string][]byte, name string) error {

--- a/pkg/provider/aws/secretsmanager/secretsmanager.go
+++ b/pkg/provider/aws/secretsmanager/secretsmanager.go
@@ -31,7 +31,6 @@ import (
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 	"github.com/external-secrets/external-secrets/pkg/find"
 	"github.com/external-secrets/external-secrets/pkg/provider/aws/util"
-	"github.com/external-secrets/external-secrets/pkg/utils"
 )
 
 // https://github.com/external-secrets/external-secrets/issues/644
@@ -159,7 +158,7 @@ func (sm *SecretsManager) findByName(ctx context.Context, ref esv1beta1.External
 			break
 		}
 	}
-	return utils.ConvertKeys(ref.ConversionStrategy, data)
+	return data, nil
 }
 
 func (sm *SecretsManager) findByTags(ctx context.Context, ref esv1beta1.ExternalSecretFind) (map[string][]byte, error) {
@@ -210,7 +209,7 @@ func (sm *SecretsManager) findByTags(ctx context.Context, ref esv1beta1.External
 			break
 		}
 	}
-	return utils.ConvertKeys(ref.ConversionStrategy, data)
+	return data, nil
 }
 
 func (sm *SecretsManager) fetchAndSet(ctx context.Context, data map[string][]byte, name string) error {


### PR DESCRIPTION
ConvertKeys is called in the external secrets controller
which takes care of mapping the keys.
Calling it before returning the data is a bug as it
interferes with the new rewrite feature.

Fixes #1447 