### PR TITLE
fix: skip publish on fork ci due to missing secrets

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,7 @@ env:
   IMAGE_NAME: ${{ inputs.image-name }}
   TAG_SUFFIX: ${{ inputs.tag-suffix }}
   DOCKERFILE: ${{ inputs.dockerfile }}
+  IS_FORK: ${{ secrets.GHCR_USERNAME == '' && 'true' || 'false' }}
 
 jobs:
   build-publish:
@@ -75,17 +76,26 @@ jobs:
 
       - name: Login to Docker
         uses: docker/login-action@v2
+        if: env.IS_FORK == 'false'
         with:
           registry: ghcr.io
           username: ${{ secrets.GHCR_USERNAME }}
           password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Build & Publish Artifacts
+        if: env.IS_FORK == 'false'
         shell: bash
         env:
           BUILD_ARGS: >-
             --push
             --platform linux/amd64,linux/arm64
+        run: make docker.build
+
+      - name: Build & Publish Artifacts fork
+        if: env.IS_FORK == 'true'
+        shell: bash
+        env:
+          BUILD_ARGS: --load
         run: make docker.build
 
       - name: Get docker image tag
@@ -96,14 +106,10 @@ jobs:
           TAG=$(make docker.tag)
           echo "::set-output name=image-tag::${TAG}"
 
-  scan:
-    runs-on: ubuntu-latest
-    needs: build-publish
-    steps:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ${{ inputs.image-name }}:${{ needs.build-publish.outputs.image-tag }}
+          image-ref: ${{ inputs.image-name }}:${{ steps.container_info.outputs.image-tag }}
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true
@@ -117,6 +123,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Sign image
+        if: env.IS_FORK == 'false'
         uses: ./.github/actions/sign
         with:
           image-name: ${{ inputs.image-name }}


### PR DESCRIPTION
publish step fails on forks; This PR will skip the publish step on forked repos. It's not needed as we have e2e tests that cover the build.