### PR TITLE
Add status_condition metric for ClusterExternalSecret

### DIFF
--- a/pkg/controllers/clusterexternalsecret/cesmetrics/cesmetrics.go
+++ b/pkg/controllers/clusterexternalsecret/cesmetrics/cesmetrics.go
@@ -16,14 +16,17 @@ package cesmetrics
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
+	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 	ctrlmetrics "github.com/external-secrets/external-secrets/pkg/controllers/metrics"
 )
 
 const (
 	ClusterExternalSecretSubsystem            = "clusterexternalsecret"
 	ClusterExternalSecretReconcileDurationKey = "reconcile_duration"
+	ClusterExternalSecretStatusConditionKey   = "status_condition"
 )
 
 var gaugeVecMetrics = map[string]*prometheus.GaugeVec{}
@@ -37,13 +40,74 @@ func SetUpMetrics() {
 		Help:      "The duration time to reconcile the Cluster External Secret",
 	}, ctrlmetrics.NonConditionMetricLabelNames)
 
+	clusterExternalSecretCondition := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: ClusterExternalSecretSubsystem,
+		Name:      ClusterExternalSecretStatusConditionKey,
+		Help:      "The status condition of a specific Cluster External Secret",
+	}, ctrlmetrics.ConditionMetricLabelNames)
+
 	metrics.Registry.MustRegister(clusterExternalSecretReconcileDuration)
 
 	gaugeVecMetrics = map[string]*prometheus.GaugeVec{
+		ClusterExternalSecretStatusConditionKey:   clusterExternalSecretCondition,
 		ClusterExternalSecretReconcileDurationKey: clusterExternalSecretReconcileDuration,
 	}
 }
 
 func GetGaugeVec(key string) *prometheus.GaugeVec {
 	return gaugeVecMetrics[key]
+}
+
+func UpdateClusterExternalSecretCondition(ces *esv1beta1.ClusterExternalSecret, condition *esv1beta1.ClusterExternalSecretStatusCondition) {
+	if condition.Status != v1.ConditionTrue {
+		// This should not happen
+		return
+	}
+
+	cesInfo := make(map[string]string)
+	cesInfo["name"] = ces.Name
+	cesInfo["namespace"] = ces.Namespace
+	for k, v := range ces.Labels {
+		cesInfo[k] = v
+	}
+	conditionLabels := ctrlmetrics.RefineConditionMetricLabels(cesInfo)
+	clusterExternalSecretCondition := GetGaugeVec(ClusterExternalSecretStatusConditionKey)
+
+	targetConditionType := condition.Type
+	var theOtherConditionTypes []esv1beta1.ClusterExternalSecretConditionType
+	for _, ct := range []esv1beta1.ClusterExternalSecretConditionType{
+		esv1beta1.ClusterExternalSecretReady,
+		esv1beta1.ClusterExternalSecretPartiallyReady,
+		esv1beta1.ClusterExternalSecretNotReady,
+	} {
+		if ct != targetConditionType {
+			theOtherConditionTypes = append(theOtherConditionTypes, ct)
+		}
+	}
+
+	// Set the target condition metric
+	clusterExternalSecretCondition.With(ctrlmetrics.RefineLabels(conditionLabels,
+		map[string]string{
+			"condition": string(targetConditionType),
+			"status":    string(v1.ConditionTrue),
+		})).Set(1)
+	clusterExternalSecretCondition.With(ctrlmetrics.RefineLabels(conditionLabels,
+		map[string]string{
+			"condition": string(targetConditionType),
+			"status":    string(v1.ConditionFalse),
+		})).Set(0)
+
+	// Remove the other condition metrics
+	for _, ct := range theOtherConditionTypes {
+		clusterExternalSecretCondition.Delete(ctrlmetrics.RefineLabels(conditionLabels,
+			map[string]string{
+				"condition": string(ct),
+				"status":    string(v1.ConditionFalse),
+			}))
+		clusterExternalSecretCondition.Delete(ctrlmetrics.RefineLabels(conditionLabels,
+			map[string]string{
+				"condition": string(ct),
+				"status":    string(v1.ConditionTrue),
+			}))
+	}
 }

