### PR TITLE
Password yaml was missing the name

### DIFF
--- a/docs/api/generator/password.md
+++ b/docs/api/generator/password.md
@@ -28,7 +28,13 @@ You can influence the behavior of the generator by providing the following args
 {% include 'generator-password.yaml' %}
 ```
 
-May produce values such as:
+The above `Password` can be used with this `ExternalSecret`
+
+```yaml
+{% include 'generator-password-external-secret.yaml' %}
+```
+
+Which will generate a `Secret` with a password key that may look like:
 
 ```
 RMngCHKtZ@@h@3aja$WZDuDVhkCkN48JBa9OF8jH$R

--- a/docs/snippets/generator-password-external-secret.yaml
+++ b/docs/snippets/generator-password-external-secret.yaml
@@ -1,0 +1,14 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: "password"
+spec:
+  refreshInterval: "30m"
+  target:
+    name: password-secret
+  dataFrom:
+  - sourceRef:
+      generatorRef:
+        apiVersion: generators.external-secrets.io/v1alpha1
+        kind: Password
+        name: "my-password"

--- a/docs/snippets/generator-password.yaml
+++ b/docs/snippets/generator-password.yaml
@@ -1,5 +1,7 @@
 apiVersion: generators.external-secrets.io/v1alpha1
 kind: Password
+metadata:
+  name: my-password
 spec:
   length: 42
   digits: 5


### PR DESCRIPTION
## Problem Statement

The yaml provided as example for Password was broken.
I also thought it could be usefull to provide an External Secret that uses the Password from the example

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
