### PR TITLE
fix sync calls metrics & defer patch status

### DIFF
--- a/pkg/controllers/externalsecret/externalsecret_controller.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller.go
@@ -96,20 +96,14 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("ExternalSecret", req.NamespacedName)
 
-	syncCallsMetricLabels := prometheus.Labels{"name": req.Name, "namespace": req.Namespace}
-
+	resourceLabels := prometheus.Labels{"name": req.Name, "namespace": req.Namespace}
 	start := time.Now()
-
-	defer externalSecretReconcileDuration.With(prometheus.Labels{
-		"name":      req.Name,
-		"namespace": req.Namespace,
-	}).Set(float64(time.Since(start)))
+	defer externalSecretReconcileDuration.With(resourceLabels).Set(float64(time.Since(start)))
+	defer syncCallsTotal.With(resourceLabels).Inc()
 
 	var externalSecret esv1beta1.ExternalSecret
-
 	err := r.Get(ctx, req.NamespacedName, &externalSecret)
 	if apierrors.IsNotFound(err) {
-		syncCallsTotal.With(syncCallsMetricLabels).Inc()
 		conditionSynced := NewExternalSecretCondition(esv1beta1.ExternalSecretDeleted, v1.ConditionFalse, esv1beta1.ConditionReasonSecretDeleted, "Secret was deleted")
 		SetExternalSecretCondition(&esv1beta1.ExternalSecret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -120,7 +114,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, nil
 	} else if err != nil {
 		log.Error(err, errGetES)
-		syncCallsError.With(syncCallsMetricLabels).Inc()
+		syncCallsError.With(resourceLabels).Inc()
 		return ctrl.Result{}, nil
 	}
 
@@ -197,7 +191,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		r.recorder.Event(&externalSecret, v1.EventTypeWarning, esv1beta1.ReasonUpdateFailed, err.Error())
 		conditionSynced := NewExternalSecretCondition(esv1beta1.ExternalSecretReady, v1.ConditionFalse, esv1beta1.ConditionReasonSecretSyncedError, errGetSecretData)
 		SetExternalSecretCondition(&externalSecret, *conditionSynced)
-		syncCallsError.With(syncCallsMetricLabels).Inc()
+		syncCallsError.With(resourceLabels).Inc()
 		return ctrl.Result{RequeueAfter: requeueAfter}, nil
 	}
 
@@ -214,7 +208,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 				r.recorder.Event(&externalSecret, v1.EventTypeWarning, esv1beta1.ReasonUpdateFailed, err.Error())
 				conditionSynced := NewExternalSecretCondition(esv1beta1.ExternalSecretReady, v1.ConditionFalse, esv1beta1.ConditionReasonSecretSyncedError, errDeleteSecret)
 				SetExternalSecretCondition(&externalSecret, *conditionSynced)
-				syncCallsError.With(syncCallsMetricLabels).Inc()
+				syncCallsError.With(resourceLabels).Inc()
 				return ctrl.Result{RequeueAfter: requeueAfter}, nil
 			}
 			err = r.Delete(ctx, secret)
@@ -223,7 +217,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 				r.recorder.Event(&externalSecret, v1.EventTypeWarning, esv1beta1.ReasonUpdateFailed, err.Error())
 				conditionSynced := NewExternalSecretCondition(esv1beta1.ExternalSecretReady, v1.ConditionFalse, esv1beta1.ConditionReasonSecretSyncedError, errDeleteSecret)
 				SetExternalSecretCondition(&externalSecret, *conditionSynced)
-				syncCallsError.With(syncCallsMetricLabels).Inc()
+				syncCallsError.With(resourceLabels).Inc()
 			}
 
 			conditionSynced := NewExternalSecretCondition(esv1beta1.ExternalSecretReady, v1.ConditionTrue, esv1beta1.ConditionReasonSecretDeleted, "secret deleted due to DeletionPolicy")
@@ -285,7 +279,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		r.recorder.Event(&externalSecret, v1.EventTypeWarning, esv1beta1.ReasonUpdateFailed, err.Error())
 		conditionSynced := NewExternalSecretCondition(esv1beta1.ExternalSecretReady, v1.ConditionFalse, esv1beta1.ConditionReasonSecretSyncedError, errUpdateSecret)
 		SetExternalSecretCondition(&externalSecret, *conditionSynced)
-		syncCallsError.With(syncCallsMetricLabels).Inc()
+		syncCallsError.With(resourceLabels).Inc()
 		return ctrl.Result{}, err
 	}
 
@@ -295,7 +289,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	SetExternalSecretCondition(&externalSecret, *conditionSynced)
 	externalSecret.Status.RefreshTime = metav1.NewTime(time.Now())
 	externalSecret.Status.SyncedResourceVersion = getResourceVersion(externalSecret)
