### PR TITLE
Reuse vault client/token when possible

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,7 @@ import (
 	"github.com/external-secrets/external-secrets/pkg/controllers/externalsecret"
 	"github.com/external-secrets/external-secrets/pkg/controllers/secretstore"
 	awsauth "github.com/external-secrets/external-secrets/pkg/provider/aws/auth"
+	"github.com/external-secrets/external-secrets/pkg/provider/vault"
 )
 
 var (
@@ -67,6 +68,8 @@ var (
 	certCheckInterval                     time.Duration
 	certLookaheadInterval                 time.Duration
 	enableAWSSession                      bool
+	enableVaultTokenCache                 bool
+	vaultTokenCacheSize                   int
 	tlsCiphers                            string
 	tlsMinVersion                         string
 )
@@ -176,6 +179,10 @@ var rootCmd = &cobra.Command{
 		if enableAWSSession {
 			awsauth.EnableCache = true
 		}
+		if enableVaultTokenCache {
+			vault.EnableCache = true
+			vault.VaultClientCache.Size = vaultTokenCacheSize
+		}
 		setupLog.Info("starting manager")
 		if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 			setupLog.Error(err, "problem running manager")
@@ -207,4 +214,6 @@ func init() {
 	rootCmd.Flags().DurationVar(&storeRequeueInterval, "store-requeue-interval", time.Minute*5, "Default Time duration between reconciling (Cluster)SecretStores")
 	rootCmd.Flags().BoolVar(&enableFloodGate, "enable-flood-gate", true, "Enable flood gate. External secret will be reconciled only if the ClusterStore or Store have an healthy or unknown state.")
 	rootCmd.Flags().BoolVar(&enableAWSSession, "experimental-enable-aws-session-cache", false, "Enable experimental AWS session cache. External secret will reuse the AWS session without creating a new one on each request.")
+	rootCmd.Flags().BoolVar(&enableVaultTokenCache, "experimental-enable-vault-token-cache", false, "Enable experimental Vault token cache. External secrets will reuse the Vault token without creating a new one on each request.")
+	rootCmd.Flags().IntVar(&vaultTokenCacheSize, "experimental-vault-token-cache-size", 100, "Maximum size of Vault token cache. Only used if --experimental-enable-vault-token-cache is set.")
 }

--- a/go.mod
+++ b/go.mod
@@ -95,7 +95,10 @@ require (
 
 require github.com/1Password/connect-sdk-go v1.5.0
 
-require sigs.k8s.io/yaml v1.3.0
+require (
+	github.com/hashicorp/golang-lru v0.5.4
+	sigs.k8s.io/yaml v1.3.0
+)
 
 require (
 	cloud.google.com/go/compute v1.9.0 // indirect
@@ -156,7 +159,6 @@ require (
 	github.com/hashicorp/go-sockaddr v1.0.2 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
-	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/hcl v1.0.1-vault-3 // indirect
 	github.com/hashicorp/vault/sdk v0.5.3 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect

--- a/pkg/provider/vault/cache.go
+++ b/pkg/provider/vault/cache.go
@@ -1,0 +1,106 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vault
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	lru "github.com/hashicorp/golang-lru"
+
+	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
+)
+
+type clientCache struct {
+	cache       *lru.Cache
+	Size        int
+	initialized bool
+	mu          sync.Mutex
+}
+
+type clientCacheKey struct {
+	Name      string
+	Namespace string
+	Kind      string
+}
+
+type clientCacheValue struct {
+	ResourceVersion string
+	Client          Client
+}
+
+func (c *clientCache) initialize() error {
+	if !c.initialized {
+		var err error
+		c.cache, err = lru.New(c.Size)
+		if err != nil {
+			return fmt.Errorf(errVaultCacheCreate, err)
+		}
+		c.initialized = true
+	}
+	return nil
+}
+
+func (c *clientCache) get(ctx context.Context, store esv1beta1.GenericStore, key clientCacheKey) (Client, bool, error) {
+	value, ok := c.cache.Get(key)
+	if ok {
+		cachedClient := value.(clientCacheValue)
+		if cachedClient.ResourceVersion == store.GetObjectMeta().ResourceVersion {
+			return cachedClient.Client, true, nil
+		}
+		// revoke token and clear old item from cache if resource has been updated
+		err := revokeTokenIfValid(ctx, cachedClient.Client)
+		if err != nil {
+			return nil, false, err
+		}
+		c.cache.Remove(key)
+	}
+	return nil, false, nil
+}
+
+func (c *clientCache) add(ctx context.Context, store esv1beta1.GenericStore, key clientCacheKey, client Client) error {
+	// don't let the LRU cache evict items
+	// remove the oldest item manually when needed so we can do some cleanup
+	for c.cache.Len() >= c.Size {
+		_, value, ok := c.cache.RemoveOldest()
+		if !ok {
+			return errors.New(errVaultCacheRemove)
+		}
+		cachedClient := value.(clientCacheValue)
+		err := revokeTokenIfValid(ctx, cachedClient.Client)
+		if err != nil {
+			return fmt.Errorf(errVaultRevokeToken, err)
+		}
+	}
+	evicted := c.cache.Add(key, clientCacheValue{ResourceVersion: store.GetObjectMeta().ResourceVersion, Client: client})
+	if evicted {
+		return errors.New(errVaultCacheEviction)
+	}
+	return nil
+}
+
+func (c *clientCache) contains(key clientCacheKey) bool {
+	return c.cache.Contains(key)
+}
+
+func (c *clientCache) lock() {
+	c.mu.Lock()
+}
+
+func (c *clientCache) unlock() {
+	c.mu.Unlock()
+}

--- a/pkg/provider/vault/fake/vault.go
+++ b/pkg/provider/vault/fake/vault.go
@@ -88,6 +88,12 @@ type VaultListResponse struct {
 	Data     *vault.Response
 }
 
+func NewAuthTokenFn() Token {
+	return Token{nil, func(ctx context.Context) (*vault.Secret, error) {
+		return &(vault.Secret{}), nil
+	}}
+}
+
 func NewSetTokenFn(ofn ...func(v string)) MockSetTokenFn {
 	return func(v string) {
 		for _, fn := range ofn {

--- a/pkg/provider/vault/vault_test.go
+++ b/pkg/provider/vault/vault_test.go
@@ -190,9 +190,11 @@ type testCase struct {
 
 func clientWithLoginMock(c *vault.Config) (Client, error) {
 	cl := fake.VaultClient{
-		MockSetToken: fake.NewSetTokenFn(),
-		MockAuth:     fake.NewVaultAuth(),
-		MockLogical:  fake.NewVaultLogical(),
+		MockAuthToken: fake.NewAuthTokenFn(),
+		MockSetToken:  fake.NewSetTokenFn(),
+		MockToken:     fake.NewTokenFn(""),
+		MockAuth:      fake.NewVaultAuth(),
+		MockLogical:   fake.NewVaultLogical(),
 	}
 	auth := cl.Auth()
 	token := cl.AuthToken()


### PR DESCRIPTION
This resolves #1273 by caching Vault clients and re-using existing tokens as long as they're valid. The approach is very similar to #1244, which implements something similar for the AWS provider. As in that PR, this new feature is gated behind a CLI flag: `--experimental-enable-vault-token-cache`. The only significant difference from the AWS implementation is that the cache key uses the SecretStore namespace rather than the secret namespace.

Also note that the token revocation implemented in #381 is disabled when token caching is enabled.I _think_ this is the right thing to do. We're now solving the underlying "lease leak" problem by not creating multiple token leases in the first place, which removes the need to clean them up.

Other minor changes:
* Fixed a couple of mis-named functions (`setSecretKeyToken` and `setAppRoleToken` function names were swapped from what they actually did)
* Added some more mocking that was needed to get tests passing
* Added logging when tokens are requested.

Is there any documentation that needs to be updated to reflect this change?