### PR TITLE
feat: add support for pushing whole Secret resources to a secret store

### DIFF
--- a/apis/externalsecrets/v1alpha1/pushsecret_types.go
+++ b/apis/externalsecrets/v1alpha1/pushsecret_types.go
@@ -91,7 +91,7 @@ func (r PushSecretRemoteRef) GetProperty() string {
 
 type PushSecretMatch struct {
 	// Secret Key to be pushed
-	SecretKey string `json:"secretKey"`
+	SecretKey string `json:"secretKey,omitempty"`
 	// Remote Refs to push to providers.
 	RemoteRef PushSecretRemoteRef `json:"remoteRef"`
 }

--- a/config/crds/bases/external-secrets.io_pushsecrets.yaml
+++ b/config/crds/bases/external-secrets.io_pushsecrets.yaml
@@ -65,7 +65,6 @@ spec:
                           type: string
                       required:
                       - remoteRef
-                      - secretKey
                       type: object
                     metadata:
                       description: Metadata is metadata attached to the secret. The
@@ -225,7 +224,6 @@ spec:
                             type: string
                         required:
                         - remoteRef
-                        - secretKey
                         type: object
                       metadata:
                         description: Metadata is metadata attached to the secret.

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -4274,7 +4274,6 @@ spec:
                             type: string
                         required:
                           - remoteRef
-                          - secretKey
                         type: object
                       metadata:
                         description: Metadata is metadata attached to the secret. The structure of metadata is provider specific, please look it up in the provider documentation.
@@ -4408,7 +4407,6 @@ spec:
                               type: string
                           required:
                             - remoteRef
-                            - secretKey
                           type: object
                         metadata:
                           description: Metadata is metadata attached to the secret. The structure of metadata is provider specific, please look it up in the provider documentation.


### PR DESCRIPTION
## Problem Statement

It is not currently possible to use a PushSecret to push a whole Secret resource to a secret store. Since the `secretKey` field is mandatory, only a subset of the secret can be pushed.



## Related Issue

Related to #2166

## Proposed Changes

This MR introduce the possibility to not provide a `secretKey`, in this case the Secret resource's data field is converted to a JSON string and pushed to the secret store.

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
