### PR TITLE
Use the cached client for the controller tests

### DIFF
--- a/pkg/controllers/clusterexternalsecret/suite_test.go
+++ b/pkg/controllers/clusterexternalsecret/suite_test.go
@@ -82,7 +82,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&Reconciler{
-		Client:          k8sClient,
+		Client:          k8sManager.GetClient(),
 		Scheme:          k8sManager.GetScheme(),
 		Log:             ctrl.Log.WithName("controllers").WithName("ClusterExternalSecrets"),
 		RequeueInterval: time.Second,

--- a/pkg/controllers/crds/suite_test.go
+++ b/pkg/controllers/crds/suite_test.go
@@ -74,7 +74,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).ToNot(BeNil())
 
-	rec := New(k8sClient, k8sManager.GetScheme(), log, time.Second*1,
+	rec := New(k8sManager.GetClient(), k8sManager.GetScheme(), log, time.Second*1,
 		"foo", "default", "foo", "default", []string{
 			"secretstores.test.io",
 		})

--- a/pkg/controllers/externalsecret/externalsecret_controller_test.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller_test.go
@@ -45,7 +45,7 @@ var (
 	fakeProvider   *fake.Client
 	metric         dto.Metric
 	metricDuration dto.Metric
-	timeout        = time.Second * 10
+	timeout        = time.Second * 20
 	interval       = time.Millisecond * 250
 )
 

--- a/pkg/controllers/externalsecret/suite_test.go
+++ b/pkg/controllers/externalsecret/suite_test.go
@@ -86,7 +86,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&Reconciler{
-		Client:                    k8sClient,
+		Client:                    k8sManager.GetClient(),
 		RestConfig:                cfg,
 		Scheme:                    k8sManager.GetScheme(),
 		Log:                       ctrl.Log.WithName("controllers").WithName("ExternalSecrets"),

--- a/pkg/controllers/pushsecret/pushsecret_controller_test.go
+++ b/pkg/controllers/pushsecret/pushsecret_controller_test.go
@@ -38,7 +38,7 @@ import (
 
 var (
 	fakeProvider *fake.Client
-	timeout      = time.Second * 10
+	timeout      = time.Second * 20
 	interval     = time.Millisecond * 250
 )
 
@@ -71,7 +71,7 @@ func checkCondition(status v1alpha1.PushSecretStatus, cond v1alpha1.PushSecretSt
 
 type testTweaks func(*testCase)
 
-var _ = Describe("ExternalSecret controller", func() {
+var _ = Describe("PushSecret controller", func() {
 	const (
 		PushSecretName             = "test-es"
 		PushSecretFQDN             = "externalsecrets.external-secrets.io/test-es"

--- a/pkg/controllers/secretstore/suite_test.go
+++ b/pkg/controllers/secretstore/suite_test.go
@@ -77,7 +77,7 @@ var _ = BeforeSuite(func() {
 	Expect(k8sClient).ToNot(BeNil())
 
 	err = (&StoreReconciler{
-		Client:          k8sClient,
+		Client:          k8sManager.GetClient(),
 		Scheme:          k8sManager.GetScheme(),
 		Log:             ctrl.Log.WithName("controllers").WithName("SecretStore"),
 		ControllerClass: defaultControllerClass,

--- a/pkg/controllers/webhookconfig/suite_test.go
+++ b/pkg/controllers/webhookconfig/suite_test.go
@@ -82,7 +82,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).ToNot(BeNil())
 
-	reconciler = New(k8sClient, k8sManager.GetScheme(), ctrl.Log, ctrlSvcName, ctrlSvcNamespace, ctrlSecretName, ctrlSecretNamespace, time.Second)
+	reconciler = New(k8sManager.GetClient(), k8sManager.GetScheme(), ctrl.Log, ctrlSvcName, ctrlSvcNamespace, ctrlSecretName, ctrlSecretNamespace, time.Second)
 	reconciler.SetupWithManager(k8sManager, controller.Options{})
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
## Problem Statement

SSIA. It would be better if we use the cached client instead of the uncached one (k8sClient) for the controller tests since that is what we use in the actual environment. Thanks!

## Related Issue

N/A

## Proposed Changes

Use the cached client instead.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
