### PR TITLE
fixed oracle secret example

### DIFF
--- a/docs/provider/oracle-vault.md
+++ b/docs/provider/oracle-vault.md
@@ -56,3 +56,12 @@ The operator will fetch the project variable and inject it as a `Kind=Secret`.
 ```
 kubectl get secret oracle-secret-to-create -o jsonpath='{.data.dev-secret-test}' | base64 -d
 ```
+
+### Creating structured external secret
+
+Follow [this guide](https://external-secrets.io/latest/guides/all-keys-one-secret/) to create a structured oracle vault secret.
+Then create the `Kind=ExternalSecret`resource, but use the dataFrom field, instead of data field.
+
+```yaml
+{% include 'oracle-external-secret-structured.yaml' %}
+```

--- a/docs/snippets/oracle-external-secret-structured.yaml
+++ b/docs/snippets/oracle-external-secret-structured.yaml
@@ -1,0 +1,15 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: example
+spec:
+  refreshInterval: 0.03m
+  secretStoreRef:
+    kind: SecretStore
+    name: example # Must match SecretStore on the cluster
+  target:
+    name: secret-to-be-created # Name for the secret on the cluster
+    creationPolicy: Owner
+  dataFrom:
+  - extract:
+      key: the-structured-secret-name    # Name of the Oracle Vault structured secret

--- a/docs/snippets/oracle-external-secret.yaml
+++ b/docs/snippets/oracle-external-secret.yaml
@@ -13,4 +13,4 @@ spec:
   data:
   - secretKey: key
     remoteRef:
-      key: the-secret-name
+      key: the-secret-name   # Name of the Oracle Vault secret

--- a/docs/snippets/oracle-external-secret.yaml
+++ b/docs/snippets/oracle-external-secret.yaml
@@ -10,6 +10,7 @@ spec:
   target:
     name: secret-to-be-created # Name for the secret on the cluster
     creationPolicy: Owner
-  dataFrom:
-  - extract:
+  data:
+  - secretKey: key
+    remoteRef:
       key: the-secret-name


### PR DESCRIPTION
## Problem Statement

Following the oracle provider documentation (for the Instance principal scenario) does not result in secret sync. These errors are displayed:

unable to unmarshal secret: invalid character 'e' in literal true (expecting 'r')
Sourceexternal-secrets
Count14
Sub-object
Last seen2023-10-11T10:39:57+02:00


the desired SecretStore example-instance-principal is not ready
Sourceexternal-secrets
Count7
Sub-object
Last seen2023-10-11T10:14:14+02:00


## Related Issue

Fixes #...

## Proposed Changes

The solution was found in this medium post: https://medium.com/oracledevs/using-the-external-secrets-operator-with-oci-kubernetes-and-oci-vault-6865f2e1fe35

## Checklist

- [ x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
