### PR TITLE
fix typo in the full-pushsecret.yaml

### DIFF
--- a/docs/snippets/full-pushsecret.yaml
+++ b/docs/snippets/full-pushsecret.yaml
@@ -14,5 +14,5 @@ spec:
   data:
     - match:
         secretKey: best-pokemon # Source Kubernetes secret key to be pushed
-        remoteRefs:
+        remoteRef:
           - remoteKey: my-first-parameter # Remote reference (where the secret is going to be pushed)

--- a/docs/snippets/full-pushsecret.yaml
+++ b/docs/snippets/full-pushsecret.yaml
@@ -15,4 +15,4 @@ spec:
     - match:
         secretKey: best-pokemon # Source Kubernetes secret key to be pushed
         remoteRef:
-          - remoteKey: my-first-parameter # Remote reference (where the secret is going to be pushed)
+          remoteKey: my-first-parameter # Remote reference (where the secret is going to be pushed)


### PR DESCRIPTION
## Problem Statement

I'm simply fixing a documentation typo to improve the experience for adopters.

## Related Issue

No related issue

## Proposed Changes

I solved it by simply patching the manifest.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
