### PR TITLE
fix: pass tenantID correctly to acr generator

### DIFF
--- a/docs/api/generator/acr.md
+++ b/docs/api/generator/acr.md
@@ -47,3 +47,31 @@ repository:my-repository:pull
 {% include 'generator-acr.yaml' %}
 ```
 
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: azurecr-credentials
+spec:
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: ACRAccessToken
+          name: myregistry.azurecr.io
+  refreshInterval: 12h
+  target:
+    name: azurecr-credentials
+    template:
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: |
+          {
+            "auths": {
+              "myregistry.azurecr.io": {
+                "username": "{{ .username }}",
+                "identitytoken": "{{ .password }}",
+              }
+            }
+          }
+```

--- a/pkg/generator/acr/acr.go
+++ b/pkg/generator/acr/acr.go
@@ -80,7 +80,7 @@ func (g *Generator) Generate(ctx context.Context, jsonSpec *apiextensions.JSON, 
 		return nil, err
 	}
 	g.clientSecretCreds = func(tenantID, clientID, clientSecret string, options *azidentity.ClientSecretCredentialOptions) (TokenGetter, error) {
-		return azidentity.NewClientSecretCredential(clientID, clientID, clientSecret, options)
+		return azidentity.NewClientSecretCredential(tenantID, clientID, clientSecret, options)
 	}
 
 	return g.generate(
@@ -175,7 +175,7 @@ func fetchACRAccessToken(acrRefreshToken, tenantID, registryURL, scope string) (
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("unexpected status code: %d", res.StatusCode)
+		return "", fmt.Errorf("could not generate access token, unexpected status code: %d", res.StatusCode)
 	}
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
@@ -210,7 +210,7 @@ func fetchACRRefreshToken(aadAccessToken, tenantID, registryURL string) (string,
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("unexpected status code %d, expected %d", res.StatusCode, http.StatusOK)
+		return "", fmt.Errorf("count not generate refresh token, unexpected status code %d, expected %d", res.StatusCode, http.StatusOK)
 	}
 	body, err := io.ReadAll(res.Body)
 	if err != nil {


### PR DESCRIPTION
This PR fixes a bug where the ACR credentials couldn't get generated properly. 

It also adds a example on how to create a proper `.dockerconfigjson` secret.


Fixes #2007