### PR TITLE
fix(1password): Resolve indentation issue in Store

### DIFF
--- a/docs/snippets/1password-secret-store.yaml
+++ b/docs/snippets/1password-secret-store.yaml
@@ -12,6 +12,6 @@ spec:
         shared: 2   # next look in here. error if not found
       auth:
         secretRef:
-        connectTokenSecretRef:
-          name: onepassword-connect-token-staging
-          key: token
+          connectTokenSecretRef:
+            name: onepassword-connect-token-staging
+            key: token


### PR DESCRIPTION
The indentation was incorrect on the website which is ultimately driven by `1password-secret-store.yaml` so this fixes the file to have the correct indentation

Error being thrown before:
```bash
Error from server (BadRequest): error when creating "secret-store.yaml": SecretStore in version "v1beta1" cannot be handled as a SecretStore: strict decoding error: unknown field "spec.provider.onepassword.auth.connectTokenSecretRef"
```

Signed-off-by: Jason Field <jason@avon-lea.co.uk>