### PR TITLE
Set builder.OnlyMetadata back for Secrets

### DIFF
--- a/pkg/controllers/externalsecret/externalsecret_controller.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -603,6 +604,6 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, opts controller.Options)
 	return ctrl.NewControllerManagedBy(mgr).
 		WithOptions(opts).
 		For(&esv1beta1.ExternalSecret{}).
-		Owns(&v1.Secret{}).
+		Owns(&v1.Secret{}, builder.OnlyMetadata).
 		Complete(r)
 }


### PR DESCRIPTION
## Problem Statement

In https://github.com/external-secrets/external-secrets/pull/2505, I removed the builder.OnlyMetadata, but as a result the operator started consuming much more memory. What I didn't understand was

1. [Owns](https://github.com/external-secrets/external-secrets/blob/aea53bc40723ec77ee6b11c92c88ec3b93575496/pkg/controllers/externalsecret/externalsecret_controller.go#L607) caches all the resources regardless of owner reference.
2. The operator [disables Secret cache](https://github.com/external-secrets/external-secrets/blob/e5fd5a90a9129194d97a566918f1b3cd328e3616/cmd/root.go#L112).

I found [a related PR](https://github.com/external-secrets/external-secrets/pull/729). Currently, we cannot disable cache for the `Owns`, so specifying the builder.OnlyMetadata makes sense since we don't really use the metadata cache except for starting ExternalSecret reconciliation. Thank you for your review 🙇 

Here are the test results in my local environment with 1000 Secrets (each consumes 150 KB, so it should be roughly 150 MB).

### v0.9.1

```
NAME                                                CPU(cores)   MEMORY(bytes)
external-secrets-589f65c6f5-pc7zl                   14m          246Mi
external-secrets-cert-controller-56f879cdd5-9mrwq   4m           26Mi
external-secrets-webhook-58d4957dbb-dqmcr           1m           19Mi
```

### v0.9.2

```
external-secrets-56d45c968b-7tmlh                   3m           718Mi
external-secrets-cert-controller-578d55ddfd-qn6gq   4m           28Mi
external-secrets-webhook-6b895787f-2cdpn            14m          17Mi
```

### This PR

```
NAME                                               CPU(cores)   MEMORY(bytes)
external-secrets-78bdffb7d-dxk44                   3m           230Mi
external-secrets-cert-controller-7996dc658-dfrgs   5m           26Mi
external-secrets-webhook-c8ddfdcd9-x9dgd           3m           19Mi
```

## Related Issue

Fixes https://github.com/external-secrets/external-secrets/issues/2608

## Proposed Changes

Set builder.OnlyMetadata back for Secrets.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
