### PR TITLE
feat: referent auth for gcp

### DIFF
--- a/docs/introduction/stability-support.md
+++ b/docs/introduction/stability-support.md
@@ -49,7 +49,7 @@ The following table show the support for features across different providers.
 | AWS Secrets Manager       |      x       |      x       |                      |                         |        x         |             |
 | AWS Parameter Store       |      x       |      x       |                      |                         |        x         |             |
 | Hashicorp Vault           |      x       |      x       |                      |                         |        x         |             |
-| GCP Secret Manager        |      x       |      x       |                      |                         |        x         |             |
+| GCP Secret Manager        |      x       |      x       |                      |            x            |        x         |             |
 | Azure Keyvault            |      x       |      x       |          x           |            x            |        x         |             |
 | Kubernetes                |      x       |      x       |                      |            x            |        x         |             |
 | IBM Cloud Secrets Manager |              |              |                      |                         |        x         |             |

--- a/e2e/suites/provider/cases/gcp/gcp.go
+++ b/e2e/suites/provider/cases/gcp/gcp.go
@@ -29,39 +29,60 @@ import (
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 )
 
+const (
+	withStaticAuth         = "with service account"
+	withReferentStaticAuth = "with service acount from referent namespace"
+)
+
 // This test uses the global ESO.
 var _ = Describe("[gcp]", Label("gcp", "secretsmanager"), func() {
 	f := framework.New("eso-gcp")
 	prov := NewFromEnv(f, "")
 
 	DescribeTable("sync secrets", framework.TableFunc(f, prov),
-		Entry(common.SimpleDataSync(f)),
-		Entry(common.JSONDataWithProperty(f)),
-		Entry(common.JSONDataFromSync(f)),
-		Entry(common.JSONDataFromRewrite(f)),
-		Entry(common.NestedJSONWithGJSON(f)),
-		Entry(common.JSONDataWithTemplate(f)),
-		Entry(common.DockerJSONConfig(f)),
-		Entry(common.DataPropertyDockerconfigJSON(f)),
-		Entry(common.SSHKeySync(f)),
-		Entry(common.SSHKeySyncDataProperty(f)),
-		Entry(common.SyncWithoutTargetName(f)),
-		Entry(common.JSONDataWithoutTargetName(f)),
-		Entry(common.FindByName(f)),
-		Entry(common.FindByNameAndRewrite(f)),
-		Entry(common.FindByNameWithPath(f)),
-		Entry(common.FindByTag(f)),
-		Entry(common.FindByTagWithPath(f)),
-		Entry(common.SyncV1Alpha1(f)),
-		Entry("should sync p12 encoded cert secret", p12Cert),
+		framework.Compose(withStaticAuth, f, common.SimpleDataSync, useStaticAuth),
+		framework.Compose(withStaticAuth, f, common.JSONDataWithProperty, useStaticAuth),
+		framework.Compose(withStaticAuth, f, common.JSONDataFromSync, useStaticAuth),
+		framework.Compose(withStaticAuth, f, common.JSONDataFromRewrite, useStaticAuth),
+		framework.Compose(withStaticAuth, f, common.NestedJSONWithGJSON, useStaticAuth),
+		framework.Compose(withStaticAuth, f, common.JSONDataWithTemplate, useStaticAuth),
+		framework.Compose(withStaticAuth, f, common.DockerJSONConfig, useStaticAuth),
+		framework.Compose(withStaticAuth, f, common.DataPropertyDockerconfigJSON, useStaticAuth),
+		framework.Compose(withStaticAuth, f, common.SSHKeySync, useStaticAuth),
+		framework.Compose(withStaticAuth, f, common.SSHKeySyncDataProperty, useStaticAuth),
+		framework.Compose(withStaticAuth, f, common.SyncWithoutTargetName, useStaticAuth),
+		framework.Compose(withStaticAuth, f, common.JSONDataWithoutTargetName, useStaticAuth),
+		framework.Compose(withStaticAuth, f, common.FindByName, useStaticAuth),
+		framework.Compose(withStaticAuth, f, common.FindByNameAndRewrite, useStaticAuth),
+		framework.Compose(withStaticAuth, f, common.FindByNameWithPath, useStaticAuth),
+		framework.Compose(withStaticAuth, f, common.FindByTag, useStaticAuth),
+		framework.Compose(withStaticAuth, f, common.FindByTagWithPath, useStaticAuth),
+		framework.Compose(withStaticAuth, f, common.SyncV1Alpha1, useStaticAuth),
+		framework.Compose(withStaticAuth, f, p12Cert, useStaticAuth),
+
+		// referent auth
+		framework.Compose(withReferentStaticAuth, f, common.SimpleDataSync, useReferentAuth),
 	)
 })
 
