### PR TITLE
fix: e2e permissions

### DIFF
--- a/.github/workflows/e2e-managed.yml
+++ b/.github/workflows/e2e-managed.yml
@@ -4,6 +4,7 @@ on:
 
 permissions:
   id-token: write
+  checks: write
   contents: read
 
 env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   id-token: write
+  checks: write
   contents: read
 
 name: e2e tests


### PR DESCRIPTION
add `checks:write` permissions to allow updating the status check.

the e2e test permissions are broken, currently. they run but they do not update the GitHub status check in the PR.