### PR TITLE
Update Dockerfile.ubi

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -1,9 +1,12 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/go-toolset AS builder
+
 ARG TARGETOS
 ARG TARGETARCH
 COPY bin/external-secrets-${TARGETOS}-${TARGETARCH} /bin/external-secrets
 
-RUN microdnf update
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+RUN microdnf update -y
 
 # Run as UID for nobody
 USER 65534


### PR DESCRIPTION
Update Dockerfile.ubi to use go-toolset (which is based on Go 1.18) to provide + FIPS compliant libraries.
I have a bit of doubts...

Signed-off-by: Idan Adar <iadar@il.ibm.com>