### PR TITLE
Flip order of `err` and nil `secret` variable check in `listSecrets()` function of vault provider

### DIFF
--- a/pkg/provider/vault/vault.go
+++ b/pkg/provider/vault/vault.go
@@ -429,11 +429,11 @@ func (v *client) listSecrets(ctx context.Context, path string) ([]string, error)
 		return nil, err
 	}
 	secret, err := v.logical.ListWithContext(ctx, url)
-	if secret == nil {
-		return nil, fmt.Errorf("provided path %v does not contain any secrets", url)
-	}
 	if err != nil {
 		return nil, fmt.Errorf(errReadSecret, err)
+	}
+	if secret == nil {
+		return nil, fmt.Errorf("provided path %v does not contain any secrets", url)
 	}
 	t, ok := secret.Data["keys"]
 	if !ok {


### PR DESCRIPTION
I tried to follow the documentation of [Getting Multiple Secrets with the Vault provider](https://external-secrets.io/v0.5.9/provider-hashicorp-vault/#getting-multiple-secrets). But it was always ending in `provided path /xyz/metadata does not contain any secret`. Even though I created the required "Custom Metadata" of a particular secret as described in the docs.

I finally found out that the used service account of my kubernetes cluster, which was bound to the kubernetes authentication in Vault has a too restrictive policy. I did not cover the `list` capability for the `xyz/metadata/*` path. This is how I solved this in the end:

```diff
path "xyz/data/*" {
     capabilities = ["read"]
}

+ path "xyz/metadata/*" {
+      capabilities = ["read", "list"]
+ }
```

**But**, it was pretty hard to find out. I actually built `external-secrets` image locally and added some debug logging which brought me to the fix in this PR. IMHO it makes much more sense to first check for the existence of an `err` and **after** that checking for a `nil` returned `secret`. At least it now shows me directly that I am missing permission to read the particular path inside Vault.