### PR TITLE
Fix #1996 - resolve find by name and metadata func

### DIFF
--- a/pkg/provider/vault/vault.go
+++ b/pkg/provider/vault/vault.go
@@ -461,18 +461,33 @@ func (v *client) GetAllSecrets(ctx context.Context, ref esv1beta1.ExternalSecret
 	if err != nil {
 		return nil, err
 	}
-	if ref.Name != nil {
-		return v.findSecretsFromName(ctx, potentialSecrets, *ref.Name)
-	}
-	return v.findSecretsFromTags(ctx, potentialSecrets, ref.Tags)
+	return v.findSecretsFromNameAndTags(ctx, potentialSecrets, ref.Name, ref.Tags)
 }
 
-func (v *client) findSecretsFromTags(ctx context.Context, candidates []string, tags map[string]string) (map[string][]byte, error) {
+func (v *client) findSecretsFromNameAndTags(ctx context.Context, candidates []string, findName *esv1beta1.FindName, tags map[string]string) (map[string][]byte, error) {
+	var matcher *find.Matcher
+	var err error
 	secrets := make(map[string][]byte)
+	if findName != nil {
+		matcher, err = find.New(*findName)
+		if err != nil {
+			return nil, err
+		}
+	}
 	for _, name := range candidates {
+		if findName != nil {
+			//check if secret matches the name
+			ok := matcher.MatchName(name)
+			if !ok {
+				break
+			}
+		}
 		match := true
 		metadata, err := v.readSecretMetadata(ctx, name)
 		if err != nil {
+			if errors.Is(err, esv1beta1.NoSecretErr) {
+				continue
+			}
 			return nil, err
 		}
 		for tk, tv := range tags {
@@ -484,34 +499,10 @@ func (v *client) findSecretsFromTags(ctx context.Context, candidates []string, t
 		}
 		if match {
 			secret, err := v.GetSecret(ctx, esv1beta1.ExternalSecretDataRemoteRef{Key: name})
-			if errors.Is(err, esv1beta1.NoSecretError{}) {
-				continue
-			}
 			if err != nil {
-				return nil, err
-			}
-			if secret != nil {
-				secrets[name] = secret
-			}
-		}
-	}
-	return secrets, nil
-}
-
-func (v *client) findSecretsFromName(ctx context.Context, candidates []string, ref esv1beta1.FindName) (map[string][]byte, error) {
-	secrets := make(map[string][]byte)
-	matcher, err := find.New(ref)
-	if err != nil {
-		return nil, err
-	}
-	for _, name := range candidates {
-		ok := matcher.MatchName(name)
-		if ok {
-			secret, err := v.GetSecret(ctx, esv1beta1.ExternalSecretDataRemoteRef{Key: name})
-			if errors.Is(err, esv1beta1.NoSecretError{}) {
-				continue
-			}
-			if err != nil {
+				if errors.Is(err, esv1beta1.NoSecretErr) {
+					continue
+				}
 				return nil, err
 			}
 			if secret != nil {

--- a/pkg/provider/vault/vault_test.go
+++ b/pkg/provider/vault/vault_test.go
@@ -1150,6 +1150,54 @@ func TestGetAllSecrets(t *testing.T) {
 				},
 			},
 		},
+		"FindByNameAndTag": {
+			reason: "should map secrets matching names and tags",
+			args: args{
+				store: makeValidSecretStoreWithVersion(esv1beta1.VaultKVStoreV2).Spec.Provider.Vault,
+				vLogical: &fake.Logical{
+					ListWithContextFn:         newListWithContextFn(secret),
+					ReadWithDataWithContextFn: newReadtWithContextFn(secret),
+				},
+				data: esv1beta1.ExternalSecretFind{
+					Name: &esv1beta1.FindName{
+						RegExp: "secret.*",
+					},
+					Tags: map[string]string{
+						"foo": "bar",
+					},
+				},
+			},
+			want: want{
+				err: nil,
+				val: map[string][]byte{
+					"secret1": secret1Bytes,
+				},
+			},
+		},
+		"FindByNameAndTagAgainstMultipleSecrets": {
+			reason: "should map secrets matching names and tags",
+			args: args{
+				store: makeValidSecretStoreWithVersion(esv1beta1.VaultKVStoreV2).Spec.Provider.Vault,
+				vLogical: &fake.Logical{
+					ListWithContextFn:         newListWithContextFn(secret),
+					ReadWithDataWithContextFn: newReadtWithContextFn(secret),
+				},
+				data: esv1beta1.ExternalSecretFind{
+					Name: &esv1beta1.FindName{
+						RegExp: "secret.*",
+					},
+					Tags: map[string]string{
+						"foo": "baz",
+					},
+				},
+			},
+			want: want{
+				err: nil,
+				val: map[string][]byte{
+					"secret2": secret2Bytes,
+				},
+			},
+		},
 		"FilterByPath": {
 			reason: "should filter secrets based on path",
 			args: args{


### PR DESCRIPTION
Fixes #1996 

Fixes behaviour of `GetAllSecrets` by using both `tag` and `name` in search

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
