### PR TITLE
Remove metrics when a resouce is deleted

### DIFF
--- a/pkg/controllers/clusterexternalsecret/cesmetrics/cesmetrics.go
+++ b/pkg/controllers/clusterexternalsecret/cesmetrics/cesmetrics.go
@@ -110,3 +110,15 @@ func UpdateClusterExternalSecretCondition(ces *esv1beta1.ClusterExternalSecret, 
 			}))
 	}
 }
+
+// RemoveMetrics deletes all metrics published by the resource.
+func RemoveMetrics(namespace, name string) {
+	for _, gaugeVecMetric := range gaugeVecMetrics {
+		gaugeVecMetric.DeletePartialMatch(
+			map[string]string{
+				"namespace": namespace,
+				"name":      name,
+			},
+		)
+	}
+}

--- a/pkg/controllers/clusterexternalsecret/clusterexternalsecret_controller.go
+++ b/pkg/controllers/clusterexternalsecret/clusterexternalsecret_controller.go
@@ -74,6 +74,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	err := r.Get(ctx, req.NamespacedName, &clusterExternalSecret)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
+			cesmetrics.RemoveMetrics(req.Namespace, req.Name)
 			return ctrl.Result{}, nil
 		}
 

--- a/pkg/controllers/secretstore/clustersecretstore_controller.go
+++ b/pkg/controllers/secretstore/clustersecretstore_controller.go
@@ -54,6 +54,7 @@ func (r *ClusterStoreReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	var css esapi.ClusterSecretStore
 	err := r.Get(ctx, req.NamespacedName, &css)
 	if apierrors.IsNotFound(err) {
+		cssmetrics.RemoveMetrics(req.Namespace, req.Name)
 		return ctrl.Result{}, nil
 	} else if err != nil {
 		log.Error(err, "unable to get ClusterSecretStore")

--- a/pkg/controllers/secretstore/cssmetrics/cssmetrics.go
+++ b/pkg/controllers/secretstore/cssmetrics/cssmetrics.go
@@ -55,3 +55,15 @@ func SetUpMetrics() {
 func GetGaugeVec(key string) *prometheus.GaugeVec {
 	return gaugeVecMetrics[key]
 }
+
+// RemoveMetrics deletes all metrics published by the resource.
+func RemoveMetrics(namespace, name string) {
+	for _, gaugeVecMetric := range gaugeVecMetrics {
+		gaugeVecMetric.DeletePartialMatch(
+			map[string]string{
+				"namespace": namespace,
+				"name":      name,
+			},
+		)
+	}
+}

--- a/pkg/controllers/secretstore/secretstore_controller.go
+++ b/pkg/controllers/secretstore/secretstore_controller.go
@@ -55,6 +55,7 @@ func (r *StoreReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	var ss esapi.SecretStore
 	err := r.Get(ctx, req.NamespacedName, &ss)
 	if apierrors.IsNotFound(err) {
+		ssmetrics.RemoveMetrics(req.Namespace, req.Name)
 		return ctrl.Result{}, nil
 	} else if err != nil {
 		log.Error(err, "unable to get SecretStore")

--- a/pkg/controllers/secretstore/ssmetrics/ssmetrics.go
+++ b/pkg/controllers/secretstore/ssmetrics/ssmetrics.go
@@ -55,3 +55,15 @@ func SetUpMetrics() {
 func GetGaugeVec(key string) *prometheus.GaugeVec {
 	return gaugeVecMetrics[key]
 }
+
+// RemoveMetrics deletes all metrics published by the resource.
+func RemoveMetrics(namespace, name string) {
+	for _, gaugeVecMetric := range gaugeVecMetrics {
+		gaugeVecMetric.DeletePartialMatch(
+			map[string]string{
+				"namespace": namespace,
+				"name":      name,
+			},
+		)
+	}
+}


### PR DESCRIPTION
## Problem Statement

The details are described in [the issue](https://github.com/external-secrets/external-secrets/issues/2542), but it would be great if we remove metrics when a parent metric has been deleted, or the Operator keeps reporting stale values. Also, it helps reduce the number of metrics users receive.

ExternalSecret Controller takes a different approach and sets the condition deleted instead of deleting the metrics themselves. The benefit of the approach is that metric collectors are more likely to be able to pull metrics before they get deleted (even though it keeps reporting the same gauge metrics until the Operator restarts or the leader changes, which I think is wasteful). I'm not too sure which approach we should take here, so I'd like to know what others think 🙂 

Thank you for your review!

https://github.com/external-secrets/external-secrets/blob/b912c334aa7d3bb39fa8d495f49503ac13f21a54/pkg/controllers/externalsecret/externalsecret_controller.go#L115-L123

## Related Issue

Closes https://github.com/external-secrets/external-secrets/issues/2542

## Proposed Changes

Remove metric when a parent resource gets deleted.

## Checklist
It is difficult to test the behavior, so I cannot add unit tests...

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
