### PR TITLE
feat: add rebuild action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,11 +6,18 @@ on:
       image-name:
         required: true
         type: string
+      image-tag:
+        required: false
+        type: string
       tag-suffix:
         required: true
         type: string
       dockerfile:
         required: true
+        type: string
+      ref:
+        required: false
+        default: main
         type: string
     secrets:
       GHCR_USERNAME:
@@ -34,6 +41,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v2
@@ -88,7 +97,9 @@ jobs:
         env:
           GITHUB_REF: ${{ github.ref }}
         run: |
-          if [ "$GITHUB_REF" == "refs/heads/main" ]; then
+          if [ "${{ inputs.image-tag }}" != "" ]; then
+            TAG="${{ inputs.image-tag }}${{ inputs.tag-suffix }}"
+          elif [ "$GITHUB_REF" == "refs/heads/main" ]; then
             TAG=main${{ inputs.tag-suffix }}
           else
             TAG=$(make docker.tag)

--- a/.github/workflows/rebuild-image.yml
+++ b/.github/workflows/rebuild-image.yml
@@ -1,0 +1,53 @@
+name: Rebuild
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'ref to rebuild, can be a tag, branch or commit sha.'
+        required: true
+        default: 'v0.6.1'
+
+jobs:
+  checkout:
+    name: Checkout repo
+    runs-on: ubuntu-latest
+    outputs:
+      timestamp: ${{ steps.timestamp.outputs.timestamp }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.ref }}
+      - name: set timestamp output
+        id: timestamp
+        run: |
+          echo "timestamp=$(date +%s)" >> $GITHUB_OUTPUT
+
+  # this rebuilds the image and creates a new tag with a timestamp suffix
+  # e.g. v0.6.1-1669145271 and v0.6.1-ubi-1669145271
+  publish-artifacts:
+    uses: ./.github/workflows/publish.yml
+    needs: checkout
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      matrix:
+        include:
+        - dockerfile: "Dockerfile"
+          tag-suffix: "-${{ needs.checkout.outputs.timestamp }}" # distroless
+        - dockerfile: "Dockerfile.ubi"
+          tag-suffix: "-ubi-${{ needs.checkout.outputs.timestamp }}"
+    with:
+      dockerfile: ${{ matrix.dockerfile }}
+      ref: ${{ github.event.inputs.ref }}
+      image-tag: ${{ github.event.inputs.ref }}
+      tag-suffix: ${{ matrix.tag-suffix }}
+      image-name: ghcr.io/${{ github.repository }}
+    secrets:
+      GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
+      GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+


### PR DESCRIPTION
This PR adds a github action that can be manually triggered to rebuild the image for a given (branch|tag|commit).
The intended use is to provide os-level patches for existing releases. We do not provide a patch guarantee for existing versions of external secrets operator - at least not for now. Rebuilds can be requested on demand through the usual channels. For context, this was requested by @IdanAdar initially.

The rebuild action rebuilds the image and creates a new tag with a timestamp suffix, e.g. `v0.6.1-1669145271`.

### Proof of work

Succesful GHA Run: https://github.com/moolen/external-secrets/actions/runs/3526770914

Images built in above run:

```
ghcr.io/moolen/external-secrets:v0.6.1-1669148355
ghcr.io/moolen/external-secrets:v0.6.1-ubi-1669148355
```
