### PR TITLE
Highlight that `property` field must be set for DSV secret

### DIFF
--- a/docs/provider/delinea.md
+++ b/docs/provider/delinea.md
@@ -39,6 +39,8 @@ If required, the URL template (`urlTemplate`) can be customized as well.
 
 Secrets can be referenced by path. Getting a specific version of a secret is not yet supported.
 
+Note that because all DSV secrets are JSON objects, you must specify `remoteRef.property`. You can access nested values or arrays using [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).
+
 ```yaml
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
@@ -53,4 +55,5 @@ spec:
       - secretKey: <KEY_IN_KUBE_SECRET>
         remoteRef:
           key: <SECRET_PATH>
+          property: <JSON_PROPERTY>
 ```


### PR DESCRIPTION
Just a small addition to the docs which I overlooked in PR #2415. 

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
