### PR TITLE
Add processPushSecret key

### DIFF
--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -115,6 +115,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | priorityClassName | string | `""` | Pod priority class name. |
 | processClusterExternalSecret | bool | `true` | if true, the operator will process cluster external secret. Else, it will ignore them. |
 | processClusterStore | bool | `true` | if true, the operator will process cluster store. Else, it will ignore them. |
+| processPushSecret | bool | `true` | if true, the operator will process push secret. Else, it will ignore them. |
 | prometheus.enabled | bool | `false` | deprecated. will be removed with 0.7.0, use serviceMonitor instead. |
 | prometheus.service.port | int | `8080` | deprecated. will be removed with 0.7.0, use serviceMonitor instead. |
 | rbac.create | bool | `true` | Specifies whether role and rolebinding resources should be created. |

--- a/deploy/charts/external-secrets/templates/deployment.yaml
+++ b/deploy/charts/external-secrets/templates/deployment.yaml
@@ -65,6 +65,9 @@ spec:
             {{- if not .Values.processClusterExternalSecret }}
           - --enable-cluster-external-secret-reconciler=false
             {{- end }}
+            {{- if not .Values.processPushSecret }}
+          - --enable-push-secret-reconciler=false
+            {{- end }}
           {{- end }}
           {{- if .Values.controllerClass }}
           - --controller-class={{ .Values.controllerClass }}

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -59,6 +59,9 @@ processClusterExternalSecret: true
 # -- if true, the operator will process cluster store. Else, it will ignore them.
 processClusterStore: true
 
+# -- if true, the operator will process push secret. Else, it will ignore them.
+processPushSecret: true
+
 # -- Specifies whether an external secret operator deployment be created.
 createOperator: true
 


### PR DESCRIPTION
## Problem Statement

Unlike `ClusterExternalSecret` and `ClusterStore` that have both CRD installation toggles and processing toggles in the helm chart, `PushSecret` has only the CRD installation toggle. 

## Related Issue

Fixes #2471

## Proposed Changes

Add the processing toggle, same as the one for the cluster resources to the helm chart.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
