### PR TITLE
IBM Provider: handle special case for imported cert secret type

### DIFF
--- a/docs/provider/ibm-secrets-manager.md
+++ b/docs/provider/ibm-secrets-manager.md
@@ -197,7 +197,7 @@ Below example creates a kubernetes secret based on ID of the secret in Secrets M
 {% include 'ibm-external-secret.yaml' %}
 ```
 
-Alternatively, secret name can be specified instead of secret ID.
+Alternatively, secret name can be specified instead of secret ID. However, note that ESO makes an additional call to fetch the relevant secret ID for the specified secret name.
 
 ```yaml
 {% include 'ibm-external-secret-by-name.yaml' %}

--- a/pkg/provider/ibm/provider.go
+++ b/pkg/provider/ibm/provider.go
@@ -227,8 +227,14 @@ func getImportCertSecret(ibm *providerIBM, secretName *string, ref esv1beta1.Ext
 	if err != nil {
 		return nil, err
 	}
-	if val, ok := secMap[ref.Property]; ok {
+	val, ok := secMap[ref.Property]
+	if ok {
 		return []byte(val.(string)), nil
+	} else if ref.Property == privateKeyConst {
+		// we want to return an empty string in case the secret doesn't contain a private key
+		// this is to ensure that secret of type 'kubernetes.io/tls' gets created as expected, even with an empty private key
+		fmt.Printf("warn: %s is empty for secret %s\n", privateKeyConst, *secretName)
+		return []byte(""), nil
 	}
 	return nil, fmt.Errorf("key %s does not exist in secret %s", ref.Property, ref.Key)
 }
@@ -418,6 +424,7 @@ func (ibm *providerIBM) GetSecretMap(_ context.Context, ref esv1beta1.ExternalSe
 	}
 
 	secretMap := make(map[string][]byte)
+	secMapBytes := make(map[string][]byte)
 	response, err := getSecretData(ibm, &secretName, secretType)
 	if err != nil {
 		return nil, err
@@ -430,36 +437,42 @@ func (ibm *providerIBM) GetSecretMap(_ context.Context, ref esv1beta1.ExternalSe
 	if ref.MetadataPolicy == esv1beta1.ExternalSecretMetadataPolicyFetch {
 		secretMap = populateSecretMap(secretMap, secMap)
 	}
+	secMapBytes = populateSecretMap(secMapBytes, secMap)
 
 	switch secretType {
 	case sm.Secret_SecretType_Arbitrary:
-		secretMap[arbitraryConst] = []byte(fmt.Sprintf("%v", secMap[payloadConst]))
+		secretMap[arbitraryConst] = secMapBytes[payloadConst]
 		return secretMap, nil
 
 	case sm.Secret_SecretType_UsernamePassword:
-		secretMap[usernameConst] = []byte(fmt.Sprintf("%v", secMap[usernameConst]))
-		secretMap[passwordConst] = []byte(fmt.Sprintf("%v", secMap[passwordConst]))
+		secretMap[usernameConst] = secMapBytes[usernameConst]
+		secretMap[passwordConst] = secMapBytes[passwordConst]
 		return secretMap, nil
 
 	case sm.Secret_SecretType_IamCredentials:
-		secretMap[apikeyConst] = []byte(fmt.Sprintf("%v", secMap[smAPIKeyConst]))
+		secretMap[apikeyConst] = secMapBytes[smAPIKeyConst]
 		return secretMap, nil
 
 	case sm.Secret_SecretType_ImportedCert:
-		secretMap[certificateConst] = []byte(fmt.Sprintf("%v", secMap[certificateConst]))
-		secretMap[intermediateConst] = []byte(fmt.Sprintf("%v", secMap[intermediateConst]))
-		secretMap[privateKeyConst] = []byte(fmt.Sprintf("%v", secMap[privateKeyConst]))
+		secretMap[certificateConst] = secMapBytes[certificateConst]
+		secretMap[intermediateConst] = secMapBytes[intermediateConst]
+		if v, ok := secMapBytes[privateKeyConst]; ok {
+			secretMap[privateKeyConst] = v
+		} else {
+			fmt.Printf("warn: %s is empty for secret %s\n", privateKeyConst, secretName)
+			secretMap[privateKeyConst] = []byte("")
+		}
 		return secretMap, nil
 
 	case sm.Secret_SecretType_PublicCert:
-		secretMap[certificateConst] = []byte(fmt.Sprintf("%v", secMap[certificateConst]))
-		secretMap[intermediateConst] = []byte(fmt.Sprintf("%v", secMap[intermediateConst]))
-		secretMap[privateKeyConst] = []byte(fmt.Sprintf("%v", secMap[privateKeyConst]))
+		secretMap[certificateConst] = secMapBytes[certificateConst]
+		secretMap[intermediateConst] = secMapBytes[intermediateConst]
+		secretMap[privateKeyConst] = secMapBytes[privateKeyConst]
 		return secretMap, nil
 
 	case sm.Secret_SecretType_PrivateCert:
-		secretMap[certificateConst] = []byte(fmt.Sprintf("%v", secMap[certificateConst]))
-		secretMap[privateKeyConst] = []byte(fmt.Sprintf("%v", secMap[privateKeyConst]))
+		secretMap[certificateConst] = secMapBytes[certificateConst]
+		secretMap[privateKeyConst] = secMapBytes[privateKeyConst]
 		return secretMap, nil
 
 	case sm.Secret_SecretType_Kv:


### PR DESCRIPTION
## Problem Statement

This is to handle a special case where the customer wants to create a secret of type `kubernetes.io/tls` referencing an imported certificate which does not contain a private key.

## Proposed Changes

The changes are made to return an empty string when a private key is referenced in case of an imported certificate. Unit test cases have been added accordingly.
This PR also includes a minor update in the provider documentation.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
