### PR TITLE
Docs: Improve Hashicorp Vault PushSecret documentation

### DIFF
--- a/docs/provider/hashicorp-vault.md
+++ b/docs/provider/hashicorp-vault.md
@@ -396,14 +396,17 @@ This approach assumes that appropriate IRSA setup is done controller's pod (i.e.
 **NOTE:** In case of a `ClusterSecretStore`, Be sure to provide `namespace` in `secretRef` with the namespace where the secret resides.
 
 ### PushSecret
-Vault supports PushSecret features which allow you to sync a given kubernetes secret key into a hashicorp vault secret. In order to do so, it is expected that the secret key is a valid JSON object.
 
-In order to use PushSecret, you need to give `create`, `read` and `update` permissions to the path where you want to push secrets to for both `data` and `metadata` of the secret. Use it with care!
+Vault supports PushSecret features which allow you to sync a given Kubernetes secret key into a Hashicorp vault secret. To do so, it is expected that the secret key is a valid JSON object or that the `property` attribute has been specified under the `remoteRef`.
+To use PushSecret, you need to give `create`, `read` and `update` permissions to the path where you want to push secrets for both `data` and `metadata` of the secret. Use it with care!
 
-Here is an example on how to set it up:
+Here is an example of how to set up `PushSecret`:
+
 ```yaml
 {% include 'vault-pushsecret.yaml' %}
 ```
+
+Note that in this example, we are generating two secrets in the target vault with the same structure but using different input formats.
 
 ### Vault Enterprise
 

--- a/docs/snippets/vault-pushsecret.yaml
+++ b/docs/snippets/vault-pushsecret.yaml
@@ -4,7 +4,8 @@ metadata:
   name: source-secret
   namespace: default
 stringData:
-  source-key: "{\"foo\":\"bar\"}" # Needs to be a JSON
+  source-key1: "{\"foo\":\"bar\"}" # Needs to be a JSON
+  source-key2: bar  # Could be a plain string
 ---
 apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
@@ -12,15 +13,20 @@ metadata:
   name: pushsecret-example
   namespace: default
 spec:
-  refreshInterval: 10s # Refresh interval for which push secret will reconcile
-  secretStoreRefs: # A list of secret stores to push secrets to
+  refreshInterval: 10s
+  secretStoreRefs:
     - name: vault-secretstore
       kind: SecretStore
   selector:
     secret:
-      name: source-secret # Source Kubernetes secret to be pushed
+      name: source-secret
   data:
     - match:
-        secretKey: source-key # Source Kubernetes secret key containing the vault secret (in JSON format)
-        remoteRef:
-          remoteKey: vault/secret # path to vault secret. This path is appended with the vault-store path.
+      secretKey: source-key1
+      remoteRef:
+        remoteKey: vault/secret1
+    - match:
+      secretKey: source-key2
+      remoteRef:
+        remoteKey: vault/secret2
+        property: foo


### PR DESCRIPTION
## Problem Statement

The utilization of the parameter `property` for the `PushSecret` in the Hashicorp Vault provider was not properly documented.

## Related Issue

Related to #2320

## Proposed Changes

Improve specific documentation for Hashicorp Vaut providers.

⚠️ Don't document the parameter in the API section as it is not supported in all providers.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
