### PR TITLE
fix: fix validation method in kubernetes provider

### DIFF
--- a/pkg/provider/kubernetes/validate.go
+++ b/pkg/provider/kubernetes/validate.go
@@ -83,7 +83,9 @@ func (c *Client) Validate() (esv1beta1.ValidationResult, error) {
 		return esv1beta1.ValidationResultUnknown, fmt.Errorf("could not verify if client is valid: %w", err)
 	}
 	for _, rev := range authReview.Status.ResourceRules {
-		if contains("secrets", rev.Resources) && contains("get", rev.Verbs) {
+		if (contains("secrets", rev.Resources) || contains("*", rev.Resources)) &&
+			(contains("get", rev.Verbs) || contains("*", rev.Verbs)) &&
+			(len(rev.APIGroups) == 0 || (contains("", rev.APIGroups) || contains("*", rev.APIGroups))) {
 			return esv1beta1.ValidationResultReady, nil
 		}
 	}

--- a/pkg/provider/kubernetes/validate_test.go
+++ b/pkg/provider/kubernetes/validate_test.go
@@ -273,6 +273,17 @@ func TestValidate(t *testing.T) {
 			},
 		},
 	}
+	successWildcardReview := authv1.SelfSubjectRulesReview{
+		Status: authv1.SubjectRulesReviewStatus{
+			ResourceRules: []authv1.ResourceRule{
+				{
+					Verbs:     []string{"*"},
+					Resources: []string{"*"},
+					APIGroups: []string{"*"},
+				},
+			},
+		},
+	}
 
 	type fields struct {
 		Client       KClient
@@ -328,6 +339,16 @@ func TestValidate(t *testing.T) {
 			fields: fields{
 				Namespace:    "default",
 				ReviewClient: fakeReviewClient{authReview: &successReview},
+				store:        &esv1beta1.KubernetesProvider{},
+			},
+			want:    esv1beta1.ValidationResultReady,
+			wantErr: false,
+		},
+		{
+			name: "allowed results in no error",
+			fields: fields{
+				Namespace:    "default",
+				ReviewClient: fakeReviewClient{authReview: &successWildcardReview},
 				store:        &esv1beta1.KubernetesProvider{},
 			},
 			want:    esv1beta1.ValidationResultReady,


### PR DESCRIPTION
RBAC allows a user to define a wildcard `*` for a given field in the Resource Rule. Prefix/Suffix matching or globbing is not supported, just simple wildcards.
For example the cluster-admin role has a `*` on all apiVersion/resource/verbs and hence validation would fail.

Fixes #850