### PR TITLE
Stop ignoring ExternalSecret reconciliation error

### DIFF
--- a/pkg/controllers/externalsecret/externalsecret_controller.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller.go
@@ -126,7 +126,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		log.Error(err, errGetES)
 		syncCallsError.With(resourceLabels).Inc()
 
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, err
 	}
 
 	// if extended metrics is enabled, refine the time series vector
@@ -163,6 +163,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}, &existingSecret)
 	if err != nil && !apierrors.IsNotFound(err) {
 		log.Error(err, errGetExistingSecret)
+		return ctrl.Result{}, err
 	}
 
 	// refresh should be skipped if


### PR DESCRIPTION
## Problem Statement

While reading the source code, I noticed the External Secret Controller mistakenly ignored an error, so I fixed it to return the received error to retry reconciliation! Thank you for your review 🙂 

## Related Issue

N/A

## Proposed Changes

Stop ignoring an error.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
