### PR TITLE
feat: add fossa check

### DIFF
--- a/.github/workflows/dlc.yml
+++ b/.github/workflows/dlc.yml
@@ -1,49 +1,25 @@
 name: Dependency License Checks
 
 on:
-  push:
-    branches:
-      - main
-      - release-*
-    paths:
-      - "go.mod"
   pull_request:
     paths:
       - "go.mod"
   workflow_dispatch: {}
 
 jobs:
-  license-check:
+  fossa-scan:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: "Checkout Code"
         uses: actions/checkout@v3
 
-      - name: Setup Go
-        uses: actions/setup-go@v3
+      - name: "Run FOSSA Scan"
+        uses: fossas/fossa-action@main
         with:
-          go-version-file: "go.mod"
+          api-key: ${{secrets.FOSSA_API_KEY}}
 
-      - name: Find the Go Cache
-        id: go
-        run: |
-          echo "::set-output name=build-cache::$(go env GOCACHE)"
-          echo "::set-output name=mod-cache::$(go env GOMODCACHE)"
-      - name: Cache the Go Build Cache
-        uses: actions/cache@v3
+      - name: "Run FOSSA Test"
+        uses: fossas/fossa-action@main
         with:
-          path: ${{ steps.go.outputs.build-cache }}
-          key: ${{ runner.os }}-build-check-diff-${{ github.sha }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-build-check-diff-${{ github.sha }}-
-
-      - name: Cache Go Dependencies
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.go.outputs.mod-cache }}
-          key: ${{ runner.os }}-pkg-${{ github.sha }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-pkg-${{ github.sha }}-
-
-      - name: License Checks
-        run: |
-          go install github.com/google/go-licenses@latest
-          make license.check
+          api-key: ${{secrets.FOSSA_API_KEY}}
+          run-tests: true

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,6 @@ export IMAGE_REGISTRY ?= ghcr.io
 export IMAGE_REPO     ?= external-secrets/external-secrets
 export IMAGE_NAME ?= $(IMAGE_REGISTRY)/$(IMAGE_REPO)
 
-#Valid licenses for license.check
-LICENSES ?= Apache-2.0|MIT|BSD-3-Clause|ISC|MPL-2.0|BSD-2-Clause
 BUNDLE_DIR     ?= deploy/crds
 CRD_DIR     ?= config/crds
 
@@ -77,19 +75,6 @@ FAIL	= (echo ${TIME} ${RED}[FAIL]${CNone} && false)
 reviewable: generate docs manifests helm.generate helm.docs lint ## Ensure a PR is ready for review.
 	@go mod tidy
 	@cd e2e/ && go mod tidy
-
-golicenses.check: ## Check install of go-licenses
-	@if ! go-licenses >> /dev/null 2>&1; then \
-		echo -e "\033[0;33mgo-licenses is not installed: run go install github.com/google/go-licenses@latest" ; \
-		exit 1; \
-	fi
-
-license.check: golicenses.check
-	@$(INFO) running dependency license checks
-	@ok=0; go-licenses csv github.com/external-secrets/external-secrets 2>/dev/null | \
-	 grep -v -E '${LICENSES}' | \
-	 tr "," " " | awk '{print "Invalid License " $$3 " for dependency " $$1 }'|| ok=1; \
-	 if [[ $$ok -eq 1 ]]; then $(OK) dependencies are compliant; else $(FAIL); fi
 
 check-diff: reviewable ## Ensure branch is clean.
 	@$(INFO) checking that branch is clean


### PR DESCRIPTION
relates to: https://github.com/external-secrets/external-secrets/issues/1820

chore: add fossa check to CI to ensure License compatibility.

Note: we need to investigate MPL compatilibity with CNCF; all `github.com/hashicorp/*` dependencies use MPL-2.0 :sweat: 

Working towards: https://github.com/cncf/toc/issues/882