### PR TITLE
fix: template funcs need to be wrapped in raw block

### DIFF
--- a/docs/guides/common-k8s-secret-types.md
+++ b/docs/guides/common-k8s-secret-types.md
@@ -38,6 +38,7 @@ kubectl get secret secret-to-be-created -n <namespace> -o jsonpath="{.data\.dock
 Alternately, if you only have the container registry name and password value, you can take advantage of the advanced ExternalSecret templating functions to create the secret:
 
 ```yaml
+{% raw %}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -51,8 +52,7 @@ spec:
     template:
       type: kubernetes.io/dockerconfigjson
       data:
-        .dockerconfigjson: '{"auths":{"{{ .registryName | lower }}.{{ .registryHost }}":{"username":"{{ .registryName }}","password":"{{ .password }}",
-          "auth":"{{ printf "%s:%s" .registryName .password | b64enc }}"}}}'
+        .dockerconfigjson: '{"auths":{"{{ .registryName | lower }}.{{ .registryHost }}":{"username":"{{ .registryName }}","password":"{{ .password }}", "auth":"{{ printf "%s:%s" .registryName .password | b64enc }}"}}}'
   data:
   - secretKey: registryName
     remoteRef:
@@ -63,6 +63,7 @@ spec:
   - secretKey: password
     remoteRef:
       key: secret/docker-registry-password
+{% endraw %}
 ```
 
 ## TLS Cert example


### PR DESCRIPTION
## Problem Statement

Fixes #2624. The template funcs need to be wrapped in `{% raw %}` blockes, otherwise it throws an error.

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
