### PR TITLE
Add lower-kebab name transformer to Doppler provider

### DIFF
--- a/apis/externalsecrets/v1beta1/secretstore_doppler_types.go
+++ b/apis/externalsecrets/v1beta1/secretstore_doppler_types.go
@@ -46,7 +46,7 @@ type DopplerProvider struct {
 	Config string `json:"config,omitempty"`
 
 	// Environment variable compatible name transforms that change secret names to a different format
-	// +kubebuilder:validation:Enum=upper-camel;camel;lower-snake;tf-var;dotnet-env
+	// +kubebuilder:validation:Enum=upper-camel;camel;lower-snake;tf-var;dotnet-env;lower-kebab
 	// +optional
 	NameTransformer string `json:"nameTransformer,omitempty"`
 

--- a/config/crds/bases/external-secrets.io_clustersecretstores.yaml
+++ b/config/crds/bases/external-secrets.io_clustersecretstores.yaml
@@ -2254,6 +2254,7 @@ spec:
                         - lower-snake
                         - tf-var
                         - dotnet-env
+                        - lower-kebab
                         type: string
                       project:
                         description: Doppler project (required if not using a Service

--- a/config/crds/bases/external-secrets.io_secretstores.yaml
+++ b/config/crds/bases/external-secrets.io_secretstores.yaml
@@ -2254,6 +2254,7 @@ spec:
                         - lower-snake
                         - tf-var
                         - dotnet-env
+                        - lower-kebab
                         type: string
                       project:
                         description: Doppler project (required if not using a Service

--- a/deploy/charts/external-secrets/tests/__snapshot__/crds_test.yaml.snap
+++ b/deploy/charts/external-secrets/tests/__snapshot__/crds_test.yaml.snap
@@ -1652,6 +1652,7 @@ should match snapshot of default values:
                                 - lower-snake
                                 - tf-var
                                 - dotnet-env
+                                - lower-kebab
                               type: string
                             project:
                               description: Doppler project (required if not using a Service Token)

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -2096,6 +2096,7 @@ spec:
                             - lower-snake
                             - tf-var
                             - dotnet-env
+                            - lower-kebab
                           type: string
                         project:
                           description: Doppler project (required if not using a Service Token)
@@ -5690,6 +5691,7 @@ spec:
                             - lower-snake
                             - tf-var
                             - dotnet-env
+                            - lower-kebab
                           type: string
                         project:
                           description: Doppler project (required if not using a Service Token)

--- a/docs/provider/doppler.md
+++ b/docs/provider/doppler.md
@@ -95,6 +95,7 @@ Name transformers format keys from Doppler's UPPER_SNAKE_CASE to one of the foll
 - lower-snake
 - tf-var
 - dotnet-env
+- lower-kebab
 
 Name transformers require a specifically configured `SecretStore`:
 


### PR DESCRIPTION
## Problem Statement

Adding support for a new `lower-kebab` name transformer to the Doppler provider.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
