### PR TITLE
Delete old ClusterExternalSecrets when name changed

### DIFF
--- a/apis/externalsecrets/v1beta1/clusterexternalsecret_types.go
+++ b/apis/externalsecrets/v1beta1/clusterexternalsecret_types.go
@@ -77,6 +77,9 @@ type ClusterExternalSecretNamespaceFailure struct {
 
 // ClusterExternalSecretStatus defines the observed state of ClusterExternalSecret.
 type ClusterExternalSecretStatus struct {
+	// ExternalSecretName is the name of the ExternalSecrets created by the ClusterExternalSecret
+	ExternalSecretName string `json:"externalSecretName,omitempty"`
+
 	// Failed namespaces are the namespaces that failed to apply an ExternalSecret
 	// +optional
 	FailedNamespaces []ClusterExternalSecretNamespaceFailure `json:"failedNamespaces,omitempty"`

--- a/config/crds/bases/external-secrets.io_clusterexternalsecrets.yaml
+++ b/config/crds/bases/external-secrets.io_clusterexternalsecrets.yaml
@@ -503,6 +503,10 @@ spec:
                   - type
                   type: object
                 type: array
+              externalSecretName:
+                description: ExternalSecretName is the name of the ExternalSecrets
+                  created by the ClusterExternalSecret
+                type: string
               failedNamespaces:
                 description: Failed namespaces are the namespaces that failed to apply
                   an ExternalSecret

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -426,6 +426,9 @@ spec:
                       - type
                     type: object
                   type: array
+                externalSecretName:
+                  description: ExternalSecretName is the name of the ExternalSecrets created by the ClusterExternalSecret
+                  type: string
                 failedNamespaces:
                   description: Failed namespaces are the namespaces that failed to apply an ExternalSecret
                   items:

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -1383,6 +1383,17 @@ Kubernetes meta/v1.Duration
 <tbody>
 <tr>
 <td>
+<code>externalSecretName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>ExternalSecretName is the name of the ExternalSecrets created by the ClusterExternalSecret</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>failedNamespaces</code></br>
 <em>
 <a href="#external-secrets.io/v1beta1.ClusterExternalSecretNamespaceFailure">

--- a/pkg/controllers/clusterexternalsecret/clusterexternalsecret_controller_test.go
+++ b/pkg/controllers/clusterexternalsecret/clusterexternalsecret_controller_test.go
@@ -166,6 +166,7 @@ var _ = Describe("ClusterExternalSecret controller", func() {
 					},
 					Spec: created.Spec,
 					Status: esv1beta1.ClusterExternalSecretStatus{
+						ExternalSecretName:    created.Name,
 						ProvisionedNamespaces: []string{namespaces[0].Name},
 						Conditions: []esv1beta1.ClusterExternalSecretStatusCondition{
 							{
@@ -209,6 +210,7 @@ var _ = Describe("ClusterExternalSecret controller", func() {
 					},
 					Spec: created.Spec,
 					Status: esv1beta1.ClusterExternalSecretStatus{
+						ExternalSecretName:    "test-es",
 						ProvisionedNamespaces: []string{namespaces[0].Name},
 						Conditions: []esv1beta1.ClusterExternalSecretStatusCondition{
 							{
@@ -227,6 +229,61 @@ var _ = Describe("ClusterExternalSecret controller", func() {
 							Name:        "test-es",
 							Labels:      map[string]string{"test-label-key1": "test-label-value1", "test-label-key2": "test-label-value2"},
 							Annotations: map[string]string{"test-annotation-key1": "test-annotation-value1", "test-annotation-key2": "test-annotation-value2"},
+						},
+						Spec: created.Spec.ExternalSecretSpec,
+					},
+				}
+			},
+		}),
+		Entry("Should delete old external secrets if name has changed", testCase{
+			namespaces: []v1.Namespace{
+				{ObjectMeta: metav1.ObjectMeta{Name: randomNamespaceName()}},
+			},
+			clusterExternalSecret: func(namespaces []v1.Namespace) esv1beta1.ClusterExternalSecret {
+				ces := defaultClusterExternalSecret()
+				ces.Spec.NamespaceSelector.MatchLabels = map[string]string{"kubernetes.io/metadata.name": namespaces[0].Name}
+				ces.Spec.ExternalSecretName = "old-es-name"
+				return *ces
+			},
+			beforeCheck: func(ctx context.Context, namespaces []v1.Namespace, created esv1beta1.ClusterExternalSecret) {
+				// Wait until the external secret is provisioned
+				var es esv1beta1.ExternalSecret
+				Eventually(func(g Gomega) {
+					key := types.NamespacedName{Namespace: namespaces[0].Name, Name: "old-es-name"}
+					g.Expect(k8sClient.Get(ctx, key, &es)).ShouldNot(HaveOccurred())
+				}).WithTimeout(timeout).WithPolling(interval).Should(Succeed())
+
+				copied := created.DeepCopy()
+				copied.Spec.ExternalSecretName = "new-es-name"
+				Expect(k8sClient.Patch(ctx, copied, crclient.MergeFrom(created.DeepCopy()))).ShouldNot(HaveOccurred())
+			},
+			expectedClusterExternalSecret: func(namespaces []v1.Namespace, created esv1beta1.ClusterExternalSecret) esv1beta1.ClusterExternalSecret {
+				updatedSpec := created.Spec.DeepCopy()
+				updatedSpec.ExternalSecretName = "new-es-name"
+
+				return esv1beta1.ClusterExternalSecret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: created.Name,
+					},
+					Spec: *updatedSpec,
+					Status: esv1beta1.ClusterExternalSecretStatus{
+						ExternalSecretName:    "new-es-name",
+						ProvisionedNamespaces: []string{namespaces[0].Name},
+						Conditions: []esv1beta1.ClusterExternalSecretStatusCondition{
+							{
+								Type:   esv1beta1.ClusterExternalSecretReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
+			},
+			expectedExternalSecrets: func(namespaces []v1.Namespace, created esv1beta1.ClusterExternalSecret) []esv1beta1.ExternalSecret {
+				return []esv1beta1.ExternalSecret{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: namespaces[0].Name,
+							Name:      "new-es-name",
 						},
 						Spec: created.Spec.ExternalSecretSpec,
 					},
@@ -275,6 +332,7 @@ var _ = Describe("ClusterExternalSecret controller", func() {
 					},
 					Spec: *updatedSpec,
 					Status: esv1beta1.ClusterExternalSecretStatus{
+						ExternalSecretName:    created.Name,
 						ProvisionedNamespaces: []string{namespaces[0].Name},
 						Conditions: []esv1beta1.ClusterExternalSecretStatusCondition{
 							{
@@ -327,6 +385,7 @@ var _ = Describe("ClusterExternalSecret controller", func() {
 					},
 					Spec: created.Spec,
 					Status: esv1beta1.ClusterExternalSecretStatus{
+						ExternalSecretName: created.Name,
 						FailedNamespaces: []esv1beta1.ClusterExternalSecretNamespaceFailure{
 							{
 								Namespace: namespaces[0].Name,
@@ -395,6 +454,7 @@ var _ = Describe("ClusterExternalSecret controller", func() {
 					},
 					Spec: created.Spec,
 					Status: esv1beta1.ClusterExternalSecretStatus{
+						ExternalSecretName:    created.Name,
 						ProvisionedNamespaces: []string{namespaces[0].Name},
 						Conditions: []esv1beta1.ClusterExternalSecretStatusCondition{
 							{
@@ -464,6 +524,7 @@ var _ = Describe("ClusterExternalSecret controller", func() {
 					},
 					Spec: created.Spec,
 					Status: esv1beta1.ClusterExternalSecretStatus{
+						ExternalSecretName: created.Name,
 						Conditions: []esv1beta1.ClusterExternalSecretStatusCondition{
 							{
 								Type:   esv1beta1.ClusterExternalSecretReady,
@@ -519,6 +580,7 @@ var _ = Describe("ClusterExternalSecret controller", func() {
 					},
 					Spec: created.Spec,
 					Status: esv1beta1.ClusterExternalSecretStatus{
+						ExternalSecretName:    created.Name,
 						ProvisionedNamespaces: provisionedNamespaces,
 						Conditions: []esv1beta1.ClusterExternalSecretStatusCondition{
 							{


### PR DESCRIPTION
## Problem Statement

The ClusterExternalSecret controller has a bug that when ExternalSecretName has changed, it creates a new ExternalSecret and leaves the old resource as is. We should delete the old one when the name has changed.

## Related Issue

N/A

## Proposed Changes

Clean up the old ExternalSecrets when the name has changed.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
