### PR TITLE
feat: add helm unit tests

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -43,8 +43,24 @@ jobs:
           if [[ -n "$changed" ]]; then
             echo "::set-output name=changed::true"
           fi
+      - name: Install chart unittest
+        run: |
+          helm env
+          helm plugin install https://github.com/helm-unittest/helm-unittest
       - name: Run chart-testing (lint)
         run: ct lint --config=.github/ci/ct.yaml
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.2.0
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Run chart-testing (install)
+        run: ct install --config=.github/ci/ct.yaml --charts deploy/charts/external-secrets
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Run unitests
+        if: steps.list-changed.outputs.changed == 'true'
+        run: make helm.test
 
   release:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -185,6 +185,18 @@ helm.generate:
 	./hack/helm.generate.sh $(BUNDLE_DIR) $(HELM_DIR)
 	@$(OK) Finished generating helm chart files
 
+helm.test: helm.generate
+	@helm unittest --file tests/*.yaml --file 'tests/**/*.yaml' deploy/charts/external-secrets/
+
+helm.update.appversion:
+	@chartversion=$$(yq .version ./deploy/charts/external-secrets/Chart.yaml) ; \
+	chartappversion=$$(yq .appVersion ./deploy/charts/external-secrets/Chart.yaml) ; \
+	chartname=$$(yq .name ./deploy/charts/external-secrets/Chart.yaml) ; \
+	$(INFO) Update chartname and chartversion string in test snapshots.; \
+	sed -s -i "s/^\([[:space:]]\+helm\.sh\/chart:\).*/\1 $${chartname}-$${chartversion}/" ./deploy/charts/external-secrets/tests/__snapshot__/*.yaml.snap ; \
+	sed -s -i "s/^\([[:space:]]\+app\.kubernetes\.io\/version:\).*/\1 $${chartappversion}/" ./deploy/charts/external-secrets/tests/__snapshot__/*.yaml.snap ; \
+	$(OK) "Version strings updated"
+
 # ====================================================================================
 # Documentation
 .PHONY: docs

--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -77,6 +77,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | certController.tolerations | list | `[]` |  |
 | concurrent | int | `1` | Specifies the number of concurrent ExternalSecret Reconciles external-secret executes at a time. |
 | controllerClass | string | `""` | If set external secrets will filter matching Secret Stores with the appropriate controller values. |
+| crds.annotations | object | `{}` |  |
+| crds.conversion.enabled | bool | `true` |  |
 | crds.createClusterExternalSecret | bool | `true` | If true, create CRDs for Cluster External Secret. |
 | crds.createClusterSecretStore | bool | `true` | If true, create CRDs for Cluster Secret Store. |
 | crds.createPushSecret | bool | `true` | If true, create CRDs for Push Secret. |

--- a/deploy/charts/external-secrets/tests/__snapshot__/controller_test.yaml.snap
+++ b/deploy/charts/external-secrets/tests/__snapshot__/controller_test.yaml.snap
@@ -1,0 +1,38 @@
+should match snapshot of default values:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: external-secrets
+        app.kubernetes.io/version: v0.7.2
+        helm.sh/chart: external-secrets-0.7.2
+      name: RELEASE-NAME-external-secrets
+      namespace: NAMESPACE
+    spec:
+      replicas: 1
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: external-secrets
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: external-secrets
+        spec:
+          automountServiceAccountToken: true
+          containers:
+            - args:
+                - --concurrent=1
+              image: ghcr.io/external-secrets/external-secrets:v0.7.2
+              imagePullPolicy: IfNotPresent
+              name: external-secrets
+              ports:
+                - containerPort: 8080
+                  name: metrics
+                  protocol: TCP
+          serviceAccountName: RELEASE-NAME-external-secrets

