### PR TITLE
Use the right metrics annotations for the webhook service

### DIFF
--- a/deploy/charts/external-secrets/templates/webhook-service.yaml
+++ b/deploy/charts/external-secrets/templates/webhook-service.yaml
@@ -13,7 +13,7 @@ metadata:
     prometheus.io/scrape: "true"
     prometheus.io/port: {{ .Values.prometheus.service.port | quote }}
   {{- else }}
-  {{- with .Values.metrics.service.annotations }}
+  {{- with .Values.webhook.metrics.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
Hi!

I think there is a typo here, leading to adding `.Values.metrics.service.annotations` to the webhook service, even with `webhook.metrics.service.enabled` set to false.

Also currently `webhook.metrics.service.annotations` is ignored.