### PR TITLE
remove hostname from keeper configuration

### DIFF
--- a/apis/externalsecrets/v1beta1/secretstore_keepersecurity_types.go
+++ b/apis/externalsecrets/v1beta1/secretstore_keepersecurity_types.go
@@ -19,6 +19,5 @@ import smmeta "github.com/external-secrets/external-secrets/apis/meta/v1"
 // KeeperSecurityProvider Configures a store to sync secrets using Keeper Security.
 type KeeperSecurityProvider struct {
 	Auth     smmeta.SecretKeySelector `json:"authRef"`
-	Hostname string                   `json:"hostname"`
 	FolderID string                   `json:"folderID"`
 }

--- a/config/crds/bases/external-secrets.io_clustersecretstores.yaml
+++ b/config/crds/bases/external-secrets.io_clustersecretstores.yaml
@@ -2388,12 +2388,9 @@ spec:
                         type: object
                       folderID:
                         type: string
-                      hostname:
-                        type: string
                     required:
                     - authRef
                     - folderID
-                    - hostname
                     type: object
                   kubernetes:
                     description: Kubernetes configures this store to sync secrets

--- a/config/crds/bases/external-secrets.io_secretstores.yaml
+++ b/config/crds/bases/external-secrets.io_secretstores.yaml
@@ -2388,12 +2388,9 @@ spec:
                         type: object
                       folderID:
                         type: string
-                      hostname:
-                        type: string
                     required:
                     - authRef
                     - folderID
-                    - hostname
                     type: object
                   kubernetes:
                     description: Kubernetes configures this store to sync secrets

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -2191,12 +2191,9 @@ spec:
                           type: object
                         folderID:
                           type: string
-                        hostname:
-                          type: string
                       required:
                         - authRef
                         - folderID
-                        - hostname
                       type: object
                     kubernetes:
                       description: Kubernetes configures this store to sync secrets using a Kubernetes cluster provider
@@ -5509,12 +5506,9 @@ spec:
                           type: object
                         folderID:
                           type: string
-                        hostname:
-                          type: string
                       required:
                         - authRef
                         - folderID
-                        - hostname
                       type: object
                     kubernetes:
                       description: Kubernetes configures this store to sync secrets using a Kubernetes cluster provider

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -3456,16 +3456,6 @@ External Secrets meta/v1.SecretKeySelector
 </tr>
 <tr>
 <td>
-<code>hostname</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
 <code>folderID</code></br>
 <em>
 string

--- a/docs/snippets/keepersecurity-secret-store.yaml
+++ b/docs/snippets/keepersecurity-secret-store.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   provider:
     keepersecurity:
-      hostname: keepersecurity.eu
       authRef: # Refer to a kubernetes secret which holds the base64 encoded json string for the configuration
         name: keeper-configuration
         key:  auth

--- a/pkg/provider/keepersecurity/provider.go
+++ b/pkg/provider/keepersecurity/provider.go
@@ -34,7 +34,6 @@ const (
 	errKeeperSecurityNilSpecProviderKeeperSecurity  = "nil spec.provider.keepersecurity"
 	errKeeperSecurityStoreMissingAuth               = "missing: spec.provider.keepersecurity.auth"
 	errKeeperSecurityStoreMissingFolderID           = "missing: spec.provider.keepersecurity.folderID"
-	errKeeperSecurityStoreInvalidConnectHost        = "unable to parse URL: spec.provider.keepersecurity.connectHost: %w"
 	errInvalidClusterStoreMissingK8sSecretNamespace = "invalid ClusterSecretStore: missing KeeperSecurity k8s Auth Secret Namespace"
 	errFetchK8sSecret                               = "could not fetch k8s Secret: %w"
 	errMissingK8sSecretKey                          = "missing Secret key: %s"

--- a/pkg/provider/keepersecurity/provider.go
+++ b/pkg/provider/keepersecurity/provider.go
@@ -16,6 +16,7 @@ package keepersecurity
 import (
 	"context"
 	"fmt"
+
 	ksm "github.com/keeper-security/secrets-manager-go/core"
 	"github.com/keeper-security/secrets-manager-go/core/logger"
 	v1 "k8s.io/api/core/v1"

--- a/pkg/provider/keepersecurity/provider.go
+++ b/pkg/provider/keepersecurity/provider.go
@@ -16,8 +16,6 @@ package keepersecurity
 import (
 	"context"
 	"fmt"
-	"net/url"
-
 	ksm "github.com/keeper-security/secrets-manager-go/core"
 	"github.com/keeper-security/secrets-manager-go/core/logger"
 	v1 "k8s.io/api/core/v1"
@@ -103,11 +101,6 @@ func (p *Provider) ValidateStore(store esv1beta1.GenericStore) error {
 
 	// check mandatory fields
 	config := spc.Provider.KeeperSecurity
-
-	// check valid URL
-	if _, err := url.Parse(config.Hostname); err != nil {
-		return fmt.Errorf(errKeeperSecurityStoreInvalidConnectHost, err)
-	}
 
 	if err := utils.ValidateSecretSelector(store, config.Auth); err != nil {
 		return fmt.Errorf(errKeeperSecurityStoreMissingAuth)


### PR DESCRIPTION
## Problem Statement

Simplify the keeper configuration as the hostname is part of the auth string 

## Related Issue

#2048 


## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] My changes have reasonable test coverage
- [X] All tests pass with `make test`
- [X] I ensured my PR is ready for review with `make reviewable`
