### PR TITLE
feat: allow to set a common set of labels in the helm chart

### DIFF
--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -82,6 +82,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | certController.serviceMonitor.scrapeTimeout | string | `"25s"` | Timeout if metrics can't be retrieved in given time interval |
 | certController.tolerations | list | `[]` |  |
 | certController.topologySpreadConstraints | list | `[]` |  |
+| commonLabels | object | `{}` | Additional labels added to all helm chart resources. |
 | concurrent | int | `1` | Specifies the number of concurrent ExternalSecret Reconciles external-secret executes at a time. |
 | controllerClass | string | `""` | If set external secrets will filter matching Secret Stores with the appropriate controller values. |
 | crds.annotations | object | `{}` |  |

--- a/deploy/charts/external-secrets/templates/_helpers.tpl
+++ b/deploy/charts/external-secrets/templates/_helpers.tpl
@@ -40,6 +40,9 @@ helm.sh/chart: {{ include "external-secrets.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{- define "external-secrets-webhook.labels" -}}
@@ -49,11 +52,17 @@ helm.sh/chart: {{ include "external-secrets.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{- define "external-secrets-webhook-metrics.labels" -}}
 {{ include "external-secrets-webhook.selectorLabels" . }}
 app.kubernetes.io/metrics: "webhook"
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{- define "external-secrets-cert-controller.labels" -}}
@@ -63,11 +72,17 @@ helm.sh/chart: {{ include "external-secrets.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{- define "external-secrets-cert-controller-metrics.labels" -}}
 {{ include "external-secrets-cert-controller.selectorLabels" . }}
 app.kubernetes.io/metrics: "cert-controller"
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/deploy/charts/external-secrets/templates/validatingwebhook.yaml
+++ b/deploy/charts/external-secrets/templates/validatingwebhook.yaml
@@ -5,6 +5,9 @@ metadata:
   name: secretstore-validate
   labels:
     external-secrets.io/component: webhook
+    {{- with .Values.commonLabels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
 webhooks:
 - name: "validate.secretstore.external-secrets.io"
   rules:
@@ -44,6 +47,9 @@ metadata:
   name: externalsecret-validate
   labels:
     external-secrets.io/component: webhook
+    {{- with .Values.commonLabels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
 webhooks:
 - name: "validate.externalsecret.external-secrets.io"
   rules:

--- a/deploy/charts/external-secrets/tests/__snapshot__/crds_test.yaml.snap
+++ b/deploy/charts/external-secrets/tests/__snapshot__/crds_test.yaml.snap
@@ -4,7 +4,7 @@ should match snapshot of default values:
     kind: CustomResourceDefinition
     metadata:
       annotations:
-        controller-gen.kubebuilder.io/version: v0.11.4
+        controller-gen.kubebuilder.io/version: v0.12.0
       name: secretstores.external-secrets.io
     spec:
       conversion:
@@ -1504,6 +1504,24 @@ should match snapshot of default values:
                                 - SecretsManager
                                 - ParameterStore
                               type: string
+                            sessionTags:
+                              description: AWS STS assume role session tags
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                  - key
+                                  - value
+                                type: object
+                              type: array
+                            transitiveTagKeys:
+                              description: AWS STS assume role transitive session tags. Required when multiple rules are used with SecretStore
+                              items:
+                                type: string
+                              type: array
                           required:
                             - region
                             - service

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -30,6 +30,9 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# -- Additional labels added to all helm chart resources.
+commonLabels: {}
+
 # -- If true, external-secrets will perform leader election between instances to ensure no more
 # than one instance of external-secrets operates at a time.
 leaderElect: false


### PR DESCRIPTION
## Problem Statement

It is not currently possible to define a common set of labels that will be added to all objects created with the helm chart.

## Related Issue

Fixes #2378

## Proposed Changes

This PR add a new value `commonLabels` in the helm chart which allows to add the set of labels defined on it to all objects.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
