### PR TITLE
fix: certController misses leases RBAC to enable leader election

### DIFF
--- a/deploy/charts/external-secrets/templates/cert-controller-rbac.yaml
+++ b/deploy/charts/external-secrets/templates/cert-controller-rbac.yaml
@@ -51,6 +51,15 @@ rules:
     - "watch"
     - "update"
     - "patch"
+  - apiGroups:
+    - "coordination.k8s.io"
+    resources:
+    - "leases"
+    verbs:
+    - "get"
+    - "create"
+    - "update"
+    - "patch"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
This PR adds missing RBAC permissions to allow `certController` to run with`--enable-leader-election=true`.