### PR TITLE
Add values for extraContainers in deployment

### DIFF
--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -84,6 +84,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | deploymentAnnotations | object | `{}` | Annotations to add to Deployment |
 | dnsConfig | object | `{}` | Specifies `dnsOptions` to deployment |
 | extraArgs | object | `{}` |  |
+| extraContainers | list | `[]` |  |
 | extraEnv | list | `[]` |  |
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |

--- a/deploy/charts/external-secrets/templates/deployment.yaml
+++ b/deploy/charts/external-secrets/templates/deployment.yaml
@@ -95,6 +95,9 @@ spec:
           volumeMounts:
           {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
           {{- end }}
+        {{- if .Values.extraContainers }}
+          {{ toYaml .Values.extraContainers | nindent 8}}
+        {{- end }}
       {{- if .Values.dnsConfig }}
       dnsConfig:
           {{- toYaml .Values.dnsConfig | nindent 8 }}

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -85,6 +85,9 @@ extraVolumes: []
 ## -- Extra volumes to mount to the container.
 extraVolumeMounts: []
 
+## -- Extra containers to add to the pod.
+extraContainers: []
+
 # -- Annotations to add to Deployment
 deploymentAnnotations: {}
 


### PR DESCRIPTION
## Problem Statement

Adding sidecar containers to the external secrets operator.

## Related Issue

Fixes #2072 

## Proposed Changes

Implementing the value `extraContainers` allows for simply configuring additional / sidecar containers via values.yaml

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
