### PR TITLE
Fix scaleway config validation in ClusterSecretStore

### DIFF
--- a/pkg/provider/scaleway/provider.go
+++ b/pkg/provider/scaleway/provider.go
@@ -134,11 +134,11 @@ func validateSecretRef(store esv1beta1.GenericStore, ref *esv1beta1.ScalewayProv
 }
 
 func doesConfigDependOnNamespace(cfg *esv1beta1.ScalewayProvider) bool {
-	if cfg.AccessKey.SecretRef != nil && cfg.AccessKey.SecretRef.Namespace != nil {
+	if cfg.AccessKey.SecretRef != nil && cfg.AccessKey.SecretRef.Namespace == nil {
 		return true
 	}
 
-	if cfg.SecretKey.SecretRef != nil && cfg.SecretKey.SecretRef.Namespace != nil {
+	if cfg.SecretKey.SecretRef != nil && cfg.SecretKey.SecretRef.Namespace == nil {
 		return true
 	}
 


### PR DESCRIPTION
## Problem Statement

When scaleway configuration in ClusterSecretStore is validated it is checked if namespace in secret refs is set. But due to bug validation code incorrectly expects missing namespace while it on the opposite must be set.

## Related Issue

Fixes #2246

## Proposed Changes

Fix incorrect conditions in validation checks

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
