### PR TITLE
fix: Add missing YAML separator in servicemonitor

### DIFF
--- a/deploy/charts/external-secrets/templates/servicemonitor.yaml
+++ b/deploy/charts/external-secrets/templates/servicemonitor.yaml
@@ -95,6 +95,7 @@ spec:
     {{- end }}
 {{- end }}
 {{- if .Values.certController.create }}
+---
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
## Problem Statement

Without the separator, Helm install fails on:
```
Helm upgrade failed: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors:
  line 29: mapping key "apiVersion" already defined at line 2
  line 30: mapping key "kind" already defined at line 3
  line 31: mapping key "metadata" already defined at line 4
  line 38: mapping key "spec" already defined at line 15
```

## Related Issue

Most probably introduced by #2024.

Fixes #2135.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
