### PR TITLE
Correct ClusterExternalSecret provisioned namespaces

### DIFF
--- a/pkg/controllers/clusterexternalsecret/util.go
+++ b/pkg/controllers/clusterexternalsecret/util.go
@@ -63,16 +63,6 @@ func filterOutCondition(conditions []esv1beta1.ClusterExternalSecretStatusCondit
 	return newConditions
 }
 
-func ContainsNamespace(namespaces v1.NamespaceList, namespace string) bool {
-	for _, ns := range namespaces.Items {
-		if ns.ObjectMeta.Name == namespace {
-			return true
-		}
-	}
-
-	return false
-}
-
 func getConditionType(failedNamespaces map[string]string, namespaceList *v1.NamespaceList) esv1beta1.ClusterExternalSecretConditionType {
 	if len(failedNamespaces) == 0 {
 		return esv1beta1.ClusterExternalSecretReady


### PR DESCRIPTION
## Problem Statement

While testing the ClusterExternalSecret, I noticed the case when the provisioned namespaces field in the status subresource is not updated correctly. Then I found CES does not update the field when `provisionedNamespaces` is empty. I believe this is not an accurate behavior. For example, if we delete all the provisioned namespaces, the provisioned namespaces field should be empty, but CES skips updating it.

I assume the `len(provisionedNamespaces) > 0` condition exists to avoid updating the field unnecessarily, but the condition is not required since the controller computes the patch and applies it (so IIUC, it does not update the status field if not necessary). Thank you for your review! 🙂 

## Related Issue

N/A

## Proposed Changes

Remove the unnecessary `len(provisionedNamespaces) > 0` condition.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
