### PR TITLE
Aws ssm parameterstore issue 1839

### DIFF
--- a/docs/provider/aws-parameter-store.md
+++ b/docs/provider/aws-parameter-store.md
@@ -21,7 +21,9 @@ way users of the `SecretStore` can only access the secrets necessary.
 
 ### IAM Policy
 
-Create a IAM Policy to pin down access to secrets matching `dev-*`, for further information see [AWS Documentation](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-access.html):
+The example policy below shows the minimum required permissions for fetching SSM parameters. This policy permits pinning down access to secrets with a path matching `dev-*`. Other operations may require additional permission. For example, finding parameters based on tags will also require `ssm:DescribeParameters` and `tag:GetResources` permission with `"Resource": "*"`. Generally, the specific permission required will be logged as an error if an operation fails.
+
+For further information see [AWS Documentation](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-access.html).
 
 ``` json
 {
@@ -30,15 +32,14 @@ Create a IAM Policy to pin down access to secrets matching `dev-*`, for further 
     {
       "Effect": "Allow",
       "Action": [
-        "ssm:GetParameter",
-        "ssm:ListTagsForResource",
-        "ssm:DescribeParameters"
+        "ssm:GetParameter*",
       ],
       "Resource": "arn:aws:ssm:us-east-2:1234567889911:parameter/dev-*"
     }
   ]
 }
 ```
+
 ### JSON Secret Values
 
 You can store JSON objects in a parameter. You can access nested values or arrays using [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md):
@@ -76,13 +77,13 @@ spec:
   # metadataPolicy to fetch all the tags in JSON format
   - secretKey: tags
     remoteRef:
-      metadataPolicy: Fetch 
+      metadataPolicy: Fetch
       key: database-credentials
 
   # metadataPolicy to fetch a specific tag (dev) from the source secret
   - secretKey: developer
     remoteRef:
