### PR TITLE
Fix E2E test setup on non-linux machines

### DIFF
--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -10,6 +10,13 @@ RUN wget -q https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_
     wget -q https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm && \
     chmod +x /usr/local/bin/helm
 
+WORKDIR /usr/src/app
+COPY go.mod go.sum ./
+RUN go mod download && go mod verify
+COPY . .
+WORKDIR /usr/src/app/e2e
+RUN make e2e-bin
+
 FROM alpine:3.15.0
 RUN apk add -U --no-cache \
     ca-certificates \
@@ -23,11 +30,11 @@ COPY --from=builder /go/bin/ginkgo /usr/local/bin/
 COPY --from=builder /usr/local/bin/kubectl /usr/local/bin/
 COPY --from=builder /usr/local/bin/helm /usr/local/bin/
 
-COPY entrypoint.sh                   /entrypoint.sh
-COPY suites/provider/provider.test   /provider.test
-COPY suites/argocd/argocd.test       /argocd.test
-COPY suites/flux/flux.test           /flux.test
-COPY suites/generator/generator.test /generator.test
-COPY k8s                             /k8s
+COPY --from=builder /usr/src/app/e2e/entrypoint.sh                   /entrypoint.sh
+COPY --from=builder /usr/src/app/e2e/suites/provider/provider.test   /provider.test
+COPY --from=builder /usr/src/app/e2e/suites/argocd/argocd.test       /argocd.test
+COPY --from=builder /usr/src/app/e2e/suites/flux/flux.test           /flux.test
+COPY --from=builder /usr/src/app/e2e/suites/generator/generator.test /generator.test
+COPY --from=builder /usr/src/app/e2e/k8s                             /k8s
 
 CMD [ "/entrypoint.sh" ]

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -41,12 +41,12 @@ test.managed: e2e-image ## Run e2e tests against current kube context
 e2e-bin:
 	CGO_ENABLED=0 go run github.com/onsi/ginkgo/v2/ginkgo build ./suites/...
 
-e2e-image: e2e-bin
+e2e-image:
 	-rm -rf ./k8s/deploy
 	mkdir -p k8s
 	$(MAKE) -C ../ helm.generate
 	cp -r ../deploy ./k8s
-	docker build $(DOCKER_BUILD_ARGS) -t $(E2E_IMAGE_NAME):$(VERSION) .
+	docker build $(DOCKER_BUILD_ARGS) -t $(E2E_IMAGE_NAME):$(VERSION) -f Dockerfile ..
 
 stop-kind: ## Stop kind cluster
 	kind delete cluster \


### PR DESCRIPTION
Fixes #2409. Not sure if this is a direction you want to go, but those changes allow me to run E2E tests locally (using an Apple M1 machine).

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
