### PR TITLE
Disable Git top-level directory owner check

### DIFF
--- a/hack/api-docs/Dockerfile
+++ b/hack/api-docs/Dockerfile
@@ -25,3 +25,6 @@ RUN apk add -U --no-cache \
     gcc \
     diffutils
 RUN pip3 install -r /requirements.txt
+# Disable the top-level directory owner check
+# https://github.com/git/git/commit/8959555cee7ec045958f9b6dd62e541affb7e7d9
+RUN git config --system --add safe.directory '*'

--- a/hack/api-docs/Makefile
+++ b/hack/api-docs/Makefile
@@ -42,7 +42,7 @@ all: build
 
 .PHONY: image
 image:
-	$(DOCKER) build -t $(MKDOCS_IMAGE) --build-arg USER_ID=$(UID) -f Dockerfile .
+	$(DOCKER) build -t $(MKDOCS_IMAGE) -f Dockerfile .
 
 .PHONY: build
 build: image generate $(SOURCES)


### PR DESCRIPTION
## Problem Statement

Since [we updated the base alpine image](https://github.com/external-secrets/external-secrets/commit/c76477550876bf466bbe5cd54bdbbe748b1dcea6), I started receiving the following error when I ran `make reviewable`.

```
I0730 10:13:05.825442   30896 main.go:167] written to /Users/shuheiktgw/Projects/external-secrets/external-secrets/hack/api-docs/../..//docs/api/spec.md
mkdir -p /Users/shuheiktgw/Projects/external-secrets/external-secrets/hack/api-docs/../..//site
docker run \
	    --mount type=bind,source=/Users/shuheiktgw/Projects/external-secrets/external-secrets/hack/api-docs/../../,target=/repo \
		--sig-proxy=true \
		--rm \
		--user 502:20 \
		--env "GIT_COMMITTER_NAME=xxx" \
		--env "GIT_COMMITTER_EMAIL=xxx" \
		github.com/external-secrets-mkdocs:latest \
		/bin/bash -c "cd /repo && mike deploy --ignore --update-aliases -F hack/api-docs/mkdocs.yml main unstable;"
Config value 'nav': Expected nav to be a list, got dict with keys ('v2', 'v1')
error: error getting latest commit:
  fatal: detected dubious ownership in repository at '/repo'
  To add an exception for this directory, call:

  	git config --global --add safe.directory /repo
make: *** [build] Error 1
```

It seems the git has been updated, and [it started validating the top-level directory ownership](https://github.com/git/git/commit/8959555cee7ec045958f9b6dd62e541affb7e7d9). As a result, since the root user owned the top level directly, it started failing. To resolve the issue, I turned off the owner check, which is unnecessary in the Docker environment. Another more decent option may be creating a HOME for the current user, but that complicates the operation, and I believe that is not worth the effort. Thank you for your review!

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
