### PR TITLE
Add jsonpath filter support to webhook

### DIFF
--- a/pkg/provider/webhook/webhook.go
+++ b/pkg/provider/webhook/webhook.go
@@ -160,7 +160,14 @@ func (w *WebHook) GetSecret(ctx context.Context, ref esv1beta1.ExternalSecretDat
 		}
 		jsonvalue, ok := jsondata.(string)
 		if !ok {
-			return nil, fmt.Errorf("failed to get response (wrong type: %T)", jsondata)
+			jsonvalues, ok := jsondata.([]interface{})
+			if !ok {
+				return nil, fmt.Errorf("failed to get response (wrong type: %T)", jsondata)
+			}
+			if len(jsonvalues) == 0 {
+				return nil, fmt.Errorf("filter worked but didn't get any result")
+			}
+			jsonvalue = jsonvalues[0].(string)
 		}
 		return []byte(jsonvalue), nil
 	}

--- a/pkg/provider/webhook/webhook_test.go
+++ b/pkg/provider/webhook/webhook_test.go
@@ -227,13 +227,12 @@ args:
   version: 1
   jsonpath: $.secrets[?@.name=="thesecret"].value
   response: '{"secrets": [{"name": "thesecret", "value": "secret-value"}, {"name": "alsosecret", "value": "another-value"}]}'
->>>>>>> 2c2047c4 (Add jsonpath filter support to webhook)
 want:
   path: /api/getsecret?id=testkey&version=1
   err: ''
   result: secret-value
 ---
-case: good json with bad temlated jsonpath
+case: good json with bad templated jsonpath
 args:
   url: /api/getsecret?id={{ .remoteRef.key }}&version={{ .remoteRef.version }}
   key: testkey

--- a/pkg/provider/webhook/webhook_test.go
+++ b/pkg/provider/webhook/webhook_test.go
@@ -220,6 +220,19 @@ want:
   err: ''
   result: secret-value
 ---
+case: good json with jsonpath filter
+args:
+  url: /api/getsecret?id={{ .remoteRef.key }}&version={{ .remoteRef.version }}
+  key: testkey
+  version: 1
+  jsonpath: $.secrets[?@.name=="thesecret"].value
+  response: '{"secrets": [{"name": "thesecret", "value": "secret-value"}, {"name": "alsosecret", "value": "another-value"}]}'
+>>>>>>> 2c2047c4 (Add jsonpath filter support to webhook)
+want:
+  path: /api/getsecret?id=testkey&version=1
+  err: ''
+  result: secret-value
+---
 case: good json with bad temlated jsonpath
 args:
   url: /api/getsecret?id={{ .remoteRef.key }}&version={{ .remoteRef.version }}
@@ -231,6 +244,17 @@ args:
 want:
   path: /api/getsecret?id=testkey&version=1
   err: 'template: webhooktemplate:1: unexpected "}" in operand'
+---
+case: error with jsonpath filter empty results
+args:
+  url: /api/getsecret?id={{ .remoteRef.key }}&version={{ .remoteRef.version }}
+  key: testkey
+  version: 1
+  jsonpath: $.secrets[?@.name=="thebadsecret"].value
+  response: '{"secrets": [{"name": "thesecret", "value": "secret-value"}, {"name": "alsosecret", "value": "another-value"}]}'
+want:
+  path: /api/getsecret?id=testkey&version=1
+  err: "filter worked but didn't get any result"
 `
 
 func TestWebhookGetSecret(t *testing.T) {


### PR DESCRIPTION
Hello, Webhook provider doesn't support jsonpath filter correctly.
When filter is used, jsonpath return a list and not a string.

Example: 
```yaml
result:
  jsonPath: "$.data.fields[?@.name==\"{{ .remoteRef.property }}\"].value"
```

With this PR, the webhook provider will try to handle list of string and get the first result of the filter.