### PR TITLE
IBM Provider: convert the fetched secret to map to access the properties

### DIFF
--- a/pkg/provider/ibm/provider.go
+++ b/pkg/provider/ibm/provider.go
@@ -48,6 +48,8 @@ const (
 	passwordConst     = "password"
 	apikeyConst       = "apikey"
 	arbitraryConst    = "arbitrary"
+	payloadConst      = "payload"
+	smApiKeyConst     = "api_key"
 
 	errIBMClient                             = "cannot setup new ibm client: %w"
 	errIBMCredSecretName                     = "invalid IBM SecretStore resource: missing IBM APIKey"
@@ -221,20 +223,14 @@ func getImportCertSecret(ibm *providerIBM, secretName *string, ref esv1beta1.Ext
 	if err != nil {
 		return nil, err
 	}
-	secret, ok := response.(*sm.ImportedCertificate)
-	if !ok {
-		return nil, fmt.Errorf(errExtractingSecret, *secretName, sm.Secret_SecretType_ImportedCert, "getImportCertSecret")
+	secMap, err := formSecretMap(response)
+	if err != nil {
+		return nil, err
 	}
-	switch ref.Property {
-	case certificateConst:
-		return []byte(*secret.Certificate), nil
-	case intermediateConst:
-		return []byte(*secret.Intermediate), nil
-	case privateKeyConst:
-		return []byte(*secret.PrivateKey), nil
-	default:
-		return nil, fmt.Errorf("unknown property type %s", ref.Property)
+	if val, ok := secMap[ref.Property]; ok {
+		return []byte(val.(string)), nil
 	}
+	return nil, fmt.Errorf("key %s does not exist in secret %s", ref.Property, ref.Key)
 }
 
 func getPublicCertSecret(ibm *providerIBM, secretName *string, ref esv1beta1.ExternalSecretDataRemoteRef) ([]byte, error) {
@@ -242,21 +238,14 @@ func getPublicCertSecret(ibm *providerIBM, secretName *string, ref esv1beta1.Ext
 	if err != nil {
 		return nil, err
 	}
-	secret, ok := response.(*sm.PublicCertificate)
-	if !ok {
-		return nil, fmt.Errorf(errExtractingSecret, *secretName, sm.Secret_SecretType_PublicCert, "getPublicCertSecret")
+	secMap, err := formSecretMap(response)
+	if err != nil {
+		return nil, err
 	}
-
-	switch ref.Property {
-	case certificateConst:
-		return []byte(*secret.Certificate), nil
-	case intermediateConst:
-		return []byte(*secret.Intermediate), nil
-	case privateKeyConst:
-		return []byte(*secret.PrivateKey), nil
-	default:
-		return nil, fmt.Errorf("unknown property type %s", ref.Property)
+	if val, ok := secMap[ref.Property]; ok {
+		return []byte(val.(string)), nil
 	}
+	return nil, fmt.Errorf("key %s does not exist in secret %s", ref.Property, ref.Key)
 }
 
 func getPrivateCertSecret(ibm *providerIBM, secretName *string, ref esv1beta1.ExternalSecretDataRemoteRef) ([]byte, error) {
@@ -264,18 +253,15 @@ func getPrivateCertSecret(ibm *providerIBM, secretName *string, ref esv1beta1.Ex
 	if err != nil {
 		return nil, err
 	}
-	secret, ok := response.(*sm.PrivateCertificate)
-	if !ok {
-		return nil, fmt.Errorf(errExtractingSecret, *secretName, sm.Secret_SecretType_PrivateCert, "getPrivateCertSecret")
+	secMap, err := formSecretMap(response)
+	if err != nil {
+		return nil, err
 	}
-	switch ref.Property {
-	case certificateConst:
-		return []byte(*secret.Certificate), nil
-	case privateKeyConst:
-		return []byte(*secret.PrivateKey), nil
-	default:
-		return nil, fmt.Errorf("unknown property type %s", ref.Property)
+	if val, ok := secMap[ref.Property]; ok {
+		return []byte(val.(string)), nil
 	}
+	return nil, fmt.Errorf("key %s does not exist in secret %s", ref.Property, ref.Key)
+
 }
 
 func getIamCredentialsSecret(ibm *providerIBM, secretName *string) ([]byte, error) {
@@ -295,18 +281,14 @@ func getUsernamePasswordSecret(ibm *providerIBM, secretName *string, ref esv1bet
 	if err != nil {
 		return nil, err
 	}
-	secret, ok := response.(*sm.UsernamePasswordSecret)
-	if !ok {
-		return nil, fmt.Errorf(errExtractingSecret, *secretName, sm.Secret_SecretType_UsernamePassword, "getUsernamePasswordSecret")
+	secMap, err := formSecretMap(response)
+	if err != nil {
+		return nil, err
 	}
-	switch ref.Property {
-	case "username":
-		return []byte(*secret.Username), nil
-	case "password":
-		return []byte(*secret.Password), nil
-	default:
-		return nil, fmt.Errorf("unknown property type %s", ref.Property)
+	if val, ok := secMap[ref.Property]; ok {
+		return []byte(val.(string)), nil
 	}
+	return nil, fmt.Errorf("key %s does not exist in secret %s", ref.Property, ref.Key)
 }
 
 // Returns a secret of type kv and supports json path.
@@ -441,70 +423,46 @@ func (ibm *providerIBM) GetSecretMap(_ context.Context, ref esv1beta1.ExternalSe
 	if err != nil {
 		return nil, err
 	}
+
+	secMap, err := formSecretMap(response)
+	if err != nil {
+		return nil, err
+	}
 	if ref.MetadataPolicy == esv1beta1.ExternalSecretMetadataPolicyFetch {
-		if err := populateSecretMap(secretMap, response); err != nil {
+		if err := populateSecretMap(secretMap, secMap); err != nil {
 			return nil, err
 		}
 	}
 
 	switch secretType {
 	case sm.Secret_SecretType_Arbitrary:
-		secretData, ok := response.(*sm.ArbitrarySecret)
-		if !ok {
-			return nil, fmt.Errorf(errExtractingSecret, secretName, sm.Secret_SecretType_Arbitrary, "GetSecretMap")
-		}
-		secretMap[arbitraryConst] = []byte(*secretData.Payload)
+		secretMap[arbitraryConst] = []byte(fmt.Sprintf("%v", secMap[payloadConst]))
 		return secretMap, nil
 
 	case sm.Secret_SecretType_UsernamePassword:
-		secretData, ok := response.(*sm.UsernamePasswordSecret)
-		if !ok {
-			return nil, fmt.Errorf(errExtractingSecret, secretName, sm.Secret_SecretType_UsernamePassword, "GetSecretMap")
-		}
-		secretMap[usernameConst] = []byte(*secretData.Username)
-		secretMap[passwordConst] = []byte(*secretData.Password)
-
+		secretMap[usernameConst] = []byte(fmt.Sprintf("%v", secMap[usernameConst]))
+		secretMap[passwordConst] = []byte(fmt.Sprintf("%v", secMap[passwordConst]))
 		return secretMap, nil
 
 	case sm.Secret_SecretType_IamCredentials:
-		secretData, ok := response.(*sm.IAMCredentialsSecret)
-		if !ok {
-			return nil, fmt.Errorf(errExtractingSecret, secretName, sm.Secret_SecretType_IamCredentials, "GetSecretMap")
-		}
-		secretMap[apikeyConst] = []byte(*secretData.ApiKey)
-
+		secretMap[apikeyConst] = []byte(fmt.Sprintf("%v", secMap[smApiKeyConst]))
 		return secretMap, nil
 
 	case sm.Secret_SecretType_ImportedCert:
-		secretData, ok := response.(*sm.ImportedCertificate)
-		if !ok {
-			return nil, fmt.Errorf(errExtractingSecret, secretName, sm.Secret_SecretType_ImportedCert, "GetSecretMap")
-		}
-		secretMap[certificateConst] = []byte(*secretData.Certificate)
-		secretMap[intermediateConst] = []byte(*secretData.Intermediate)
-		secretMap[privateKeyConst] = []byte(*secretData.PrivateKey)
-
+		secretMap[certificateConst] = []byte(fmt.Sprintf("%v", secMap[certificateConst]))
+		secretMap[intermediateConst] = []byte(fmt.Sprintf("%v", secMap[intermediateConst]))
+		secretMap[privateKeyConst] = []byte(fmt.Sprintf("%v", secMap[privateKeyConst]))
 		return secretMap, nil
 
 	case sm.Secret_SecretType_PublicCert:
-		secretData, ok := response.(*sm.PublicCertificate)
-		if !ok {
-			return nil, fmt.Errorf(errExtractingSecret, secretName, sm.Secret_SecretType_PublicCert, "GetSecretMap")
-		}
-		secretMap[certificateConst] = []byte(*secretData.Certificate)
-		secretMap[intermediateConst] = []byte(*secretData.Intermediate)
-		secretMap[privateKeyConst] = []byte(*secretData.PrivateKey)
-
+		secretMap[certificateConst] = []byte(fmt.Sprintf("%v", secMap[certificateConst]))
+		secretMap[intermediateConst] = []byte(fmt.Sprintf("%v", secMap[intermediateConst]))
+		secretMap[privateKeyConst] = []byte(fmt.Sprintf("%v", secMap[privateKeyConst]))
 		return secretMap, nil
 
 	case sm.Secret_SecretType_PrivateCert:
-		secretData, ok := response.(*sm.PrivateCertificate)
-		if !ok {
-			return nil, fmt.Errorf(errExtractingSecret, secretName, sm.Secret_SecretType_PrivateCert, "GetSecretMap")
-		}
-		secretMap[certificateConst] = []byte(*secretData.Certificate)
-		secretMap[privateKeyConst] = []byte(*secretData.PrivateKey)
-
+		secretMap[certificateConst] = []byte(fmt.Sprintf("%v", secMap[certificateConst]))
+		secretMap[privateKeyConst] = []byte(fmt.Sprintf("%v", secMap[privateKeyConst]))
 		return secretMap, nil
 
 	case sm.Secret_SecretType_Kv:
@@ -704,17 +662,21 @@ func init() {
 }
 
 // populateSecretMap populates the secretMap with metadata information that is pulled from IBM provider.
-func populateSecretMap(secretMap map[string][]byte, secretData interface{}) error {
-	secretDataMap := make(map[string]interface{})
-	data, err := json.Marshal(secretData)
-	if err != nil {
-		return fmt.Errorf(errJSONSecretMarshal, err)
-	}
-	if err := json.Unmarshal(data, &secretDataMap); err != nil {
-		return fmt.Errorf(errJSONSecretUnmarshal, err)
-	}
+func populateSecretMap(secretMap map[string][]byte, secretDataMap map[string]interface{}) error {
 	for key, value := range secretDataMap {
 		secretMap[key] = []byte(fmt.Sprintf("%v", value))
 	}
 	return nil
+}
+
+func formSecretMap(secretData interface{}) (map[string]interface{}, error) {
+	secretDataMap := make(map[string]interface{})
+	data, err := json.Marshal(secretData)
+	if err != nil {
+		return nil, fmt.Errorf(errJSONSecretMarshal, err)
+	}
+	if err := json.Unmarshal(data, &secretDataMap); err != nil {
+		return nil, fmt.Errorf(errJSONSecretUnmarshal, err)
+	}
+	return secretDataMap, nil
 }


### PR DESCRIPTION
Fix nil pointer exceptions when fetching a property not available in the secret.


## Proposed Changes
Way of accessing the properties has changed in the latest Secrets Manager provider sdk v2, and ESO has been updated accordingly: https://github.com/external-secrets/external-secrets/pull/2254.
However, customer reported nil pointer exceptions and ESO crashing when accessing properties not available in the secret.
This PR converts the fetched secret to a map and then handles accessing the properties. This is similar to that of how it was accessed prior to the sdk update (https://github.com/external-secrets/external-secrets/blob/1cf7c3a6e31d699c78d0034810a5db21a871e249/pkg/provider/ibm/provider.go#L214-L217)

Based on the current changes in PR, when a non-existing `private_key` property is provided in the ExternalSecret definition
```
apiVersion: external-secrets.io/v1beta1
kind: ExternalSecret
metadata:
  name: ibmcloud-secrets-manager-example
spec:
  secretStoreRef:
    name: ibmcloud-secrets-manager-example
    kind: SecretStore
  target:
    name: test-app-secret
  data:
  - secretKey: .secret
    remoteRef:
      key: imported_cert/010134d2-1115-e460-5842-62cf8341d744
      property: private_key
```
ESO does not crash, but throws an error:
```
{"level":"error","ts":1691667380.9251184,"logger":"controllers.ExternalSecret","msg":"could not get secret data from provider","ExternalSecret":{"name":"ibmcloud-secrets-manager-example","namespace":"external-secrets"},"error":"key private_key does not exist in secret imported_cert/010134d2-1115-e460-5842-62cf8341d744","stacktrace":"github.com/external-secrets/external-secrets/pkg/controllers/externalsecret.(*Reconciler).Reconcile\n\t/Users/shantigundumalla/goworkspace/src/github.com/external-secrets/pkg/controllers/externalsecret/externalsecret_controller.go:204\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\t/Users/shantigundumalla/goworkspace/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.0/pkg/internal/controller/controller.go:118\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/Users/shantigundumalla/goworkspace/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.0/pkg/internal/controller/controller.go:314\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/Users/shantigundumalla/goworkspace/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.0/pkg/internal/controller/controller.go:265\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/Users/shantigundumalla/goworkspace/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.0/pkg/internal/controller/controller.go:226"}
```

Below is the description of the created ExternalSecret:
```
...
Status:
  Conditions:
    Last Transition Time:  2023-08-10T11:37:09Z
    Message:               could not get secret data from provider
    Reason:                SecretSyncedError
    Status:                False
    Type:                  Ready
Events:
  Type     Reason        Age              From              Message
  ----     ------        ----             ----              -------
  Warning  UpdateFailed  1s (x5 over 4s)  external-secrets  key private_key does not exist in secret imported_cert/010134d2-1115-e460-5842-62cf8341d744
```

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
