### PR TITLE
Use closures for ExternalSecretController metrics

### DIFF
--- a/pkg/controllers/externalsecret/externalsecret_controller.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller.go
@@ -100,9 +100,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	resourceLabels := ctrlmetrics.RefineNonConditionMetricLabels(map[string]string{"name": req.Name, "namespace": req.Namespace})
 	start := time.Now()
 
-	externalSecretReconcileDuration := esmetrics.GetGaugeVec(esmetrics.ExternalSecretReconcileDurationKey)
-	syncCallsTotal := esmetrics.GetCounterVec(esmetrics.SyncCallsKey)
 	syncCallsError := esmetrics.GetCounterVec(esmetrics.SyncCallsErrorKey)
+
+	// use closures to dynamically update resourceLabels
+	defer func() {
+		esmetrics.GetGaugeVec(esmetrics.ExternalSecretReconcileDurationKey).With(resourceLabels).Set(float64(time.Since(start)))
+		esmetrics.GetCounterVec(esmetrics.SyncCallsKey).With(resourceLabels).Inc()
+	}()
 
 	var externalSecret esv1beta1.ExternalSecret
 	err := r.Get(ctx, req.NamespacedName, &externalSecret)
@@ -117,26 +121,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 				},
 			}, *conditionSynced)
 
-			externalSecretReconcileDuration.With(resourceLabels).Set(float64(time.Since(start)))
-			syncCallsTotal.With(resourceLabels).Inc()
-
 			return ctrl.Result{}, nil
 		}
 
 		log.Error(err, errGetES)
 		syncCallsError.With(resourceLabels).Inc()
 
-		externalSecretReconcileDuration.With(resourceLabels).Set(float64(time.Since(start)))
-		syncCallsTotal.With(resourceLabels).Inc()
-
 		return ctrl.Result{}, nil
 	}
 
 	// if extended metrics is enabled, refine the time series vector
 	resourceLabels = ctrlmetrics.RefineLabels(resourceLabels, externalSecret.Labels)
-
-	defer externalSecretReconcileDuration.With(resourceLabels).Set(float64(time.Since(start)))
-	defer syncCallsTotal.With(resourceLabels).Inc()
 
 	if shouldSkipClusterSecretStore(r, externalSecret) {
 		log.Info("skipping cluster secret store as it is disabled")


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?

## Related Issue

Relates to https://github.com/external-secrets/external-secrets/issues/2151

## Proposed Changes

As I commented in https://github.com/external-secrets/external-secrets/pull/2334#discussion_r1198780218, using closures makes the code more readable and error-proof, so I updated it. Thanks for your review!

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
