### PR TITLE
bump Kubernetes support version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 env:
   # Common versions
   GOLANGCI_VERSION: 'v1.52.2'
-  KUBERNETES_VERSION: '1.24.x'
+  KUBERNETES_VERSION: '1.28.x'
 
   # Sonar
   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -304,7 +304,7 @@ GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
 GOLANGCI_VERSION := 1.52.2
-KUBERNETES_VERSION := 1.24.x
+KUBERNETES_VERSION := 1.28.x
 
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.

--- a/docs/introduction/stability-support.md
+++ b/docs/introduction/stability-support.md
@@ -19,8 +19,8 @@ We want to cover the following cases:
 
 | ESO Version | Kubernetes Version | Release Date | End of Life    |
 | ----------- | ------------------ | ------------ | -------------- |
-| 0.9.x       | 1.19 → 1.27        | Jun 22, 2023 | Release of 1.1 |
-| 0.8.x       | 1.19 → 1.26        | Mar 16, 2023 | Release of 1.0 |
+| 0.9.x       | 1.19 → 1.28        | Jun 22, 2023 | Release of 1.1 |
+| 0.8.x       | 1.19 → 1.28        | Mar 16, 2023 | Release of 1.0 |
 | 0.7.x       | 1.19 → 1.26        | Dec 11, 2022 | Jun 22, 2023   |
 | 0.6.x       | 1.19 → 1.24        | Oct 9, 2022  | Mar 16, 2023   |
 | 0.5.x       | 1.19 → 1.24        | Apr 6, 2022  | Dec 11, 2022   |


### PR DESCRIPTION
This PR bumps the Kubernetes version used in CI and documents it in the "supported versions" docs.