### PR TITLE
Scaleway secret path

### DIFF
--- a/docs/provider/scaleway.md
+++ b/docs/provider/scaleway.md
@@ -28,7 +28,7 @@ spec:
 
 ### Referencing Secrets
 
-Secrets can be referenced by name or by id, using the prefixes `"name:"` and `"id:"` respectively.
+Secrets can be referenced by name, id or path, using the prefixes `"name:"`, `"id:"` and `"path:"` respectively.
 
 A PushSecret resource can only use a name reference.
 

--- a/pkg/provider/scaleway/client.go
+++ b/pkg/provider/scaleway/client.go
@@ -468,7 +468,7 @@ func extractJSONProperty(secretData []byte, property string) ([]byte, error) {
 	return jsonToSecretData(json.RawMessage(result.Raw)), nil
 }
 
-func splitNameAndPath(ref string) (name string, path string, ok bool) {
+func splitNameAndPath(ref string) (name, path string, ok bool) {
 	if !strings.HasPrefix(ref, "/") {
 		return
 	}


### PR DESCRIPTION
## Problem Statement

The scaleway provider now supports referencing secrets by path.

## Related Issue

No related issues.

## Proposed Changes

This PR adds the path support in the Scaleway provider implementation. It is now possible to use `path:` to reference a secret to get or push it.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
