### PR TITLE
📚  Update stability-support.md

### DIFF
--- a/docs/introduction/stability-support.md
+++ b/docs/introduction/stability-support.md
@@ -60,7 +60,7 @@ The following table show the support for features across different providers.
 | AWS Secrets Manager       |      x       |      x       |          x           |            x            |        x         |      x      |              x              |
 | AWS Parameter Store       |      x       |      x       |          x           |            x            |        x         |      x      |              x              |
 | Hashicorp Vault           |      x       |      x       |          x           |            x            |        x         |      x      |              x              |
-| GCP Secret Manager        |      x       |      x       |                      |            x            |        x         |      x      |              x              |
+| GCP Secret Manager        |      x       |      x       |          x           |            x            |        x         |      x      |              x              |
 | Azure Keyvault            |      x       |      x       |          x           |            x            |        x         |      x      |              x              |
 | Kubernetes                |      x       |      x       |          x           |            x            |        x         |      x      |              x              |
 | IBM Cloud Secrets Manager |              |              |                      |                         |        x         |             |                             |


### PR DESCRIPTION
## Problem Statement

GCP Secret Manager compatibility with MetadataPolicy is not reflected in the Stability support page.

Simple update on docs

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
