### PR TITLE
hashicorp-vault pushsecret doc update

### DIFF
--- a/docs/provider/hashicorp-vault.md
+++ b/docs/provider/hashicorp-vault.md
@@ -385,7 +385,7 @@ This approach assumes that appropriate IRSA setup is done controller's pod (i.e.
 ### PushSecret
 Vault supports PushSecret features which allow you to sync a given kubernetes secret key into a hashicorp vault secret. In order to do so, it is expected that the secret key is a valid JSON object.
 
-In order to use PushSecret, you need to give `create`, `read` and `update` permissions to the path where you want to push secrets to. Use it with care!
+In order to use PushSecret, you need to give `create`, `read` and `update` permissions to the path where you want to push secrets to for both `data` and `metadata` of the secret. Use it with care!
 
 Here is an example on how to set it up:
 ```yaml


### PR DESCRIPTION
## Problem Statement

Hashicorp Vault PushSecret docs don't specify to set permissions for both data and metadata updates. Important distinction here.

## Related Issue

n/a

## Proposed Changes

Update docs to include mention of both data and metadata permissions

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
