### PR TITLE
Adding documentation for populating Kubernetes Secret with metadata f…

### DIFF
--- a/docs/provider/ibm-secrets-manager.md
+++ b/docs/provider/ibm-secrets-manager.md
@@ -212,14 +212,13 @@ kubectl get secret secret-to-be-created -n <namespace> | -o jsonpath='{.data.tes
 ### Populating the Kubernetes secret with metadata from IBM Secrets Manager Provider
 ESO can add metadata while creating or updating a Kubernetes secret to be reflected in its labels or annotations. The metadata could be any of the fields that are supported and returned in the response by IBM Secrets Manager.
 
-In order for the user to opt-in to adding metadata to secret, an existing optional field can be leveraged under `spec.dataFrom.extract.metadataPolicy`. The required metadata can then be specified under `template.metadata.labels` or `template.metadata.annotations`. The required secret data can be specified under `template.data`. While the secret is being reconciled, it will have the secret data along with the required labels.
+In order for the user to opt-in to adding metadata to secret, an existing optional field `spec.dataFrom.extract.metadataPolicy` can be be set to `Fetch`, its default value being `None`. In addition to this, templating provided be ESO can be leveraged to specify the key-value pairs of the resultant secrets' labels and annotation.
 
-The possible values of `metadataPolicy` are as below
-- If metadataPolicy is set to `Fetch`, metadata is populated in K8s secret labels or annotations as specified in `template.metadata.labels` or `template.metadata.annotations`.
-- If metadataPolicy is set to `None`, metadata is not populated in K8s secret labels or annotations and is set as <no_value> even if `template.metadata.labels` or `template.metadata.annotations` is specified in the External Secrets CRD.
-- If metadataPolicy is not set, it defaults to None and exhibits the same behavior.
-
-In the below example, `secret_id` and `updated_at` are the metadata of a secret in IBM Secrets Manager.
+In order for the required metadata to be populated in the Kubernetes secret, combination of below should be provided in the External Secrets resource:
+1. The required metadata should be specified under `template.metadata.labels` or `template.metadata.annotations`.
+2. The required secret data should be specified under `template.data`.
+3. The spec.dataFrom.extract should be specified with details of the Secrets Manager secret with `spec.dataFrom.extract.metadataPolicy` set to `Fetch`.
+Below is an example, where `secret_id` and `updated_at` are the metadata of a secret in IBM Secrets Manager.:
 
 ```yaml
 apiVersion: external-secrets.io/v1beta1
@@ -243,12 +242,12 @@ spec:
       data:
         secret: "{{ .password }}" 
       metadata:
-        labels:
-          secret_id: "{{ .id }}"     # Adding metadata key whose value would be added to the secret as a label
+        annotations:
+          secret_id: "{{ .id }}"     # adding metadata key whose value would be added to the secret as a label
           updated_at: "{{ .updated_at }}"
 ```
 
-Below is the example of the secret after reconciliation:
+While the secret is being reconciled, it will have the secret data along with the required annotations. Below is the example of the secret after reconciliation:
 
 ```yaml
 apiVersion: v1
@@ -260,7 +259,7 @@ metadata:
   annotations:
     reconcile.external-secrets.io/data-hash: 02217008d13ed228e75cf6d26fe74324
   creationTimestamp: "2023-05-04T08:41:24Z"
-  labels:
+  annotations:
     secret_id: 1234
     updated_at: 2023-05-04T08:57:19Z
   name: database-credentials


### PR DESCRIPTION
Staring 0.9.1, IBM Cloud Secrets Manager supports populating k8s secret metadata with metadata pulled from IBM Cloud Secrets Manager - https://github.com/external-secrets/external-secrets/pull/2429

This PR to add documentation for the feature.