### PR TITLE
:bug: remove cgo in boringcrypto build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,7 @@ jobs:
           build-platform: "linux/amd64,linux/arm64"
           tag-suffix: "-ubi"
         - dockerfile: "Dockerfile.ubi"
-          build-args: "CGO_ENABLED=1 GOEXPERIMENT=boringcrypto"
+          build-args: "CGO_ENABLED=0 GOEXPERIMENT=boringcrypto"
           build-arch: "amd64"
           build-platform: "linux/amd64"
           tag-suffix: "-ubi-boringssl"

--- a/.github/workflows/rebuild-image.yml
+++ b/.github/workflows/rebuild-image.yml
@@ -46,9 +46,9 @@ jobs:
           build-args: "CGO_ENABLED=0"
           build-arch: "amd64 arm64"
           build-platform: "linux/amd64,linux/arm64"
-          tag-suffix: "-ubi-${{ needs.checkout.outputs.timestamp }}" #ubi
+          tag-suffix: "-ubi-${{ needs.checkout.outputs.timestamp }}" # ubi
         - dockerfile: "Dockerfile.ubi"
-          build-args: "CGO_ENABLED=1 GOEXPERIMENT=boringcrypto" # fips
+          build-args: "CGO_ENABLED=0 GOEXPERIMENT=boringcrypto" # fips
           build-arch: "amd64"
           build-platform: "linux/amd64"
           tag-suffix: "-ubi-boringssl-${{ needs.checkout.outputs.timestamp }}"


### PR DESCRIPTION
There's no need to use cgo with go 1.19 `GOEXPERIMENT=boringcrypto`, hence this should be a simple fix for #1898.


Container built in this CI run can be run without issues:
```
ghcr.io/external-secrets/external-secrets:v0.7.2-10.g32c75c9e-ubi-boringssl@sha256:7a0d22eb5180ec75cfb00206ec33392ee10792cc68e1de5c104a250506866a1b
```

fixes #1898 