### PR TITLE
feat: exempt `kind/feature` issues from going stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,5 +13,6 @@ jobs:
           stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 30 days.'
           stale-pr-message: 'This pr is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 30 days.'
           close-issue-message: 'This issue was closed because it has been stalled for 30 days with no activity.'
+          exempt-issue-labels: kind/feature
           days-before-stale: 90
           days-before-close: 30


### PR DESCRIPTION
## Problem Statement

This prevents the need to continuously remove `Stale` over time, and there shouldn't be a need to close an issue if the required information is there and there is an intent to act upon it.

WRT: https://github.com/external-secrets/external-secrets/issues/987#issuecomment-1444558657


## Related Issue
N/A

## Proposed Changes

Do not mark issues as Stale when they are labeled `kind/feature`.
