### PR TITLE
Using Bitwarden notes for multiline secrets

### DIFF
--- a/docs/examples/bitwarden.md
+++ b/docs/examples/bitwarden.md
@@ -87,6 +87,7 @@ Here the two ClusterSecretStore to deploy
 
 * If you need the `username` or the `password` of a secret, you have to use `bitwarden-login`
 * If you need a custom field of a secret, you have to use `bitwarden-fields`
+* If you need to use a Bitwarden Note for multiline strings (SSH keys, service account json files), you have to use `bitwarden-notes`
 * The `key` is the ID of a secret, which can be find in the URL with the `itemId` value:
   `https://myvault.com/#/vault?itemId=........-....-....-....-............`
 * The `property` is the name of the field:

--- a/docs/provider/ibm-secrets-manager.md
+++ b/docs/provider/ibm-secrets-manager.md
@@ -197,7 +197,7 @@ Below example creates a kubernetes secret based on ID of the secret in Secrets M
 {% include 'ibm-external-secret.yaml' %}
 ```
 
-Alternatively, secret name can be specified instead of secret ID. However, note that ESO makes an additional call to fetch the relevant secret ID for the specified secret name.
+Alternatively, secret name can be specified instead of secret ID.
 
 ```yaml
 {% include 'ibm-external-secret-by-name.yaml' %}

--- a/docs/snippets/bitwarden-secret-store.yaml
+++ b/docs/snippets/bitwarden-secret-store.yaml
@@ -23,4 +23,15 @@ spec:
       url: "http://bitwarden-cli:8087/object/item/{{ .remoteRef.key }}"
       result:
         jsonPath: "$.data.fields[?@.name==\"{{ .remoteRef.property }}\"].value"
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: bitwarden-notes
+spec:
+  provider:
+    webhook:
+      url: "http://bitwarden-cli:8087/object/item/{{ .remoteRef.key }}"
+      result:
+        jsonPath: "$.data.notes"
 {% endraw %}

--- a/docs/snippets/bitwarden-secret.yaml
+++ b/docs/snippets/bitwarden-secret.yaml
@@ -21,6 +21,8 @@ spec:
           {{ .postgres_replication_password }}
         db_url: |-
           postgresql://{{ .username }}:{{ .password }}@my-postgresql:5432/mydb
+        seervice_account_key: |-
+          {{ .service_account_key }}
   data:
     - secretKey: username
       sourceRef:
@@ -54,4 +56,11 @@ spec:
       remoteRef:
         key: aaaabbbb-cccc-dddd-eeee-000011112222
         property: postgres-replication-password
+    - secretKey: service_account_key
+      sourceRef:
+        storeRef:
+          name: bitwarden-notes
+          kind: ClusterSecretStore  # or SecretStore
+      remoteRef:
+        key: service_account_key
 {% endraw %}

--- a/pkg/provider/ibm/provider_test.go
+++ b/pkg/provider/ibm/provider_test.go
@@ -340,22 +340,6 @@ func TestIBMSecretManagerGetSecret(t *testing.T) {
 	}
 	setSecretCert := funcSetCertSecretTest(importedCert, "good case: imported_cert type with property", sm.Secret_SecretType_ImportedCert, true)
 
-	// good case: imported_cert type without a private_key
-	importedCertNoPvtKey := func(smtc *secretManagerTestCase) {
-		secret := &sm.ImportedCertificate{
-			SecretType:  utilpointer.To(sm.Secret_SecretType_ImportedCert),
-			Name:        utilpointer.To("testyname"),
-			ID:          utilpointer.To(secretUUID),
-			Certificate: utilpointer.To(secretCertificate),
-		}
-		smtc.name = "good case: imported cert without private key"
-		smtc.apiInput.ID = utilpointer.To(secretUUID)
-		smtc.apiOutput = secret
-		smtc.ref.Key = "imported_cert/" + secretUUID
-		smtc.ref.Property = "private_key"
-		smtc.expectedSecret = ""
-	}
-
 	// bad case: imported_cert type without property
 	badSecretCert := funcSetCertSecretTest(importedCert, "bad case: imported_cert type without property", sm.Secret_SecretType_ImportedCert, false)
 
