### PR TITLE
chore: use more inclusive language

### DIFF
--- a/pkg/provider/azure/keyvault/keyvault_test.go
+++ b/pkg/provider/azure/keyvault/keyvault_test.go
@@ -828,7 +828,7 @@ func TestAzureKeyVaultSecretManagerGetSecret(t *testing.T) {
 		smtc.secretName = "name"
 		smtc.expectedSecret = ""
 		smtc.expectError = fmt.Sprintf("unknown Azure Keyvault object Type for %s", smtc.secretName)
-		smtc.ref.Key = fmt.Sprintf("dummy/%s", smtc.secretName)
+		smtc.ref.Key = fmt.Sprintf("example/%s", smtc.secretName)
 	}
 
 	setSecretWithTag := func(smtc *secretManagerTestCase) {
@@ -1170,7 +1170,7 @@ func TestAzureKeyVaultSecretManagerGetSecretMap(t *testing.T) {
 		smtc.secretName = "name"
 		smtc.expectedSecret = ""
 		smtc.expectError = fmt.Sprintf("unknown Azure Keyvault object Type for %s", smtc.secretName)
-		smtc.ref.Key = fmt.Sprintf("dummy/%s", smtc.secretName)
+		smtc.ref.Key = fmt.Sprintf("example/%s", smtc.secretName)
 	}
 
 	setSecretTags := func(smtc *secretManagerTestCase) {

--- a/pkg/provider/gcp/secretmanager/provider.go
+++ b/pkg/provider/gcp/secretmanager/provider.go
@@ -85,7 +85,7 @@ func (p *Provider) NewClient(ctx context.Context, store esv1beta1.GenericStore, 
 	// allow SecretStore controller validation to pass
 	// when using referent namespace.
 	if namespace == "" && isClusterKind && isReferentSpec(gcpStore) {
-		// dummy smClient to prevent closing the client twice
+		// placeholder smClient to prevent closing the client twice
 		client.smClient, _ = secretmanager.NewClient(ctx, option.WithTokenSource(oauth2.StaticTokenSource(&oauth2.Token{})))
 		return client, nil
 	}


### PR DESCRIPTION
Our organisation requires us to scan all third-party applications that we use for inclusive language, and where possible provide upstream fixes for these.

If you're happy with these changes we can create more for other issues.