### PR TITLE
fix: re-generate helm test fixtures

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -7,9 +7,11 @@ on:
       - release-*
     paths:
       - 'deploy/charts/**'
+      - 'deploy/crds'
   pull_request:
     paths:
       - 'deploy/charts/**'
+      - 'deploy/crds'
   workflow_dispatch: {}
 
 jobs:

--- a/deploy/charts/external-secrets/tests/__snapshot__/crds_test.yaml.snap
+++ b/deploy/charts/external-secrets/tests/__snapshot__/crds_test.yaml.snap
@@ -194,6 +194,23 @@ should match snapshot of default values:
                             auth:
                               description: AlibabaAuth contains a secretRef for credentials.
                               properties:
+                                rrsa:
+                                  description: Authenticate against Alibaba using RRSA.
+                                  properties:
+                                    oidcProviderArn:
+                                      type: string
+                                    oidcTokenFilePath:
+                                      type: string
+                                    roleArn:
+                                      type: string
+                                    sessionName:
+                                      type: string
+                                  required:
+                                    - oidcProviderArn
+                                    - oidcTokenFilePath
+                                    - roleArn
+                                    - sessionName
+                                  type: object
                                 secretRef:
                                   description: AlibabaAuthSecretRef holds secret references for Alibaba credentials.
                                   properties:
@@ -227,11 +244,7 @@ should match snapshot of default values:
                                     - accessKeyIDSecretRef
                                     - accessKeySecretSecretRef
                                   type: object
-                              required:
-                                - secretRef
                               type: object
-                            endpoint:
-                              type: string
                             regionID:
                               description: Alibaba Region to be used for the provider
                               type: string
@@ -1343,6 +1356,23 @@ should match snapshot of default values:
                             auth:
                               description: AlibabaAuth contains a secretRef for credentials.
                               properties:
+                                rrsa:
+                                  description: Authenticate against Alibaba using RRSA.
+                                  properties:
+                                    oidcProviderArn:
+                                      type: string
+                                    oidcTokenFilePath:
+                                      type: string
+                                    roleArn:
+                                      type: string
+                                    sessionName:
+                                      type: string
+                                  required:
+                                    - oidcProviderArn
+                                    - oidcTokenFilePath
+                                    - roleArn
+                                    - sessionName
+                                  type: object
                                 secretRef:
                                   description: AlibabaAuthSecretRef holds secret references for Alibaba credentials.
                                   properties:
@@ -1376,11 +1406,7 @@ should match snapshot of default values:
                                     - accessKeyIDSecretRef
                                     - accessKeySecretSecretRef
                                   type: object
-                              required:
-                                - secretRef
                               type: object
-                            endpoint:
-                              type: string
                             regionID:
                               description: Alibaba Region to be used for the provider
                               type: string


### PR DESCRIPTION
This PR:

1. re-generates helm test fixtures for #2237.
2. runs helm tests when CRDs change

Root cause: The initial PR didn't change the helm chart, hence the helm tests didn't ran and the test fixtures haven't been updated as a result.