### PR TITLE
Refacto scaleway provider

### DIFF
--- a/pkg/provider/scaleway/fake_secret_api_test.go
+++ b/pkg/provider/scaleway/fake_secret_api_test.go
@@ -150,19 +150,6 @@ func (f *fakeSecretAPI) getSecretByID(secretID string) (*fakeSecret, error) {
 	return secret, nil
 }
 
-func (f *fakeSecretAPI) getSecretByName(secretName string) (*fakeSecret, error) {
-	secret, foundSecret := f._secretsByName[secretName]
-
-	if !foundSecret {
-		return nil, &scw.ResourceNotFoundError{
-			Resource:   "secret",
-			ResourceID: secretName,
-		}
-	}
-
-	return secret, nil
-}
-
 func (f *fakeSecretAPI) GetSecret(request *smapi.GetSecretRequest, _ ...scw.RequestOption) (*smapi.Secret, error) {
 	if request.Region != "" {
 		panic("explicit region in request is not supported")
@@ -265,7 +252,6 @@ func matchListSecretFilter(secret *fakeSecret, filter *smapi.ListSecretsRequest)
 	if filter.Tags != nil {
 		matchTag = true
 		for _, requiredTag := range filter.Tags {
-
 			for _, secretTag := range secret.tags {
 				if requiredTag == secretTag {
 					found = true

--- a/pkg/provider/scaleway/fake_secret_api_test.go
+++ b/pkg/provider/scaleway/fake_secret_api_test.go
@@ -260,26 +260,41 @@ func (f *fakeSecretAPI) DisableSecretVersion(request *smapi.DisableSecretVersion
 }
 
 func matchListSecretFilter(secret *fakeSecret, filter *smapi.ListSecretsRequest) bool {
-	for _, requiredTag := range filter.Tags {
-		found := false
+	var matchTag, matchName, found bool
 
-		for _, secretTag := range secret.tags {
-			if requiredTag == secretTag {
-				found = true
-				break
+	if filter.Tags != nil {
+		matchTag = true
+		for _, requiredTag := range filter.Tags {
+
+			for _, secretTag := range secret.tags {
+				if requiredTag == secretTag {
+					found = true
+					break
+				}
 			}
-		}
-
-		if !found {
-			return false
 		}
 	}
 
-	if filter.Name == &secret.name {
+	if filter.Name != nil {
+		matchName = true
+		if *filter.Name == secret.name {
+			found = true
+		}
+	}
+
+	if matchTag && found {
 		return true
 	}
 
-	return true
+	if matchName && found {
+		return true
+	}
+
+	if !matchName && !matchTag {
+		return true
+	}
+
+	return false
 }
 
 func (f *fakeSecretAPI) ListSecrets(request *smapi.ListSecretsRequest, _ ...scw.RequestOption) (*smapi.ListSecretsResponse, error) {

--- a/pkg/provider/scaleway/secret_api.go
+++ b/pkg/provider/scaleway/secret_api.go
@@ -20,9 +20,7 @@ import (
 
 type secretAPI interface {
 	GetSecret(req *smapi.GetSecretRequest, opts ...scw.RequestOption) (*smapi.Secret, error)
-	GetSecretByName(req *smapi.GetSecretByNameRequest, opts ...scw.RequestOption) (*smapi.Secret, error)
 	GetSecretVersion(req *smapi.GetSecretVersionRequest, opts ...scw.RequestOption) (*smapi.SecretVersion, error)
-	GetSecretVersionByName(req *smapi.GetSecretVersionByNameRequest, opts ...scw.RequestOption) (*smapi.SecretVersion, error)
 	AccessSecretVersion(request *smapi.AccessSecretVersionRequest, option ...scw.RequestOption) (*smapi.AccessSecretVersionResponse, error)
 	DisableSecretVersion(request *smapi.DisableSecretVersionRequest, option ...scw.RequestOption) (*smapi.SecretVersion, error)
 	ListSecrets(request *smapi.ListSecretsRequest, option ...scw.RequestOption) (*smapi.ListSecretsResponse, error)


### PR DESCRIPTION
## Problem Statement

Scaleway will soon refacto its Secret Manager API and deprecate the endpoints `GetSecretByName` and `GetSecretVersionByName`. The goal is to use the `ListSecrets` endpoint instead and to filter by name.

## Related Issue

No issue related.

## Proposed Changes

As stated in the problem section, I replaced the calls to use `ListSecrets` inatead.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
