### PR TITLE
fix: enable sharedConfigState in AWS auth provider

### DIFF
--- a/pkg/provider/aws/auth/auth.go
+++ b/pkg/provider/aws/auth/auth.go
@@ -373,9 +373,8 @@ func getAWSSession(config *aws.Config, enableCache bool, name, kind, namespace, 
 	handlers := defaults.Handlers()
 	handlers.Build.PushBack(request.WithAppendUserAgent("external-secrets"))
 	sess, err := session.NewSessionWithOptions(session.Options{
-		Config:            *config,
-		Handlers:          handlers,
-		SharedConfigState: session.SharedConfigDisable,
+		Config:   *config,
+		Handlers: handlers,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Explanation

The value `session.SharedConfigDisable` prevented the AWS SDK to use the default provider chain. By removing this value from the getAWSSession function the default SDK provider chain is used. This enables the SDK to use the shared config file:
https://github.com/aws/aws-sdk-go/blob/main/aws/session/env_config.go#L84 as well as the shared credentials file:
https://github.com/aws/aws-sdk-go/blob/main/aws/session/env_config.go#L76

This fixes the code to be correct with the documentation of NewGeneratorSession which notes that it uses the authentication order:

1. service-account token.
2. static credentials.
3. sdk default provider.

See also the AWS documentation:
https://github.com/aws/aws-sdk-go/blob/main/aws/session/session.go#L158

I'm not sure why this was included initially. I've gone through the git history, but couldn't find an answer. My current guess is that the field was set due to a copy-paste error, as it is needed for the service-account authentication flow, which uses a very similar code flow.

## Problem Statement

The AWS auth provider does not support the default auth provider chain due to session.SharedConfigDisable being configured.

While testing the External Secrets Operator I noticed that the default AWS SDK auth provider chain is not used, even though it's documented that it should fall back to that. I could not authenticate with the default `~/.aws/config` file.

## Related Issue

N/A

## Proposed Changes

By not setting `session.SharedConfigDisable` the behaviour of using the default AWS SDK auth provider chain is restored.

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] My changes have reasonable test coverage
- [X] All tests pass with `make test`
- [X] I ensured my PR is ready for review with `make reviewable`
