### PR TITLE
Stop discarding golangci-lint errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ fmt: lint.check ## Ensure consistent code style
 	@go mod tidy
 	@cd e2e/ && go mod tidy
 	@go fmt ./...
-	@golangci-lint run --fix > /dev/null 2>&1 || true
+	@golangci-lint run --fix
 	@$(OK) Ensured consistent code style
 
 generate: ## Generate code and crds


### PR DESCRIPTION
## Problem Statement

Currently, `make fmt` discards errors raised from the golangci-lint, but that makes it really difficult to tell if the command ran successfully or not. In my case, the command actually failed due to https://github.com/golangci/golangci-lint/issues/3338, and the code was not fully formatted,  but I haven't noticed it a while since the command does not show the error messages. I'm not too sure why they need to be suppressed in the first place, but I believe it is more developer-friendly to show the messages.

## Related Issue

None

## Proposed Changes

Show the error messages.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
