### PR TITLE
feat: add @shuheiktgw as maintainer :tada:

### DIFF
--- a/.github/PAUL.yaml
+++ b/.github/PAUL.yaml
@@ -5,6 +5,7 @@ maintainers:
 - sebagomez
 - rodrmartinez
 - IdanAdar
+- shuheiktgw
 # Emeritus Approvers
 - Flydiverny
 - silasbw


### PR DESCRIPTION
I'm delighted to welcome @shuheiktgw as a maintainer to the project :tada: 

As per [GOVERNANCE.md](https://github.com/external-secrets/external-secrets/blob/main/GOVERNANCE.md#maintainers):

> New maintainers must be nominated by an existing maintainer(e.g. via https://github.com/external-secrets/external-secrets/pull/1591) and must be elected by a supermajority of existing maintainers


The math has spoken: we'll need 4 approvals on this one :pray: :rocket: 

@gusfcarvalho @knelasevero @IdanAdar @moolen @sebagomez