### PR TITLE
initial openshift support

### DIFF
--- a/deploy/charts/external-secrets/templates/cert-controller-deployment.yaml
+++ b/deploy/charts/external-secrets/templates/cert-controller-deployment.yaml
@@ -34,16 +34,29 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "external-secrets-cert-controller.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.certController.serviceAccount.automount }}
-      {{- with .Values.certController.podSecurityContext }}
+      {{- if .Values.openshift.install }}
+        {{- with .Values.openshift.podSecurityContext }}
       securityContext:
-        {{- toYaml . | nindent 8 }}
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+      {{- else }}
+        {{- with .Values.podSecurityContext }}
+      securityContext:
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       hostNetwork: {{ .Values.certController.hostNetwork }}
       containers:
         - name: cert-controller
-          {{- with .Values.certController.securityContext }}
           securityContext:
+          {{- if .Values.openshift.install }}
+            {{- with .Values.openshift.securityContext }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- else }}
+            {{- with .Values.securityContext }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           image: "{{ .Values.certController.image.repository }}:{{ .Values.certController.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.certController.image.pullPolicy }}

--- a/deploy/charts/external-secrets/templates/deployment.yaml
+++ b/deploy/charts/external-secrets/templates/deployment.yaml
@@ -34,16 +34,29 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "external-secrets.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
-      {{- with .Values.podSecurityContext }}
+      {{- if .Values.openshift.install }}
+        {{- with .Values.openshift.podSecurityContext }}
       securityContext:
-        {{- toYaml . | nindent 8 }}
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+      {{- else }}
+        {{- with .Values.podSecurityContext }}
+      securityContext:
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       hostNetwork: {{ .Values.hostNetwork }}
       containers:
         - name: {{ .Chart.Name }}
-          {{- with .Values.securityContext }}
           securityContext:
-            {{- toYaml . | nindent 12 }}
+          {{- if .Values.openshift.install }}
+            {{- with .Values.openshift.securityContext }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- else }}
+            {{- with .Values.securityContext }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/deploy/charts/external-secrets/templates/webhook-deployment.yaml
+++ b/deploy/charts/external-secrets/templates/webhook-deployment.yaml
@@ -35,15 +35,28 @@ spec:
       hostNetwork: {{ .Values.webhook.hostNetwork}}
       serviceAccountName: {{ include "external-secrets-webhook.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.webhook.serviceAccount.automount }}
-      {{- with .Values.webhook.podSecurityContext }}
+      {{- if .Values.openshift.install }}
+        {{- with .Values.openshift.podSecurityContext }}
       securityContext:
-        {{- toYaml . | nindent 8 }}
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+      {{- else }}
+        {{- with .Values.podSecurityContext }}
+      securityContext:
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       containers:
         - name: webhook
-          {{- with .Values.webhook.securityContext }}
           securityContext:
+          {{- if .Values.openshift.install }}
+            {{- with .Values.openshift.securityContext }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- else }}
+            {{- with .Values.securityContext }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           image: "{{ .Values.webhook.image.repository }}:{{ .Values.webhook.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.webhook.image.pullPolicy }}

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -1,3 +1,21 @@
+---
+# -- Install on openshift
+openshift:
+  # -- Set installation to false by default
+  install: false
+
+  # -- Set securityContext for openshift
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+
+  # -- Set podSecurityContext for openshift
+  podSecurityContext: {}
+
 replicaCount: 1
 
 # -- Specifies the amount of historic ReplicaSets k8s should keep (see https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy)


### PR DESCRIPTION
## Problem Statement
Native openshift support

## Related Issue

Not applicable

## Proposed Changes

Have native support for openshift inside the helm chart, without any hacks, like in https://github.com/external-secrets/external-secrets-helm-operator/blob/main/hack/download-helm-chart.sh

## Checklist

- [ x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [x ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