--- a/pkg/controllers/clusterexternalsecret/cesmetrics/cesmetrics.go
+++ b/pkg/controllers/clusterexternalsecret/cesmetrics/cesmetrics.go
@@ -46,7 +46,7 @@ func SetUpMetrics() {
 		Help:      "The status condition of a specific Cluster External Secret",
 	}, ctrlmetrics.ConditionMetricLabelNames)
 
-	metrics.Registry.MustRegister(clusterExternalSecretReconcileDuration)
+	metrics.Registry.MustRegister(clusterExternalSecretReconcileDuration, clusterExternalSecretCondition)
 
 	gaugeVecMetrics = map[string]*prometheus.GaugeVec{
 		ClusterExternalSecretStatusConditionKey:   clusterExternalSecretCondition,

--- a/pkg/controllers/clusterexternalsecret/cesmetrics/cesmetrics.go
+++ b/pkg/controllers/clusterexternalsecret/cesmetrics/cesmetrics.go
@@ -66,7 +66,6 @@ func UpdateClusterExternalSecretCondition(ces *esv1beta1.ClusterExternalSecret, 
 
 	cesInfo := make(map[string]string)
 	cesInfo["name"] = ces.Name
-	cesInfo["namespace"] = ces.Namespace
 	for k, v := range ces.Labels {
 		cesInfo[k] = v
 	}

--- a/pkg/controllers/clusterexternalsecret/cesmetrics/cesmetrics_test.go
+++ b/pkg/controllers/clusterexternalsecret/cesmetrics/cesmetrics_test.go
@@ -34,7 +34,6 @@ func TestUpdateClusterExternalSecretCondition(t *testing.T) {
 	}()
 	metrics.ConditionMetricLabels = map[string]string{"name": "", "namespace": "", "condition": "", "status": ""}
 
-	namespace := "test-namespace"
 	name := "test"
 
 	tests := []struct {
@@ -58,7 +57,7 @@ func TestUpdateClusterExternalSecretCondition(t *testing.T) {
 			}{
 				{
 					labels: prometheus.Labels{
-						"namespace": namespace,
+						"namespace": "",
 						"name":      name,
 						"condition": "Ready",
 						"status":    "True",
@@ -67,7 +66,7 @@ func TestUpdateClusterExternalSecretCondition(t *testing.T) {
 				},
 				{
 					labels: prometheus.Labels{
-						"namespace": namespace,
+						"namespace": "",
 						"name":      name,
 						"condition": "Ready",
 						"status":    "False",
@@ -89,8 +88,7 @@ func TestUpdateClusterExternalSecretCondition(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			ces := &esv1beta1.ClusterExternalSecret{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: namespace,
-					Name:      name,
+					Name: name,
 				},
 			}
 

--- a/pkg/controllers/clusterexternalsecret/cesmetrics/cesmetrics_test.go
+++ b/pkg/controllers/clusterexternalsecret/cesmetrics/cesmetrics_test.go
@@ -1,0 +1,122 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cesmetrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
+	"github.com/external-secrets/external-secrets/pkg/controllers/metrics"
+)
+
+func TestUpdateClusterExternalSecretCondition(t *testing.T) {
+	// Evacuate the original condition metric labels
+	tmpConditionMetricLabels := metrics.ConditionMetricLabels
+	defer func() {
+		metrics.ConditionMetricLabels = tmpConditionMetricLabels
+	}()
+	metrics.ConditionMetricLabels = map[string]string{"name": "", "namespace": "", "condition": "", "status": ""}
+
+	namespace := "test-namespace"
+	name := "test"
+
+	tests := []struct {
+		desc           string
+		condition      *esv1beta1.ClusterExternalSecretStatusCondition
+		expectedCount  int
+		expectedValues []struct {
+			labels        prometheus.Labels
+			expectedValue float64
+		}
+	}{
+		{
+			desc: "ConditionTrue",
+			condition: &esv1beta1.ClusterExternalSecretStatusCondition{
+				Type:   esv1beta1.ClusterExternalSecretReady,
+				Status: v1.ConditionTrue,
+			},
+			expectedValues: []struct {
+				labels        prometheus.Labels
+				expectedValue float64
+			}{
+				{
+					labels: prometheus.Labels{
+						"namespace": namespace,
+						"name":      name,
+						"condition": "Ready",
+						"status":    "True",
+					},
+					expectedValue: 1.0,
+				},
+				{
+					labels: prometheus.Labels{
+						"namespace": namespace,
+						"name":      name,
+						"condition": "Ready",
+						"status":    "False",
+					},
+					expectedValue: 0.0,
+				},
+			},
+		},
+		{
+			desc: "ConditionFalse",
+			condition: &esv1beta1.ClusterExternalSecretStatusCondition{
+				Type:   esv1beta1.ClusterExternalSecretReady,
+				Status: v1.ConditionFalse,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			ces := &esv1beta1.ClusterExternalSecret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+				},
+			}
+
+			// Evacuate the original gauge vec
+			tmpGaugeVec := GetGaugeVec(ClusterExternalSecretStatusConditionKey)
+			defer func() {
+				gaugeVecMetrics[ClusterExternalSecretStatusConditionKey] = tmpGaugeVec
+			}()
+
+			gaugeVec := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+				Subsystem: "csmetrics",
+				Name:      "TestUpdateClusterExternalSecretCondition",
+			}, []string{"name", "namespace", "condition", "status"})
+
+			gaugeVecMetrics[ClusterExternalSecretStatusConditionKey] = gaugeVec
+			UpdateClusterExternalSecretCondition(ces, test.condition)
+
+			if got := testutil.CollectAndCount(gaugeVec); got != len(test.expectedValues) {
+				t.Fatalf("unexpected number of calls: got: %d, expected: %d", got, len(test.expectedValues))
+			}
+
+			for i, expected := range test.expectedValues {
+				if got := testutil.ToFloat64(gaugeVec.With(expected.labels)); got != expected.expectedValue {
+					t.Fatalf("#%d received unexpected gauge value: got: %v, expected: %v", i, got, expected.expectedValue)
+				}
+			}
+		})
+	}
+}

--- a/pkg/controllers/clusterexternalsecret/clusterexternalsecret_controller.go
+++ b/pkg/controllers/clusterexternalsecret/clusterexternalsecret_controller.go
@@ -127,14 +127,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		provisionedNamespaces = append(provisionedNamespaces, namespace.ObjectMeta.Name)
 	}
 
-	conditionType := getCondition(failedNamespaces, &namespaceList)
-
-	condition := NewClusterExternalSecretCondition(conditionType, v1.ConditionTrue)
-
-	if conditionType != esv1beta1.ClusterExternalSecretReady {
-		condition.Message = errNamespacesFailed
-	}
-
+	condition := NewClusterExternalSecretCondition(failedNamespaces, &namespaceList)
 	SetClusterExternalSecretCondition(&clusterExternalSecret, *condition)
 	setFailedNamespaces(&clusterExternalSecret, failedNamespaces)
 
@@ -235,18 +228,6 @@ func checkForError(getError error, existingES *esv1beta1.ExternalSecret) string 
 	}
 
 	return ""
-}
-
-func getCondition(namespaces map[string]string, namespaceList *v1.NamespaceList) esv1beta1.ClusterExternalSecretConditionType {
-	if len(namespaces) == 0 {
-		return esv1beta1.ClusterExternalSecretReady
-	}
-
-	if len(namespaces) < len(namespaceList.Items) {
-		return esv1beta1.ClusterExternalSecretPartiallyReady
-	}
-
-	return esv1beta1.ClusterExternalSecretNotReady
 }
 
 func getRemovedNamespaces(nsList v1.NamespaceList, provisionedNs []string) []string {


### PR DESCRIPTION
## Problem Statement

SSIA. I've added a status condition metric similar to the one for the external secret controller. Thanks for your review!

## Related Issue

Relates to https://github.com/external-secrets/external-secrets/issues/2151

## Proposed Changes

Add a new metric.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
