### PR TITLE
feat: allow to get auth data from vault response

### DIFF
--- a/apis/generators/v1alpha1/generator_vault.go
+++ b/apis/generators/v1alpha1/generator_vault.go
@@ -33,12 +33,27 @@ type VaultDynamicSecretSpec struct {
 	// Parameters to pass to Vault write (for non-GET methods)
 	Parameters *apiextensions.JSON `json:"parameters,omitempty"`
 
+	// Result type defines which data is returned from the generator.
+	// By default it is the "data" section of the Vault API response.
+	// When using e.g. /auth/token/create the "data" section is empty but
+	// the "auth" section contains the generated token.
+	// Please refer to the vault docs regarding the result data structure.
+	// +kubebuilder:default=Data
+	ResultType VaultDynamicSecretResultType `json:"resultType,omitempty"`
+
 	// Vault provider common spec
 	Provider *esv1beta1.VaultProvider `json:"provider"`
 
 	// Vault path to obtain the dynamic secret from
 	Path string `json:"path"`
 }
+
+type VaultDynamicSecretResultType string
+
+const (
+	VaultDynamicSecretResultTypeData VaultDynamicSecretResultType = "Data"
+	VaultDynamicSecretResultTypeAuth VaultDynamicSecretResultType = "Auth"
+)
 
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion

--- a/config/crds/bases/generators.external-secrets.io_vaultdynamicsecrets.yaml
+++ b/config/crds/bases/generators.external-secrets.io_vaultdynamicsecrets.yaml
@@ -580,6 +580,14 @@ spec:
                 - auth
                 - server
                 type: object
+              resultType:
+                default: Data
+                description: Result type defines which data is returned from the generator.
+                  By default it is the "data" section of the Vault API response. When
+                  using e.g. /auth/token/create the "data" section is empty but the
+                  "auth" section contains the generated token. Please refer to the
+                  vault docs regarding the result data structure.
+                type: string
             required:
             - path
             - provider

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -7644,6 +7644,10 @@ spec:
                     - auth
                     - server
                   type: object
+                resultType:
+                  default: Data
+                  description: Result type defines which data is returned from the generator. By default it is the "data" section of the Vault API response. When using e.g. /auth/token/create the "data" section is empty but the "auth" section contains the generated token. Please refer to the vault docs regarding the result data structure.
+                  type: string
               required:
                 - path
                 - provider

--- a/pkg/generator/vault/vault.go
+++ b/pkg/generator/vault/vault.go
@@ -98,9 +98,23 @@ func (g *Generator) generate(ctx context.Context, c *provider.Connector, jsonSpe
 		return nil, fmt.Errorf(errGetSecret, fmt.Errorf("empty response from Vault"))
 	}
 
+	data := make(map[string]interface{})
 	response := make(map[string][]byte)
-	for k := range result.Data {
-		response[k], err = provider.GetTypedKey(result.Data, k)
+	if res.Spec.ResultType == genv1alpha1.VaultDynamicSecretResultTypeAuth {
+		authJSON, err := json.Marshal(result.Auth)
+		if err != nil {
+			return nil, err
+		}
+		err = json.Unmarshal(authJSON, &data)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		data = result.Data
+	}
+
+	for k := range data {
+		response[k], err = provider.GetTypedKey(data, k)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Fixes #2324 

This PR allows users to extract information from the vault response that is not in the `data` node.
In particular the `/auth/token/create` endpoint returns `null` data, but instead all information is under the `auth` node.

Docs: https://developer.hashicorp.com/vault/api-docs/auth/token

Sample vault response from `/auth/token/create`:

```json
{
  "request_id": "f00341c1-fad5-f6e6-13fd-235617f858a1",
  "lease_id": "",
  "renewable": false,
  "lease_duration": 0,
  "data": null,
  "wrap_info": null,
  "warnings": [
    "Policy \"stage\" does not exist",
    "Policy \"web\" does not exist"
  ],
  "auth": {
    "client_token": "s.wOrq9dO9kzOcuvB06CMviJhZ",
    "accessor": "B6oixijqmeR4bsLOJH88Ska9",
    "policies": ["default", "stage", "web"],
    "token_policies": ["default", "stage", "web"],
    "metadata": {
      "user": "armon"
    },
    "lease_duration": 3600,
    "renewable": true,
    "entity_id": "",
    "token_type": "service",
    "orphan": false,
    "num_uses": 0
  }
}

```