### PR TITLE
fix: prevent goroutine leak on workload identity reconciliation

### DIFF
--- a/pkg/provider/gcp/secretmanager/auth.go
+++ b/pkg/provider/gcp/secretmanager/auth.go
@@ -36,6 +36,7 @@ func NewTokenSource(ctx context.Context, auth esv1beta1.GCPSMAuth, projectID str
 		useMu.Unlock()
 		return nil, fmt.Errorf("unable to initialize workload identity")
 	}
+	defer wi.Close()
 	ts, err = wi.TokenSource(ctx, auth, isClusterKind, kube, namespace)
 	if ts != nil || err != nil {
 		return ts, err

--- a/pkg/provider/gcp/secretmanager/workload_identity.go
+++ b/pkg/provider/gcp/secretmanager/workload_identity.go
@@ -78,11 +78,11 @@ type saTokenGenerator interface {
 }
 
 func newWorkloadIdentity(ctx context.Context, projectID string) (*workloadIdentity, error) {
-	iamc, err := newIAMClient(ctx)
+	satg, err := newSATokenGenerator()
 	if err != nil {
 		return nil, err
 	}
-	satg, err := newSATokenGenerator()
+	iamc, err := newIAMClient(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
https://github.com/external-secrets/external-secrets/issues/1901

This PR fixes the issue by calling `workloadIdentity.Close` because it seems not to be called from anywhere.
Then, I confirmed that `go_goroutine` did not increase on applying an `ExternalSecret` CR to my GKE cluster.