### PR TITLE
Update docs in common-k8s-secret-types.md

### DIFF
--- a/docs/guides/common-k8s-secret-types.md
+++ b/docs/guides/common-k8s-secret-types.md
@@ -32,7 +32,7 @@ This will generate a valid dockerconfigjson secret for you to use!
 You can get the final value with:
 
 ```bash
-kubectl get secret secret-to-be-created -n <namespace> | -o jsonpath="{.data\.dockerconfigjson}" | base64 -d
+kubectl get secret secret-to-be-created -n <namespace> -o jsonpath="{.data\.dockerconfigjson}" | base64 -d
 ```
 
 ## TLS Cert example
@@ -56,8 +56,8 @@ And now you can create an ExternalSecret that gets it. You will end up with a k8
 You can get their values with:
 
 ```bash
-kubectl get secret secret-to-be-created -n <namespace> | -o jsonpath="{.data.tls\.crt}" | base64 -d
-kubectl get secret secret-to-be-created -n <namespace> | -o jsonpath="{.data.tls\.key}" | base64 -d
+kubectl get secret secret-to-be-created -n <namespace> -o jsonpath="{.data.tls\.crt}" | base64 -d
+kubectl get secret secret-to-be-created -n <namespace> -o jsonpath="{.data.tls\.key}" | base64 -d
 ```
 
 
@@ -76,7 +76,7 @@ And now you can create an ExternalSecret that gets it. You will end up with a k8
 You can get the privkey value with:
 
 ```bash
-kubectl get secret secret-to-be-created -n <namespace> | -o jsonpath="{.data.ssh-privatekey}" | base64 -d
+kubectl get secret secret-to-be-created -n <namespace> -o jsonpath="{.data.ssh-privatekey}" | base64 -d
 ```
 
 ## More examples


### PR DESCRIPTION
corrected kubectl command syntax in docs in https://external-secrets.io/main/guides/common-k8s-secret-types/

## Problem Statement

What is the problem you're trying to solve?

`-o: command not found`

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

update common-k8s-secret-types.md file

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
