### PR TITLE
Add support for AWS STS AssumeRole with External ID

### DIFF
--- a/apis/externalsecrets/v1beta1/secretstore_aws_types.go
+++ b/apis/externalsecrets/v1beta1/secretstore_aws_types.go
@@ -83,4 +83,7 @@ type AWSProvider struct {
 	// AdditionalRoles is a chained list of Role ARNs which the SecretManager provider will sequentially assume before assuming Role
 	// +optional
 	AdditionalRoles []string `json:"additionalRoles,omitempty"`
+
+	// AWS External ID set on assumed IAM roles
+	ExternalID string `json:"externalID,omitempty"`
 }

--- a/config/crds/bases/external-secrets.io_clustersecretstores.yaml
+++ b/config/crds/bases/external-secrets.io_clustersecretstores.yaml
@@ -2015,6 +2015,9 @@ spec:
                                 type: object
                             type: object
                         type: object
+                      externalID:
+                        description: AWS External ID set on assumed IAM roles
+                        type: string
                       region:
                         description: AWS Region to be used for the provider
                         type: string

--- a/config/crds/bases/external-secrets.io_secretstores.yaml
+++ b/config/crds/bases/external-secrets.io_secretstores.yaml
@@ -2015,6 +2015,9 @@ spec:
                                 type: object
                             type: object
                         type: object
+                      externalID:
+                        description: AWS External ID set on assumed IAM roles
+                        type: string
                       region:
                         description: AWS Region to be used for the provider
                         type: string

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -1909,6 +1909,9 @@ spec:
                                   type: object
                               type: object
                           type: object
+                        externalID:
+                          description: AWS External ID set on assumed IAM roles
+                          type: string
                         region:
                           description: AWS Region to be used for the provider
                           type: string
@@ -5337,6 +5340,9 @@ spec:
                                   type: object
                               type: object
                           type: object
+                        externalID:
+                          description: AWS External ID set on assumed IAM roles
+                          type: string
                         region:
                           description: AWS Region to be used for the provider
                           type: string

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -230,6 +230,17 @@ string
 <p>AdditionalRoles is a chained list of Role ARNs which the SecretManager provider will sequentially assume before assuming Role</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>externalID</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>AWS External ID set on assumed IAM roles</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="external-secrets.io/v1beta1.AWSServiceType">AWSServiceType


### PR DESCRIPTION
## Problem Statement

Add support for AWS STS AssumeRole with External ID.

## Related Issue

Fixes #[1478](https://github.com/external-secrets/external-secrets/issues/1478)

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
