### PR TITLE
Fix the test Make task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,8 +161,6 @@ jobs:
 
       - name: Run Unit Tests
         run: |
-          export KUBEBUILDER_ATTACH_CONTROL_PLANE_OUTPUT=true
-          source <(setup-envtest use ${{env.KUBERNETES_VERSION}} -p env --os $(go env GOOS) --arch $(go env GOARCH))
           make test
 
   publish-artifacts:

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,8 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+KUBERNETES_VERSION := '1.24.x'
+
 # check if there are any existing `git tag` values
 ifeq ($(shell git tag),)
 # no tags found - default to initial tag `v0.0.0`
@@ -91,6 +93,7 @@ update-deps:
 # Golang
 
 .PHONY: test
+test: export KUBEBUILDER_ASSETS := $(shell setup-envtest use $(KUBERNETES_VERSION) -p path --os $(shell go env GOOS) --arch $(shell go env GOARCH))
 test: generate ## Run tests
 	@$(INFO) go test unit-tests
 	go test -race -v $(shell go list ./... | grep -v e2e) -coverprofile cover.out


### PR DESCRIPTION
## Problem Statement

I've noticed when I run `make test`, the task filed with the following error message.

```
  [FAILED] in [BeforeSuite] - /Users/shuheiktgw/Projects/external-secrets/external-secrets/pkg/controllers/webhookconfig/suite_test.go:69 @ 06/03/23 17:03:53.923
  << Timeline

  [FAILED] Unexpected error:
      <*fmt.wrapError | 0xc0003f8800>:
      unable to start control plane itself: failed to start the controlplane. retried 5 times: fork/exec /usr/local/kubebuilder/bin/etcd: no such file or directory
      {
          msg: "unable to start control plane itself: failed to start the controlplane. retried 5 times: fork/exec /usr/local/kubebuilder/bin/etcd: no such file or directory",
          err: <*fmt.wrapError | 0xc0003f87e0>{
              msg: "failed to start the controlplane. retried 5 times: fork/exec /usr/local/kubebuilder/bin/etcd: no such file or directory",
              err: <*fs.PathError | 0xc0000b8c90>{
                  Op: "fork/exec",
                  Path: "/usr/local/kubebuilder/bin/etcd",
                  Err: <syscall.Errno>0x2,
              },
          },
      }
  occurred
  In [BeforeSuite] at: /Users/shuheiktgw/Projects/external-secrets/external-secrets/pkg/controllers/webhookconfig/suite_test.go:69 @ 06/03/23 17:03:53.923
```

Then I checked .github/workflows/ci.yml and noticed I need to set `KUBEBUILDER_ASSETS` so that the unit tests run properly. I think that would be great if the Make task itself sets `KUBEBUILDER_ASSETS`, so I fixed it so 🙂 

## Related Issue

None

## Proposed Changes

To improve the developer experience.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
