### PR TITLE
fix: remove stale keys from templated secret

### DIFF
--- a/pkg/controllers/externalsecret/externalsecret_controller.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller.go
@@ -240,9 +240,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 				return fmt.Errorf(errSetCtrlReference, err)
 			}
 		}
-		if secret.Data == nil {
+		if secret.Data == nil || externalSecret.Spec.Target.CreationPolicy != esv1beta1.CreatePolicyMerge {
 			secret.Data = make(map[string][]byte)
 		}
+
 		err = r.applyTemplate(ctx, &externalSecret, secret, dataMap)
 		if err != nil {
 			return fmt.Errorf(errApplyTemplate, err)


### PR DESCRIPTION
**Issue**

One of the issues covered in #1721 is that when using templated `ExternalSecret`, the operator does not clean up keys that are removed from template.

So, say, we go from:

```yaml
apiVersion: external-secrets.io/v1beta1
kind: ExternalSecret
metadata:
  name: test-secret
  namespace: default
spec:
  target:
    creationPolicy: Owner
    template:
      engineVersion: v2
      data:
        # For this issue to be reproduced, it's not necessary to have keys pointing
        # at values retrieved through remoreRefs
        A: "B"
        C: "D"
  data:
    - remoteRef:
        key: mykey
      secretKey: mykey
  refreshInterval: 1h
  secretStoreRef:
    kind: ClusterSecretStore
    name: default
```

to:

```yaml
apiVersion: external-secrets.io/v1beta1
kind: ExternalSecret
metadata:
  name: test-secret
  namespace: default
spec:
  target:
    creationPolicy: Owner
    template:
      engineVersion: v2
      data:
        A: "B"
  data:
    - remoteRef:
        key: mykey
      secretKey: mykey
  refreshInterval: 1h
  secretStoreRef:
    kind: ClusterSecretStore
    name: default
```

So, the resulting secret would still contain:
```
A: "B"
C: "D"
```

**Fix**

I'm not sure how we should approach secrets with Creation Policy Merge (I actually haven't used those at all), but for other cases it's enough to erase the contents of `secret.Data` before the secret mutation phase is triggered.

**Special notes**

With this PR, I'm not necessarily expecting these exact changes to be merged since I'm not very familiar with the project's code base (=> maybe the fix should have been added in a different place), but it should be a good starting point for eventual fix.
So, please, let me know what you think of that :)