### PR TITLE
feat: run scanner on pr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.19'
   GOLANGCI_VERSION: 'v1.49.0'
   KUBERNETES_VERSION: '1.24.x'
   DOCKER_BUILDX_VERSION: 'v0.4.2'
@@ -50,7 +49,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: "go.mod"
 
       - name: Find the Go Cache
         id: go
@@ -96,7 +95,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: "go.mod"
 
       - name: Find the Go Cache
         id: go
@@ -108,15 +107,15 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ steps.go.outputs.build-cache }}
-          key: ${{ runner.os }}-${{ env.GO_VERSION }}-build-check-diff-${{ github.sha }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-${{ env.GO_VERSION }}-build-check-diff-${{ github.sha }}-
+          key: ${{ runner.os }}-build-check-diff-${{ github.sha }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-build-check-diff-${{ github.sha }}-
 
       - name: Cache Go Dependencies
         uses: actions/cache@v3
         with:
           path: ${{ steps.go.outputs.mod-cache }}
-          key: ${{ runner.os }}-${{ env.GO_VERSION }}-pkg-${{ github.sha }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-${{ env.GO_VERSION }}-pkg-${{ github.sha }}-
+          key: ${{ runner.os }}-pkg-${{ github.sha }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-pkg-${{ github.sha }}-
 
       # Check DIff also runs Reviewable which needs golangci-lint installed
       - name: Check Diff
@@ -140,7 +139,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: "go.mod"
 
       - name: Find the Go Cache
         id: go
@@ -211,7 +210,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: "go.mod"
 
       - name: Find the Go Cache
         id: go
@@ -246,6 +245,20 @@ jobs:
         env:
           BUILD_ARGS: "--push --platform linux/amd64,linux/arm64"
         run: make docker.build
+
+      - name: Get docker image tag
+        id: image_version
+        run: echo "::set-output name=image::$(make docker.image)"
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: '${{ steps.image_version.outputs.image }}'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
 
       - name: Promote Artifacts to main release channel
         if: github.ref == 'refs/heads/main' && env.GHCR_USERNAME != ''

--- a/.github/workflows/dlc.yml
+++ b/.github/workflows/dlc.yml
@@ -11,9 +11,6 @@ on:
     paths:
       - "go.mod"
   workflow_dispatch: {}
-env:
-  # Common versions
-  GO_VERSION: '1.19'
 
 jobs:
   license-check:
@@ -25,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: "go.mod"
 
       - name: Find the Go Cache
         id: go

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-env:
-  # Common versions
-  GO_VERSION: '1.19'
 
 jobs:
   deploy:
@@ -19,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: "go.mod"
 
       - name: Build Docs
         run: make docs.publish

--- a/.github/workflows/e2e-managed.yml
+++ b/.github/workflows/e2e-managed.yml
@@ -5,7 +5,6 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.19'
   GINKGO_VERSION: 'v2.1.6'
   DOCKER_BUILDX_VERSION: 'v0.4.2'
 
@@ -102,7 +101,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+          go-version-file: "go.mod"
 
     - name: Find the Go Cache
       id: go

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+          go-version-file: "go.mod"
 
     - name: Find the Go Cache
       id: go
@@ -111,7 +111,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+          go-version-file: "go.mod"
 
     - name: Find the Go Cache
       id: go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,6 @@ on:
 
 env:
   GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
-  GO_VERSION: '1.19'
 
 jobs:
   release:
@@ -59,7 +58,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: "go.mod"
 
       - name: Update Docs
         run: make docs.publish DOCS_VERSION=${{ github.event.inputs.version }} DOCS_ALIAS=latest
@@ -83,7 +82,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: "go.mod"
 
       - name: Find the Go Cache
         id: go

--- a/Makefile
+++ b/Makefile
@@ -204,6 +204,9 @@ docs.serve: ## Serve docs
 
 build.all: docker.build helm.build ## Build all artifacts (docker image, helm chart)
 
+docker.image:
+	@echo $(IMAGE_REGISTRY):$(VERSION)
+
 docker.build: $(addprefix build-,$(ARCH)) ## Build the docker image
 	@$(INFO) docker build
 	@docker build . $(BUILD_ARGS) -t $(IMAGE_REGISTRY):$(VERSION)

--- a/go.mod
+++ b/go.mod
@@ -207,7 +207,7 @@ require (
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
-	golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b // indirect
+	golang.org/x/net v0.0.0-20220909164309-bea034e7d591 // indirect
 	golang.org/x/sys v0.0.0-20220829200755-d48e67d00261 // indirect
 	golang.org/x/term v0.0.0-20220722155259-a9ba230a4035 // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1016,8 +1016,8 @@ golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su
 golang.org/x/net v0.0.0-20220607020251-c690dde0001d/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.0.0-20220617184016-355a448f1bc9/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
-golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b h1:ZmngSVLe/wycRns9MKikG9OWIEjGcGAkacif7oYQaUY=
-golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
+golang.org/x/net v0.0.0-20220909164309-bea034e7d591 h1:D0B/7al0LLrVC8aWF4+oxpv/m8bc7ViFfVS8/gXGdqI=
+golang.org/x/net v0.0.0-20220909164309-bea034e7d591/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=


### PR DESCRIPTION
Run trivy when building the image in a PR. instead of explicitly defining `go-version` it is inferred from the `go.mod` file ([see docs](https://github.com/actions/setup-go#getting-go-version-from-the-gomod-file)) - this will automatically use the latest patch version of go.

Also fixes `CVE-2022-27664`. Dependency was patched with `go get -u golang.org/x/net`

See run:
* [failing](https://github.com/external-secrets/external-secrets/actions/runs/3055094104/jobs/4927767604) (pre-fix)
* [latest job](https://github.com/external-secrets/external-secrets/actions/runs/3055294629/jobs/4928196555) :heavy_check_mark: 