--- a/deploy/charts/external-secrets/tests/__snapshot__/crds_test.yaml.snap
+++ b/deploy/charts/external-secrets/tests/__snapshot__/crds_test.yaml.snap
@@ -1,0 +1,2536 @@
+should match snapshot of default values:
+  1: |
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      annotations:
+        controller-gen.kubebuilder.io/version: v0.11.3
+      creationTimestamp: null
+      name: secretstores.external-secrets.io
+    spec:
+      conversion:
+        strategy: Webhook
+        webhook:
+          clientConfig:
+            service:
+              name: RELEASE-NAME-external-secrets-webhook
+              namespace: NAMESPACE
+              path: /convert
+          conversionReviewVersions:
+            - v1
+      group: external-secrets.io
+      names:
+        categories:
+          - externalsecrets
+        kind: SecretStore
+        listKind: SecretStoreList
+        plural: secretstores
+        shortNames:
+          - ss
+        singular: secretstore
+      scope: Namespaced
+      versions:
+        - additionalPrinterColumns:
+            - jsonPath: .metadata.creationTimestamp
+              name: AGE
+              type: date
+            - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+              name: Status
+              type: string
+          deprecated: true
+          name: v1alpha1
+          schema:
+            openAPIV3Schema:
+              description: SecretStore represents a secure external location for storing secrets, which can be referenced as part of `storeRef` fields.
+              properties:
+                apiVersion:
+                  description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                  type: string
+                kind:
+                  description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                metadata:
+                  type: object
+                spec:
+                  description: SecretStoreSpec defines the desired state of SecretStore.
+                  properties:
+                    controller:
+                      description: 'Used to select the correct KES controller (think: ingress.ingressClassName) The KES controller is instantiated with a specific controller name and filters ES based on this property'
+                      type: string
+                    provider:
+                      description: Used to configure the provider. Only one provider may be set
+                      maxProperties: 1
+                      minProperties: 1
+                      properties:
+                        akeyless:
+                          description: Akeyless configures this store to sync secrets using Akeyless Vault provider
+                          properties:
+                            akeylessGWApiURL:
+                              description: Akeyless GW API Url from which the secrets to be fetched from.
+                              type: string
+                            authSecretRef:
+                              description: Auth configures how the operator authenticates with Akeyless.
+                              properties:
+                                kubernetesAuth:
+                                  description: Kubernetes authenticates with Akeyless by passing the ServiceAccount token stored in the named Secret resource.
+                                  properties:
+                                    accessID:
+                                      description: the Akeyless Kubernetes auth-method access-id
+                                      type: string
+                                    k8sConfName:
+                                      description: Kubernetes-auth configuration name in Akeyless-Gateway
+                                      type: string
+                                    secretRef:
+                                      description: Optional secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Akeyless. If a name is specified without a key, `token` is the default. If one is not specified, the one bound to the controller will be used.
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                    serviceAccountRef:
+                                      description: Optional service account field containing the name of a kubernetes ServiceAccount. If the service account is specified, the service account secret token JWT will be used for authenticating with Akeyless. If the service account selector is not supplied, the secretRef will be used instead.
+                                      properties:
+                                        audiences:
+                                          description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                          items:
+                                            type: string
+                                          type: array
+                                        name:
+                                          description: The name of the ServiceAccount resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  required:
+                                    - accessID
+                                    - k8sConfName
+                                  type: object
+                                secretRef:
+                                  description: Reference to a Secret that contains the details to authenticate with Akeyless.
+                                  properties:
+                                    accessID:
+                                      description: The SecretAccessID is used for authentication
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                    accessType:
+                                      description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                    accessTypeParam:
+                                      description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                  type: object
+                              type: object
+                            caBundle:
+                              description: PEM/base64 encoded CA bundle used to validate Akeyless Gateway certificate. Only used if the AkeylessGWApiURL URL is using HTTPS protocol. If not set the system root certificates are used to validate the TLS connection.
+                              format: byte
+                              type: string
+                            caProvider:
+                              description: The provider for the CA bundle to use to validate Akeyless Gateway certificate.
+                              properties:
+                                key:
+                                  description: The key the value inside of the provider type to use, only used with "Secret" type
+                                  type: string
+                                name:
+                                  description: The name of the object located at the provider type.
+                                  type: string
+                                namespace:
+                                  description: The namespace the Provider type is in.
+                                  type: string
+                                type:
+                                  description: The type of provider to use such as "Secret", or "ConfigMap".
+                                  enum:
+                                    - Secret
+                                    - ConfigMap
+                                  type: string
+                              required:
+                                - name
+                                - type
+                              type: object
+                          required:
+                            - akeylessGWApiURL
+                            - authSecretRef
+                          type: object
+                        alibaba:
+                          description: Alibaba configures this store to sync secrets using Alibaba Cloud provider
+                          properties:
+                            auth:
+                              description: AlibabaAuth contains a secretRef for credentials.
+                              properties:
+                                secretRef:
+                                  description: AlibabaAuthSecretRef holds secret references for Alibaba credentials.
+                                  properties:
+                                    accessKeyIDSecretRef:
+                                      description: The AccessKeyID is used for authentication
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                    accessKeySecretSecretRef:
+                                      description: The AccessKeySecret is used for authentication
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                  required:
+                                    - accessKeyIDSecretRef
+                                    - accessKeySecretSecretRef
+                                  type: object
+                              required:
+                                - secretRef
+                              type: object
+                            endpoint:
+                              type: string
+                            regionID:
+                              description: Alibaba Region to be used for the provider
+                              type: string
+                          required:
+                            - auth
+                            - regionID
+                          type: object
+                        aws:
+                          description: AWS configures this store to sync secrets using AWS Secret Manager provider
+                          properties:
+                            auth:
+                              description: 'Auth defines the information necessary to authenticate against AWS if not set aws sdk will infer credentials from your environment see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                              properties:
+                                jwt:
+                                  description: Authenticate against AWS using service account tokens.
+                                  properties:
+                                    serviceAccountRef:
+                                      description: A reference to a ServiceAccount resource.
+                                      properties:
+                                        audiences:
+                                          description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                          items:
+                                            type: string
+                                          type: array
+                                        name:
+                                          description: The name of the ServiceAccount resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  type: object
+                                secretRef:
+                                  description: AWSAuthSecretRef holds secret references for AWS credentials both AccessKeyID and SecretAccessKey must be defined in order to properly authenticate.
+                                  properties:
+                                    accessKeyIDSecretRef:
+                                      description: The AccessKeyID is used for authentication
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                    secretAccessKeySecretRef:
+                                      description: The SecretAccessKey is used for authentication
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                  type: object
+                              type: object
+                            region:
+                              description: AWS Region to be used for the provider
+                              type: string
+                            role:
+                              description: Role is a Role ARN which the SecretManager provider will assume
+                              type: string
+                            service:
+                              description: Service defines which service should be used to fetch the secrets
+                              enum:
+                                - SecretsManager
+                                - ParameterStore
+                              type: string
+                          required:
+                            - region
+                            - service
+                          type: object
+                        azurekv:
+                          description: AzureKV configures this store to sync secrets using Azure Key Vault provider
+                          properties:
+                            authSecretRef:
+                              description: Auth configures how the operator authenticates with Azure. Required for ServicePrincipal auth type.
+                              properties:
+                                clientId:
+                                  description: The Azure clientId of the service principle used for authentication.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                clientSecret:
+                                  description: The Azure ClientSecret of the service principle used for authentication.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                            authType:
+                              default: ServicePrincipal
+                              description: 'Auth type defines how to authenticate to the keyvault service. Valid values are: - "ServicePrincipal" (default): Using a service principal (tenantId, clientId, clientSecret) - "ManagedIdentity": Using Managed Identity assigned to the pod (see aad-pod-identity)'
+                              enum:
+                                - ServicePrincipal
+                                - ManagedIdentity
+                                - WorkloadIdentity
+                              type: string
+                            identityId:
+                              description: If multiple Managed Identity is assigned to the pod, you can select the one to be used
+                              type: string
+                            serviceAccountRef:
+                              description: ServiceAccountRef specified the service account that should be used when authenticating with WorkloadIdentity.
+                              properties:
+                                audiences:
+                                  description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                  items:
+                                    type: string
+                                  type: array
+                                name:
+                                  description: The name of the ServiceAccount resource being referred to.
+                                  type: string
+                                namespace:
+                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            tenantId:
+                              description: TenantID configures the Azure Tenant to send requests to. Required for ServicePrincipal auth type.
+                              type: string
+                            vaultUrl:
+                              description: Vault Url from which the secrets to be fetched from.
+                              type: string
+                          required:
+                            - vaultUrl
+                          type: object
+                        fake:
+                          description: Fake configures a store with static key/value pairs
+                          properties:
+                            data:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  value:
+                                    type: string
+                                  valueMap:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  version:
+                                    type: string
+                                required:
+                                  - key
+                                type: object
+                              type: array
+                          required:
+                            - data
+                          type: object
+                        gcpsm:
+                          description: GCPSM configures this store to sync secrets using Google Cloud Platform Secret Manager provider
+                          properties:
+                            auth:
+                              description: Auth defines the information necessary to authenticate against GCP
+                              properties:
+                                secretRef:
+                                  properties:
+                                    secretAccessKeySecretRef:
+                                      description: The SecretAccessKey is used for authentication
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                  type: object
+                                workloadIdentity:
+                                  properties:
+                                    clusterLocation:
+                                      type: string
+                                    clusterName:
+                                      type: string
+                                    clusterProjectID:
+                                      type: string
+                                    serviceAccountRef:
+                                      description: A reference to a ServiceAccount resource.
+                                      properties:
+                                        audiences:
+                                          description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                          items:
+                                            type: string
+                                          type: array
+                                        name:
+                                          description: The name of the ServiceAccount resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  required:
+                                    - clusterLocation
+                                    - clusterName
+                                    - serviceAccountRef
+                                  type: object
+                              type: object
+                            projectID:
+                              description: ProjectID project where secret is located
+                              type: string
+                          type: object
+                        gitlab:
+                          description: Gitlab configures this store to sync secrets using Gitlab Variables provider
+                          properties:
+                            auth:
+                              description: Auth configures how secret-manager authenticates with a GitLab instance.
+                              properties:
+                                SecretRef:
+                                  properties:
+                                    accessToken:
+                                      description: AccessToken is used for authentication.
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                  type: object
+                              required:
+                                - SecretRef
+                              type: object
+                            projectID:
+                              description: ProjectID specifies a project where secrets are located.
+                              type: string
+                            url:
+                              description: URL configures the GitLab instance URL. Defaults to https://gitlab.com/.
+                              type: string
+                          required:
+                            - auth
+                          type: object
+                        ibm:
+                          description: IBM configures this store to sync secrets using IBM Cloud provider
+                          properties:
+                            auth:
+                              description: Auth configures how secret-manager authenticates with the IBM secrets manager.
+                              properties:
+                                secretRef:
+                                  properties:
+                                    secretApiKeySecretRef:
+                                      description: The SecretAccessKey is used for authentication
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                  type: object
+                              required:
+                                - secretRef
+                              type: object
+                            serviceUrl:
+                              description: ServiceURL is the Endpoint URL that is specific to the Secrets Manager service instance
+                              type: string
+                          required:
+                            - auth
+                          type: object
+                        kubernetes:
+                          description: Kubernetes configures this store to sync secrets using a Kubernetes cluster provider
+                          properties:
+                            auth:
+                              description: Auth configures how secret-manager authenticates with a Kubernetes instance.
+                              maxProperties: 1
+                              minProperties: 1
+                              properties:
+                                cert:
+                                  description: has both clientCert and clientKey as secretKeySelector
+                                  properties:
+                                    clientCert:
+                                      description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                    clientKey:
+                                      description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                  type: object
+                                serviceAccount:
+                                  description: points to a service account that should be used for authentication
+                                  properties:
+                                    serviceAccount:
+                                      description: A reference to a ServiceAccount resource.
+                                      properties:
+                                        audiences:
+                                          description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                          items:
+                                            type: string
+                                          type: array
+                                        name:
+                                          description: The name of the ServiceAccount resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  type: object
+                                token:
+                                  description: use static token to authenticate with
+                                  properties:
+                                    bearerToken:
+                                      description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                  type: object
+                              type: object
+                            remoteNamespace:
+                              default: default
+                              description: Remote namespace to fetch the secrets from
+                              type: string
+                            server:
+                              description: configures the Kubernetes server Address.
+                              properties:
+                                caBundle:
+                                  description: CABundle is a base64-encoded CA certificate
+                                  format: byte
+                                  type: string
+                                caProvider:
+                                  description: 'see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider'
+                                  properties:
+                                    key:
+                                      description: The key the value inside of the provider type to use, only used with "Secret" type
+                                      type: string
+                                    name:
+                                      description: The name of the object located at the provider type.
+                                      type: string
+                                    namespace:
+                                      description: The namespace the Provider type is in.
+                                      type: string
+                                    type:
+                                      description: The type of provider to use such as "Secret", or "ConfigMap".
+                                      enum:
+                                        - Secret
+                                        - ConfigMap
+                                      type: string
+                                  required:
+                                    - name
+                                    - type
+                                  type: object
+                                url:
+                                  default: kubernetes.default
+                                  description: configures the Kubernetes server Address.
+                                  type: string
+                              type: object
+                          required:
+                            - auth
+                          type: object
+                        oracle:
+                          description: Oracle configures this store to sync secrets using Oracle Vault provider
+                          properties:
+                            auth:
+                              description: Auth configures how secret-manager authenticates with the Oracle Vault. If empty, use the instance principal, otherwise the user credentials specified in Auth.
+                              properties:
+                                secretRef:
+                                  description: SecretRef to pass through sensitive information.
+                                  properties:
+                                    fingerprint:
+                                      description: Fingerprint is the fingerprint of the API private key.
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                    privatekey:
+                                      description: PrivateKey is the user's API Signing Key in PEM format, used for authentication.
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                  required:
+                                    - fingerprint
+                                    - privatekey
+                                  type: object
+                                tenancy:
+                                  description: Tenancy is the tenancy OCID where user is located.
+                                  type: string
+                                user:
+                                  description: User is an access OCID specific to the account.
+                                  type: string
+                              required:
+                                - secretRef
+                                - tenancy
+                                - user
+                              type: object
+                            region:
+                              description: Region is the region where vault is located.
+                              type: string
+                            vault:
+                              description: Vault is the vault's OCID of the specific vault where secret is located.
+                              type: string
+                          required:
+                            - region
+                            - vault
+                          type: object
+                        vault:
+                          description: Vault configures this store to sync secrets using Hashi provider
+                          properties:
+                            auth:
+                              description: Auth configures how secret-manager authenticates with the Vault server.
+                              properties:
+                                appRole:
+                                  description: AppRole authenticates with Vault using the App Role auth mechanism, with the role and secret stored in a Kubernetes Secret resource.
+                                  properties:
+                                    path:
+                                      default: approle
+                                      description: 'Path where the App Role authentication backend is mounted in Vault, e.g: "approle"'
+                                      type: string
+                                    roleId:
+                                      description: RoleID configured in the App Role authentication backend when setting up the authentication backend in Vault.
+                                      type: string
+                                    secretRef:
+                                      description: Reference to a key in a Secret that contains the App Role secret used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role secret.
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                  required:
+                                    - path
+                                    - roleId
+                                    - secretRef
+                                  type: object
+                                cert:
+                                  description: Cert authenticates with TLS Certificates by passing client certificate, private key and ca certificate Cert authentication method
+                                  properties:
+                                    clientCert:
+                                      description: ClientCert is a certificate to authenticate using the Cert Vault authentication method
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                    secretRef:
+                                      description: SecretRef to a key in a Secret resource containing client private key to authenticate with Vault using the Cert authentication method
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                  type: object
+                                jwt:
+                                  description: Jwt authenticates with Vault by passing role and JWT token using the JWT/OIDC authentication method
+                                  properties:
+                                    kubernetesServiceAccountToken:
+                                      description: Optional ServiceAccountToken specifies the Kubernetes service account for which to request a token for with the `TokenRequest` API.
+                                      properties:
+                                        audiences:
+                                          description: Optional audiences field that will be used to request a temporary Kubernetes service account token for the service account referenced by `serviceAccountRef`. Defaults to a single audience `vault` it not specified.
+                                          items:
+                                            type: string
+                                          type: array
+                                        expirationSeconds:
+                                          description: Optional expiration time in seconds that will be used to request a temporary Kubernetes service account token for the service account referenced by `serviceAccountRef`. Defaults to 10 minutes.
+                                          format: int64
+                                          type: integer
+                                        serviceAccountRef:
+                                          description: Service account field containing the name of a kubernetes ServiceAccount.
+                                          properties:
+                                            audiences:
+                                              description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                              items:
+                                                type: string
+                                              type: array
+                                            name:
+                                              description: The name of the ServiceAccount resource being referred to.
+                                              type: string
+                                            namespace:
+                                              description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                      required:
+                                        - serviceAccountRef
+                                      type: object
+                                    path:
+                                      default: jwt
+                                      description: 'Path where the JWT authentication backend is mounted in Vault, e.g: "jwt"'
+                                      type: string
+                                    role:
+                                      description: Role is a JWT role to authenticate using the JWT/OIDC Vault authentication method
+                                      type: string
+                                    secretRef:
+                                      description: Optional SecretRef that refers to a key in a Secret resource containing JWT token to authenticate with Vault using the JWT/OIDC authentication method.
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                  required:
+                                    - path
+                                  type: object
+                                kubernetes:
+                                  description: Kubernetes authenticates with Vault by passing the ServiceAccount token stored in the named Secret resource to the Vault server.
+                                  properties:
+                                    mountPath:
+                                      default: kubernetes
+                                      description: 'Path where the Kubernetes authentication backend is mounted in Vault, e.g: "kubernetes"'
+                                      type: string
+                                    role:
+                                      description: A required field containing the Vault Role to assume. A Role binds a Kubernetes ServiceAccount with a set of Vault policies.
+                                      type: string
+                                    secretRef:
+                                      description: Optional secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Vault. If a name is specified without a key, `token` is the default. If one is not specified, the one bound to the controller will be used.
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                    serviceAccountRef:
+                                      description: Optional service account field containing the name of a kubernetes ServiceAccount. If the service account is specified, the service account secret token JWT will be used for authenticating with Vault. If the service account selector is not supplied, the secretRef will be used instead.
+                                      properties:
+                                        audiences:
+                                          description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                          items:
+                                            type: string
+                                          type: array
+                                        name:
+                                          description: The name of the ServiceAccount resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  required:
+                                    - mountPath
+                                    - role
+                                  type: object
+                                ldap:
+                                  description: Ldap authenticates with Vault by passing username/password pair using the LDAP authentication method
+                                  properties:
+                                    path:
+                                      default: ldap
+                                      description: 'Path where the LDAP authentication backend is mounted in Vault, e.g: "ldap"'
+                                      type: string
+                                    secretRef:
+                                      description: SecretRef to a key in a Secret resource containing password for the LDAP user used to authenticate with Vault using the LDAP authentication method
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                    username:
+                                      description: Username is a LDAP user name used to authenticate using the LDAP Vault authentication method
+                                      type: string
+                                  required:
+                                    - path
+                                    - username
+                                  type: object
+                                tokenSecretRef:
+                                  description: TokenSecretRef authenticates with Vault by presenting a token.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                            caBundle:
+                              description: PEM encoded CA bundle used to validate Vault server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.
+                              format: byte
+                              type: string
+                            caProvider:
+                              description: The provider for the CA bundle to use to validate Vault server certificate.
+                              properties:
+                                key:
+                                  description: The key the value inside of the provider type to use, only used with "Secret" type
+                                  type: string
+                                name:
+                                  description: The name of the object located at the provider type.
+                                  type: string
+                                namespace:
+                                  description: The namespace the Provider type is in.
+                                  type: string
+                                type:
+                                  description: The type of provider to use such as "Secret", or "ConfigMap".
+                                  enum:
+                                    - Secret
+                                    - ConfigMap
+                                  type: string
+                              required:
+                                - name
+                                - type
+                              type: object
+                            forwardInconsistent:
+                              description: ForwardInconsistent tells Vault to forward read-after-write requests to the Vault leader instead of simply retrying within a loop. This can increase performance if the option is enabled serverside. https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header
+                              type: boolean
+                            namespace:
+                              description: 'Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1". More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
+                              type: string
+                            path:
+                              description: 'Path is the mount path of the Vault KV backend endpoint, e.g: "secret". The v2 KV secret engine version specific "/data" path suffix for fetching secrets from Vault is optional and will be appended if not present in specified path.'
+                              type: string
+                            readYourWrites:
+                              description: ReadYourWrites ensures isolated read-after-write semantics by providing discovered cluster replication states in each request. More information about eventual consistency in Vault can be found here https://www.vaultproject.io/docs/enterprise/consistency
+                              type: boolean
+                            server:
+                              description: 'Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".'
+                              type: string
+                            version:
+                              default: v2
+                              description: Version is the Vault KV secret engine version. This can be either "v1" or "v2". Version defaults to "v2".
+                              enum:
+                                - v1
+                                - v2
+                              type: string
+                          required:
+                            - auth
+                            - server
+                          type: object
+                        webhook:
+                          description: Webhook configures this store to sync secrets using a generic templated webhook
+                          properties:
+                            body:
+                              description: Body
+                              type: string
+                            caBundle:
+                              description: PEM encoded CA bundle used to validate webhook server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.
+                              format: byte
+                              type: string
+                            caProvider:
+                              description: The provider for the CA bundle to use to validate webhook server certificate.
+                              properties:
+                                key:
+                                  description: The key the value inside of the provider type to use, only used with "Secret" type
+                                  type: string
+                                name:
+                                  description: The name of the object located at the provider type.
+                                  type: string
+                                namespace:
+                                  description: The namespace the Provider type is in.
+                                  type: string
+                                type:
+                                  description: The type of provider to use such as "Secret", or "ConfigMap".
+                                  enum:
+                                    - Secret
+                                    - ConfigMap
+                                  type: string
+                              required:
+                                - name
+                                - type
+                              type: object
+                            headers:
+                              additionalProperties:
+                                type: string
+                              description: Headers
+                              type: object
+                            method:
+                              description: Webhook Method
+                              type: string
+                            result:
+                              description: Result formatting
+                              properties:
+                                jsonPath:
+                                  description: Json path of return value
+                                  type: string
+                              type: object
+                            secrets:
+                              description: Secrets to fill in templates These secrets will be passed to the templating function as key value pairs under the given name
+                              items:
+                                properties:
+                                  name:
+                                    description: Name of this secret in templates
+                                    type: string
+                                  secretRef:
+                                    description: Secret ref to fill in credentials
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: The name of the Secret resource being referred to.
+                                        type: string
+                                      namespace:
+                                        description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                        type: string
+                                    type: object
+                                required:
+                                  - name
+                                  - secretRef
+                                type: object
+                              type: array
+                            timeout:
+                              description: Timeout
+                              type: string
+                            url:
+                              description: Webhook url to call
+                              type: string
+                          required:
+                            - result
+                            - url
+                          type: object
+                        yandexlockbox:
+                          description: YandexLockbox configures this store to sync secrets using Yandex Lockbox provider
+                          properties:
+                            apiEndpoint:
+                              description: Yandex.Cloud API endpoint (e.g. 'api.cloud.yandex.net:443')
+                              type: string
+                            auth:
+                              description: Auth defines the information necessary to authenticate against Yandex Lockbox
+                              properties:
+                                authorizedKeySecretRef:
+                                  description: The authorized key used for authentication
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                            caProvider:
+                              description: The provider for the CA bundle to use to validate Yandex.Cloud server certificate.
+                              properties:
+                                certSecretRef:
+                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                          required:
+                            - auth
+                          type: object
+                      type: object
+                    retrySettings:
+                      description: Used to configure http retries if failed
+                      properties:
+                        maxRetries:
+                          format: int32
+                          type: integer
+                        retryInterval:
+                          type: string
+                      type: object
+                  required:
+                    - provider
+                  type: object
+                status:
+                  description: SecretStoreStatus defines the observed state of the SecretStore.
+                  properties:
+                    conditions:
+                      items:
+                        properties:
+                          lastTransitionTime:
+                            format: date-time
+                            type: string
+                          message:
+                            type: string
+                          reason:
+                            type: string
+                          status:
+                            type: string
+                          type:
+                            type: string
+                        required:
+                          - status
+                          - type
+                        type: object
+                      type: array
+                  type: object
+              type: object
+          served: true
+          storage: false
+          subresources:
+            status: {}
+        - additionalPrinterColumns:
+            - jsonPath: .metadata.creationTimestamp
+              name: AGE
+              type: date
+            - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+              name: Status
+              type: string
+            - jsonPath: .status.capabilities
+              name: Capabilities
+              type: string
+            - jsonPath: .status.conditions[?(@.type=="Ready")].status
+              name: Ready
+              type: string
+          name: v1beta1
+          schema:
+            openAPIV3Schema:
+              description: SecretStore represents a secure external location for storing secrets, which can be referenced as part of `storeRef` fields.
+              properties:
+                apiVersion:
+                  description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                  type: string
+                kind:
+                  description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                metadata:
+                  type: object
+                spec:
+                  description: SecretStoreSpec defines the desired state of SecretStore.
+                  properties:
+                    conditions:
+                      description: Used to constraint a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore
+                      items:
+                        description: ClusterSecretStoreCondition describes a condition by which to choose namespaces to process ExternalSecrets in for a ClusterSecretStore instance.
+                        properties:
+                          namespaceSelector:
+                            description: Choose namespace using a labelSelector
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          namespaces:
+                            description: Choose namespaces by name
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      type: array
+                    controller:
+                      description: 'Used to select the correct KES controller (think: ingress.ingressClassName) The KES controller is instantiated with a specific controller name and filters ES based on this property'
+                      type: string
+                    provider:
+                      description: Used to configure the provider. Only one provider may be set
+                      maxProperties: 1
+                      minProperties: 1
+                      properties:
+                        akeyless:
+                          description: Akeyless configures this store to sync secrets using Akeyless Vault provider
+                          properties:
+                            akeylessGWApiURL:
+                              description: Akeyless GW API Url from which the secrets to be fetched from.
+                              type: string
+                            authSecretRef:
+                              description: Auth configures how the operator authenticates with Akeyless.
+                              properties:
+                                kubernetesAuth:
+                                  description: Kubernetes authenticates with Akeyless by passing the ServiceAccount token stored in the named Secret resource.
+                                  properties:
+                                    accessID:
+                                      description: the Akeyless Kubernetes auth-method access-id
+                                      type: string
+                                    k8sConfName:
+                                      description: Kubernetes-auth configuration name in Akeyless-Gateway
+                                      type: string
+                                    secretRef:
+                                      description: Optional secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Akeyless. If a name is specified without a key, `token` is the default. If one is not specified, the one bound to the controller will be used.
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                    serviceAccountRef:
+                                      description: Optional service account field containing the name of a kubernetes ServiceAccount. If the service account is specified, the service account secret token JWT will be used for authenticating with Akeyless. If the service account selector is not supplied, the secretRef will be used instead.
+                                      properties:
+                                        audiences:
+                                          description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                          items:
+                                            type: string
+                                          type: array
+                                        name:
+                                          description: The name of the ServiceAccount resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  required:
+                                    - accessID
+                                    - k8sConfName
+                                  type: object
+                                secretRef:
+                                  description: Reference to a Secret that contains the details to authenticate with Akeyless.
+                                  properties:
+                                    accessID:
+                                      description: The SecretAccessID is used for authentication
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                    accessType:
+                                      description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                    accessTypeParam:
+                                      description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                  type: object
+                              type: object
+                            caBundle:
+                              description: PEM/base64 encoded CA bundle used to validate Akeyless Gateway certificate. Only used if the AkeylessGWApiURL URL is using HTTPS protocol. If not set the system root certificates are used to validate the TLS connection.
+                              format: byte
+                              type: string
+                            caProvider:
+                              description: The provider for the CA bundle to use to validate Akeyless Gateway certificate.
+                              properties:
+                                key:
+                                  description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                                  type: string
+                                name:
+                                  description: The name of the object located at the provider type.
+                                  type: string
+                                namespace:
+                                  description: The namespace the Provider type is in. Can only be defined when used in a ClusterSecretStore.
+                                  type: string
+                                type:
+                                  description: The type of provider to use such as "Secret", or "ConfigMap".
+                                  enum:
+                                    - Secret
+                                    - ConfigMap
+                                  type: string
+                              required:
+                                - name
+                                - type
+                              type: object
+                          required:
+                            - akeylessGWApiURL
+                            - authSecretRef
+                          type: object
+                        alibaba:
+                          description: Alibaba configures this store to sync secrets using Alibaba Cloud provider
+                          properties:
+                            auth:
+                              description: AlibabaAuth contains a secretRef for credentials.
+                              properties:
+                                secretRef:
+                                  description: AlibabaAuthSecretRef holds secret references for Alibaba credentials.
+                                  properties:
+                                    accessKeyIDSecretRef:
+                                      description: The AccessKeyID is used for authentication
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                    accessKeySecretSecretRef:
+                                      description: The AccessKeySecret is used for authentication
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                  required:
+                                    - accessKeyIDSecretRef
+                                    - accessKeySecretSecretRef
+                                  type: object
+                              required:
+                                - secretRef
+                              type: object
+                            endpoint:
+                              type: string
+                            regionID:
+                              description: Alibaba Region to be used for the provider
+                              type: string
+                          required:
+                            - auth
+                            - regionID
+                          type: object
+                        aws:
+                          description: AWS configures this store to sync secrets using AWS Secret Manager provider
+                          properties:
+                            additionalRoles:
+                              description: AdditionalRoles is a chained list of Role ARNs which the SecretManager provider will sequentially assume before assuming Role
+                              items:
+                                type: string
+                              type: array
+                            auth:
+                              description: 'Auth defines the information necessary to authenticate against AWS if not set aws sdk will infer credentials from your environment see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                              properties:
+                                jwt:
+                                  description: Authenticate against AWS using service account tokens.
+                                  properties:
+                                    serviceAccountRef:
+                                      description: A reference to a ServiceAccount resource.
+                                      properties:
+                                        audiences:
+                                          description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                          items:
+                                            type: string
+                                          type: array
+                                        name:
+                                          description: The name of the ServiceAccount resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  type: object
+                                secretRef:
+                                  description: AWSAuthSecretRef holds secret references for AWS credentials both AccessKeyID and SecretAccessKey must be defined in order to properly authenticate.
+                                  properties:
+                                    accessKeyIDSecretRef:
+                                      description: The AccessKeyID is used for authentication
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                    secretAccessKeySecretRef:
+                                      description: The SecretAccessKey is used for authentication
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                    sessionTokenSecretRef:
+                                      description: 'The SessionToken used for authentication This must be defined if AccessKeyID and SecretAccessKey are temporary credentials see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html'
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                  type: object
+                              type: object
+                            region:
+                              description: AWS Region to be used for the provider
+                              type: string
+                            role:
+                              description: Role is a Role ARN which the SecretManager provider will assume
+                              type: string
+                            service:
+                              description: Service defines which service should be used to fetch the secrets
+                              enum:
+                                - SecretsManager
+                                - ParameterStore
+                              type: string
+                          required:
+                            - region
+                            - service
+                          type: object
+                        azurekv:
+                          description: AzureKV configures this store to sync secrets using Azure Key Vault provider
+                          properties:
+                            authSecretRef:
+                              description: Auth configures how the operator authenticates with Azure. Required for ServicePrincipal auth type.
+                              properties:
+                                clientId:
+                                  description: The Azure clientId of the service principle used for authentication.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                clientSecret:
+                                  description: The Azure ClientSecret of the service principle used for authentication.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                            authType:
+                              default: ServicePrincipal
+                              description: 'Auth type defines how to authenticate to the keyvault service. Valid values are: - "ServicePrincipal" (default): Using a service principal (tenantId, clientId, clientSecret) - "ManagedIdentity": Using Managed Identity assigned to the pod (see aad-pod-identity)'
+                              enum:
+                                - ServicePrincipal
+                                - ManagedIdentity
+                                - WorkloadIdentity
+                              type: string
+                            environmentType:
+                              default: PublicCloud
+                              description: 'EnvironmentType specifies the Azure cloud environment endpoints to use for connecting and authenticating with Azure. By default it points to the public cloud AAD endpoint. The following endpoints are available, also see here: https://github.com/Azure/go-autorest/blob/main/autorest/azure/environments.go#L152 PublicCloud, USGovernmentCloud, ChinaCloud, GermanCloud'
+                              enum:
+                                - PublicCloud
+                                - USGovernmentCloud
+                                - ChinaCloud
+                                - GermanCloud
+                              type: string
+                            identityId:
+                              description: If multiple Managed Identity is assigned to the pod, you can select the one to be used
+                              type: string
+                            serviceAccountRef:
+                              description: ServiceAccountRef specified the service account that should be used when authenticating with WorkloadIdentity.
+                              properties:
+                                audiences:
+                                  description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                  items:
+                                    type: string
+                                  type: array
+                                name:
+                                  description: The name of the ServiceAccount resource being referred to.
+                                  type: string
+                                namespace:
+                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            tenantId:
+                              description: TenantID configures the Azure Tenant to send requests to. Required for ServicePrincipal auth type.
+                              type: string
+                            vaultUrl:
+                              description: Vault Url from which the secrets to be fetched from.
+                              type: string
+                          required:
+                            - vaultUrl
+                          type: object
+                        doppler:
+                          description: Doppler configures this store to sync secrets using the Doppler provider
+                          properties:
+                            auth:
+                              description: Auth configures how the Operator authenticates with the Doppler API
+                              properties:
+                                secretRef:
+                                  properties:
+                                    dopplerToken:
+                                      description: The DopplerToken is used for authentication. See https://docs.doppler.com/reference/api#authentication for auth token types. The Key attribute defaults to dopplerToken if not specified.
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                  required:
+                                    - dopplerToken
+                                  type: object
+                              required:
+                                - secretRef
+                              type: object
+                            config:
+                              description: Doppler config (required if not using a Service Token)
+                              type: string
+                            format:
+                              description: Format enables the downloading of secrets as a file (string)
+                              enum:
+                                - json
+                                - dotnet-json
+                                - env
+                                - yaml
+                                - docker
+                              type: string
+                            nameTransformer:
+                              description: Environment variable compatible name transforms that change secret names to a different format
+                              enum:
+                                - upper-camel
+                                - camel
+                                - lower-snake
+                                - tf-var
+                                - dotnet-env
+                              type: string
+                            project:
+                              description: Doppler project (required if not using a Service Token)
+                              type: string
+                          required:
+                            - auth
+                          type: object
+                        fake:
+                          description: Fake configures a store with static key/value pairs
+                          properties:
+                            data:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  value:
+                                    type: string
+                                  valueMap:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  version:
+                                    type: string
+                                required:
+                                  - key
+                                type: object
+                              type: array
+                          required:
+                            - data
+                          type: object
+                        gcpsm:
+                          description: GCPSM configures this store to sync secrets using Google Cloud Platform Secret Manager provider
+                          properties:
+                            auth:
+                              description: Auth defines the information necessary to authenticate against GCP
+                              properties:
+                                secretRef:
+                                  properties:
+                                    secretAccessKeySecretRef:
+                                      description: The SecretAccessKey is used for authentication
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                  type: object
+                                workloadIdentity:
+                                  properties:
+                                    clusterLocation:
+                                      type: string
+                                    clusterName:
+                                      type: string
+                                    clusterProjectID:
+                                      type: string
+                                    serviceAccountRef:
+                                      description: A reference to a ServiceAccount resource.
+                                      properties:
+                                        audiences:
+                                          description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                          items:
+                                            type: string
+                                          type: array
+                                        name:
+                                          description: The name of the ServiceAccount resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  required:
+                                    - clusterLocation
+                                    - clusterName
+                                    - serviceAccountRef
+                                  type: object
+                              type: object
+                            projectID:
+                              description: ProjectID project where secret is located
+                              type: string
+                          type: object
+                        gitlab:
+                          description: Gitlab configures this store to sync secrets using Gitlab Variables provider
+                          properties:
+                            auth:
+                              description: Auth configures how secret-manager authenticates with a GitLab instance.
+                              properties:
+                                SecretRef:
+                                  properties:
+                                    accessToken:
+                                      description: AccessToken is used for authentication.
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                  type: object
+                              required:
+                                - SecretRef
+                              type: object
+                            environment:
+                              description: Environment environment_scope of gitlab CI/CD variables (Please see https://docs.gitlab.com/ee/ci/environments/#create-a-static-environment on how to create environments)
+                              type: string
+                            groupIDs:
+                              description: GroupIDs specify, which gitlab groups to pull secrets from. Group secrets are read from left to right followed by the project variables.
+                              items:
+                                type: string
+                              type: array
+                            inheritFromGroups:
+                              description: InheritFromGroups specifies whether parent groups should be discovered and checked for secrets.
+                              type: boolean
+                            projectID:
+                              description: ProjectID specifies a project where secrets are located.
+                              type: string
+                            url:
+                              description: URL configures the GitLab instance URL. Defaults to https://gitlab.com/.
+                              type: string
+                          required:
+                            - auth
+                          type: object
+                        ibm:
+                          description: IBM configures this store to sync secrets using IBM Cloud provider
+                          properties:
+                            auth:
+                              description: Auth configures how secret-manager authenticates with the IBM secrets manager.
+                              maxProperties: 1
+                              minProperties: 1
+                              properties:
+                                containerAuth:
+                                  description: IBM Container-based auth with IAM Trusted Profile.
+                                  properties:
+                                    iamEndpoint:
+                                      type: string
+                                    profile:
+                                      description: the IBM Trusted Profile
+                                      type: string
+                                    tokenLocation:
+                                      description: Location the token is mounted on the pod
+                                      type: string
+                                  required:
+                                    - profile
+                                  type: object
+                                secretRef:
+                                  properties:
+                                    secretApiKeySecretRef:
+                                      description: The SecretAccessKey is used for authentication
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                  type: object
+                              type: object
+                            serviceUrl:
+                              description: ServiceURL is the Endpoint URL that is specific to the Secrets Manager service instance
+                              type: string
+                          required:
+                            - auth
+                          type: object
+                        keepersecurity:
+                          description: KeeperSecurity configures this store to sync secrets using the KeeperSecurity provider
+                          properties:
+                            authRef:
+                              description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  type: string
+                                namespace:
+                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  type: string
+                              type: object
+                            folderID:
+                              type: string
+                          required:
+                            - authRef
+                            - folderID
+                          type: object
+                        kubernetes:
+                          description: Kubernetes configures this store to sync secrets using a Kubernetes cluster provider
+                          properties:
+                            auth:
+                              description: Auth configures how secret-manager authenticates with a Kubernetes instance.
+                              maxProperties: 1
+                              minProperties: 1
+                              properties:
+                                cert:
+                                  description: has both clientCert and clientKey as secretKeySelector
+                                  properties:
+                                    clientCert:
+                                      description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                    clientKey:
+                                      description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                  type: object
+                                serviceAccount:
+                                  description: points to a service account that should be used for authentication
+                                  properties:
+                                    audiences:
+                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                token:
+                                  description: use static token to authenticate with
+                                  properties:
+                                    bearerToken:
+                                      description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                  type: object
+                              type: object
+                            remoteNamespace:
+                              default: default
+                              description: Remote namespace to fetch the secrets from
+                              type: string
+                            server:
+                              description: configures the Kubernetes server Address.
+                              properties:
+                                caBundle:
+                                  description: CABundle is a base64-encoded CA certificate
+                                  format: byte
+                                  type: string
+                                caProvider:
+                                  description: 'see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider'
+                                  properties:
+                                    key:
+                                      description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                                      type: string
+                                    name:
+                                      description: The name of the object located at the provider type.
+                                      type: string
+                                    namespace:
+                                      description: The namespace the Provider type is in. Can only be defined when used in a ClusterSecretStore.
+                                      type: string
+                                    type:
+                                      description: The type of provider to use such as "Secret", or "ConfigMap".
+                                      enum:
+                                        - Secret
+                                        - ConfigMap
+                                      type: string
+                                  required:
+                                    - name
+                                    - type
+                                  type: object
+                                url:
+                                  default: kubernetes.default
+                                  description: configures the Kubernetes server Address.
+                                  type: string
+                              type: object
+                          required:
+                            - auth
+                          type: object
+                        onepassword:
+                          description: OnePassword configures this store to sync secrets using the 1Password Cloud provider
+                          properties:
+                            auth:
+                              description: Auth defines the information necessary to authenticate against OnePassword Connect Server
+                              properties:
+                                secretRef:
+                                  description: OnePasswordAuthSecretRef holds secret references for 1Password credentials.
+                                  properties:
+                                    connectTokenSecretRef:
+                                      description: The ConnectToken is used for authentication to a 1Password Connect Server.
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                  required:
+                                    - connectTokenSecretRef
+                                  type: object
+                              required:
+                                - secretRef
+                              type: object
+                            connectHost:
+                              description: ConnectHost defines the OnePassword Connect Server to connect to
+                              type: string
+                            vaults:
+                              additionalProperties:
+                                type: integer
+                              description: Vaults defines which OnePassword vaults to search in which order
+                              type: object
+                          required:
+                            - auth
+                            - connectHost
+                            - vaults
+                          type: object
+                        oracle:
+                          description: Oracle configures this store to sync secrets using Oracle Vault provider
+                          properties:
+                            auth:
+                              description: Auth configures how secret-manager authenticates with the Oracle Vault. If empty, use the instance principal, otherwise the user credentials specified in Auth.
+                              properties:
+                                secretRef:
+                                  description: SecretRef to pass through sensitive information.
+                                  properties:
+                                    fingerprint:
+                                      description: Fingerprint is the fingerprint of the API private key.
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                    privatekey:
+                                      description: PrivateKey is the user's API Signing Key in PEM format, used for authentication.
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                  required:
+                                    - fingerprint
+                                    - privatekey
+                                  type: object
+                                tenancy:
+                                  description: Tenancy is the tenancy OCID where user is located.
+                                  type: string
+                                user:
+                                  description: User is an access OCID specific to the account.
+                                  type: string
+                              required:
+                                - secretRef
+                                - tenancy
+                                - user
+                              type: object
+                            region:
+                              description: Region is the region where vault is located.
+                              type: string
+                            vault:
+                              description: Vault is the vault's OCID of the specific vault where secret is located.
+                              type: string
+                          required:
+                            - region
+                            - vault
+                          type: object
+                        senhasegura:
+                          description: Senhasegura configures this store to sync secrets using senhasegura provider
+                          properties:
+                            auth:
+                              description: Auth defines parameters to authenticate in senhasegura
+                              properties:
+                                clientId:
+                                  type: string
+                                clientSecretSecretRef:
+                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              required:
+                                - clientId
+                                - clientSecretSecretRef
+                              type: object
+                            ignoreSslCertificate:
+                              default: false
+                              description: IgnoreSslCertificate defines if SSL certificate must be ignored
+                              type: boolean
+                            module:
+                              description: Module defines which senhasegura module should be used to get secrets
+                              type: string
+                            url:
+                              description: URL of senhasegura
+                              type: string
+                          required:
+                            - auth
+                            - module
+                            - url
+                          type: object
+                        vault:
+                          description: Vault configures this store to sync secrets using Hashi provider
+                          properties:
+                            auth:
+                              description: Auth configures how secret-manager authenticates with the Vault server.
+                              properties:
+                                appRole:
+                                  description: AppRole authenticates with Vault using the App Role auth mechanism, with the role and secret stored in a Kubernetes Secret resource.
+                                  properties:
+                                    path:
+                                      default: approle
+                                      description: 'Path where the App Role authentication backend is mounted in Vault, e.g: "approle"'
+                                      type: string
+                                    roleId:
+                                      description: RoleID configured in the App Role authentication backend when setting up the authentication backend in Vault.
+                                      type: string
+                                    secretRef:
+                                      description: Reference to a key in a Secret that contains the App Role secret used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role secret.
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                  required:
+                                    - path
+                                    - roleId
+                                    - secretRef
+                                  type: object
+                                cert:
+                                  description: Cert authenticates with TLS Certificates by passing client certificate, private key and ca certificate Cert authentication method
+                                  properties:
+                                    clientCert:
+                                      description: ClientCert is a certificate to authenticate using the Cert Vault authentication method
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                    secretRef:
+                                      description: SecretRef to a key in a Secret resource containing client private key to authenticate with Vault using the Cert authentication method
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                  type: object
+                                jwt:
+                                  description: Jwt authenticates with Vault by passing role and JWT token using the JWT/OIDC authentication method
+                                  properties:
+                                    kubernetesServiceAccountToken:
+                                      description: Optional ServiceAccountToken specifies the Kubernetes service account for which to request a token for with the `TokenRequest` API.
+                                      properties:
+                                        audiences:
+                                          description: 'Optional audiences field that will be used to request a temporary Kubernetes service account token for the service account referenced by `serviceAccountRef`. Defaults to a single audience `vault` it not specified. Deprecated: use serviceAccountRef.Audiences instead'
+                                          items:
+                                            type: string
+                                          type: array
+                                        expirationSeconds:
+                                          description: 'Optional expiration time in seconds that will be used to request a temporary Kubernetes service account token for the service account referenced by `serviceAccountRef`. Deprecated: this will be removed in the future. Defaults to 10 minutes.'
+                                          format: int64
+                                          type: integer
+                                        serviceAccountRef:
+                                          description: Service account field containing the name of a kubernetes ServiceAccount.
+                                          properties:
+                                            audiences:
+                                              description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                              items:
+                                                type: string
+                                              type: array
+                                            name:
+                                              description: The name of the ServiceAccount resource being referred to.
+                                              type: string
+                                            namespace:
+                                              description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                      required:
+                                        - serviceAccountRef
+                                      type: object
+                                    path:
+                                      default: jwt
+                                      description: 'Path where the JWT authentication backend is mounted in Vault, e.g: "jwt"'
+                                      type: string
+                                    role:
+                                      description: Role is a JWT role to authenticate using the JWT/OIDC Vault authentication method
+                                      type: string
+                                    secretRef:
+                                      description: Optional SecretRef that refers to a key in a Secret resource containing JWT token to authenticate with Vault using the JWT/OIDC authentication method.
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                  required:
+                                    - path
+                                  type: object
+                                kubernetes:
+                                  description: Kubernetes authenticates with Vault by passing the ServiceAccount token stored in the named Secret resource to the Vault server.
+                                  properties:
+                                    mountPath:
+                                      default: kubernetes
+                                      description: 'Path where the Kubernetes authentication backend is mounted in Vault, e.g: "kubernetes"'
+                                      type: string
+                                    role:
+                                      description: A required field containing the Vault Role to assume. A Role binds a Kubernetes ServiceAccount with a set of Vault policies.
+                                      type: string
+                                    secretRef:
+                                      description: Optional secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Vault. If a name is specified without a key, `token` is the default. If one is not specified, the one bound to the controller will be used.
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                    serviceAccountRef:
+                                      description: Optional service account field containing the name of a kubernetes ServiceAccount. If the service account is specified, the service account secret token JWT will be used for authenticating with Vault. If the service account selector is not supplied, the secretRef will be used instead.
+                                      properties:
+                                        audiences:
+                                          description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                          items:
+                                            type: string
+                                          type: array
+                                        name:
+                                          description: The name of the ServiceAccount resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  required:
+                                    - mountPath
+                                    - role
+                                  type: object
+                                ldap:
+                                  description: Ldap authenticates with Vault by passing username/password pair using the LDAP authentication method
+                                  properties:
+                                    path:
+                                      default: ldap
+                                      description: 'Path where the LDAP authentication backend is mounted in Vault, e.g: "ldap"'
+                                      type: string
+                                    secretRef:
+                                      description: SecretRef to a key in a Secret resource containing password for the LDAP user used to authenticate with Vault using the LDAP authentication method
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                    username:
+                                      description: Username is a LDAP user name used to authenticate using the LDAP Vault authentication method
+                                      type: string
+                                  required:
+                                    - path
+                                    - username
+                                  type: object
+                                tokenSecretRef:
+                                  description: TokenSecretRef authenticates with Vault by presenting a token.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                            caBundle:
+                              description: PEM encoded CA bundle used to validate Vault server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.
+                              format: byte
+                              type: string
+                            caProvider:
+                              description: The provider for the CA bundle to use to validate Vault server certificate.
+                              properties:
+                                key:
+                                  description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                                  type: string
+                                name:
+                                  description: The name of the object located at the provider type.
+                                  type: string
+                                namespace:
+                                  description: The namespace the Provider type is in. Can only be defined when used in a ClusterSecretStore.
+                                  type: string
+                                type:
+                                  description: The type of provider to use such as "Secret", or "ConfigMap".
+                                  enum:
+                                    - Secret
+                                    - ConfigMap
+                                  type: string
+                              required:
+                                - name
+                                - type
+                              type: object
+                            forwardInconsistent:
+                              description: ForwardInconsistent tells Vault to forward read-after-write requests to the Vault leader instead of simply retrying within a loop. This can increase performance if the option is enabled serverside. https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header
+                              type: boolean
+                            namespace:
+                              description: 'Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1". More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
+                              type: string
+                            path:
+                              description: 'Path is the mount path of the Vault KV backend endpoint, e.g: "secret". The v2 KV secret engine version specific "/data" path suffix for fetching secrets from Vault is optional and will be appended if not present in specified path.'
+                              type: string
+                            readYourWrites:
+                              description: ReadYourWrites ensures isolated read-after-write semantics by providing discovered cluster replication states in each request. More information about eventual consistency in Vault can be found here https://www.vaultproject.io/docs/enterprise/consistency
+                              type: boolean
+                            server:
+                              description: 'Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".'
+                              type: string
+                            version:
+                              default: v2
+                              description: Version is the Vault KV secret engine version. This can be either "v1" or "v2". Version defaults to "v2".
+                              enum:
+                                - v1
+                                - v2
+                              type: string
+                          required:
+                            - auth
+                            - server
+                          type: object
+                        webhook:
+                          description: Webhook configures this store to sync secrets using a generic templated webhook
+                          properties:
+                            body:
+                              description: Body
+                              type: string
+                            caBundle:
+                              description: PEM encoded CA bundle used to validate webhook server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.
+                              format: byte
+                              type: string
+                            caProvider:
+                              description: The provider for the CA bundle to use to validate webhook server certificate.
+                              properties:
+                                key:
+                                  description: The key the value inside of the provider type to use, only used with "Secret" type
+                                  type: string
+                                name:
+                                  description: The name of the object located at the provider type.
+                                  type: string
+                                namespace:
+                                  description: The namespace the Provider type is in.
+                                  type: string
+                                type:
+                                  description: The type of provider to use such as "Secret", or "ConfigMap".
+                                  enum:
+                                    - Secret
+                                    - ConfigMap
+                                  type: string
+                              required:
+                                - name
+                                - type
+                              type: object
+                            headers:
+                              additionalProperties:
+                                type: string
+                              description: Headers
+                              type: object
+                            method:
+                              description: Webhook Method
+                              type: string
+                            result:
+                              description: Result formatting
+                              properties:
+                                jsonPath:
+                                  description: Json path of return value
+                                  type: string
+                              type: object
+                            secrets:
+                              description: Secrets to fill in templates These secrets will be passed to the templating function as key value pairs under the given name
+                              items:
+                                properties:
+                                  name:
+                                    description: Name of this secret in templates
+                                    type: string
+                                  secretRef:
+                                    description: Secret ref to fill in credentials
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: The name of the Secret resource being referred to.
+                                        type: string
+                                      namespace:
+                                        description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                        type: string
+                                    type: object
+                                required:
+                                  - name
+                                  - secretRef
+                                type: object
+                              type: array
+                            timeout:
+                              description: Timeout
+                              type: string
+                            url:
+                              description: Webhook url to call
+                              type: string
+                          required:
+                            - result
+                            - url
+                          type: object
+                        yandexcertificatemanager:
+                          description: YandexCertificateManager configures this store to sync secrets using Yandex Certificate Manager provider
+                          properties:
+                            apiEndpoint:
+                              description: Yandex.Cloud API endpoint (e.g. 'api.cloud.yandex.net:443')
+                              type: string
+                            auth:
+                              description: Auth defines the information necessary to authenticate against Yandex Certificate Manager
+                              properties:
+                                authorizedKeySecretRef:
+                                  description: The authorized key used for authentication
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                            caProvider:
+                              description: The provider for the CA bundle to use to validate Yandex.Cloud server certificate.
+                              properties:
+                                certSecretRef:
+                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                          required:
+                            - auth
+                          type: object
+                        yandexlockbox:
+                          description: YandexLockbox configures this store to sync secrets using Yandex Lockbox provider
+                          properties:
+                            apiEndpoint:
+                              description: Yandex.Cloud API endpoint (e.g. 'api.cloud.yandex.net:443')
+                              type: string
+                            auth:
+                              description: Auth defines the information necessary to authenticate against Yandex Lockbox
+                              properties:
+                                authorizedKeySecretRef:
+                                  description: The authorized key used for authentication
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                            caProvider:
+                              description: The provider for the CA bundle to use to validate Yandex.Cloud server certificate.
+                              properties:
+                                certSecretRef:
+                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                          required:
+                            - auth
+                          type: object
+                      type: object
+                    refreshInterval:
+                      description: Used to configure store refresh interval in seconds. Empty or 0 will default to the controller config.
+                      type: integer
+                    retrySettings:
+                      description: Used to configure http retries if failed
+                      properties:
+                        maxRetries:
+                          format: int32
+                          type: integer
+                        retryInterval:
+                          type: string
+                      type: object
+                  required:
+                    - provider
+                  type: object
+                status:
+                  description: SecretStoreStatus defines the observed state of the SecretStore.
+                  properties:
+                    capabilities:
+                      description: SecretStoreCapabilities defines the possible operations a SecretStore can do.
+                      type: string
+                    conditions:
+                      items:
+                        properties:
+                          lastTransitionTime:
+                            format: date-time
+                            type: string
+                          message:
+                            type: string
+                          reason:
+                            type: string
+                          status:
+                            type: string
+                          type:
+                            type: string
+                        required:
+                          - status
+                          - type
+                        type: object
+                      type: array
+                  type: object
+              type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}

