### PR TITLE
[Documentation] Align getting started documents CRDs with the rest of external-secrets

### DIFF
--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -9,9 +9,9 @@ and manages Kubernetes secret resources with ExternalSecret resources.
 
 ## Installing with Helm
 
-To automatically install and manage the CRDs as part of your Helm release, you must add the --set installCRDs=true flag to your Helm installation command.
+The default install options will automatically install and manage the CRDs as part of your helm release. If you do not want the CRDs to be automatically upgraded and managed, you must set the `installCRDs` option to `false`. (e.g. `--set installCRDS=false`)
 
-Uncomment the relevant line in the next steps to enable this.
+Uncomment the relevant line in the next steps to disable the automatic install of CRDs.
 
 ### Option 1: Install from chart repository
 
@@ -22,7 +22,7 @@ helm install external-secrets \
    external-secrets/external-secrets \
     -n external-secrets \
     --create-namespace \
-  # --set installCRDs=true
+  # --set installCRDs=false
 ```
 
 ### Option 2: Install chart from local build
@@ -36,7 +36,7 @@ helm install external-secrets \
     ./bin/chart/external-secrets.tgz \
     -n external-secrets \
     --create-namespace \
-  # --set installCRDs=true
+  # --set installCRDs=false
 ```
 
 ### Create a secret containing your AWS credentials


### PR DESCRIPTION
## Problem Statement

Seems like there is a mismatch in the actual helm default `values.yaml` and what is instructed in the Getting Started page. I described it in this issue https://github.com/external-secrets/external-secrets/issues/2209

## Related Issue

Fixes: https://github.com/external-secrets/external-secrets/issues/2209
Related to the confusion, but doesn't actually fix: https://github.com/external-secrets/external-secrets/issues/1409

## Proposed Changes

This is just a documentation update. I would like the team to be able to sign off that this is the intended behavior and not the other way around. There may have been some intention writing that in the first place. 

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage (n/a)
- [ ] All tests pass with `make test` (n/a)
- [x] I ensured my PR is ready for review with `make reviewable`
