### PR TITLE
fix: run helm release on release branch as well

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -86,7 +86,9 @@ jobs:
           make helm.generate
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0
-        if: github.ref == 'refs/heads/main'
+        if: |
+          github.ref == 'refs/heads/main' ||
+          startsWith(github.ref, 'refs/heads/release-')
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_RELEASE_NAME_TEMPLATE: "helm-chart-{{ .Version }}"


### PR DESCRIPTION
helm release isn't triggered on `release-*` branches. This PR fixes that.


tested here: https://github.com/external-secrets/external-secrets/actions/runs/5350381790/jobs/9702906525
as a result we have a release: https://github.com/external-secrets/external-secrets/releases/tag/helm-chart-0.8.4
