### PR TITLE
Fix snippet for MI authentication (docs)

### DIFF
--- a/docs/provider/azure-key-vault.md
+++ b/docs/provider/azure-key-vault.md
@@ -43,7 +43,7 @@ A Managed Identity should be created in Azure, and that Identity should have pro
 If there are multiple Managed Identitites for different keyvaults, the operator should have been assigned all identities via [aad-pod-identity](https://azure.github.io/aad-pod-identity/docs/), then the SecretStore configuration should include the Id of the idenetity to be used via the `identityId` field.
 
 ```yaml
-{% include 'azkv-credentials-secret.yaml' %}
+{% include 'azkv-secret-store-mi.yaml' %}
 ```
 
 #### Workload Identity


### PR DESCRIPTION
The wrong snippet is refrenced for managed identity authentication on azure Key Vault. This MR changes the include statement to the correct one.