### PR TITLE
Remove unused values from helm chart

### DIFF
--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -76,10 +76,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | certController.serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
 | certController.serviceAccount.extraLabels | object | `{}` | Extra Labels to add to the service account. |
 | certController.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. |
-| certController.serviceMonitor.additionalLabels | object | `{}` | Additional labels |
-| certController.serviceMonitor.enabled | bool | `false` | Specifies whether to create a ServiceMonitor resource for collecting Prometheus metrics |
-| certController.serviceMonitor.interval | string | `"30s"` | Interval to scrape metrics |
-| certController.serviceMonitor.scrapeTimeout | string | `"25s"` | Timeout if metrics can't be retrieved in given time interval |
 | certController.tolerations | list | `[]` |  |
 | certController.topologySpreadConstraints | list | `[]` |  |
 | commonLabels | object | `{}` | Additional labels added to all helm chart resources. |
@@ -204,9 +200,5 @@ The command removes all the Kubernetes components associated with the chart and 
 | webhook.serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
 | webhook.serviceAccount.extraLabels | object | `{}` | Extra Labels to add to the service account. |
 | webhook.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. |
-| webhook.serviceMonitor.additionalLabels | object | `{}` | Additional labels |
-| webhook.serviceMonitor.enabled | bool | `false` | Specifies whether to create a ServiceMonitor resource for collecting Prometheus metrics |
-| webhook.serviceMonitor.interval | string | `"30s"` | Interval to scrape metrics |
-| webhook.serviceMonitor.scrapeTimeout | string | `"25s"` | Timeout if metrics can't be retrieved in given time interval |
 | webhook.tolerations | list | `[]` |  |
 | webhook.topologySpreadConstraints | list | `[]` |  |

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -303,19 +303,6 @@ webhook:
       # -- deprecated. will be removed with 0.7.0, use serviceMonitor instead
       port: 8080
 
-  serviceMonitor:
-    # -- Specifies whether to create a ServiceMonitor resource for collecting Prometheus metrics
-    enabled: false
-
-    # -- Additional labels
-    additionalLabels: {}
-
-    # --  Interval to scrape metrics
-    interval: 30s
-
-    # -- Timeout if metrics can't be retrieved in given time interval
-    scrapeTimeout: 25s
-
   metrics:
     service:
       # -- Enable if you use another monitoring tool than Prometheus to scrape the metrics
@@ -434,19 +421,6 @@ certController:
     service:
       # -- deprecated. will be removed with 0.7.0, use serviceMonitor instead
       port: 8080
-
-  serviceMonitor:
-    # -- Specifies whether to create a ServiceMonitor resource for collecting Prometheus metrics
-    enabled: false
-
-    # -- Additional labels
-    additionalLabels: {}
-
-    # --  Interval to scrape metrics
-    interval: 30s
-
-    # -- Timeout if metrics can't be retrieved in given time interval
-    scrapeTimeout: 25s
 
   metrics:
     service:

--- a/docs/api/metrics.md
+++ b/docs/api/metrics.md
@@ -5,7 +5,7 @@ hide:
 
 # Metrics
 
-The External Secrets Operator exposes its Prometheus metrics in the `/metrics` path. To enable it, set the `serviceMonitor.enabled` Helm flag to `true`. In addition you can also set `webhook.serviceMonitor.enabled=true` and `certController.serviceMonitor.enabled=true` to create `ServiceMonitor` resources for the other components.
+The External Secrets Operator exposes its Prometheus metrics in the `/metrics` path. To enable it, set the `serviceMonitor.enabled` Helm flag to `true`.
 
 If you are using a different monitoring tool that also needs a `/metrics` endpoint, you can set the `metrics.service.enabled` Helm flag to `true`. In addition you can also set `webhook.metrics.service.enabled` and `certController.metrics.service.enabled` to scrape the other components.
 


### PR DESCRIPTION
## Problem Statement
The `values.yaml` of the helm-chart contains values, which are no longer used.

## Related Issue
Fixes #2466 

## Proposed Changes
This PR removes obsolete values from the helm-chart since the corresponding templates have been deleted in [!2136.](https://github.com/external-secrets/external-secrets/pull/2136).
```
$ grep -R "webhook.serviceMonitor" .
./docs/api/metrics.md:The External Secrets Operator exposes its Prometheus metrics in the `/metrics` path. To enable it, set the `serviceMonitor.enabled` Helm flag to `true`. In addition you can also set `webhook.serviceMonitor.enabled=true` and `certController.serviceMonitor.enabled=true` to create `ServiceMonitor` resources for the other components.
./deploy/charts/external-secrets/README.md:| webhook.serviceMonitor.additionalLabels | object | `{}` | Additional labels |
./deploy/charts/external-secrets/README.md:| webhook.serviceMonitor.enabled | bool | `false` | Specifies whether to create a ServiceMonitor resource for collecting Prometheus metrics |
./deploy/charts/external-secrets/README.md:| webhook.serviceMonitor.interval | string | `"30s"` | Interval to scrape metrics |
./deploy/charts/external-secrets/README.md:| webhook.serviceMonitor.scrapeTimeout | string | `"25s"` | Timeout if metrics can't be retrieved in given time interval |

$ grep -R "certController.serviceMonitor" .
./docs/api/metrics.md:The External Secrets Operator exposes its Prometheus metrics in the `/metrics` path. To enable it, set the `serviceMonitor.enabled` Helm flag to `true`. In addition you can also set `webhook.serviceMonitor.enabled=true` and `certController.serviceMonitor.enabled=true` to create `ServiceMonitor` resources for the other components.
./deploy/charts/external-secrets/README.md:| certController.serviceMonitor.additionalLabels | object | `{}` | Additional labels |
./deploy/charts/external-secrets/README.md:| certController.serviceMonitor.enabled | bool | `false` | Specifies whether to create a ServiceMonitor resource for collecting Prometheus metrics |
./deploy/charts/external-secrets/README.md:| certController.serviceMonitor.interval | string | `"30s"` | Interval to scrape metrics |
./deploy/charts/external-secrets/README.md:| certController.serviceMonitor.scrapeTimeout | string | `"25s"` | Timeout if metrics can't be retrieved in given time interval |

```
## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