-      metadataPolicy: Fetch 
+      metadataPolicy: Fetch
       key: database-credentials
       property: dev
 ```

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -14,13 +14,14 @@ limitations under the License.
 package constants
 
 const (
-	ProviderAWSSM           = "AWS/SecretsManager"
-	CallAWSSMGetSecretValue = "GetSecretValue"
-	CallAWSSMDescribeSecret = "DescribeSecret"
-	CallAWSSMDeleteSecret   = "DeleteSecret"
-	CallAWSSMCreateSecret   = "CreateSecret"
-	CallAWSSMPutSecretValue = "PutSecretValue"
-	CallAWSSMListSecrets    = "ListSecrets"
+	ProviderAWSSM                = "AWS/SecretsManager"
+	CallAWSSMGetSecretValue      = "GetSecretValue"
+	CallAWSPSGetParametersByPath = "GetParametersByPath"
+	CallAWSSMDescribeSecret      = "DescribeSecret"
+	CallAWSSMDeleteSecret        = "DeleteSecret"
+	CallAWSSMCreateSecret        = "CreateSecret"
+	CallAWSSMPutSecretValue      = "PutSecretValue"
+	CallAWSSMListSecrets         = "ListSecrets"
 
 	ProviderAWSPS                = "AWS/ParameterStore"
 	CallAWSPSGetParameter        = "GetParameter"

--- a/pkg/provider/aws/parameterstore/fake/fake.go
+++ b/pkg/provider/aws/parameterstore/fake/fake.go
@@ -26,6 +26,7 @@ import (
 // Client implements the aws parameterstore interface.
 type Client struct {
 	GetParameterWithContextFn        GetParameterWithContextFn
+	GetParametersByPathWithContextFn GetParametersByPathWithContextFn
 	PutParameterWithContextFn        PutParameterWithContextFn
 	DeleteParameterWithContextFn     DeleteParameterWithContextFn
 	DescribeParametersWithContextFn  DescribeParametersWithContextFn
@@ -33,6 +34,7 @@ type Client struct {
 }
 
 type GetParameterWithContextFn func(aws.Context, *ssm.GetParameterInput, ...request.Option) (*ssm.GetParameterOutput, error)
+type GetParametersByPathWithContextFn func(aws.Context, *ssm.GetParametersByPathInput, ...request.Option) (*ssm.GetParametersByPathOutput, error)
 type PutParameterWithContextFn func(aws.Context, *ssm.PutParameterInput, ...request.Option) (*ssm.PutParameterOutput, error)
 type DescribeParametersWithContextFn func(aws.Context, *ssm.DescribeParametersInput, ...request.Option) (*ssm.DescribeParametersOutput, error)
 type ListTagsForResourceWithContextFn func(aws.Context, *ssm.ListTagsForResourceInput, ...request.Option) (*ssm.ListTagsForResourceOutput, error)
@@ -60,6 +62,10 @@ func NewDeleteParameterWithContextFn(output *ssm.DeleteParameterOutput, err erro
 
 func (sm *Client) GetParameterWithContext(ctx aws.Context, input *ssm.GetParameterInput, options ...request.Option) (*ssm.GetParameterOutput, error) {
 	return sm.GetParameterWithContextFn(ctx, input, options...)
+}
+
+func (sm *Client) GetParametersByPathWithContext(ctx aws.Context, input *ssm.GetParametersByPathInput, options ...request.Option) (*ssm.GetParametersByPathOutput, error) {
+	return sm.GetParametersByPathWithContextFn(ctx, input, options...)
 }
 
 func NewGetParameterWithContextFn(output *ssm.GetParameterOutput, err error) GetParameterWithContextFn {

--- a/pkg/provider/aws/parameterstore/parameterstore.go
+++ b/pkg/provider/aws/parameterstore/parameterstore.go
@@ -53,6 +53,7 @@ type ParameterStore struct {
 // see: https://docs.aws.amazon.com/sdk-for-go/api/service/ssm/ssmiface/
 type PMInterface interface {
 	GetParameterWithContext(aws.Context, *ssm.GetParameterInput, ...request.Option) (*ssm.GetParameterOutput, error)
+	GetParametersByPathWithContext(aws.Context, *ssm.GetParametersByPathInput, ...request.Option) (*ssm.GetParametersByPathOutput, error)
 	PutParameterWithContext(aws.Context, *ssm.PutParameterInput, ...request.Option) (*ssm.PutParameterOutput, error)
 	DescribeParametersWithContext(aws.Context, *ssm.DescribeParametersInput, ...request.Option) (*ssm.DescribeParametersOutput, error)
 	ListTagsForResourceWithContext(aws.Context, *ssm.ListTagsForResourceInput, ...request.Option) (*ssm.ListTagsForResourceOutput, error)
@@ -61,6 +62,7 @@ type PMInterface interface {
 
 const (
 	errUnexpectedFindOperator = "unexpected find operator"
+	errAccessDeniedException  = "AccessDeniedException"
 )
 
 // New constructs a ParameterStore Provider that is specific to a store.
@@ -219,7 +221,57 @@ func (pm *ParameterStore) GetAllSecrets(ctx context.Context, ref esv1beta1.Exter
 	return nil, errors.New(errUnexpectedFindOperator)
 }
 
+// findByName requires `ssm:GetParametersByPath` IAM permission, but the `Resource` scope can be limited.
 func (pm *ParameterStore) findByName(ctx context.Context, ref esv1beta1.ExternalSecretFind) (map[string][]byte, error) {
+	matcher, err := find.New(*ref.Name)
+	if err != nil {
+		return nil, err
+	}
+	if ref.Path == nil {
+		ref.Path = aws.String("/")
+	}
+	data := make(map[string][]byte)
+	var nextToken *string
+	for {
+		it, err := pm.client.GetParametersByPathWithContext(
+			ctx,
+			&ssm.GetParametersByPathInput{
+				NextToken: nextToken,
+				Path:      ref.Path,
+			})
+		metrics.ObserveAPICall(constants.ProviderAWSPS, constants.CallAWSPSGetParametersByPath, err)
+		if err != nil {
+			/*
+				Check for AccessDeniedException when calling `GetParametersByPathWithContext`. If so,
+				use fallbackFindByName and `DescribeParametersWithContext`.
+				https://github.com/external-secrets/external-secrets/issues/1839#issuecomment-1489023522
+			*/
+			var awsError awserr.Error
+			if errors.As(err, &awsError) && awsError.Code() == errAccessDeniedException {
+				return pm.fallbackFindByName(ctx, ref)
+			}
+			return nil, err
+		}
+		for _, param := range it.Parameters {
+			if !matcher.MatchName(*param.Name) {
+				continue
+			}
+			err = pm.fetchAndSet(ctx, data, *param.Name)
+			if err != nil {
+				return nil, err
+			}
+		}
+		nextToken = it.NextToken
+		if nextToken == nil {
+			break
+		}
+	}
+
+	return data, nil
+}
+
+// fallbackFindByName requires `ssm:DescribeParameters` IAM permission on `"Resource": "*"`.
+func (pm *ParameterStore) fallbackFindByName(ctx context.Context, ref esv1beta1.ExternalSecretFind) (map[string][]byte, error) {
 	matcher, err := find.New(*ref.Name)
 	if err != nil {
 		return nil, err
@@ -259,10 +311,10 @@ func (pm *ParameterStore) findByName(ctx context.Context, ref esv1beta1.External
 			break
 		}
 	}
-
 	return data, nil
 }
 
+// findByTags requires ssm:DescribeParameters,tag:GetResources IAM permission on `"Resource": "*"`.
 func (pm *ParameterStore) findByTags(ctx context.Context, ref esv1beta1.ExternalSecretFind) (map[string][]byte, error) {
 	filters := make([]*ssm.ParameterStringFilter, 0)
 	for k, v := range ref.Tags {

--- a/pkg/provider/aws/parameterstore/parameterstore.go
+++ b/pkg/provider/aws/parameterstore/parameterstore.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/tidwall/gjson"
 	utilpointer "k8s.io/utils/pointer"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 	"github.com/external-secrets/external-secrets/pkg/constants"
@@ -40,6 +41,7 @@ var (
 	_               esv1beta1.SecretsClient = &ParameterStore{}
 	managedBy                               = "managed-by"
 	externalSecrets                         = "external-secrets"
+	logger                                  = ctrl.Log.WithName("provider").WithName("parameterstore")
 )
 
 // ParameterStore is a provider for AWS ParameterStore.
@@ -248,6 +250,7 @@ func (pm *ParameterStore) findByName(ctx context.Context, ref esv1beta1.External
 			*/
 			var awsError awserr.Error
 			if errors.As(err, &awsError) && awsError.Code() == errAccessDeniedException {
+				logger.Info("GetParametersByPath: access denied. using fallback to describe parameters. It is recommended to add ssm:GetParametersByPath permissions", "path", ref.Path)
 				return pm.fallbackFindByName(ctx, ref)
 			}
 			return nil, err

--- a/pkg/provider/aws/parameterstore/parameterstore.go
+++ b/pkg/provider/aws/parameterstore/parameterstore.go
@@ -238,8 +238,10 @@ func (pm *ParameterStore) findByName(ctx context.Context, ref esv1beta1.External
 		it, err := pm.client.GetParametersByPathWithContext(
 			ctx,
 			&ssm.GetParametersByPathInput{
-				NextToken: nextToken,
-				Path:      ref.Path,
+				NextToken:      nextToken,
+				Path:           ref.Path,
+				Recursive:      aws.Bool(true),
+				WithDecryption: aws.Bool(true),
 			})
 		metrics.ObserveAPICall(constants.ProviderAWSPS, constants.CallAWSPSGetParametersByPath, err)
 		if err != nil {


### PR DESCRIPTION
## Problem Statement

Copied from #1839:

* use `GetParametersByPath` API calls to implement `dataFrom[].find`
* keep current behavior of `dataFrom[].find` as a fallback
* add docs about the different permissions required for using this

## Related Issue

Fixes #1839 and #1066

## Proposed Changes

To maintain backward compatibility I moved the original `findByname` function to `fallbackFindByName` and created a new `findByName` function that uses the `GetParametersByPathWithContext` API call.

In function `findByName`, if we receive an `AccessDeniedException` when calling GetParametersByPathWithContext `return pm.fallbackFindByName(ctx, ref)`.

This seemed like the simplest approach. 

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage (there was no existing coverage; I did not add any)
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`

## Additional Notes on Tags

I found while working on this that if _both_  `name` and `tags` are set in the `dataFrom` block that the tags are completely ignored. 

In this example all parameters in the `/eso-secret/` path will be pulled into the secret. 

```
  dataFrom:
    - find:
        path: /eso-secret/
        name:
          regexp: "/eso-secret/(.*)"
        tags:
          type: development
```

The reason this happens is [here](https://github.com/external-secrets/external-secrets/blob/cd91168322ad842dcfce39a7fd9dd6c183c707ac/pkg/provider/aws/parameterstore/parameterstore.go#L213-L220).

If this is the expected behavior the docs should probably be updated to call this out. 

If not an issue should be opened to fix this behavior. Unfortunately, `GetParametersByPath` does not support [filtering by tags](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_GetParametersByPath.html#API_GetParametersByPath_RequestParameters) so some additional thought will be required when deciding the best way to fetch parameters based on both names and tags. 
