### PR TITLE
chore: adding VMware Tanzu to the adopters list

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -18,5 +18,6 @@
 - [Radio France](https://www.radiofrance.fr/)
 - [Made People](https://madepeople.se/)
 - [Voiceflow](https://www.voiceflow.com/)
+- [VMware Tanzu](https://tanzu.vmware.com/)
 
 Countless others that can't disclose that information! :)


### PR DESCRIPTION
## Problem Statement

ESO is used inside VMware Tanzu, so adding the product to the adopters list.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
