### PR TITLE
fix(kubernetes):change capabilities to readwrite

### DIFF
--- a/pkg/provider/kubernetes/provider.go
+++ b/pkg/provider/kubernetes/provider.go
@@ -87,7 +87,7 @@ func init() {
 }
 
 func (p *Provider) Capabilities() esv1beta1.SecretStoreCapabilities {
-	return esv1beta1.SecretStoreReadOnly
+	return esv1beta1.SecretStoreReadWrite
 }
 
 // NewClient constructs a Kubernetes Provider.


### PR DESCRIPTION
## Problem Statement

With https://github.com/external-secrets/external-secrets/pull/2322 being merged, kubernetes based SecretStores habe readwrite capabilities

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
