### PR TITLE
helm: Add certController readiness port configuration and link prometheus.service.port to args

### DIFF
--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -61,6 +61,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | certController.prometheus.enabled | bool | `false` | deprecated. will be removed with 0.7.0, use serviceMonitor instead |
 | certController.prometheus.service.port | int | `8080` | deprecated. will be removed with 0.7.0, use serviceMonitor instead |
 | certController.rbac.create | bool | `true` | Specifies whether role and rolebinding resources should be created. |
+| certController.readinessProbe.address | string | `""` | Address for readiness probe |
+| certController.readinessProbe.port | int | `8081` | ReadinessProbe port for kubelet |
 | certController.replicaCount | int | `1` |  |
 | certController.requeueInterval | string | `"5m"` |  |
 | certController.resources | object | `{}` |  |

--- a/deploy/charts/external-secrets/templates/cert-controller-deployment.yaml
+++ b/deploy/charts/external-secrets/templates/cert-controller-deployment.yaml
@@ -54,6 +54,8 @@ spec:
           - --service-namespace={{ .Release.Namespace }}
           - --secret-name={{ include "external-secrets.fullname" . }}-webhook
           - --secret-namespace={{ .Release.Namespace }}
+          - --metrics-addr=:{{ .Values.certController.prometheus.service.port }}
+          - --healthz-addr={{ .Values.certController.readinessProbe.address }}:{{ .Values.certController.readinessProbe.port }}
           {{ if not .Values.crds.createClusterSecretStore -}}
           - --crd-names=externalsecrets.external-secrets.io
           - --crd-names=secretstores.external-secrets.io

--- a/deploy/charts/external-secrets/tests/__snapshot__/cert_controller_test.yaml.snap
+++ b/deploy/charts/external-secrets/tests/__snapshot__/cert_controller_test.yaml.snap
@@ -33,6 +33,8 @@ should match snapshot of default values:
                 - --service-namespace=NAMESPACE
                 - --secret-name=RELEASE-NAME-external-secrets-webhook
                 - --secret-namespace=NAMESPACE
+                - --metrics-addr=:8080
+                - --healthz-addr=:8081
               image: ghcr.io/external-secrets/external-secrets:v0.9.1
               imagePullPolicy: IfNotPresent
               name: cert-controller

--- a/deploy/charts/external-secrets/tests/cert_controller_test.yaml
+++ b/deploy/charts/external-secrets/tests/cert_controller_test.yaml
@@ -47,3 +47,17 @@ tests:
       - equal:
           path: spec.template.spec.hostNetwork
           value: true
+  - it: should override readinessProbe port
+    set:
+      certController.readinessProbe.port: 8082
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args[7]
+          value: "--healthz-addr=:8082"
+  - it: should override metrics port
+    set:
+      certController.prometheus.service.port: 8888
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args[6]
+          value: "--metrics-addr=:8888"

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -436,6 +436,12 @@ certController:
       # -- Additional service annotations
       annotations: {}
 
+  readinessProbe:
+    # -- Address for readiness probe
+    address: ""
+    # -- ReadinessProbe port for kubelet
+    port: 8081
+
     ## -- Extra environment variables to add to container.
   extraEnv: []
 


### PR DESCRIPTION
## Problem Statement

* when defining certController.prometheus.service.port the port is not automatically set on certController args, we need an extra step by using certController.extraArgs. This simplify the change of the port for metrics.
* The readiness probe of certController should be configurable

## Related Issue

N/A

## Proposed Changes

I have made some change in helm to support both.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
