### PR TITLE
Fix wrong IAM permissions in docs for the AWS Parameter Store

### DIFF
--- a/docs/provider/aws-parameter-store.md
+++ b/docs/provider/aws-parameter-store.md
@@ -31,9 +31,8 @@ Create a IAM Policy to pin down access to secrets matching `dev-*`, for further 
       "Effect": "Allow",
       "Action": [
         "ssm:GetParameter",
-        "ssm:GetParameterWithContext",
-        "ssm:ListTagsForResourceWithContext",
-        "ssm:DescribeParametersWithContext",
+        "ssm:ListTagsForResource",
+        "ssm:DescribeParameters"
       ],
       "Resource": "arn:aws:ssm:us-east-2:1234567889911:parameter/dev-*"
     }


### PR DESCRIPTION
This PR fixes the wrong IAM permissions in the Docs for the AWS Parameter Store.
It seems like the Go functions names were wrongly assumed to be the IAM permissions.