### PR TITLE
Using Bitwarden notes for multiline secrets

### DIFF
--- a/docs/examples/bitwarden.md
+++ b/docs/examples/bitwarden.md
@@ -87,6 +87,7 @@ Here the two ClusterSecretStore to deploy
 
 * If you need the `username` or the `password` of a secret, you have to use `bitwarden-login`
 * If you need a custom field of a secret, you have to use `bitwarden-fields`
+* If you need to use a Bitwarden Note for multiline strings (SSH keys, service account json files), you have to use `bitwarden-notes`
 * The `key` is the ID of a secret, which can be find in the URL with the `itemId` value:
   `https://myvault.com/#/vault?itemId=........-....-....-....-............`
 * The `property` is the name of the field:

--- a/docs/snippets/bitwarden-secret-store.yaml
+++ b/docs/snippets/bitwarden-secret-store.yaml
@@ -23,4 +23,15 @@ spec:
       url: "http://bitwarden-cli:8087/object/item/{{ .remoteRef.key }}"
       result:
         jsonPath: "$.data.fields[?@.name==\"{{ .remoteRef.property }}\"].value"
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: bitwarden-notes
+spec:
+  provider:
+    webhook:
+      url: "http://bitwarden-cli:8087/object/item/{{ .remoteRef.key }}"
+      result:
+        jsonPath: "$.data.notes"
 {% endraw %}

--- a/docs/snippets/bitwarden-secret.yaml
+++ b/docs/snippets/bitwarden-secret.yaml
@@ -21,6 +21,8 @@ spec:
           {{ .postgres_replication_password }}
         db_url: |-
           postgresql://{{ .username }}:{{ .password }}@my-postgresql:5432/mydb
+        seervice_account_key: |-
+          {{ .service_account_key }}
   data:
     - secretKey: username
       sourceRef:
@@ -54,4 +56,11 @@ spec:
       remoteRef:
         key: aaaabbbb-cccc-dddd-eeee-000011112222
         property: postgres-replication-password
+    - secretKey: service_account_key
+      sourceRef:
+        storeRef:
+          name: bitwarden-notes
+          kind: ClusterSecretStore  # or SecretStore
+      remoteRef:
+        key: service_account_key
 {% endraw %}

--- a/docs/snippets/bitwarden-secret.yaml
+++ b/docs/snippets/bitwarden-secret.yaml
@@ -21,7 +21,7 @@ spec:
           {{ .postgres_replication_password }}
         db_url: |-
           postgresql://{{ .username }}:{{ .password }}@my-postgresql:5432/mydb
-        seervice_account_key: |-
+        service_account_key: |-
           {{ .service_account_key }}
   data:
     - secretKey: username


### PR DESCRIPTION
## Problem Statement

Example on how to use a Bitwarden note entry as a multiline secret in Kubernetes.

## Related Issue

none

## Proposed Changes

Example on how to use a Bitwarden note entry as a multiline secret in Kubernetes.

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
