### PR TITLE
feat: add pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Problem Statement
+
+What is the problem you're trying to solve?
+
+## Related Issue
+
+Fixes #...
+
+## Proposed Changes
+
+How do you like to solve the issue and why?
+
+## Checklist
+
+- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
+- [ ] All commits are signed with `git commit --signoff`
+- [ ] My changes have reasonable test coverage
+- [ ] All tests pass with `make test`
+- [ ] I ensured my PR is ready for review with `make reviewable`


### PR DESCRIPTION
## Problem Statement

First time contributors can not know what needs to be done in order to get the PR merged.
This simple checklist helps with the formalities and helps with the most common issues.

## Related Issue

Fixes #...

## Proposed Changes

This is the de-facto standard to help contributors before they open the PR.

[GitHub Docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) say that this can be defined in `.github/pull_request_template.md` (among others).

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
