### PR TITLE
Introduce RetrySettings support for Hashicorp Vault

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,7 +225,7 @@ docker.tag:  ## Emit IMAGE_TAG
 docker.build: $(addprefix build-,$(ARCH)) ## Build the docker image
 	@$(INFO) docker build
 	echo docker build -f $(DOCKERFILE) . $(DOCKER_BUILD_ARGS) -t $(IMAGE_NAME):$(IMAGE_TAG)
-	docker build -f $(DOCKERFILE) . $(DOCKER_BUILD_ARGS) -t $(IMAGE_NAME):$(IMAGE_TAG)
+	DOCKER_BUILDKIT=1 docker build -f $(DOCKERFILE) . $(DOCKER_BUILD_ARGS) -t $(IMAGE_NAME):$(IMAGE_TAG)
 	@$(OK) docker build
 
 .PHONY: docker.push

--- a/docs/contributing/devguide.md
+++ b/docs/contributing/devguide.md
@@ -25,7 +25,7 @@ Building the operator binary and docker image:
 
 ```shell
 make build
-make docker.build IMG=external-secrets:latest
+make docker.build IMAGE_NAME=external-secrets IMAGE_TAG=latest
 ```
 
 Run tests and lint the code:

--- a/docs/snippets/full-secret-store.yaml
+++ b/docs/snippets/full-secret-store.yaml
@@ -14,7 +14,7 @@ spec:
   # You can specify retry settings for the http connection
   # these fields allow you to set a maxRetries before failure, and
   # an interval between the retries.
-  # Current supported providers: AWS, IBM
+  # Current supported providers: AWS, Hashicorp Vault, IBM
   retrySettings:
     maxRetries: 5
     retryInterval: "10s"
@@ -42,6 +42,7 @@ spec:
             name: awssm-secret
             key: secret-access-key
 
+    # (2) Hashicorp Vault
     vault:
       server: "https://vault.acme.org"
       # Path is the mount path of the Vault KV backend endpoint
@@ -89,7 +90,7 @@ spec:
             name: "my-secret"
             key: "vault"
 
-    # (2): GCP Secret Manager
+    # (3): GCP Secret Manager
     gcpsm:
       # Auth defines the information necessary to authenticate against GCP by getting
       # the credentials from an already created Kubernetes Secret.


### PR DESCRIPTION
## Problem Statement

Hashicorp vault sdk supports retry attempts/interval, but those are not bound to the `{Cluster,}SecretStore` ones, bind them.

More about the actual use case, I have many secrets set at a 1m interval, and I see rare failures in syncing due to vault internal errors.
Those failures are transmitted to Argocd via the ES status and then to humans via email, I want to see if setting the retry amount to 1 or 2 (up from effectively 0) solves it.

## Related Issue

I opened no issue, tell me if I need to.

## Proposed Changes

Make it so the `SecretStoreSpec.retrySettings` are actually passed to the vault provider implementation.
Also update the documentation.

It's my first time writing anything in go, it was not easy to set everything up and get this done, please advise if the code has issues.
I've tested the image in a real cluster for a bit, everything worked, adding a new e2e test is outside my current ability.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
