### PR TITLE
docs: mention auth-delegator role in vault provider

### DIFF
--- a/docs/provider/hashicorp-vault.md
+++ b/docs/provider/hashicorp-vault.md
@@ -306,6 +306,8 @@ options of obtaining credentials for vault:
 3.  by using transient credentials from the mounted service account token within the
     external-secrets operator
 
+Vault validates the service account token by using the TokenReview API. ⚠️ You have to bind the `system:auth-delegator` ClusterRole to the service account that is used for authentication. Please follow the [Vault documentation](https://developer.hashicorp.com/vault/docs/auth/kubernetes#configuring-kubernetes).
+
 ```yaml
 {% include 'vault-kubernetes-store.yaml' %}
 ```

--- a/hack/api-docs/Makefile
+++ b/hack/api-docs/Makefile
@@ -77,7 +77,7 @@ clean:
 # serve runs mkdocs as a local webserver for interactive development.
 # This will serve the live copy of the docs on 127.0.0.1:8000.
 .PHONY: serve
-serve:
+serve: build
 	$(DOCKER) run \
 		-it \
 		--sig-proxy=true \


### PR DESCRIPTION
Fixes #619

This PR mentions the `system:auth-delegator` ClusterRole which is needed for the Vault provider when using Kubernetes auth.