### PR TITLE
fix: downgrade pyyaml <6.0

### DIFF
--- a/hack/api-docs/Dockerfile
+++ b/hack/api-docs/Dockerfile
@@ -11,11 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.11
+FROM alpine:3.18
 COPY requirements.txt /
 RUN apk add -U --no-cache \
     python3 \
     python3-dev \
+    py3-pip \
     musl-dev \
     git \
     openssh \

--- a/hack/api-docs/Makefile
+++ b/hack/api-docs/Makefile
@@ -52,8 +52,8 @@ build: image generate $(SOURCES)
 		--sig-proxy=true \
 		--rm \
 		--user $(UID):$(GID) \
-		--env GIT_COMMITTER_NAME=$(shell git config user.name) \
-		--env GIT_COMMITTER_EMAIL=$(shell git config user.email) \
+		--env "GIT_COMMITTER_NAME=$(shell git config user.name)" \
+		--env "GIT_COMMITTER_EMAIL=$(shell git config user.email)" \
 		$(MKDOCS_IMAGE) \
 		/bin/bash -c "cd /repo && $(MIKE) deploy --ignore --update-aliases -F hack/api-docs/mkdocs.yml $(DOCS_VERSION) $(DOCS_ALIAS);"
 .PHONY: build.publish

--- a/hack/api-docs/requirements.txt
+++ b/hack/api-docs/requirements.txt
@@ -12,7 +12,7 @@ mkdocs-minify-plugin==0.5.0
 pep562==1.1
 Pygments==2.15.1
 pymdown-extensions==9.11
-PyYAML==6.0
+PyYAML==5.3.1 # 6.0 is broken: https://github.com/yaml/pyyaml/issues/601
 six==1.16.0
 tornado==6.1
 mkdocs-macros-plugin==0.7.0


### PR DESCRIPTION
Latest cython 3.0 breaks pyyaml 6.0. Installation fails with: `AttributeError: cython_sources`
Cython 3.0 is in beta at the moment and this needs to be fixed upstream.

See upstream issue: https://github.com/yaml/pyyaml/issues/601

Latest jobs failing on main:

https://github.com/external-secrets/external-secrets/actions/runs/5578892196/jobs/10193698145
https://github.com/external-secrets/external-secrets/actions/runs/5578892208/jobs/10193703882


Note: 5.3.1 is susceptible to [CVE-2020-14343](https://www.cvedetails.com/cve/CVE-2020-14343/), however this is not relevant as we have a completely static site, which doesn't render any code dynamically. 
Unfortunately we can not bump to `5.4+`, because the same error surfaces as described above.