### PR TITLE
fix: vault deletionPolicy

### DIFF
--- a/pkg/provider/vault/vault.go
+++ b/pkg/provider/vault/vault.go
@@ -707,7 +707,7 @@ func (v *client) GetSecret(ctx context.Context, ref esv1beta1.ExternalSecretData
 
 	// Return nil if secret value is null
 	if data == nil {
-		return nil, nil
+		return nil, esv1beta1.NoSecretError{}
 	}
 	jsonStr, err := json.Marshal(data)
 	if err != nil {

--- a/pkg/provider/vault/vault_test.go
+++ b/pkg/provider/vault/vault_test.go
@@ -632,6 +632,22 @@ func TestGetSecret(t *testing.T) {
 				val: []byte("something different"),
 			},
 		},
+		"ReadSecretWithMissingValueFromData": {
+			reason: "Should return a NoSecretErr",
+			args: args{
+				store: makeValidSecretStoreWithVersion(esv1beta1.VaultKVStoreV1).Spec.Provider.Vault,
+				data: esv1beta1.ExternalSecretDataRemoteRef{
+					Property: "not-relevant",
+				},
+				vLogical: &fake.Logical{
+					ReadWithDataWithContextFn: fake.NewReadWithContextFn(nil, nil),
+				},
+			},
+			want: want{
+				err: esv1beta1.NoSecretErr,
+				val: nil,
+			},
+		},
 		"ReadSecretWithSliceValue": {
 			reason: "Should return property as a joined slice",
 			args: args{


### PR DESCRIPTION
## Problem Statement

Vault provider has a code path where it returns `nil, nil`. This results in empty secret values, which shouldn't be the case.
This behaviour currently isn't covered by tests, and AFAIK it isn't triggered by a code path with "regular" kv engine usage.
This bug surfaced, when using SecretStore `spec.provider.vault.version=v1` when vault kv actually runs with `v2`.

Repro case:

```sh
helm install vault hashicorp/vault \
    --set "server.dev.enabled=true" --set injector.enabled=false
# ...
vault secrets enable -version=1 kv
vault kv put kv/my-secret my-value=s3cr3t
```

Sync secret with ESO. This should work.
```yaml
apiVersion: external-secrets.io/v1beta1
kind: SecretStore
metadata:
  name: vault-backend
spec:
  provider:
    vault:
      server: "http://localhost:8200"
      path: "kv"
      version: "v1" # <-- 
      auth:
        tokenSecretRef:
          name: "vault-token"
          key: "token"
---
apiVersion: external-secrets.io/v1beta1
kind: ExternalSecret
metadata:
  name: vault-example
spec:
  refreshInterval: "15s"
  secretStoreRef:
    name: vault-backend
    kind: SecretStore
  target:
    name: example-sync
  data:
  - secretKey: foobar
    remoteRef:
      key: my-secret
      property: my-value
```

Migrate vault kv engine to v2.
```
vault kv enable-versioning kv/
vault read /sys/mounts | grep kv/
# ... options:map[version:2]  ...

# force reconcile
kubectl annotate es vault-example --overwrite foo=bar5

# --- without this fix: empty value!!! ---
kubectl get secret example-sync -o yaml | yq .data
foobar: ""

# --- with this PR: error out ---
kubectl get es vault-example
NAME            STORE           REFRESH INTERVAL   STATUS              READY
vault-example   vault-backend   15s                SecretSyncedError   False

kubectl describe es vault-example
# ...
Warning  UpdateFailed  5m43s (x19 over 27m)  external-secrets  Secret does not exist
```

Issue is described here: https://kubernetes.slack.com/archives/C017BF84G2Y/p1687822882229619
relates to #1502 #1512 

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
