### PR TITLE
fix: allow controller to `delete` delete externalsecrets

### DIFF
--- a/deploy/charts/external-secrets/templates/rbac.yaml
+++ b/deploy/charts/external-secrets/templates/rbac.yaml
@@ -91,6 +91,7 @@ rules:
     verbs:
     - "create"
     - "update"
+    - "delete"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if and .Values.scopedNamespace .Values.scopedRBAC }}

--- a/pkg/controllers/clusterexternalsecret/clusterexternalsecret_controller.go
+++ b/pkg/controllers/clusterexternalsecret/clusterexternalsecret_controller.go
@@ -170,7 +170,6 @@ func (r *Reconciler) resolveExternalSecret(ctx context.Context, clusterExternalS
 }
 
 func (r *Reconciler) removeExternalSecret(ctx context.Context, esName, namespace string) (string, error) {
-	//
 	var existingES esv1beta1.ExternalSecret
 	err := r.Get(ctx, types.NamespacedName{
 		Name:      esName,
@@ -205,7 +204,11 @@ func (r *Reconciler) removeOldNamespaces(ctx context.Context, namespaceList v1.N
 	failedNamespaces := map[string]string{}
 	// Loop through existing namespaces first to make sure they still have our labels
 	for _, namespace := range getRemovedNamespaces(namespaceList, provisionedNamespaces) {
-		if result, _ := r.removeExternalSecret(ctx, esName, namespace); result != "" {
+		result, err := r.removeExternalSecret(ctx, esName, namespace)
+		if err != nil {
+			r.Log.Error(err, "unable to delete external-secret")
+		}
+		if result != "" {
 			failedNamespaces[namespace] = result
 		}
 	}


### PR DESCRIPTION
When using ClusterExternalSecret the controller needs to delete external-secret resources.
Also: never swallow errors.

Fixes #1255