### PR TITLE
chore: bump release docs

### DIFF
--- a/docs/contributing/release.md
+++ b/docs/contributing/release.md
@@ -38,7 +38,7 @@ export VERSION=x.y.z
 sed -i "s/^VERSION ?= .*/VERSION ?= ${VERSION}/" Makefile
 
 # prep release
-make prepare-stable-release
+make prepare-stable-release ATTACH_IMAGE_DIGESTS=0
 ```
 
 Check the generated files in the `bundle/` directory. If they look good add & commit them, open a PR against this repository. You can always use the [OperatorHub.io/preview](https://operatorhub.io/preview) page to preview the generated CSV.
@@ -50,8 +50,9 @@ git commit -s -m "chore: bump version xyz"
 git push
 ```
 
-Once the PR is merged we need create a pull request against both community-operators repositories. There's a make target that does the heavy lifting for you:
+Once the PR is merged and the image build job on `main` has completed, we need create a pull request against both community-operators repositories. There's a make target that does the heavy lifting for you:
 ```bash
+make attach-image-digests
 make bundle-operatorhub
 ```
 


### PR DESCRIPTION
This PR updates the docs from recent changes in https://github.com/external-secrets/external-secrets-operator and https://github.com/external-secrets/external-secrets.

That allows us to drive a smooth release.