### PR TITLE
Mount ~/.gitconfig when running make docs

### DIFF
--- a/hack/api-docs/Makefile
+++ b/hack/api-docs/Makefile
@@ -52,6 +52,7 @@ build: image generate $(SOURCES)
 		--sig-proxy=true \
 		--rm \
 		--user $(UID):$(GID) \
+		-v $(HOME)/.gitconfig:/.gitconfig \
 		$(MKDOCS_IMAGE) \
 		/bin/bash -c "cd /repo && $(MIKE) deploy --ignore --update-aliases -F hack/api-docs/mkdocs.yml $(DOCS_VERSION) $(DOCS_ALIAS);"
 .PHONY: build.publish

--- a/hack/api-docs/Makefile
+++ b/hack/api-docs/Makefile
@@ -52,7 +52,8 @@ build: image generate $(SOURCES)
 		--sig-proxy=true \
 		--rm \
 		--user $(UID):$(GID) \
-		-v $(HOME)/.gitconfig:/.gitconfig \
+		--env GIT_COMMITTER_NAME=$(shell git config user.name) \
+		--env GIT_COMMITTER_EMAIL=$(shell git config user.email) \
 		$(MKDOCS_IMAGE) \
 		/bin/bash -c "cd /repo && $(MIKE) deploy --ignore --update-aliases -F hack/api-docs/mkdocs.yml $(DOCS_VERSION) $(DOCS_ALIAS);"
 .PHONY: build.publish

--- a/hack/api-docs/requirements.txt
+++ b/hack/api-docs/requirements.txt
@@ -6,7 +6,7 @@ livereload==2.6.3
 Markdown==3.3.6
 MarkupSafe==2.0.1
 mkdocs==1.4.3
-mike @ git+https://github.com/jimporter/mike@master
+mike @ git+https://github.com/jimporter/mike@300593c
 mkdocs-material==9.1.9
 mkdocs-minify-plugin==0.5.0
 pep562==1.1

--- a/hack/api-docs/requirements.txt
+++ b/hack/api-docs/requirements.txt
@@ -6,7 +6,7 @@ livereload==2.6.3
 Markdown==3.3.6
 MarkupSafe==2.0.1
 mkdocs==1.4.3
-mike==1.1.2
+mike @ git+https://github.com/jimporter/mike@master
 mkdocs-material==9.1.9
 mkdocs-minify-plugin==0.5.0
 pep562==1.1


### PR DESCRIPTION
## Problem Statement

When we run `make reviewable`, it runs `make docs` and fails with the following error message.

```
error: error getting config 'user.name'
```

It seems [mike](https://github.com/jimporter/mike) needs to access the git configurations, but since we don't usually set the configs project-wise, it fails. People typically use the global git configurations which reside in ~/.gitconfig, so I'd like to mount it when we run mike to improve DX. Thanks for your review!

## Related Issue

N/A

## Proposed Changes

Mount  ~/.gitconfig when we run `make docs`

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
