### PR TITLE
Fix ClusterExternalSecret printcolumns

### DIFF
--- a/apis/externalsecrets/v1beta1/clusterexternalsecret_types.go
+++ b/apis/externalsecrets/v1beta1/clusterexternalsecret_types.go
@@ -93,9 +93,8 @@ type ClusterExternalSecretStatus struct {
 // +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={externalsecrets},shortName=ces
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Store",type=string,JSONPath=`.spec.secretStoreRef.name`
-// +kubebuilder:printcolumn:name="Refresh Interval",type=string,JSONPath=`.spec.refreshInterval`
-// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].reason`
+// +kubebuilder:printcolumn:name="Store",type=string,JSONPath=`.spec.externalSecretSpec.secretStoreRef.name`
+// +kubebuilder:printcolumn:name="Refresh Interval",type=string,JSONPath=`.spec.refreshTime`
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // ClusterExternalSecret is the Schema for the clusterexternalsecrets API.
 type ClusterExternalSecret struct {

--- a/config/crds/bases/external-secrets.io_clusterexternalsecrets.yaml
+++ b/config/crds/bases/external-secrets.io_clusterexternalsecrets.yaml
@@ -18,14 +18,11 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.secretStoreRef.name
+    - jsonPath: .spec.externalSecretSpec.secretStoreRef.name
       name: Store
       type: string
-    - jsonPath: .spec.refreshInterval
+    - jsonPath: .spec.refreshTime
       name: Refresh Interval
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].reason
-      name: Status
       type: string
     - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -18,14 +18,11 @@ spec:
   scope: Cluster
   versions:
     - additionalPrinterColumns:
-        - jsonPath: .spec.secretStoreRef.name
+        - jsonPath: .spec.externalSecretSpec.secretStoreRef.name
           name: Store
           type: string
-        - jsonPath: .spec.refreshInterval
+        - jsonPath: .spec.refreshTime
           name: Refresh Interval
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].reason
-          name: Status
           type: string
         - jsonPath: .status.conditions[?(@.type=="Ready")].status
           name: Ready


### PR DESCRIPTION
## Problem Statement

SSIA. It seems some of the JSON paths were incorrect, and `kubectl get clusterexternalsecret.external-secrets.io/xxx` does not show anything for the `Store`, `Refresh Interval`, and `Status` columns. Thank you for your review!

## Related Issue

N/A

## Proposed Changes

Fix the JSON paths.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
