### PR TITLE
Update Flux example to  0.9.4

### DIFF
--- a/docs/snippets/gitops/deployment.yaml
+++ b/docs/snippets/gitops/deployment.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     spec:
       chart: external-secrets
-      version: 0.3.9
+      version: 0.9.4
       sourceRef:
         kind: HelmRepository
         name: external-secrets


### PR DESCRIPTION
I was following the [official docs](https://external-secrets.io/latest/examples/gitops-using-fluxcd/) to install External Secrets via Flux, when I ran into the following error.

```
E0919 16:44:23.502828       1 reflector.go:138] pkg/mod/k8s.io/client-go@v0.21.2/tools/cache/reflector.go:167: Failed to watch *v1alpha1.ExternalSecret: failed to list *v1alpha1.ExternalSecret: conversion webhook for external-secrets.io/v1beta1, Kind=ExternalSecret failed: the server could not find the requested resource
```

The problem is, the examples in the docs are having you install a very old version of External Secrets. Once upgraded, everything works perfectly. Just bumping the version so future flux users dont run into the same problem I did.
