### PR TITLE
doc: add more info for clusterLocation parameter in gcp

### DIFF
--- a/docs/provider/google-secrets-manager.md
+++ b/docs/provider/google-secrets-manager.md
@@ -38,6 +38,8 @@ metadata:
 
 You can reference this particular ServiceAccount in a `SecretStore` or `ClusterSecretStore`. It's important that you also set the `projectID`, `clusterLocation` and `clusterName`. The Namespace on the `serviceAccountRef` is ignored when using a `SecretStore` resource. This is needed to isolate the namespaces properly.
 
+*When filling `clusterLocation` parameter keep in mind if it is Regional or Zonal cluster.*
+
 ```yaml
 {% include 'gcpsm-wi-secret-store.yaml' %}
 ```

--- a/docs/snippets/gcpsm-wi-secret-store.yaml
+++ b/docs/snippets/gcpsm-wi-secret-store.yaml
@@ -8,7 +8,7 @@ spec:
       projectID: alphabet-123
       auth:
         workloadIdentity:
-          # name of the cluster region
+          # name of the cluster Location, region or zone
           clusterLocation: europe-central2
           # name of the GKE cluster
           clusterName: alpha-cluster-42


### PR DESCRIPTION
## Problem Statement

Found that documentation could be more clear with GCP clusterLocation parameter.

## Related Issue

#2740

## Proposed Changes

Added some lines just to emphasize the proper use of the parameter because the current example can be confusing.

## Checklist

- [ X ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ X ] All commits are signed with `git commit --signoff`
- [ X ] My changes have reasonable test coverage
- [ X ] All tests pass with `make test`
- [ X ] I ensured my PR is ready for review with `make reviewable`
