### PR TITLE
Support template for webhook jsonpath

### DIFF
--- a/pkg/provider/webhook/webhook.go
+++ b/pkg/provider/webhook/webhook.go
@@ -145,18 +145,18 @@ func (w *WebHook) GetSecret(ctx context.Context, ref esv1beta1.ExternalSecretDat
 	if err != nil {
 		return nil, err
 	}
-	resultJsonPath, err := executeTemplateString(provider.Result.JSONPath, data)
+	resultJSONPath, err := executeTemplateString(provider.Result.JSONPath, data)
 	if err != nil {
 		return nil, err
 	}
-	if resultJsonPath != "" {
+	if resultJSONPath != "" {
 		jsondata := interface{}(nil)
 		if err := yaml.Unmarshal(result, &jsondata); err != nil {
 			return nil, fmt.Errorf("failed to parse response json: %w", err)
 		}
-		jsondata, err = jsonpath.Get(resultJsonPath, jsondata)
+		jsondata, err = jsonpath.Get(resultJSONPath, jsondata)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get response path %s: %w", resultJsonPath, err)
+			return nil, fmt.Errorf("failed to get response path %s: %w", resultJSONPath, err)
 		}
 		jsonvalue, ok := jsondata.(string)
 		if !ok {

--- a/pkg/provider/webhook/webhook.go
+++ b/pkg/provider/webhook/webhook.go
@@ -141,14 +141,22 @@ func (w *WebHook) GetSecret(ctx context.Context, ref esv1beta1.ExternalSecretDat
 		return nil, err
 	}
 	// Only parse as json if we have a jsonpath set
-	if provider.Result.JSONPath != "" {
+	data, err := w.getTemplateData(ctx, ref, provider.Secrets)
+	if err != nil {
+		return nil, err
+	}
+	resultJsonPath, err := executeTemplateString(provider.Result.JSONPath, data)
+	if err != nil {
+		return nil, err
+	}
+	if resultJsonPath != "" {
 		jsondata := interface{}(nil)
 		if err := yaml.Unmarshal(result, &jsondata); err != nil {
 			return nil, fmt.Errorf("failed to parse response json: %w", err)
 		}
-		jsondata, err = jsonpath.Get(provider.Result.JSONPath, jsondata)
+		jsondata, err = jsonpath.Get(resultJsonPath, jsondata)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get response path %s: %w", provider.Result.JSONPath, err)
+			return nil, fmt.Errorf("failed to get response path %s: %w", resultJsonPath, err)
 		}
 		jsonvalue, ok := jsondata.(string)
 		if !ok {

--- a/pkg/provider/webhook/webhook_test.go
+++ b/pkg/provider/webhook/webhook_test.go
@@ -41,6 +41,7 @@ type args struct {
 	Body       string `json:"body,omitempty"`
 	Timeout    string `json:"timeout,omitempty"`
 	Key        string `json:"key,omitempty"`
+	Property   string `json:"property,omitempty"`
 	Version    string `json:"version,omitempty"`
 	JSONPath   string `json:"jsonpath,omitempty"`
 	Response   string `json:"response,omitempty"`
@@ -137,6 +138,7 @@ args:
   response: secret-value
 want:
   path: /api/getsecret?id=testkey&version=1
+  err: ''
   result: secret-value
 ---
 case: good json
@@ -148,6 +150,7 @@ args:
   response: '{"result":{"thesecret":"secret-value"}}'
 want:
   path: /api/getsecret?id=testkey&version=1
+  err: ''
   result: secret-value
 ---
 case: good json map
@@ -159,6 +162,7 @@ args:
   response: '{"result":{"thesecret":"secret-value","alsosecret":"another-value"}}'
 want:
   path: /api/getsecret?id=testkey&version=1
+  err: ''
   resultmap:
     thesecret: secret-value
     alsosecret: another-value
@@ -171,6 +175,7 @@ args:
   response: '{"thesecret":"secret-value","alsosecret":"another-value"}'
 want:
   path: /api/getsecret?id=testkey&version=1
+  err: ''
   resultmap:
     thesecret: secret-value
     alsosecret: another-value
@@ -201,6 +206,31 @@ want:
   resultmap:
     thesecret: secret-value
     alsosecret: another-value
+---
+case: good json with good templated jsonpath
+args:
+  url: /api/getsecret?id={{ .remoteRef.key }}&version={{ .remoteRef.version }}
+  key: testkey
+  property: thesecret
+  version: 1
+  jsonpath: $.result.{{ .remoteRef.property }}
+  response: '{"result":{"thesecret":"secret-value"}}'
+want:
+  path: /api/getsecret?id=testkey&version=1
+  err: ''
+  result: secret-value
+---
+case: good json with bad temlated jsonpath
+args:
+  url: /api/getsecret?id={{ .remoteRef.key }}&version={{ .remoteRef.version }}
+  key: testkey
+  property: thesecret
+  version: 1
+  jsonpath: $.result.{{ .remoteRef.property }
+  response: '{"result":{"thesecret":"secret-value"}}'
+want:
+  path: /api/getsecret?id=testkey&version=1
+  err: 'template: webhooktemplate:1: unexpected "}" in operand'
 `
 
 func TestWebhookGetSecret(t *testing.T) {
@@ -294,8 +324,9 @@ func testGetSecretMap(tc testCase, t *testing.T, client esv1beta1.SecretsClient)
 
 func testGetSecret(tc testCase, t *testing.T, client esv1beta1.SecretsClient) {
 	testRef := esv1beta1.ExternalSecretDataRemoteRef{
-		Key:     tc.Args.Key,
-		Version: tc.Args.Version,
+		Key:      tc.Args.Key,
+		Property: tc.Args.Property,
+		Version:  tc.Args.Version,
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()


### PR DESCRIPTION
According the docs, https://external-secrets.io/v0.7.2/provider/webhook/#all-parameters, jsonpath is supposed supporting templating.

But it's not. Here an example of error:
```
{"level":"error","ts":1674265983.2843204,"logger":"controllers.ExternalSecret","msg":"could not get secret data from provider","ExternalSecret":"TEST/test-ext-secret3","error":"failed to get response path $.data.login.{{ .remoteRef.property }}: parsing error: $.data.login.{{ .remoteRef.property }}\t:1:14 - 1:15 unexpected \"{\" while scanning JSON select expected Ident, \".\" or \"*\"","stacktrace":"github.com/external-secrets/external-secrets/pkg/controllers/externalsecret.(*Reconciler).Reconcile\n\t/home/tcohen/perso/gits/github.com/external-secrets/external-secrets/pkg/controllers/externalsecret/externalsecret_controller.go:190\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\t/home/tcohen/gits/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.1/pkg/internal/controller/controller.go:122\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/tcohen/gits/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.1/pkg/internal/controller/controller.go:323\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/tcohen/gits/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.1/pkg/internal/controller/controller.go:274\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/home/tcohen/gits/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.1/pkg/internal/controller/controller.go:235"}
```
with `jsonpath: $.data.login.{{ .remoteRef.property }}` set in the secretStore.

This PR fixes the issue