### PR TITLE
Bug/escape special characters vault

### DIFF
--- a/pkg/provider/vault/vault.go
+++ b/pkg/provider/vault/vault.go
@@ -484,7 +484,11 @@ func (v *client) PushSecret(ctx context.Context, value []byte, remoteRef esv1bet
 			return fmt.Errorf("secret not managed by external-secrets")
 		}
 	}
-	vaultSecretValue, err := json.Marshal(vaultSecret)
+	buf := &bytes.Buffer{}
+	enc := json.NewEncoder(buf)
+	enc.SetEscapeHTML(false)
+	enc.Encode(vaultSecret)
+	vaultSecretValue := bytes.TrimSpace(buf.Bytes())
 	if err != nil {
 		return fmt.Errorf("error marshaling vault secret: %w", err)
 	}

--- a/pkg/provider/vault/vault_test.go
+++ b/pkg/provider/vault/vault_test.go
@@ -830,6 +830,10 @@ func TestGetSecretMap(t *testing.T) {
 		"access_key":    "access_key",
 		"access_secret": "access_secret",
 	}
+	secretWithSpecialCharacter := map[string]interface{}{
+		"access_key":    "acc<ess_&ke.,y",
+		"access_secret": "acce&?ss_s>ecret",
+	}
 	secretWithNilVal := map[string]interface{}{
 		"access_key":    "access_key",
 		"access_secret": "access_secret",
@@ -903,6 +907,40 @@ func TestGetSecretMap(t *testing.T) {
 				val: map[string][]byte{
 					"access_key":    []byte("access_key"),
 					"access_secret": []byte("access_secret"),
+				},
+			},
+		},
+		"ReadSecretWithSpecialCharactersKV1": {
+			reason: "Should map the secret even if it has a nil value",
+			args: args{
+				store: makeValidSecretStoreWithVersion(esv1beta1.VaultKVStoreV1).Spec.Provider.Vault,
+				vClient: &fake.Logical{
+					ReadWithDataWithContextFn: fake.NewReadWithContextFn(secretWithSpecialCharacter, nil),
+				},
+			},
+			want: want{
+				err: nil,
+				val: map[string][]byte{
+					"access_key":    []byte("acc<ess_&ke.,y"),
+					"access_secret": []byte("acce&?ss_s>ecret"),
+				},
+			},
+		},
+		"ReadSecretWithSpecialCharactersKV2": {
+			reason: "Should map the secret even if it has a nil value",
+			args: args{
+				store: makeValidSecretStoreWithVersion(esv1beta1.VaultKVStoreV2).Spec.Provider.Vault,
+				vClient: &fake.Logical{
+					ReadWithDataWithContextFn: fake.NewReadWithContextFn(map[string]interface{}{
+						"data": secretWithSpecialCharacter,
+					}, nil),
+				},
+			},
+			want: want{
+				err: nil,
+				val: map[string][]byte{
+					"access_key":    []byte("acc<ess_&ke.,y"),
+					"access_secret": []byte("acce&?ss_s>ecret"),
 				},
 			},
 		},


### PR DESCRIPTION
## Problem Statement

Trying to solve the issue with special characters getting escaped in UTF-8 by json.Marshal in the Vault provider.

## Related Issue

Fixes #2534

## Proposed Changes

The issue is intended behavior for the function https://pkg.go.dev/encoding/json#Marshal, the proposed solution would be to switch solution and use the Encoder which allows for the special characters to be properly escaped. https://pkg.go.dev/encoding/json#Encoder.SetEscapeHTML 

## Checklist

- [ x ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ x ] All commits are signed with `git commit --signoff`
- [ x ] My changes have reasonable test coverage
- [ x ] All tests pass with `make test`
- [  ] I ensured my PR is ready for review with `make reviewable`
