### PR TITLE
fix: explicitly use new kubectl gcp auth

### DIFF
--- a/.github/actions/e2e-managed/action.yml
+++ b/.github/actions/e2e-managed/action.yml
@@ -107,6 +107,7 @@ runs:
       with:
         service_account_key: ${{ env.GCP_SM_SA_GKE_JSON }}
         project_id: ${{ env.GCP_PROJECT_ID }}
+        install_components: 'gke-gcloud-auth-plugin'
 
     - name: Get the GKE credentials
       shell: bash

--- a/.github/workflows/e2e-managed.yml
+++ b/.github/workflows/e2e-managed.yml
@@ -19,6 +19,7 @@ env:
   GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
   GCP_SM_SA_JSON: ${{ secrets.GCP_SM_SA_JSON}}
   GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID}}
+  USE_GKE_GCLOUD_AUTH_PLUGIN: true
   TF_VAR_GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID}}
   GCP_SM_SA_GKE_JSON: ${{ secrets.GCP_SM_SA_GKE_JSON}}
   GCP_GKE_CLUSTER: test-cluster


### PR DESCRIPTION
fixes CI in this PR: https://github.com/external-secrets/external-secrets/issues/1902
GHA: https://github.com/external-secrets/external-secrets/actions/runs/3900100494/jobs/6660393056


during e2e-managed we encounter an error when trying to access the GKE cluster:

```
./run.sh
Kubernetes cluster:
[...]
"https://34.79.53.178/api?timeout=32s": getting credentials: exec: executable gke-gcloud-auth-plugin not found

It looks like you are trying to use a client-go credential plugin that is not installed.

To learn more about this feature, consult the documentation available at:
      https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins

Install gke-gcloud-auth-plugin for use with kubectl by following https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
[...]
"https://34.79.53.178/api?timeout=32s": getting credentials: exec: executable gke-gcloud-auth-plugin not found
```

This PR installs the credential component and enables it. [See docs](https://github.com/google-github-actions/setup-gcloud) and [related issue](https://github.com/google-github-actions/setup-gcloud/issues/561) for context.

This PR can not be tested from a PR branch, it has to be merged into main. Gonna rebase #1902 and re-test there.