### PR TITLE
add force flag to bitwarden sync in bitwarden cli deployment documentation

### DIFF
--- a/docs/snippets/bitwarden-cli-deployment.yaml
+++ b/docs/snippets/bitwarden-cli-deployment.yaml
@@ -50,7 +50,7 @@ spec:
               command:
                 - wget
                 - -q
-                - http://127.0.0.1:8087/sync
+                - http://127.0.0.1:8087/sync?force=true
                 - --post-data=''
             initialDelaySeconds: 20
             failureThreshold: 3


### PR DESCRIPTION
## Problem Statement

Whilst implementing integration with Vaultwarden I noticed that the local vault was not being updated.


## Proposed Changes

I had to add  "force=true" to the sync api call for it to work as expected.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage - n/a
- [ ] All tests pass with `make test` - n/a
- [ ] I ensured my PR is ready for review with `make reviewable` - n/a