+func useStaticAuth(tc *framework.TestCase) {
+	tc.ExternalSecret.Spec.SecretStoreRef.Name = tc.Framework.Namespace.Name
+	if tc.ExternalSecretV1Alpha1 != nil {
+		tc.ExternalSecretV1Alpha1.Spec.SecretStoreRef.Name = tc.Framework.Namespace.Name
+	}
+}
+
+func useReferentAuth(tc *framework.TestCase) {
+	tc.ExternalSecret.Spec.SecretStoreRef.Name = referentName(tc.Framework)
+	tc.ExternalSecret.Spec.SecretStoreRef.Kind = esv1beta1.ClusterSecretStoreKind
+}
+
 // P12Cert case creates a secret with a p12 cert containing a privkey and cert bundled together.
 // It uses templating to generate a k8s secret of type tls with pem values.
-var p12Cert = func(tc *framework.TestCase) {
-	cloudSecretName := fmt.Sprintf("%s-%s", tc.Framework.Namespace.Name, "p12-cert-example")
-	certPEM := `-----BEGIN CERTIFICATE-----
+func p12Cert(f *framework.Framework) (string, func(*framework.TestCase)) {
+	return "should sync p12 encoded cert secret", func(tc *framework.TestCase) {
+		cloudSecretName := fmt.Sprintf("%s-%s", tc.Framework.Namespace.Name, "p12-cert-example")
+		certPEM := `-----BEGIN CERTIFICATE-----
 MIIFQjCCBCqgAwIBAgISBHszg5W2maz/7CIxGrf7mqukMA0GCSqGSIb3DQEBCwUA
 MDIxCzAJBgNVBAYTAlVTMRYwFAYDVQQKEw1MZXQncyBFbmNyeXB0MQswCQYDVQQD
 EwJSMzAeFw0yMTA3MjQxMjQyMzNaFw0yMTEwMjIxMjQyMzFaMCgxJjAkBgNVBAMT
@@ -93,7 +114,7 @@ XMYitHfpGhc+DTTiTWMQ13J0b1j4yv8A7ZaG2366aa28oSTD6eQFhmVCBwa54j++
 IOwzHn5R
 -----END CERTIFICATE-----
 `
-	privkeyPEM := `-----BEGIN PRIVATE KEY-----
+		privkeyPEM := `-----BEGIN PRIVATE KEY-----
 MIIEwAIBADANBgkqhkiG9w0BAQEFAASCBKowggSmAgEAAoIBAQDJFE51myQDyqca
 egyBDlHLkxVj+WCjcfOWEqrTa7bcnbDXjD4uIRTaFxIkpi/k5fKxt+rszna7bNdh
 lezqSuRBmVg2kXDul5nQm1RtWRKlJP9fhvUYkoNKRGzt9OL6/6lv05P2tNu13yN8
@@ -122,40 +143,41 @@ Jdx0ECYawviQoreDAyIXV6HouoeRbDtLZ9AJvxMoIjGcjAR2FQHc3yx4h/lf3Tfx
 x6HaRh+EUwU51von6M9lEF9/p5Q=
 -----END PRIVATE KEY-----
 `
-	blockCert, _ := pem.Decode([]byte(certPEM))
-	cert, _ := x509.ParseCertificate(blockCert.Bytes)
-	blockPrivKey, _ := pem.Decode([]byte(privkeyPEM))
-	privkey, _ := x509.ParsePKCS8PrivateKey(blockPrivKey.Bytes)
-	emptyCACerts := []*x509.Certificate{}
-	p12Cert, _ := p12.Encode(rand.Reader, privkey, cert, emptyCACerts, "")
+		blockCert, _ := pem.Decode([]byte(certPEM))
+		cert, _ := x509.ParseCertificate(blockCert.Bytes)
+		blockPrivKey, _ := pem.Decode([]byte(privkeyPEM))
+		privkey, _ := x509.ParsePKCS8PrivateKey(blockPrivKey.Bytes)
+		emptyCACerts := []*x509.Certificate{}
+		p12Cert, _ := p12.Encode(rand.Reader, privkey, cert, emptyCACerts, "")
 
-	tc.Secrets = map[string]framework.SecretEntry{
-		cloudSecretName: {Value: string(p12Cert)},
-	}
+		tc.Secrets = map[string]framework.SecretEntry{
+			cloudSecretName: {Value: string(p12Cert)},
+		}
 
-	tc.ExpectedSecret = &v1.Secret{
-		Type: v1.SecretTypeTLS,
-		Data: map[string][]byte{
-			"tls.crt": []byte(certPEM),
-			"tls.key": []byte(privkeyPEM),
-		},
-	}
-
-	tc.ExternalSecret.Spec.Data = []esv1beta1.ExternalSecretData{
-		{
-			SecretKey: "mysecret",
-			RemoteRef: esv1beta1.ExternalSecretDataRemoteRef{
-				Key: cloudSecretName,
+		tc.ExpectedSecret = &v1.Secret{
+			Type: v1.SecretTypeTLS,
+			Data: map[string][]byte{
+				"tls.crt": []byte(certPEM),
+				"tls.key": []byte(privkeyPEM),
 			},
-		},
-	}
+		}
 
-	tc.ExternalSecret.Spec.Target.Template = &esv1beta1.ExternalSecretTemplate{
-		Type:          v1.SecretTypeTLS,
-		EngineVersion: esv1beta1.TemplateEngineV1,
-		Data: map[string]string{
-			"tls.crt": "{{ .mysecret | pkcs12cert | pemCertificate }}",
-			"tls.key": "{{ .mysecret | pkcs12key | pemPrivateKey }}",
-		},
+		tc.ExternalSecret.Spec.Data = []esv1beta1.ExternalSecretData{
+			{
+				SecretKey: "mysecret",
+				RemoteRef: esv1beta1.ExternalSecretDataRemoteRef{
+					Key: cloudSecretName,
+				},
+			},
+		}
+
+		tc.ExternalSecret.Spec.Target.Template = &esv1beta1.ExternalSecretTemplate{
+			Type:          v1.SecretTypeTLS,
+			EngineVersion: esv1beta1.TemplateEngineV1,
+			Data: map[string]string{
+				"tls.crt": "{{ .mysecret | pkcs12cert | pemCertificate }}",
+				"tls.key": "{{ .mysecret | pkcs12key | pemPrivateKey }}",
+			},
+		}
 	}
 }

--- a/pkg/controllers/secretstore/common.go
+++ b/pkg/controllers/secretstore/common.go
@@ -99,7 +99,6 @@ func validateStore(ctx context.Context, namespace, controllerClass string, store
 		recorder.Event(store, v1.EventTypeWarning, esapi.ReasonInvalidProviderConfig, err.Error())
 		return fmt.Errorf(errStoreClient, err)
 	}
-
 	validationResult, err := cl.Validate()
 	if err != nil && validationResult != esapi.ValidationResultUnknown {
 		cond := NewSecretStoreCondition(esapi.SecretStoreReady, v1.ConditionFalse, esapi.ReasonValidationFailed, errUnableValidateStore)

--- a/pkg/provider/gcp/secretmanager/auth.go
+++ b/pkg/provider/gcp/secretmanager/auth.go
@@ -33,7 +33,6 @@ func NewTokenSource(ctx context.Context, auth esv1beta1.GCPSMAuth, projectID str
 	}
 	wi, err := newWorkloadIdentity(ctx, projectID)
 	if err != nil {
-		useMu.Unlock()
 		return nil, fmt.Errorf("unable to initialize workload identity")
 	}
 	ts, err = wi.TokenSource(ctx, auth, isClusterKind, kube, namespace)
@@ -54,14 +53,8 @@ func serviceAccountTokenSource(ctx context.Context, auth esv1beta1.GCPSMAuth, is
 		Name:      credentialsSecretName,
 		Namespace: namespace,
 	}
-
-	// only ClusterStore is allowed to set namespace (and then it's required)
-	if isClusterKind {
-		if credentialsSecretName != "" && sr.SecretAccessKey.Namespace == nil {
-			return nil, fmt.Errorf(errInvalidClusterStoreMissingSAKNamespace)
-		} else if credentialsSecretName != "" {
-			objectKey.Namespace = *sr.SecretAccessKey.Namespace
-		}
+	if isClusterKind && sr.SecretAccessKey.Namespace != nil {
+		objectKey.Namespace = *sr.SecretAccessKey.Namespace
 	}
 	err := kube.Get(ctx, objectKey, credentialsSecret)
 	if err != nil {

--- a/pkg/provider/gcp/secretmanager/client.go
+++ b/pkg/provider/gcp/secretmanager/client.go
@@ -38,21 +38,19 @@ import (
 )
 
 const (
-	CloudPlatformRole                         = "https://www.googleapis.com/auth/cloud-platform"
-	defaultVersion                            = "latest"
-	errGCPSMStore                             = "received invalid GCPSM SecretStore resource"
-	errUnableGetCredentials                   = "unable to get credentials: %w"
-	errClientClose                            = "unable to close SecretManager client: %w"
-	errMissingStoreSpec                       = "invalid: missing store spec"
-	errInvalidClusterStoreMissingSAKNamespace = "invalid ClusterSecretStore: missing GCP SecretAccessKey Namespace"
-	errInvalidClusterStoreMissingSANamespace  = "invalid ClusterSecretStore: missing GCP Service Account Namespace"
-	errFetchSAKSecret                         = "could not fetch SecretAccessKey secret: %w"
-	errMissingSAK                             = "missing SecretAccessKey"
-	errUnableProcessJSONCredentials           = "failed to process the provided JSON credentials: %w"
-	errUnableCreateGCPSMClient                = "failed to create GCP secretmanager client: %w"
-	errUninitalizedGCPProvider                = "provider GCP is not initialized"
-	errClientGetSecretAccess                  = "unable to access Secret from SecretManager Client: %w"
-	errJSONSecretUnmarshal                    = "unable to unmarshal secret: %w"
+	CloudPlatformRole               = "https://www.googleapis.com/auth/cloud-platform"
+	defaultVersion                  = "latest"
+	errGCPSMStore                   = "received invalid GCPSM SecretStore resource"
+	errUnableGetCredentials         = "unable to get credentials: %w"
+	errClientClose                  = "unable to close SecretManager client: %w"
+	errMissingStoreSpec             = "invalid: missing store spec"
+	errFetchSAKSecret               = "could not fetch SecretAccessKey secret: %w"
+	errMissingSAK                   = "missing SecretAccessKey"
+	errUnableProcessJSONCredentials = "failed to process the provided JSON credentials: %w"
+	errUnableCreateGCPSMClient      = "failed to create GCP secretmanager client: %w"
+	errUninitalizedGCPProvider      = "provider GCP is not initialized"
+	errClientGetSecretAccess        = "unable to access Secret from SecretManager Client: %w"
+	errJSONSecretUnmarshal          = "unable to unmarshal secret: %w"
 
 	errInvalidStore           = "invalid store"
 	errInvalidStoreSpec       = "invalid store spec"
@@ -64,9 +62,10 @@ const (
 )
 
 type Client struct {
-	smClient GoogleSecretManagerClient
-	kube     kclient.Client
-	store    *esv1beta1.GCPSMProvider
+	smClient  GoogleSecretManagerClient
+	kube      kclient.Client
+	store     *esv1beta1.GCPSMProvider
+	storeKind string
 
 	// namespace of the external secret
 	namespace        string
@@ -404,5 +403,8 @@ func (c *Client) Close(ctx context.Context) error {
 }
 
 func (c *Client) Validate() (esv1beta1.ValidationResult, error) {
+	if c.storeKind == esv1beta1.ClusterSecretStoreKind && isReferentSpec(c.store) {
+		return esv1beta1.ValidationResultUnknown, nil
+	}
 	return esv1beta1.ValidationResultReady, nil
 }

--- a/pkg/provider/gcp/secretmanager/workload_identity.go
+++ b/pkg/provider/gcp/secretmanager/workload_identity.go
@@ -105,10 +105,7 @@ func (w *workloadIdentity) TokenSource(ctx context.Context, auth esv1beta1.GCPSM
 	}
 
 	// only ClusterStore is allowed to set namespace (and then it's required)
-	if isClusterKind {
-		if wi.ServiceAccountRef.Namespace == nil {
-			return nil, fmt.Errorf(errInvalidClusterStoreMissingSANamespace)
-		}
+	if isClusterKind && wi.ServiceAccountRef.Namespace != nil {
 		saKey.Namespace = *wi.ServiceAccountRef.Namespace
 	}
 

--- a/pkg/provider/gcp/secretmanager/workload_identity_test.go
+++ b/pkg/provider/gcp/secretmanager/workload_identity_test.go
@@ -83,8 +83,8 @@ func TestWorkloadIdentity(t *testing.T) {
 			}),
 		),
 		composeTestcase(
-			defaultTestCase("invalid ClusterSecretStore: missing service account namespace"),
-			expErr("invalid ClusterSecretStore: missing GCP Service Account Namespace"),
+			defaultTestCase("ClusterSecretStore: referent auth / service account without namespace"),
+			expTokenSource(),
 			withStore(
 				composeStore(defaultClusterStore()),
 			),
@@ -92,6 +92,22 @@ func TestWorkloadIdentity(t *testing.T) {
 				&v1.ServiceAccount{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        "example",
+						Namespace:   "default",
+						Annotations: map[string]string{},
+					},
+				},
+			}),
+		),
+		composeTestcase(
+			defaultTestCase("ClusterSecretStore: invalid service account"),
+			expErr("foobar"),
+			withStore(
+				composeStore(defaultClusterStore()),
+			),
+			withK8sResources([]client.Object{
+				&v1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "does not exist",
 						Namespace:   "default",
 						Annotations: map[string]string{},
 					},


### PR DESCRIPTION
This PR allows using referent auth with the gcp provider. Towards #961 

TODO:
- [x] implement referent auth
- [x] e2e tests
- [x] docs