--- a/deploy/charts/external-secrets/tests/controller_test.yaml
+++ b/deploy/charts/external-secrets/tests/controller_test.yaml
@@ -1,0 +1,34 @@
+suite: test controller deployment
+templates:
+  - deployment.yaml
+tests:
+  - it: should match snapshot of default values
+    asserts:
+      - matchSnapshot: {}
+  - it: should set imagePullPolicy to Always
+    set:
+      image.pullPolicy: Always
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+  - it: should imagePullPolicy to be default value IfNotPresent
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent
+  - it: should override securityContext
+    set:
+      podSecurityContext:
+        runAsUser: 2000
+      securityContext:
+        runAsUser: 3000
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext
+          value:
+            runAsUser: 2000
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value:
+            runAsUser: 3000

--- a/deploy/charts/external-secrets/tests/crds_test.yaml
+++ b/deploy/charts/external-secrets/tests/crds_test.yaml
@@ -1,0 +1,27 @@
+suite: test crds
+templates:
+  - crds/secretstore.yaml
+tests:
+  - it: should match snapshot of default values
+    asserts:
+      - matchSnapshot: {}
+  - it: should disable conversion webhook
+    set:
+      crds.conversion.enabled: false
+    asserts:
+      - isNull:
+          path: spec.conversion
+
+  - it: should add annotations
+    set:
+      crds:
+        annotations:
+          foo: bar
+          baz: bang
+    asserts:
+      - equal:
+          path: metadata.annotations.foo
+          value: bar
+      - equal:
+          path: metadata.annotations.baz
+          value: bang

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -22,6 +22,9 @@ crds:
   createClusterSecretStore: true
   # -- If true, create CRDs for Push Secret.
   createPushSecret: true
