### PR TITLE
chore: bump EKS e2e test version

### DIFF
--- a/terraform/aws/modules/cluster/main.tf
+++ b/terraform/aws/modules/cluster/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
 locals {
   name            = var.cluster_name
-  cluster_version = "1.24"
+  cluster_version = "1.27"
   region          = var.cluster_region
 
   serviceaccount_name      = var.irsa_sa_name


### PR DESCRIPTION
This PR bumps the EKS version to 1.27 in our `e2e-managed` tests to match the Kubebuilder tests in the CI pipeline and the e2e tests. 
Note: GKE version will be set to the most recent official release (1.27 at this point in time)

#### Proof of work
During e2e-managed tests i checked the version of the spun up cluster:
![Screenshot from 2023-08-29 22-11-43](https://github.com/external-secrets/external-secrets/assets/1709030/2fb1b2d7-dbd5-4634-9289-5dcc201d6150)

