### PR TITLE
Complement full-cluster-secret-store oracle provider example

### DIFF
--- a/docs/snippets/full-cluster-secret-store.yaml
+++ b/docs/snippets/full-cluster-secret-store.yaml
@@ -131,10 +131,12 @@ spec:
             # The secret that contains your privatekey
             name: oci-secret-name
             key: privateKey
+            namespace: example-namespace
           fingerprint:
             # The secret that contains your fingerprint
             name: oci-secret-name
             key: fingerprint
+            namespace: example-namespace
 
     # (TODO): add more provider examples here
 


### PR DESCRIPTION
Add namespace to secretRef.privatekey and secretRef.fingerprint in oracle provider example at full-cluster-secret-store.yaml to avoid confusion like in #2727

## Problem Statement

What is the problem you're trying to solve?
There is a necessary property that is not included in the example of ClusterSecretStore for oracle provider


## Related Issue

Would avoid issues like #2727

## Proposed Changes

How do you like to solve the issue and why?
Just adding the missing necessary property in the example

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] My changes have reasonable test coverage
- [X] All tests pass with `make test`
- [X] I ensured my PR is ready for review with `make reviewable`
