### PR TITLE
Update docs for AWS Parameter Store provider

### DIFF
--- a/docs/provider/aws-parameter-store.md
+++ b/docs/provider/aws-parameter-store.md
@@ -30,6 +30,7 @@ Create a IAM Policy to pin down access to secrets matching `dev-*`, for further 
     {
       "Effect": "Allow",
       "Action": [
+        "ssm:GetParameter",
         "ssm:GetParameterWithContext",
         "ssm:ListTagsForResourceWithContext",
         "ssm:DescribeParametersWithContext",


### PR DESCRIPTION
### Description
The policy from the documentation didn't work for me when using AWS Parameter Store as a `ClusterSecretStore`. I'm running ESO (v0.7.2) on EKS, using credentials from IRSA, and I was getting the following error:
```
AccessDeniedException: User: arn:aws:sts::<>:assumed-role/external-secrets-dev/external-secrets-provider-aws is not authorized to perform: ssm:GetParameter on resource ...
```
I fixed it by adding the `ssm:GetParameter` permission on my policy.

### Changes

- Updated IAM policy for AWS Parameter Store provider