### PR TITLE
fix: generate manifests with the correct version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,7 +132,11 @@ jobs:
         run: make docker.promote
 
       - name: Build release manifests
-        run: make manifests
+        run: |
+          # temporarily patch the version so we generate manifests with the new version
+          yq e -i '.version = "${{ github.event.inputs.version }}"' ./deploy/charts/external-secrets/Chart.yaml
+          yq e -i '.appVersion = "${{ github.event.inputs.version }}"' ./deploy/charts/external-secrets/Chart.yaml
+          make manifests
 
       - name: Sign promoted image
         id: sign


### PR DESCRIPTION
## Problem Statement

The release asset `external-secrets.yaml` contains the wrong image and version tags: The version is always the previous version. The release assets of the latest releases `0.7.3` and `0.8.2` have been fixed manually.  

## Proposed changes
This PR automates the process so that we don't need to manually patch the release assets. Instead, before rendering the  manifests we set the correct `.version` / `.appVersion` in the helm chart.


## Proof of work
See [fork release](https://github.com/moolen/external-secrets/releases/tag/v0.8.3) / attached [external-secrets.yaml](https://github.com/moolen/external-secrets/releases/download/v0.8.3/external-secrets.yaml) - it contains the new tag version.