### PR TITLE
feat: Updated check ServiceMontior check to include APIVersions check for  helm charts

### DIFF
--- a/deploy/charts/external-secrets/templates/servicemonitor.yaml
+++ b/deploy/charts/external-secrets/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceMonitor.enabled }}
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) .Values.serviceMonitor.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/deploy/charts/external-secrets/tests/__snapshot__/crds_test.yaml.snap
+++ b/deploy/charts/external-secrets/tests/__snapshot__/crds_test.yaml.snap
@@ -4,7 +4,7 @@ should match snapshot of default values:
     kind: CustomResourceDefinition
     metadata:
       annotations:
-        controller-gen.kubebuilder.io/version: v0.12.1
+        controller-gen.kubebuilder.io/version: v0.13.0
       name: secretstores.external-secrets.io
     spec:
       conversion:

--- a/deploy/charts/external-secrets/tests/service_monitor_test.yaml
+++ b/deploy/charts/external-secrets/tests/service_monitor_test.yaml
@@ -1,0 +1,34 @@
+suite: test service monitor
+templates: 
+  - servicemonitor.yaml
+tests:
+  - it: should render service monitor when APIVersions is present and serviceMonitor is enabled
+    set:
+      serviceMonitor.enabled: true
+    capabilities:
+      apiVersions:
+        - "monitoring.coreos.com/v1"
+    asserts:
+      - hasDocuments:
+          count: 6
+  - it: should not render service monitor when APIVersions is not present but serviceMonitor is enabled
+    set:
+      serviceMonitor.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should not render service monitor when APIVersions is present and serviceMonitor is disabled
+    set:
+      serviceMonitor.enabled: false
+    capabilities:
+      apiVersions:
+        - "monitoring.coreos.com/v1"
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should not render service monitor when APIVersions is not present and serviceMonitor is disabled
+    set:
+      serviceMonitor.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
## Problem Statement

When using the `external-charts` with the kube-prometheus-stack, it leads to issues with the missing CRD and throws error message as displayed in the issue.

## Related Issue

Fixes #2547 

## Proposed Changes

Adding an additional check which checks that "monitoring.coreos.com/v1" is available when creating the serviceMonitor helm charts

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [ x I ensured my PR is ready for review with `make reviewable`
