### PR TITLE
fix: replace bad URLs

### DIFF
--- a/.github/PAUL.yaml
+++ b/.github/PAUL.yaml
@@ -43,8 +43,8 @@ pull_requests:
     Greetings!
     Thank you for contributing to this project!
     If this is your first time contributing, please make
-    sure to read the [Developer](https://www.external-secrets.io/latest/contributing-devguide/) and [Contributing Process](https://www.external-secrets.io/latest/contributing-process/) guides.
-    Please also mind and follow our [Code of Conduct](https://www.external-secrets.io/latest/contributing-coc/).
+    sure to read the [Developer](https://external-secrets.io/latest/contributing/devguide/) and [Contributing Process](https://external-secrets.io/latest/contributing/process/) guides.
+    Please also mind and follow our [Code of Conduct](https://external-secrets.io/latest/contributing/coc/).
 
     Useful commands:
       - `make fmt`: Formats the code


### PR DESCRIPTION
With recent changes in the documentation, the URLs have changed and links need to be replaced.