### PR TITLE
Update common-k8s-secret-types.md

### DIFF
--- a/docs/guides/common-k8s-secret-types.md
+++ b/docs/guides/common-k8s-secret-types.md
@@ -35,6 +35,36 @@ You can get the final value with:
 kubectl get secret secret-to-be-created -n <namespace> -o jsonpath="{.data\.dockerconfigjson}" | base64 -d
 ```
 
+Alternately, if you only have the container registry name and password value, you can take advantage of the advanced ExternalSecret templating functions to create the secret:
+
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: dk-cfg-example
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: example
+    kind: SecretStore
+  target:
+    template:
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: '{"auths":{"{{ .registryName | lower }}.{{ .registryHost }}":{"username":"{{ .registryName }}","password":"{{ .password }}",
+          "auth":"{{ printf "%s:%s" .registryName .password | b64enc }}"}}}'
+  data:
+  - secretKey: registryName
+    remoteRef:
+      key: secret/docker-registry-name # "myRegistry"
+  - secretKey: registryHost
+    remoteRef:
+      key: secret/docker-registry-host # "docker.io"
+  - secretKey: password
+    remoteRef:
+      key: secret/docker-registry-password
+```
+
 ## TLS Cert example
 
 We are assuming here that you already have valid certificates, maybe generated with letsencrypt or any other CA. So to simplify you can use openssl to generate a single secret pkcs12 cert based on your cert.pem and privkey.pen files.


### PR DESCRIPTION
Add example for templating dockerconfigjson given:
* container registry name
* container registry host (e.g. ghcr.io)
* container registry password

## Problem Statement

What is the problem you're trying to solve?

Trying to assist other adopters with advanced templating of dockerconfigjson secret.

## Related Issue

Fixes N/A

## Proposed Changes

How do you like to solve the issue and why?

This is just an addition to the documentation for common-k8s-secret-types

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] My changes have reasonable test coverage
- [X] All tests pass with `make test`
- [X] I ensured my PR is ready for review with `make reviewable`
