### PR TITLE
feat: fips compliant build using boringcrypto

### DIFF
--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -62,7 +62,7 @@ runs:
     - name: Run e2e Tests
       shell: bash
       env:
-        BUILD_ARGS: --load
+        DOCKER_BUILD_ARGS: --load
       run: |
         export PATH=$PATH:$(go env GOPATH)/bin
         go install github.com/onsi/ginkgo/v2/ginkgo@${{ env.GINKGO_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,13 +170,28 @@ jobs:
       matrix:
         include:
         - dockerfile: "Dockerfile"
+          build-args: "CGO_ENABLED=0"
+          build-arch: "amd64 arm64"
+          build-platform: "linux/amd64,linux/arm64"
           tag-suffix: "" # distroless
         - dockerfile: "Dockerfile.ubi"
+          build-args: "CGO_ENABLED=0"
+          build-arch: "amd64 arm64"
+          build-platform: "linux/amd64,linux/arm64"
           tag-suffix: "-ubi"
+        - dockerfile: "Dockerfile.ubi"
+          build-args: "CGO_ENABLED=1 GOEXPERIMENT=boringcrypto"
+          build-arch: "amd64"
+          build-platform: "linux/amd64"
+          tag-suffix: "-ubi-boringssl"
     with:
       dockerfile: ${{ matrix.dockerfile }}
       tag-suffix: ${{ matrix.tag-suffix }}
       image-name: ghcr.io/${{ github.repository }}
+      build-platform: ${{ matrix.build-platform }}
+      build-args: ${{ matrix.build-args }}
+      build-arch: ${{ matrix.build-arch }}
+      ref: ${{ github.ref }}
     secrets:
       GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
       GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,15 @@ on:
         required: false
         default: main
         type: string
+      build-args:
+        required: true
+        type: string
+      build-arch:
+        required: true
+        type: string
+      build-platform:
+        required: true
+        type: string
     secrets:
       GHCR_USERNAME:
         required: true
@@ -28,6 +37,7 @@ on:
 env:
   IMAGE_NAME: ${{ inputs.image-name }}
   TAG_SUFFIX: ${{ inputs.tag-suffix }}
+  ARCH: ${{ inputs.build-arch }}
   DOCKERFILE: ${{ inputs.dockerfile }}
   IS_FORK: ${{ secrets.GHCR_USERNAME == '' && 'true' || 'false' }}
 
@@ -111,9 +121,10 @@ jobs:
         shell: bash
         env:
           IMAGE_TAG: ${{ steps.container_info.outputs.image-tag }}
-          BUILD_ARGS: >-
+          BUILD_ARGS: ${{ inputs.build-args }}
+          DOCKER_BUILD_ARGS: >-
             --push
-            --platform linux/amd64,linux/arm64
+            --platform ${{ inputs.build-platform }}
         run: make docker.build
 
       - name: Build & Publish Artifacts fork
@@ -121,7 +132,8 @@ jobs:
         shell: bash
         env:
           IMAGE_TAG: ${{ steps.container_info.outputs.image-tag }}
-          BUILD_ARGS: --load
+          BUILD_ARGS: ${{ inputs.build-args }}
+          DOCKER_BUILD_ARGS: --load
         run: make docker.build
 
       - name: Run Trivy vulnerability scanner

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
         run: |
           echo "Image: \`${{ env.IMAGE_NAME }}:${{ github.event.inputs.version }}\`" >> .changelog
           echo "Image: \`${{ env.IMAGE_NAME }}:${{ github.event.inputs.version }}-ubi\`" >> .changelog
+          echo "Image: \`${{ env.IMAGE_NAME }}:${{ github.event.inputs.version }}-ubi-boringssl\`" >> .changelog
           echo "${{ steps.build_changelog.outputs.changelog }}" >> .changelog
 
       - name: Update Release
@@ -71,6 +72,7 @@ jobs:
         include:
         - tag_suffix: "" # distroless image
         - tag_suffix: "-ubi" # ubi image
+        - tag_suffix: "-ubi-boringssl" # ubi image
 
     permissions:
       id-token: write

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,9 @@ SHELL         := /bin/bash
 MAKEFLAGS     += --warn-undefined-variables
 .SHELLFLAGS   := -euo pipefail -c
 
-ARCH = amd64 arm64
-BUILD_ARGS ?=
+ARCH ?= amd64 arm64
+BUILD_ARGS ?= CGO_ENABLED=0
+DOCKER_BUILD_ARGS ?=
 DOCKERFILE ?= Dockerfile
 
 # default target is build
@@ -122,7 +123,7 @@ build: $(addprefix build-,$(ARCH)) ## Build binary
 .PHONY: build-%
 build-%: generate ## Build binary for the specified arch
 	@$(INFO) go build $*
-	@CGO_ENABLED=0 GOOS=linux GOARCH=$* \
+	$(BUILD_ARGS) GOOS=linux GOARCH=$* \
 		go build -o '$(OUTPUT_DIR)/external-secrets-linux-$*' main.go
 	@$(OK) go build $*
 
@@ -220,7 +221,7 @@ docker.tag:
 
 docker.build: $(addprefix build-,$(ARCH)) ## Build the docker image
 	@$(INFO) docker build
-	@docker build -f $(DOCKERFILE) . $(BUILD_ARGS) -t $(IMAGE_NAME):$(IMAGE_TAG)
+	@docker build -f $(DOCKERFILE) . $(DOCKER_BUILD_ARGS) -t $(IMAGE_NAME):$(IMAGE_TAG)
 	@$(OK) docker build
 
 docker.push: ## Push the docker image to the registry

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -3,7 +3,7 @@ SHELL       := /bin/bash
 .SHELLFLAGS := -euo pipefail -c
 
 KIND_IMG       = "kindest/node:v1.24.2@sha256:1f0cee2282f43150b52dc7933183ed96abdcfc8d293f30ec07082495874876f1"
-BUILD_ARGS     ?=
+DOCKER_BUILD_ARGS     ?=
 
 export E2E_IMAGE_NAME ?= ghcr.io/external-secrets/external-secrets-e2e
 export GINKGO_LABELS ?= !managed
@@ -21,7 +21,7 @@ test: e2e-image ## Run e2e tests against current kube context
 		IMAGE_NAME=$(IMAGE_NAME) \
 		VERSION=$(VERSION) \
 		ARCH=amd64 \
-		BUILD_ARGS="${BUILD_ARGS} --build-arg TARGETARCH=amd64 --build-arg TARGETOS=linux"
+		DOCKER_BUILD_ARGS="${DOCKER_BUILD_ARGS} --build-arg TARGETARCH=amd64 --build-arg TARGETOS=linux"
 	kind load docker-image --name="external-secrets" $(IMAGE_NAME):$(VERSION)
 	kind load docker-image --name="external-secrets" $(E2E_IMAGE_NAME):$(VERSION)
 	./run.sh
@@ -30,7 +30,7 @@ test.managed: e2e-image ## Run e2e tests against current kube context
 	$(MAKE) -C ../ docker.build \
 		VERSION=$(VERSION) \
 		ARCH=amd64 \
-		BUILD_ARGS="${BUILD_ARGS} --build-arg TARGETARCH=amd64 --build-arg TARGETOS=linux"
+		DOCKER_BUILD_ARGS="${DOCKER_BUILD_ARGS} --build-arg TARGETARCH=amd64 --build-arg TARGETOS=linux"
 	$(MAKE) -C ../ docker.push \
 		VERSION=$(VERSION)
 	$(MAKE) -C ../ docker.push \
@@ -46,7 +46,7 @@ e2e-image: e2e-bin
 	mkdir -p k8s
 	$(MAKE) -C ../ helm.generate
 	cp -r ../deploy ./k8s
-	docker build $(BUILD_ARGS) -t $(E2E_IMAGE_NAME):$(VERSION) .
+	docker build $(DOCKER_BUILD_ARGS) -t $(E2E_IMAGE_NAME):$(VERSION) .
 
 stop-kind: ## Stop kind cluster
 	kind delete cluster \


### PR DESCRIPTION
This PR adds a new image to offer a FIPS compliant build of ESO.
More context here: https://kupczynski.info/posts/fips-golang/

It is debatable whether or not we want to rely on `EXPERIMENT_` env vars or not :thinking: 

I exported the container image build from CI and checked if there are `boring*` symbols.
```
$ docker pull ghcr.io/external-secrets/external-secrets:v0.6.1-13.g6d5878b7-ubi-boringssl

$ docker save ghcr.io/external-secrets/external-secrets:v0.6.1-13.g6d5878b7-ubi-boringssl -o ubi-boringssl

$ tar xvf ubi-boringssl
```

![2022-11-19-225200_1209x615_scrot](https://user-images.githubusercontent.com/1709030/202872881-f1e0683c-13e7-4d45-adfc-c17cdea57a74.png)
