### PR TITLE
fix: remove ability to call env and expandenv in webhook

### DIFF
--- a/pkg/provider/webhook/webhook.go
+++ b/pkg/provider/webhook/webhook.go
@@ -27,7 +27,6 @@ import (
 	tpl "text/template"
 	"time"
 
-	"github.com/Masterminds/sprig/v3"
 	"github.com/PaesslerAG/jsonpath"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
@@ -446,7 +445,7 @@ func executeTemplate(tmpl string, data map[string]map[string]string) (bytes.Buff
 	if tmpl == "" {
 		return result, nil
 	}
-	urlt, err := tpl.New("webhooktemplate").Funcs(sprig.TxtFuncMap()).Funcs(template.FuncMap()).Parse(tmpl)
+	urlt, err := tpl.New("webhooktemplate").Funcs(template.FuncMap()).Parse(tmpl)
 	if err != nil {
 		return result, err
 	}


### PR DESCRIPTION
This PR removes the ability to call env and expandenv from the webhook provider.

It shouldn't be possible to use `env` or `expandenv` in any template function due to security concerns. eso-controller potentially has sensitive environment variables set and it shouldn't be possible to read/exfiltrate them using the webhook provider.

This is technically a breaking change but i'd classify this as a bug - it's unintentional behaviour that is being removed and poses a security threat to our users.