### PR TITLE
Add note on required Service Account roles.

### DIFF
--- a/docs/provider/google-secrets-manager.md
+++ b/docs/provider/google-secrets-manager.md
@@ -80,6 +80,8 @@ You just need to set the `projectID`, all other fields can be omitted.
 ### GCP Service Account authentication
 
 You can use [GCP Service Account](https://cloud.google.com/iam/docs/service-accounts) to authenticate with GCP. These are static, long-lived credentials. A GCP Service Account is a JSON file that needs to be stored in a `Kind=Secret`. ESO will use that Secret to authenticate with GCP. See here how you [manage GCP Service Accounts](https://cloud.google.com/iam/docs/creating-managing-service-accounts).
+After creating a GCP Service acount go to `IAM & Admin` web UI, click `ADD ANOTHER ROLE` button, add `Secret Manager Secret Accessor` role to this service account.
+The `Secret Manager Secret Accessor` role is required to access secrets.
 
 ```yaml
 {% include 'gcpsm-credentials-secret.yaml' %}


### PR DESCRIPTION
I wasted a couple of hours to figure out that this documentation only works with the correct roles attached to the GCP Service account as described here:  https://stackoverflow.com/a/63240340

Adding a hint to the docs could make it more accessible for others.

Signed-off-by: Jakob Kolb <jakob.j.kolb@gmail.com>