### PR TITLE
feat: add support for keeping Vault token valid

### DIFF
--- a/apis/externalsecrets/v1beta1/secretstore_vault_types.go
+++ b/apis/externalsecrets/v1beta1/secretstore_vault_types.go
@@ -78,6 +78,11 @@ type VaultProvider struct {
 	// https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header
 	// +optional
 	ForwardInconsistent bool `json:"forwardInconsistent,omitempty"`
+
+	// Don't revoke Vault token after secret reading/writing is finished.
+	// This makes the provider compatible with dynamic Vault secrets, as it
+	// avoids revoking the issued dynamic secret's lease along with the token.
+	KeepTokenValid bool `json:"keepTokenValid,omitempty"`
 }
 
 // VaultAuth is the configuration used to authenticate with a Vault server.

--- a/config/crds/bases/external-secrets.io_clustersecretstores.yaml
+++ b/config/crds/bases/external-secrets.io_clustersecretstores.yaml
@@ -3196,6 +3196,12 @@ spec:
                           within a loop. This can increase performance if the option
                           is enabled serverside. https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header
                         type: boolean
+                      keepTokenValid:
+                        description: Don't revoke Vault token after secret reading/writing
+                          is finished. This makes the provider compatible with dynamic
+                          Vault secrets, as it avoids revoking the issued dynamic
+                          secret's lease along with the token.
+                        type: boolean
                       namespace:
                         description: 'Name of the vault namespace. Namespaces is a
                           set of features within Vault Enterprise that allows Vault

--- a/config/crds/bases/external-secrets.io_secretstores.yaml
+++ b/config/crds/bases/external-secrets.io_secretstores.yaml
@@ -3196,6 +3196,12 @@ spec:
                           within a loop. This can increase performance if the option
                           is enabled serverside. https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header
                         type: boolean
+                      keepTokenValid:
+                        description: Don't revoke Vault token after secret reading/writing
+                          is finished. This makes the provider compatible with dynamic
+                          Vault secrets, as it avoids revoking the issued dynamic
+                          secret's lease along with the token.
+                        type: boolean
                       namespace:
                         description: 'Name of the vault namespace. Namespaces is a
                           set of features within Vault Enterprise that allows Vault

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -2752,6 +2752,9 @@ spec:
                         forwardInconsistent:
                           description: ForwardInconsistent tells Vault to forward read-after-write requests to the Vault leader instead of simply retrying within a loop. This can increase performance if the option is enabled serverside. https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header
                           type: boolean
+                        keepTokenValid:
+                          description: Don't revoke Vault token after secret reading/writing is finished. This makes the provider compatible with dynamic Vault secrets, as it avoids revoking the issued dynamic secret's lease along with the token.
+                          type: boolean
                         namespace:
                           description: 'Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1". More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
                           type: string
@@ -6132,6 +6135,9 @@ spec:
                           type: object
                         forwardInconsistent:
                           description: ForwardInconsistent tells Vault to forward read-after-write requests to the Vault leader instead of simply retrying within a loop. This can increase performance if the option is enabled serverside. https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header
+                          type: boolean
+                        keepTokenValid:
+                          description: Don't revoke Vault token after secret reading/writing is finished. This makes the provider compatible with dynamic Vault secrets, as it avoids revoking the issued dynamic secret's lease along with the token.
                           type: boolean
                         namespace:
                           description: 'Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1". More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces'

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -5855,6 +5855,20 @@ the option is enabled serverside.
 <a href="https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header">https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header</a></p>
 </td>
 </tr>
+<tr>
+<td>
+<code>keepTokenValid</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>KeepTokenValid prevents the automatic revoke of the Vault token right after a
+secret is read or written. This can be useful when, for example, dynamic secrets are
+to be issued by Vault, as it prevents their auto-revoking along with the token.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="external-secrets.io/v1beta1.WebhookCAProvider">WebhookCAProvider

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -5587,6 +5587,20 @@ the option is enabled serverside.
 <a href="https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header">https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header</a></p>
 </td>
 </tr>
+<tr>
+<td>
+<code>keepTokenValid</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>KeepTokenValid prevents the automatic revoke of the Vault token right after a
+secret is read or written. This can be useful when, for example, dynamic secrets are
+to be issued by Vault, as it prevents their auto-revoking along with the token.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="external-secrets.io/v1beta1.WebhookCAProvider">WebhookCAProvider

--- a/pkg/provider/vault/vault.go
+++ b/pkg/provider/vault/vault.go
@@ -701,9 +701,12 @@ func getTypedKey(data map[string]interface{}, key string) ([]byte, error) {
 }
 
 func (v *client) Close(ctx context.Context) error {
-	// Revoke the token if we have one set, it wasn't sourced from a TokenSecretRef,
-	// and token caching isn't enabled
-	if !enableCache && v.client.Token() != "" && v.store.Auth.TokenSecretRef == nil {
+	// Revoke the token under following conditions:
+	// - token caching isn't enabled;
+	// - keeping token valid wasn't requested;
+	// - the token is set; and
+	// - the token wasn't sourced from a TokenSecretRef.
+	if !enableCache && !v.store.KeepTokenValid && v.client.Token() != "" && v.store.Auth.TokenSecretRef == nil {
 		err := revokeTokenIfValid(ctx, v.client)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Problem Statement
Enable Vault tokens to remain valid even after secret reading or writing is finished. This enables obtaining dynamic credentials from Vault without their leases being revoked prematurely; all the user needs to care about is ensuring that their configured Vault token TTL is longer than the dynamic secret's validity.

The existing caching feature does not work for this use case as a race condition may occur: if a cached token is reused to issue the dynamic secret and the remaining token TTL is shorter than dynamic secret TTL, the secret would be revoked once the token expires.

I believe this is a reasonable step towards adding a support for dynamic credentials that cannot yet be used with external-secrets; with this feature, nothing else seems to prevent their usage.

## Related Issue
Fixes an issue introduced by #381 that effectively prevents dynamic secrets usage.

Relates to  #1537. May also possibly fix #1199.

## Proposed Changes
Introduce a new boolean attribute called `keepVaultToken` in the `vault` provider for `SecretStore`.

I believe this is preferable to a CLI option (as used for enabling the Vault token cache), since only specific
`SecretStore` instances (those used to read dynamic secrets) will ever really need this.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`

(Note: I am unable to get Docker running on my machine, therefore some of the `make` commands didn't work for me.)