-	syncCallsTotal.With(syncCallsMetricLabels).Inc()
 	if currCond == nil || currCond.Status != conditionSynced.Status {
 		log.Info("reconciled secret") // Log once if on success in any verbosity
 	} else {

--- a/pkg/controllers/externalsecret/externalsecret_controller.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller.go
@@ -130,15 +130,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, nil
 	}
 
-	// patch status when done processing
-	p := client.MergeFrom(externalSecret.DeepCopy())
-	defer func() {
-		err = r.Status().Patch(ctx, &externalSecret, p)
-		if err != nil {
-			log.Error(err, errPatchStatus)
-		}
-	}()
-
 	refreshInt := r.RequeueInterval
 	if externalSecret.Spec.RefreshInterval != nil {
 		refreshInt = externalSecret.Spec.RefreshInterval.Duration
@@ -175,6 +166,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			Requeue:      false,
 		}, nil
 	}
+
+	// patch status when done processing
+	p := client.MergeFrom(externalSecret.DeepCopy())
+	defer func() {
+		err = r.Status().Patch(ctx, &externalSecret, p)
+		if err != nil {
+			log.Error(err, errPatchStatus)
+		}
+	}()
 
 	secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controllers/externalsecret/externalsecret_controller_test.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller_test.go
@@ -296,7 +296,8 @@ var _ = Describe("ExternalSecret controller", func() {
 			Eventually(func() bool {
 				Expect(syncCallsTotal.WithLabelValues(ExternalSecretName, ExternalSecretNamespace).Write(&metric)).To(Succeed())
 				Expect(externalSecretReconcileDuration.WithLabelValues(ExternalSecretName, ExternalSecretNamespace).Write(&metricDuration)).To(Succeed())
-				return metric.GetCounter().GetValue() == 1.0 && metricDuration.GetGauge().GetValue() > 0.0
+				// three reconciliations: initial sync, status update, secret update
+				return metric.GetCounter().GetValue() >= 2.0 && metricDuration.GetGauge().GetValue() > 0.0
 			}, timeout, interval).Should(BeTrue())
 		}
 	}


### PR DESCRIPTION
Two small changes:

#### 1. defer patch status update
Adressing #1725 

This improves reconciliation duration when the controller pod is restarted.
Previously, the `status` update is patched every time even if the controller didn't do anything at all.
This PR defers the status update after the controller has examined if an update is needed.

More info in this comment: https://github.com/external-secrets/external-secrets/issues/1725#issuecomment-1326873699

![eso-perf](https://user-images.githubusercontent.com/1709030/204897376-0b43d01e-d5c1-4239-bc5e-af7c68209490.png)


<summary>
loadtest setup snippet
<details>

This script creates 1 CES with 1000 ES pointing to it.
Then restart controller and see how long it takes to reconcile all resources.
 
```bash
#!/usr/bin/env bash

helm upgrade --install prometheus prometheus-community/kube-prometheus-stack
helm upgrade --install foobar ./deploy/charts/external-secrets/ \
  --set serviceMonitor.enabled=true \
  --set concurrent=10 \
  --set serviceMonitor.additionalLabels.release=prometheus

kubectl apply -f - <<EOF
apiVersion: external-secrets.io/v1beta1
kind: ClusterSecretStore
metadata:
  name: fake
spec:
  provider:
    fake:
      data:
      - key: "/foo/bar"
        value: "Zm9vOiBiYXIKYmF6OgogIGJhbmc6CiAgICBib286IG5lc3RlZA=="
        version: "v1"
EOF

for i in $(seq 1 1000); do
  echo $i
  kubectl apply -f - <<EOF
apiVersion: external-secrets.io/v1beta1
kind: ExternalSecret
metadata:
  name: example-${i}
  labels:
    loadtest: "true"
spec:
  refreshInterval: "30m"
  secretStoreRef:
    name: fake
    kind: ClusterSecretStore
  target:
    name: "fart-${i}"
    template:
      metadata:
        annotations:
          "foo": "{{ \$obj := .foo_bar_v1 | b64dec | fromYaml -}}{{ \$obj.baz.bang.boo }}"
      data:
        my_nested_val: |
          {{ \$obj := .foo_bar_v1 | b64dec | fromYaml -}}
          {{ \$obj.baz.bang.boo }}
  data:
  - secretKey: foo_bar_v1
    remoteRef:
      key: /foo/bar
      version: v1
EOF
done
```
</details>
</summary>


---

#### fix sync calls metric

The sync calls metric isn't incremented correctly, see 668a10ea8178211a850e3351301e8d3325ff03fd.
Fixes #1722