+  annotations: {}
+  conversion:
+    enabled: true
 
 imagePullSecrets: []
 nameOverride: ""

--- a/docs/contributing/devguide.md
+++ b/docs/contributing/devguide.md
@@ -32,6 +32,12 @@ source <(setup-envtest use 1.20.2 -p env --os $(go env GOOS) --arch $(go env GOA
 
 for more information, please see [setup-envtest docs](https://github.com/kubernetes-sigs/controller-runtime/tree/master/tools/setup-envtest)
 
+Our helm chart is tested using `helm-unittest`. You will need it to run tests locally if you modify the helm chart. Install it with the following command:
+
+```
+$ helm plugin install https://github.com/helm-unittest/helm-unittest
+```
+
 ## Building & Testing
 
 The project uses the `make` build system. It'll run code generators, tests and

--- a/docs/contributing/release.md
+++ b/docs/contributing/release.md
@@ -12,7 +12,7 @@ The external-secrets project is released on a as-needed basis. Feel free to open
 
 ## Release Helm Chart
 
-1. Update `version` and/or `appVersion` in `Chart.yaml` and run `make helm.docs`
+1. Update `version` and/or `appVersion` in `Chart.yaml` and run `make helm.docs helm.update.appversion`
 1. push to branch and open pr
 1. run `/ok-to-test-managed` commands for all cloud providers
 1. merge PR if everyhing is green

--- a/hack/helm.generate.sh
+++ b/hack/helm.generate.sh
@@ -21,7 +21,7 @@ for i in "${HELM_DIR}"/templates/crds/*.yml; do
   cp "$i" "$i.bkp"
   if [[ "$CRDS_FLAG_NAME" == *"Cluster"* ]]; then
     echo "{{- if and (.Values.installCRDs) (.Values.crds.$CRDS_FLAG_NAME) }}" > "$i"
-  elif [[ "$CRDS_FLAG_NAME" == *"PushSecret"* ]]; then 
+  elif [[ "$CRDS_FLAG_NAME" == *"PushSecret"* ]]; then
 			echo "{{- if and (.Values.installCRDs) (.Values.crds.$CRDS_FLAG_NAME) }}" > "$i"
   else
     echo "{{- if .Values.installCRDs }}" > "$i"
@@ -31,5 +31,9 @@ for i in "${HELM_DIR}"/templates/crds/*.yml; do
   rm "$i.bkp"
   $SEDPRG -i 's/name: kubernetes/name: {{ include "external-secrets.fullname" . }}-webhook/g' "$i"
   $SEDPRG -i 's/namespace: default/namespace: {{ .Release.Namespace | quote }}/g' "$i"
+  $SEDPRG -i '0,/annotations/!b;//a\    {{- with .Values.crds.annotations }}\n    {{- toYaml . | nindent 4}}\n    {{- end }}' "$i"
+
+  sed -i '/  conversion:/i{{- if .Values.crds.conversion.enabled }}' "$i"
+  echo "{{- end }}" >> "$i"
   mv "$i" "${i%.yml}.yaml"
 done


### PR DESCRIPTION
## Problem Statement

Our helm chart doesn't have unit tests. In order to provide a high-quality helm chart and to spot errors and regressions early we need a proper test suite for it.

This PR also adds two small features:
1. allow to specify crd annotations with `crds.annotations` #2112 #1965 
2. allow a user to disable/remove conversion webhook - that way a user is able to install ESO without certController and doesn't need to install the CRDs seperately #1965 #1367 

The idea is to start small with a few tests to get the system going and then add more tests gradually.

See [CI Job](https://github.com/external-secrets/external-secrets/actions/runs/4388109290/jobs/7684215974):

```
make helm.test
# [...]
### Chart [ external-secrets ] deploy/charts/external-secrets/

 PASS  test controller deployment	deploy/charts/external-secrets/tests/controller_test.yaml
 PASS  test crds	deploy/charts/external-secrets/tests/crds_test.yaml

Charts:      1 passed, 1 total
Test Suites: 2 passed, 2 total
Tests:       7 passed, 7 total
Snapshot:    2 passed, 2 total
Time:        156.197799ms
```

## Related Issue

Fixes #2112 #1965 #1367

## Proposed Changes

This PR runs `helm unittest` whenever the helm chart source code is changed.
