### PR TITLE
Fix ACRPullGenerator

### DIFF
--- a/pkg/generator/acr/acr.go
+++ b/pkg/generator/acr/acr.go
@@ -233,7 +233,7 @@ func accessTokenForWorkloadIdentity(ctx context.Context, crClient client.Client,
 	if !strings.HasSuffix(acrRegistry, "/") {
 		acrRegistry += "/"
 	}
-	acrResource := fmt.Sprintf("https://%s/.default", acrRegistry)
+	acrResource := fmt.Sprintf("https://%s.default", acrRegistry)
 	// if no serviceAccountRef was provided
 	// we expect certain env vars to be present.
 	// They are set by the azure workload identity webhook.


### PR DESCRIPTION
## Problem Statement

The ACRPullGenerator is not working properly. 

## Related Issue

Fixes #2244

## Proposed Changes

The access token was not being retrieved properly due to the wrong URL with an extra `/` before the `./default`. 

I'm removing the extra `/` to send the proper URL.
   
## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
