### PR TITLE
GitLab: use Version field to choose one environment or another.

### DIFF
--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -3,7 +3,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -174,7 +174,12 @@ func (g *Gitlab) GetSecret(ctx context.Context, ref esv1beta1.ExternalSecretData
 	// 	"value": "TEST_1",
 	// 	"protected": false,
 	// 	"masked": true
-	data, _, err := g.client.GetVariable(g.projectID, ref.Key, nil) // Optional 'filter' parameter could be added later
+
+	var vopts *gitlab.GetProjectVariableOptions
+	if ref.Version != "" {
+		vopts = &gitlab.GetProjectVariableOptions{Filter: &gitlab.VariableFilter{EnvironmentScope: ref.Version}}
+	}
+	data, _, err := g.client.GetVariable(g.projectID, ref.Key, vopts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Goal: implement something for #1460 that works
Way to do it:
- Use the `ref.Version` field to select what environment to use for a variable.

Help needed:
- Write tests for it that mock it.

Signed-off-by: Matcha @sennder <matcha.desoutter@sennder.com>