### PR TITLE
Fix flaky ClusterExternalSecret test

### DIFF
--- a/pkg/controllers/clusterexternalsecret/clusterexternalsecret_controller_test.go
+++ b/pkg/controllers/clusterexternalsecret/clusterexternalsecret_controller_test.go
@@ -309,16 +309,16 @@ var _ = Describe("ClusterExternalSecret controller", func() {
 			clusterExternalSecret: func(namespaces []v1.Namespace) esv1beta1.ClusterExternalSecret {
 				ces := defaultClusterExternalSecret()
 				ces.Spec.NamespaceSelector.MatchLabels = map[string]string{"kubernetes.io/metadata.name": namespaces[0].Name}
-				return *ces
-			},
-			beforeCheck: func(ctx context.Context, namespaces []v1.Namespace, created esv1beta1.ClusterExternalSecret) {
+
 				es := &esv1beta1.ExternalSecret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      created.Name,
+						Name:      ces.Name,
 						Namespace: namespaces[0].Name,
 					},
 				}
-				Expect(k8sClient.Create(ctx, es)).ShouldNot(HaveOccurred())
+				Expect(k8sClient.Create(context.Background(), es)).ShouldNot(HaveOccurred())
+
+				return *ces
 			},
 			expectedClusterExternalSecret: func(namespaces []v1.Namespace, created esv1beta1.ClusterExternalSecret) esv1beta1.ClusterExternalSecret {
 				return esv1beta1.ClusterExternalSecret{


### PR DESCRIPTION
## Problem Statement

I've refactored CES tests in https://github.com/external-secrets/external-secrets/pull/2499, but [one of them seems to have been flaky as a result](https://github.com/external-secrets/external-secrets/actions/runs/5635494885/job/15266559989?pr=2527), so I fixed it 🙇 

The problem was that we used to create an external secret in the before-check section. However, depending on the reconciliation loop, a cluster external secret generates a child external secret with the same name before we create it in the before check. To fix the problem, I changed the test to prepare an external secret before creating a cluster external secret.

## Related Issue

N/A

## Proposed Changes

Fix the resource creation order

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
