### PR TITLE
fix: docs build

### DIFF
--- a/docs/api/generator/acr.md
+++ b/docs/api/generator/acr.md
@@ -47,31 +47,7 @@ repository:my-repository:pull
 {% include 'generator-acr.yaml' %}
 ```
 
+Example ExternalSecret that references the ACR generator:
 ```yaml
-apiVersion: external-secrets.io/v1beta1
-kind: ExternalSecret
-metadata:
-  name: azurecr-credentials
-spec:
-  dataFrom:
-    - sourceRef:
-        generatorRef:
-          apiVersion: generators.external-secrets.io/v1alpha1
-          kind: ACRAccessToken
-          name: myregistry.azurecr.io
-  refreshInterval: 12h
-  target:
-    name: azurecr-credentials
-    template:
-      type: kubernetes.io/dockerconfigjson
-      data:
-        .dockerconfigjson: |
-          {
-            "auths": {
-              "myregistry.azurecr.io": {
-                "username": "{{ .username }}",
-                "identitytoken": "{{ .password }}",
-              }
-            }
-          }
+{% include 'generator-acr-example.yaml' %}
 ```

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -5105,7 +5105,7 @@ External Secrets meta/v1.SecretKeySelector
 <td><p>Error indicates that there is a misconfiguration.</p>
 </td>
 </tr><tr><td><p>0</p></td>
-<td><p>Ready indicates that the client is confgured correctly
+<td><p>Ready indicates that the client is configured correctly
 and can be used.</p>
 </td>
 </tr><tr><td><p>1</p></td>

--- a/docs/provider/keeper-security.md
+++ b/docs/provider/keeper-security.md
@@ -14,6 +14,7 @@ KSM can authenticate using *One Time Access Token* or *Secret Manager Configurat
 You can find the documentation for the Secret Manager Configuration creation [here](https://docs.keeper.io/secrets-manager/secrets-manager/about/secrets-manager-configuration). Make sure you add the proper permissions to your device in order to be able to read and write secrets
 
 Once you have created your SMC, you will get a config.json file or a base64 json encoded string containing the following keys:
+
 - `hostname`
 - `clientId`
 - `privateKey`
@@ -34,6 +35,7 @@ Be sure the `keepersecurity` provider is listed in the `Kind=SecretStore`
 ```
 
 **NOTE 1:** `folderID` target the folder ID where the secrets should be pushed to. It requires write permissions within the folder
+
 **NOTE 2:** In case of a `ClusterSecretStore`, Be sure to provide `namespace` for `SecretAccessKeyRef` with the namespace of the secret that we just created.
 
 ## External Secrets
@@ -69,6 +71,7 @@ kubectl get secret secret-to-be-created -n <namespace> | -o jsonpath='{.data.dev
 ## Limitations
 
 There are some limitations using this provider.
+
 * Keeper Secret Manager does not work with `General` Records types nor legacy non-typed records
 * Using tags `find.tags` is not supported by KSM
 * Using path `find.path` is not supported at the moment

--- a/docs/snippets/generator-acr-example.yaml
+++ b/docs/snippets/generator-acr-example.yaml
@@ -1,0 +1,29 @@
+{% raw %}
+
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: azurecr-credentials
+spec:
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: ACRAccessToken
+          name: myregistry.azurecr.io
+  refreshInterval: 12h
+  target:
+    name: azurecr-credentials
+    template:
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: |
+          {
+            "auths": {
+              "myregistry.azurecr.io": {
+                "username": "{{ .username }}",
+                "identitytoken": "{{ .password }}",
+              }
+            }
+          }
+{% endraw %}

--- a/docs/snippets/keepersecurity-external-secret.yaml
+++ b/docs/snippets/keepersecurity-external-secret.yaml
@@ -1,3 +1,4 @@
+{% raw %}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -69,3 +70,4 @@ spec:
       remoteRef:
         key: OqPt3Vd37My7G8rTb-8Q
         property: password
+{% endraw %}


### PR DESCRIPTION
docs build is broken, this PR fixes an issue: expressions like `{{ .foobar}}`  need to be escaped within a `{% raw %}` block.