### PR TITLE
Let ManagedField handle metadata

### DIFF
--- a/pkg/controllers/externalsecret/externalsecret_controller.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller.go
@@ -286,7 +286,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return nil
 	}
 
-	switch externalSecret.Spec.Target.CreationPolicy { //nolint
+	switch externalSecret.Spec.Target.CreationPolicy { //nolint:exhaustive
 	case esv1beta1.CreatePolicyMerge:
 		err = patchSecret(ctx, r.Client, r.Scheme, secret, mutationFunc, externalSecret.Name)
 		if err == nil {

--- a/pkg/controllers/externalsecret/externalsecret_controller_template.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller_template.go
@@ -26,7 +26,7 @@ import (
 	// Loading registered providers.
 	_ "github.com/external-secrets/external-secrets/pkg/provider/register"
 	"github.com/external-secrets/external-secrets/pkg/template"
-	utils "github.com/external-secrets/external-secrets/pkg/utils"
+	"github.com/external-secrets/external-secrets/pkg/utils"
 )
 
 type Parser struct {
@@ -147,7 +147,7 @@ func (p *Parser) MergeMap(tplMap map[string]string, target esv1beta1.TemplateTar
 // * template.templateFrom
 // * secret via es.data or es.dataFrom.
 func (r *Reconciler) applyTemplate(ctx context.Context, es *esv1beta1.ExternalSecret, secret *v1.Secret, dataMap map[string][]byte) error {
-	mergeMetadata(secret, es)
+	setMetadata(secret, es)
 
 	// no template: copy data and return
 	if es.Spec.Target.Template == nil {
@@ -187,7 +187,7 @@ func (r *Reconciler) applyTemplate(ctx context.Context, es *esv1beta1.ExternalSe
 	if err != nil {
 		return fmt.Errorf(errExecTpl, err)
 	}
-	// get template data for labels
+	// get template data for annotations
 	err = p.MergeMap(es.Spec.Target.Template.Metadata.Annotations, esv1beta1.TemplateTargetAnnotations)
 	if err != nil {
 		return fmt.Errorf(errExecTpl, err)
@@ -200,15 +200,11 @@ func (r *Reconciler) applyTemplate(ctx context.Context, es *esv1beta1.ExternalSe
 	return nil
 }
 
-// we do not want to force-override the label/annotations
-// and only copy the necessary key/value pairs.
-func mergeMetadata(secret *v1.Secret, externalSecret *esv1beta1.ExternalSecret) {
-	if secret.ObjectMeta.Labels == nil {
-		secret.ObjectMeta.Labels = make(map[string]string)
-	}
-	if secret.ObjectMeta.Annotations == nil {
-		secret.ObjectMeta.Annotations = make(map[string]string)
-	}
+// setMetadata sets Labels and Annotations to the given secret.
+func setMetadata(secret *v1.Secret, externalSecret *esv1beta1.ExternalSecret) {
+	// It is safe to override the metadata since the Server-Side Apply merges those fields if necessary
+	secret.ObjectMeta.Labels = make(map[string]string)
+	secret.ObjectMeta.Annotations = make(map[string]string)
 	if externalSecret.Spec.Target.Template == nil {
 		utils.MergeStringMap(secret.ObjectMeta.Labels, externalSecret.ObjectMeta.Labels)
 		utils.MergeStringMap(secret.ObjectMeta.Annotations, externalSecret.ObjectMeta.Annotations)


### PR DESCRIPTION
## Problem Statement
The problem is described in the issue but in short, users cannot remove labels/annotations from secrets once they set. This is because right now we just merge all the labels/annotations to the Secret metadata every time the controller reconciles a resource.

- https://github.com/external-secrets/external-secrets/blob/9559c2a124ede009a6d649b36ff3f3ed57cd9fb4/pkg/controllers/externalsecret/externalsecret_controller_template.go#L205-L221

## Related Issue

Fixes https://github.com/external-secrets/external-secrets/issues/2682

## Proposed Changes

Currently, the controller merges labels/annotations manually, but we don't have to do that since the server-side apply merges those fields if necessary. So instead of merging them manually, let the Kubernetes API handle it.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
