### PR TITLE
Fixed broken link

### DIFF
--- a/docs/api/externalsecret.md
+++ b/docs/api/externalsecret.md
@@ -27,7 +27,7 @@ kubectl annotate es my-es force-sync=$(date +%s) --overwrite
 
 ## Features
 
-Individual features are described in the [Guides section](../guides/):
+Individual features are described in the [Guides section](../guides/introduction.md):
 
 * [Find many secrets / Extract from structured data](../guides/getallsecrets.md)
 * [Templating](../guides/templating.md)


### PR DESCRIPTION
The documentation was redirecting to 404 when we hit the Guides section link under https://external-secrets.io/v0.7.2/api/externalsecret/

<img width="1139" alt="image" src="https://user-images.githubusercontent.com/1637983/217264420-0b1a8656-4a11-4eb2-88fa-086eba080fba.png">
