### PR TITLE
feat(helm): use good securityContext by default

### DIFF
--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -64,7 +64,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | certController.requeueInterval | string | `"5m"` |  |
 | certController.resources | object | `{}` |  |
 | certController.revisionHistoryLimit | int | `10` | Specifies the amount of historic ReplicaSets k8s should keep (see https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy) |
-| certController.securityContext | object | `{}` |  |
+| certController.securityContext.allowPrivilegeEscalation | bool | `false` |  |
+| certController.securityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| certController.securityContext.readOnlyRootFilesystem | bool | `true` |  |
+| certController.securityContext.runAsNonRoot | bool | `true` |  |
+| certController.securityContext.runAsUser | int | `1000` |  |
+| certController.securityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
 | certController.serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
 | certController.serviceAccount.automount | bool | `true` | Automounts the service account token in all containers of the pod |
 | certController.serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
@@ -118,7 +123,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | revisionHistoryLimit | int | `10` | Specifies the amount of historic ReplicaSets k8s should keep (see https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy) |
 | scopedNamespace | string | `""` | If set external secrets are only reconciled in the provided namespace |
 | scopedRBAC | bool | `false` | Must be used with scopedNamespace. If true, create scoped RBAC roles under the scoped namespace and implicitly disable cluster stores and cluster external secrets |
-| securityContext | object | `{}` |  |
+| securityContext.allowPrivilegeEscalation | bool | `false` |  |
+| securityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| securityContext.readOnlyRootFilesystem | bool | `true` |  |
+| securityContext.runAsNonRoot | bool | `true` |  |
+| securityContext.runAsUser | int | `1000` |  |
+| securityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
 | serviceAccount.automount | bool | `true` | Automounts the service account token in all containers of the pod |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
@@ -171,7 +181,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | webhook.resources | object | `{}` |  |
 | webhook.revisionHistoryLimit | int | `10` | Specifies the amount of historic ReplicaSets k8s should keep (see https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy) |
 | webhook.secretAnnotations | object | `{}` | Annotations to add to Secret |
-| webhook.securityContext | object | `{}` |  |
+| webhook.securityContext.allowPrivilegeEscalation | bool | `false` |  |
+| webhook.securityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| webhook.securityContext.readOnlyRootFilesystem | bool | `true` |  |
+| webhook.securityContext.runAsNonRoot | bool | `true` |  |
+| webhook.securityContext.runAsUser | int | `1000` |  |
+| webhook.securityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
 | webhook.serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
 | webhook.serviceAccount.automount | bool | `true` | Automounts the service account token in all containers of the pod |
 | webhook.serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |

--- a/deploy/charts/external-secrets/tests/__snapshot__/controller_test.yaml.snap
+++ b/deploy/charts/external-secrets/tests/__snapshot__/controller_test.yaml.snap
@@ -35,4 +35,14 @@ should match snapshot of default values:
                 - containerPort: 8080
                   name: metrics
                   protocol: TCP
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 1000
+                seccompProfile:
+                  type: RuntimeDefault
           serviceAccountName: RELEASE-NAME-external-secrets

--- a/deploy/charts/external-secrets/tests/controller_test.yaml
+++ b/deploy/charts/external-secrets/tests/controller_test.yaml
@@ -31,4 +31,12 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].securityContext
           value:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
             runAsUser: 3000
+            seccompProfile:
+              type: RuntimeDefault

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -110,7 +110,7 @@ securityContext:
   allowPrivilegeEscalation: false
   capabilities:
     drop:
-    - ALL
+      - ALL
   readOnlyRootFilesystem: true
   runAsNonRoot: true
   runAsUser: 1000
@@ -319,7 +319,7 @@ webhook:
     allowPrivilegeEscalation: false
     capabilities:
       drop:
-      - ALL
+        - ALL
     readOnlyRootFilesystem: true
     runAsNonRoot: true
     runAsUser: 1000
@@ -436,7 +436,7 @@ certController:
     allowPrivilegeEscalation: false
     capabilities:
       drop:
-      - ALL
+        - ALL
     readOnlyRootFilesystem: true
     runAsNonRoot: true
     runAsUser: 1000

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -106,13 +106,16 @@ podLabels: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+    - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1000
+  seccompProfile:
+    type: RuntimeDefault
 
 resources: {}
   # requests:
@@ -312,13 +315,16 @@ webhook:
   podSecurityContext: {}
       # fsGroup: 2000
 
-  securityContext: {}
-      # capabilities:
-      #   drop:
-      #   - ALL
-      # readOnlyRootFilesystem: true
-      # runAsNonRoot: true
-      # runAsUser: 1000
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 1000
+    seccompProfile:
+      type: RuntimeDefault
 
   resources: {}
       # requests:
@@ -426,13 +432,16 @@ certController:
   podSecurityContext: {}
       # fsGroup: 2000
 
-  securityContext: {}
-      # capabilities:
-      #   drop:
-      #   - ALL
-      # readOnlyRootFilesystem: true
-      # runAsNonRoot: true
-      # runAsUser: 1000
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 1000
+    seccompProfile:
+      type: RuntimeDefault
 
   resources: {}
       # requests:


### PR DESCRIPTION
## Problem Statement

Better default securityContext for the pods, see https://github.com/external-secrets/external-secrets/issues/2207 for details

## Related Issue

Fixes https://github.com/external-secrets/external-secrets/issues/2207

## Proposed Changes

By using strong securityContext as the default values. User can still lessen the provided configuration, should the need arise.

## Additional Information

I have been using the provided securityContexts without issue for some time, although I would appreciate someone other than me testing it as well.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] I ensured my PR is ready for review with `make reviewable`
