### PR TITLE
test: use `T.Setenv` to set env vars in tests

### DIFF
--- a/pkg/provider/aws/auth/auth_test.go
+++ b/pkg/provider/aws/auth/auth_test.go
@@ -16,7 +16,6 @@ package auth
 
 import (
 	"context"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -423,7 +422,7 @@ func testRow(t *testing.T, row TestSessionRow) {
 		assert.Nil(t, err)
 	}
 	for k, v := range row.env {
-		os.Setenv(k, v)
+		t.Setenv(k, v)
 	}
 	if row.sa != nil {
 		err := kc.Create(context.Background(), row.sa)
@@ -436,11 +435,6 @@ func testRow(t *testing.T, row TestSessionRow) {
 		},
 	})
 	assert.Nil(t, err)
-	defer func() {
-		for k := range row.env {
-			os.Unsetenv(k)
-		}
-	}()
 	s, err := New(context.Background(), row.store, kc, row.namespace, row.stsProvider, row.jwtProvider)
 	if !ErrorContains(err, row.expectErr) {
 		t.Errorf("expected error %s but found %s", row.expectErr, err.Error())
@@ -460,10 +454,8 @@ func testRow(t *testing.T, row TestSessionRow) {
 
 func TestSMEnvCredentials(t *testing.T) {
 	k8sClient := clientfake.NewClientBuilder().Build()
-	os.Setenv("AWS_SECRET_ACCESS_KEY", "1111")
-	os.Setenv("AWS_ACCESS_KEY_ID", "2222")
-	defer os.Unsetenv("AWS_SECRET_ACCESS_KEY")
-	defer os.Unsetenv("AWS_ACCESS_KEY_ID")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "1111")
+	t.Setenv("AWS_ACCESS_KEY_ID", "2222")
 	s, err := New(context.Background(), &esv1beta1.SecretStore{
 		Spec: esv1beta1.SecretStoreSpec{
 			Provider: &esv1beta1.SecretStoreProvider{
@@ -500,10 +492,8 @@ func TestSMAssumeRole(t *testing.T) {
 			}, nil
 		},
 	}
-	os.Setenv("AWS_SECRET_ACCESS_KEY", "1111")
-	os.Setenv("AWS_ACCESS_KEY_ID", "2222")
-	defer os.Unsetenv("AWS_SECRET_ACCESS_KEY")
-	defer os.Unsetenv("AWS_ACCESS_KEY_ID")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "1111")
+	t.Setenv("AWS_ACCESS_KEY_ID", "2222")
 	s, err := New(context.Background(), &esv1beta1.SecretStore{
 		Spec: esv1beta1.SecretStoreSpec{
 			Provider: &esv1beta1.SecretStoreProvider{

--- a/pkg/provider/aws/auth/resolver_test.go
+++ b/pkg/provider/aws/auth/resolver_test.go
@@ -14,7 +14,6 @@ limitations under the License.
 package auth
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -44,7 +43,7 @@ func TestResolver(t *testing.T) {
 	}
 
 	for _, item := range tbl {
-		os.Setenv(item.env, item.url)
+		t.Setenv(item.env, item.url)
 	}
 
 	f := ResolveEndpoint()
@@ -53,9 +52,5 @@ func TestResolver(t *testing.T) {
 		ep, err := f.EndpointFor(item.service, "")
 		assert.Nil(t, err)
 		assert.Equal(t, item.url, ep.URL)
-	}
-
-	for _, item := range tbl {
-		os.Unsetenv(item.env)
 	}
 }

--- a/pkg/provider/aws/provider_test.go
+++ b/pkg/provider/aws/provider_test.go
@@ -17,7 +17,6 @@ package aws
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -45,10 +44,8 @@ func TestProvider(t *testing.T) {
 	// inject fake static credentials because we test
 	// if we are able to get credentials when constructing the client
 	// see #415
-	os.Setenv("AWS_ACCESS_KEY_ID", "1234")
-	os.Setenv("AWS_SECRET_ACCESS_KEY", "1234")
-	defer os.Unsetenv("AWS_ACCESS_KEY_ID")
-	defer os.Unsetenv("AWS_SECRET_ACCESS_KEY")
+	t.Setenv("AWS_ACCESS_KEY_ID", "1234")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "1234")
 
 	tbl := []struct {
 		test    string


### PR DESCRIPTION
This PR replaces `os.Setenv` with `t.Setenv`. Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

```go
func TestFoo(t *testing.T) {
	// before
	key := "ENV"
	originalEnv := os.Getenv(key)
	
	if err := os.Setenv(key, "new value"); err != nil {
		t.Fatal(err)
	}
	defer func() {
		if err := os.Setenv(key, originalEnv); err != nil {
			t.Logf("failed to set env %s back to original value: %v", key, err)
		}
	}()
	
	// after
	t.Setenv(key, "new value")
}
```