### PR TITLE
feat: add RBAC rules for user-facing ClusterRoles

### DIFF
--- a/deploy/charts/external-secrets/templates/rbac.yaml
+++ b/deploy/charts/external-secrets/templates/rbac.yaml
@@ -138,6 +138,19 @@ rules:
       - "get"
       - "watch"
       - "list"
+  - apiGroups:
+    - "generators.external-secrets.io"
+    resources:
+    - "acraccesstokens"
+    - "ecrauthorizationtokens"
+    - "fakes"
+    - "gcraccesstokens"
+    - "passwords"
+    - "vaultdynamicsecrets"
+    verbs:
+      - "get"
+      - "watch"
+      - "list"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if and .Values.scopedNamespace .Values.scopedRBAC }}
@@ -162,6 +175,21 @@ rules:
       - "secretstores"
       - "clustersecretstores"
       - "pushsecrets"
+    verbs:
+      - "create"
+      - "delete"
+      - "deletecollection"
+      - "patch"
+      - "update"
+  - apiGroups:
+    - "generators.external-secrets.io"
+    resources:
+    - "acraccesstokens"
+    - "ecrauthorizationtokens"
+    - "fakes"
+    - "gcraccesstokens"
+    - "passwords"
+    - "vaultdynamicsecrets"
     verbs:
       - "create"
       - "delete"


### PR DESCRIPTION
## Problem Statement

Having default user-facing ClusterRoles be able to CRUD group `generators.external-secrets.io`.

## Related Issue

Fixes #2285 

## Proposed Changes

Adding the appropriate rules to the ClusterRoles.

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [X] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