@@ -509,7 +493,6 @@ func TestIBMSecretManagerGetSecret(t *testing.T) {
 		makeValidSecretManagerTestCaseCustom(setSecretKVWithOutKey),
 		makeValidSecretManagerTestCaseCustom(badSecretKV),
 		makeValidSecretManagerTestCaseCustom(badSecretCert),
-		makeValidSecretManagerTestCaseCustom(importedCertNoPvtKey),
 		makeValidSecretManagerTestCaseCustom(setSecretPublicCert),
 		makeValidSecretManagerTestCaseCustom(badSecretPublicCert),
 		makeValidSecretManagerTestCaseCustom(setSecretPrivateCert),
@@ -517,16 +500,16 @@ func TestIBMSecretManagerGetSecret(t *testing.T) {
 	}
 
 	sm := providerIBM{}
-	for _, v := range successCases {
+	for k, v := range successCases {
 		t.Run(v.name, func(t *testing.T) {
 			sm.IBMClient = v.mockClient
 			sm.cache = NewCache(10, 1*time.Minute)
 			out, err := sm.GetSecret(context.Background(), *v.ref)
 			if !ErrorContains(err, v.expectError) {
-				t.Errorf("unexpected error:\n%s, expected:\n'%s'", err.Error(), v.expectError)
+				t.Errorf("[%d] unexpected error: %s, expected: '%s'", k, err.Error(), v.expectError)
 			}
 			if string(out) != v.expectedSecret {
-				t.Errorf("unexpected secret: expected:\n%s\ngot:\n%s", v.expectedSecret, string(out))
+				t.Errorf("[%d] unexpected secret: expected %s, got %s", k, v.expectedSecret, string(out))
 			}
 		})
 	}
@@ -796,29 +779,6 @@ func TestGetSecretMap(t *testing.T) {
 		}
 	}
 
-	// good case: imported_cert without a private_key
-	setimportedCertWithNoPvtKey := func(smtc *secretManagerTestCase) {
-		secret := &sm.ImportedCertificate{
-			CreatedBy:    utilpointer.To("testCreatedBy"),
-			CreatedAt:    &strfmt.DateTime{},
-			Downloaded:   utilpointer.To(false),
-			Labels:       []string{"abc", "def", "xyz"},
-			LocksTotal:   utilpointer.To(int64(20)),
-			Certificate:  utilpointer.To(secretCertificate),
-			Intermediate: utilpointer.To(secretIntermediate),
-		}
-		smtc.name = "good case: imported_cert without private key"
-		smtc.apiInput.ID = utilpointer.To(secretUUID)
-		smtc.apiOutput = secret
-		smtc.ref.Key = "imported_cert/" + secretUUID
-
-		smtc.expectedData = map[string][]byte{
-			"certificate":  []byte(secretCertificate),
-			"intermediate": []byte(secretIntermediate),
-			"private_key":  []byte(""),
-		}
-	}
-
 	// good case: public_cert with metadata
 	setPublicCertWithMetadata := func(smtc *secretManagerTestCase) {
 		secret := &sm.PublicCertificate{
@@ -1032,7 +992,6 @@ func TestGetSecretMap(t *testing.T) {
 		makeValidSecretManagerTestCaseCustom(badSecretKVWithUnknownProperty),
 		makeValidSecretManagerTestCaseCustom(setSecretPublicCert),
 		makeValidSecretManagerTestCaseCustom(setSecretPrivateCert),
-		makeValidSecretManagerTestCaseCustom(setimportedCertWithNoPvtKey),
 		makeValidSecretManagerTestCaseCustom(setSecretIamWithMetadata),
 		makeValidSecretManagerTestCaseCustom(setArbitraryWithMetadata),
 		makeValidSecretManagerTestCaseCustom(setSecretUserPassWithMetadata),
@@ -1044,15 +1003,15 @@ func TestGetSecretMap(t *testing.T) {
 	}
 
 	sm := providerIBM{}
-	for _, v := range successCases {
+	for k, v := range successCases {
 		t.Run(v.name, func(t *testing.T) {
 			sm.IBMClient = v.mockClient
 			out, err := sm.GetSecretMap(context.Background(), *v.ref)
 			if !ErrorContains(err, v.expectError) {
-				t.Errorf("unexpected error: %s, expected: '%s'", err.Error(), v.expectError)
+				t.Errorf(" unexpected error: %s, expected: '%s'", err.Error(), v.expectError)
 			}
 			if err == nil && !reflect.DeepEqual(out, v.expectedData) {
-				t.Errorf("unexpected secret data: expected:\n%+v\ngot:\n%+v", v.expectedData, out)
+				t.Errorf("[%d] unexpected secret data: expected %+v, got %v", k, v.expectedData, out)
 			}
 		})
 	}


### PR DESCRIPTION
## Problem Statement

Adding a new `ClusterSecretStore` for Bitwarden to use notes as multiline secrets.

## Related Issue

none

## Proposed Changes

I wanted to use multiline strings (SSH keys and service account json files) and Bitwarden notes seems the right kind of type for them.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
