### PR TITLE
Remove '|' symbol when getting secret

### DIFF
--- a/docs/provider/azure-key-vault.md
+++ b/docs/provider/azure-key-vault.md
@@ -123,7 +123,7 @@ You can manage keys/secrets/certificates saved inside the keyvault , by setting 
 The operator will fetch the Azure Key vault secret and inject it as a `Kind=Secret`. Then the Kubernetes secret can be fetched by issuing:
 
 ```sh
-kubectl get secret secret-to-be-created -n <namespace> | -o jsonpath='{.data.dev-secret-test}' | base64 -d
+kubectl get secret secret-to-be-created -n <namespace> -o jsonpath='{.data.dev-secret-test}' | base64 -d
 ```
 
 To select all secrets inside the key vault or all tags inside a secret, you can use the `dataFrom` directive:


### PR DESCRIPTION
Removing redundant pipe

## Problem Statement

Syntax error, likely a typo of sorts. 

## Related Issue

N/A

## Proposed Changes

Remove '|'

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
