### PR TITLE
Remove builder.OnlyMetadata

### DIFF
--- a/pkg/controllers/externalsecret/externalsecret_controller.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -555,6 +554,6 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, opts controller.Options)
 	return ctrl.NewControllerManagedBy(mgr).
 		WithOptions(opts).
 		For(&esv1beta1.ExternalSecret{}).
-		Owns(&v1.Secret{}, builder.OnlyMetadata).
+		Owns(&v1.Secret{}).
 		Complete(r)
 }


### PR DESCRIPTION
## Problem Statement

ExternalSecrets Controller has the same problem with https://github.com/external-secrets/external-secrets/pull/2504. but in this case, we cannot replace `v1.Secret` with `metav1. PartialObjectMetadata` since [the controller needs to access a non-metadata field to compute a hash](https://github.com/external-secrets/external-secrets/blob/0bfc31addcb95a4aa8e1023cd4f74a546c54d483/pkg/controllers/externalsecret/externalsecret_controller.go#L544). Therefore, I just deleted the `builder.OnlyMetadata` option to remove the unnecessary metadata cache 🙂 

## Related Issue

N/A

## Proposed Changes

Deleted the unnecessary `builder.OnlyMetadata` option.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
