### PR TITLE
Fixed potential linting issue on webhook pdb manifest

### DIFF
--- a/deploy/charts/external-secrets/templates/webhook-poddisruptionbudget.yaml
+++ b/deploy/charts/external-secrets/templates/webhook-poddisruptionbudget.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "external-secrets-webhook.labels" . | nindent 4 }}
-    external-secrets.io/component : webhook
+    external-secrets.io/component: webhook
 spec:
   {{- if .Values.webhook.podDisruptionBudget.minAvailable }}
   minAvailable: {{ .Values.webhook.podDisruptionBudget.minAvailable }}


### PR DESCRIPTION
## Problem Statement

Unneeded whitespace is tripping yaml linter

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
