### PR TITLE
gitlab: getAllSecrets

### DIFF
--- a/docs/contributing/devguide.md
+++ b/docs/contributing/devguide.md
@@ -80,7 +80,7 @@ To remove the CRDs run:
 make crds.uninstall
 ```
 
-If you need to test some other k8s integrations and need the operator to be deployed to the actuall cluster while developing, you can use the following workflow:
+If you need to test some other k8s integrations and need the operator to be deployed to the actual cluster while developing, you can use the following workflow:
 
 ```
 kind create cluster --name external-secrets

--- a/docs/guides/datafrom-rewrite.md
+++ b/docs/guides/datafrom-rewrite.md
@@ -11,7 +11,7 @@ Rewrite operations are all applied before `ConversionStrategy` is applied.
 ### Regexp
 This method implements rewriting through the use of regular expressions. It needs a `source` and a `target` field. The source field is where the definition of the matching regular expression goes, where the `target` field is where the replacing expression goes.
 
-Some considerations about the impelementation of Regexp Rewrite:
+Some considerations about the implementation of Regexp Rewrite:
 
 1. The input of a subsequent rewrite operation are the outputs of the previous rewrite.
 2. If a given set of keys do not match any Rewrite operation, there will be no error. Rather, the original keys will be used.

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -102,7 +102,7 @@ func (c *gClient) setAuth(ctx context.Context) error {
 	}
 
 	c.credentials = credentialsSecret.Data[c.store.Auth.SecretRef.AccessToken.Key]
-	if (c.credentials == nil) || (len(c.credentials) == 0) {
+	if c.credentials == nil || len(c.credentials) == 0 {
 		return fmt.Errorf(errMissingSAK)
 	}
 	// I don't know where ProjectID is being set

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -27,6 +27,7 @@ import (
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
+	"github.com/external-secrets/external-secrets/pkg/find"
 	"github.com/external-secrets/external-secrets/pkg/utils"
 )
 
@@ -38,6 +39,9 @@ const (
 	errList                                   = "could not verify if the client is valid: %w"
 	errAuth                                   = "client is not allowed to get secrets"
 	errUninitializedGitlabProvider            = "provider gitlab is not initialized"
+	errNameNotDefined                         = "'find.name' is mandatory"
+	errTagsNotImplemented                     = "'find.tags' is not implemented in the Gitlab provider"
+	errPathNotImplemented                     = "'find.path' is not implemented in the Gitlab provider"
 	errJSONSecretUnmarshal                    = "unable to unmarshal secret: %w"
 )
 
@@ -155,10 +159,44 @@ func (g *Gitlab) NewClient(ctx context.Context, store esv1beta1.GenericStore, ku
 	return g, nil
 }
 
-// Empty GetAllSecrets.
+// GetAllSecrets syncs all gitlab project variables into a single Kubernetes Secret.
 func (g *Gitlab) GetAllSecrets(ctx context.Context, ref esv1beta1.ExternalSecretFind) (map[string][]byte, error) {
-	// TO be implemented
-	return nil, fmt.Errorf("GetAllSecrets not implemented")
+	if utils.IsNil(g.client) {
+		return nil, fmt.Errorf(errUninitializedGitlabProvider)
+	}
+	if ref.Tags != nil {
+		return nil, fmt.Errorf(errTagsNotImplemented)
+	}
+	if ref.Path != nil {
+		return nil, fmt.Errorf(errPathNotImplemented)
+	}
+	if ref.Name == nil {
+		return nil, fmt.Errorf(errNameNotDefined)
+	}
+
+	allData, _, err := g.client.ListVariables(g.projectID, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var matcher *find.Matcher
+	if ref.Name != nil {
+		m, err := find.New(*ref.Name)
+		if err != nil {
+			return nil, err
+		}
+		matcher = m
+	}
+	secretData := make(map[string][]byte)
+	for _, data := range allData {
+		matching, key := matchesFilter(g.environment, data, matcher)
+		if !matching {
+			continue
+		}
+		secretData[key] = []byte(data.Value)
+	}
+
+	return secretData, nil
 }
 
 func (g *Gitlab) GetSecret(ctx context.Context, ref esv1beta1.ExternalSecretDataRemoteRef) ([]byte, error) {
@@ -176,6 +214,7 @@ func (g *Gitlab) GetSecret(ctx context.Context, ref esv1beta1.ExternalSecretData
 	// 	"masked": true,
 	// 	"environment_scope": "*"
 	// }
+
 	var vopts *gitlab.GetProjectVariableOptions
 	if g.environment != "" {
 		vopts = &gitlab.GetProjectVariableOptions{Filter: &gitlab.VariableFilter{EnvironmentScope: g.environment}}
@@ -224,6 +263,22 @@ func (g *Gitlab) GetSecretMap(ctx context.Context, ref esv1beta1.ExternalSecretD
 		secretData[k] = []byte(v)
 	}
 	return secretData, nil
+}
+
+func matchesFilter(environment string, data *gitlab.ProjectVariable, matcher *find.Matcher) (bool, string) {
+	if environment != "" && environment != "*" {
+		// as of now gitlab does not support filtering of EnvironmentScope through the api call
+		if data.EnvironmentScope != environment {
+			return false, ""
+		}
+	}
+
+	key := data.Key
+	if key == "" || (matcher != nil && !matcher.MatchName(key)) {
+		return false, ""
+	}
+
+	return true, key
 }
 
 func (g *Gitlab) Close(ctx context.Context) error {

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -40,7 +40,7 @@ const (
 	errAuth                                   = "client is not allowed to get secrets"
 	errUninitializedGitlabProvider            = "provider gitlab is not initialized"
 	errNameNotDefined                         = "'find.name' is mandatory"
-	errTagsNotImplemented                     = "'find.tags' is not implemented in the Gitlab provider"
+	errTagsNotImplemented                     = "'find.tags' is not currently supported by Gitlab provider"
 	errPathNotImplemented                     = "'find.path' is not implemented in the Gitlab provider"
 	errJSONSecretUnmarshal                    = "unable to unmarshal secret: %w"
 )

--- a/pkg/provider/gitlab/gitlab_test.go
+++ b/pkg/provider/gitlab/gitlab_test.go
@@ -216,7 +216,7 @@ func TestGetAllSecrets(t *testing.T) {
 	}
 	setUnsupportedFindTags := func(smtc *secretManagerTestCase) {
 		smtc.refFind.Tags = map[string]string{}
-		smtc.expectError = "'find.tags' is not implemented in the Gitlab provider"
+		smtc.expectError = "'find.tags' is not currently supported by Gitlab provider"
 	}
 	setUnsupportedFindPath := func(smtc *secretManagerTestCase) {
 		path := "path"


### PR DESCRIPTION
This PR implements the missing GetAllSecrets call for the gitlab provider.

This pulls in all CI/CD variables of the defined gitlab project. Afterwards the result is filtered via the configurable regex and scope.

This addresses: https://github.com/external-secrets/external-secrets/issues/1615

Signed-off-by: Dominik Zeiger <dominik@zeiger.biz>