### PR TITLE
docs: fix auth secretRef in API docs

### DIFF
--- a/docs/snippets/full-secret-store.yaml
+++ b/docs/snippets/full-secret-store.yaml
@@ -35,10 +35,10 @@ spec:
       # getting the accessKeyID and secretAccessKey from an already created Kubernetes Secret
       auth:
         secretRef:
-          accessKeyID:
+          accessKeyIDSecretRef:
             name: awssm-secret
             key: access-key
-          secretAccessKey:
+          secretAccessKeySecretRef:
             name: awssm-secret
             key: secret-access-key
 


### PR DESCRIPTION
## Problem Statement

The [API docs](https://external-secrets.io/v0.7.2/api/secretstore/) reference `accessKeyID` and `secretAccessKey` but looking at [SecretStore CRD](https://github.com/external-secrets/external-secrets/blob/main/config/crds/bases/external-secrets.io_secretstores.yaml), it seems the correct field names should be `accessKeyIDSecretRef` and `accessKeySecretSecretRef` respectively. 

## Related Issue

Faced this validation error when using the example in API docs
```hcl
error: error validating "secretstore.yaml": error validating data: [ValidationError(SecretStore.spec.provider.aws.auth.secretRef): unknown field "accessKeyID" in io.external-secrets.v1beta1.SecretStore.spec.provider.aws.auth.secretRef, ValidationError(SecretStore.spec.provider.aws.auth.secretRef): unknown field "secretAccessKey" in io.external-secrets.v1beta1.SecretStore.spec.provider.aws.auth.secretRef]; if you choose to ignore these errors, turn validation off with --validate=false
```

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
