### PR TITLE
Fix a command in Google Cloud Secret Manager document

### DIFF
--- a/docs/provider/google-secrets-manager.md
+++ b/docs/provider/google-secrets-manager.md
@@ -107,5 +107,5 @@ To create a kubernetes secret from the GCP Secret Manager secret a `Kind=Externa
 
 The operator will fetch the GCP Secret Manager secret and inject it as a `Kind=Secret`
 ```
-kubectl get secret secret-to-be-created -n <namespace> | -o jsonpath='{.data.dev-secret-test}' | base64 -d
+kubectl get secret secret-to-be-created -n <namespace> -o jsonpath='{.data.dev-secret-test}' | base64 -d
 ```


### PR DESCRIPTION
## Problem Statement

https://external-secrets.io/v0.9.3/provider/google-secrets-manager/#creating-external-secret
`kubectl get secret secret-to-be-created -n <namespace> | -o jsonpath='{.data.dev-secret-test}' | base64 -d`
This command does not work. The first '|' in the command is unnecessary.

## Related Issue

N/A
I skipped creating an issue since it was just a typo correction.

## Proposed Changes

I removed the unnecessary '|' from the command to make it work properly.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`

I believe we can skip running tests since it's just a typo correction in the documentation.