### PR TITLE
Fix helm.test by reflecting recent changes

### DIFF
--- a/deploy/charts/external-secrets/tests/__snapshot__/crds_test.yaml.snap
+++ b/deploy/charts/external-secrets/tests/__snapshot__/crds_test.yaml.snap
@@ -1645,11 +1645,72 @@ should match snapshot of default values:
                                     - apiKeyRef
                                     - userRef
                                   type: object
-                              required:
-                                - apikey
+                                jwt:
+                                  properties:
+                                    account:
+                                      type: string
+                                    secretRef:
+                                      description: Optional SecretRef that refers to a key in a Secret resource containing JWT token to authenticate with Conjur using the JWT authentication method.
+                                      properties:
+                                        key:
+                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                    serviceAccountRef:
+                                      description: Optional ServiceAccountRef specifies the Kubernetes service account for which to request a token for with the `TokenRequest` API.
+                                      properties:
+                                        audiences:
+                                          description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                          items:
+                                            type: string
+                                          type: array
+                                        name:
+                                          description: The name of the ServiceAccount resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                    serviceID:
+                                      description: The conjur authn jwt webservice id
+                                      type: string
+                                  required:
+                                    - account
+                                    - serviceID
+                                  type: object
                               type: object
                             caBundle:
                               type: string
+                            caProvider:
+                              description: Used to provide custom certificate authority (CA) certificates for a secret store. The CAProvider points to a Secret or ConfigMap resource that contains a PEM-encoded certificate.
+                              properties:
+                                key:
+                                  description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                                  type: string
+                                name:
+                                  description: The name of the object located at the provider type.
+                                  type: string
+                                namespace:
+                                  description: The namespace the Provider type is in. Can only be defined when used in a ClusterSecretStore.
+                                  type: string
+                                type:
+                                  description: The type of provider to use such as "Secret", or "ConfigMap".
+                                  enum:
+                                    - Secret
+                                    - ConfigMap
+                                  type: string
+                              required:
+                                - name
+                                - type
+                              type: object
                             url:
                               type: string
                           required:


### PR DESCRIPTION
## Problem Statement

`make helm.test` started failing since we merged https://github.com/external-secrets/external-secrets/pull/2591, so I've updated the test to fix the problem

## Related Issue

N/A

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
