### PR TITLE
change type of RetryInterval to *metav1.Duration

### DIFF
--- a/apis/externalsecrets/v1alpha1/secretstore_types.go
+++ b/apis/externalsecrets/v1alpha1/secretstore_types.go
@@ -92,8 +92,8 @@ type SecretStoreProvider struct {
 }
 
 type SecretStoreRetrySettings struct {
-	MaxRetries    *int32  `json:"maxRetries,omitempty"`
-	RetryInterval *string `json:"retryInterval,omitempty"`
+	MaxRetries    *int32           `json:"maxRetries,omitempty"`
+	RetryInterval *metav1.Duration `json:"retryInterval,omitempty"`
 }
 
 type SecretStoreConditionType string

--- a/apis/externalsecrets/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/externalsecrets/v1alpha1/zz_generated.deepcopy.go
@@ -1443,7 +1443,7 @@ func (in *SecretStoreRetrySettings) DeepCopyInto(out *SecretStoreRetrySettings) 
 	}
 	if in.RetryInterval != nil {
 		in, out := &in.RetryInterval, &out.RetryInterval
-		*out = new(string)
+		*out = new(v1.Duration)
 		**out = **in
 	}
 }

--- a/apis/externalsecrets/v1beta1/secretstore_types.go
+++ b/apis/externalsecrets/v1beta1/secretstore_types.go
@@ -172,8 +172,8 @@ type CAProvider struct {
 }
 
 type SecretStoreRetrySettings struct {
-	MaxRetries    *int32  `json:"maxRetries,omitempty"`
-	RetryInterval *string `json:"retryInterval,omitempty"`
+	MaxRetries    *int32           `json:"maxRetries,omitempty"`
+	RetryInterval *metav1.Duration `json:"retryInterval,omitempty"`
 }
 
 type SecretStoreConditionType string

--- a/apis/externalsecrets/v1beta1/zz_generated.deepcopy.go
+++ b/apis/externalsecrets/v1beta1/zz_generated.deepcopy.go
@@ -1990,7 +1990,7 @@ func (in *SecretStoreRetrySettings) DeepCopyInto(out *SecretStoreRetrySettings) 
 	}
 	if in.RetryInterval != nil {
 		in, out := &in.RetryInterval, &out.RetryInterval
-		*out = new(string)
+		*out = new(v1.Duration)
 		**out = **in
 	}
 }

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -30,18 +30,25 @@ spec:
       name: v1beta1
       schema:
         openAPIV3Schema:
-          description: ClusterExternalSecret is the Schema for the clusterexternalsecrets API.
+          description: ClusterExternalSecret is the Schema for the clusterexternalsecrets
+            API.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
             spec:
-              description: ClusterExternalSecretSpec defines the desired state of ClusterExternalSecret.
+              description: ClusterExternalSecretSpec defines the desired state of
+                ClusterExternalSecret.
               properties:
                 externalSecretMetadata:
                   description: The metadata of the external secrets to be created
@@ -56,18 +63,23 @@ spec:
                       type: object
                   type: object
                 externalSecretName:
-                  description: The name of the external secrets to be created defaults to the name of the ClusterExternalSecret
+                  description: The name of the external secrets to be created defaults
+                    to the name of the ClusterExternalSecret
                   type: string
                 externalSecretSpec:
                   description: The spec for the ExternalSecrets to be created
                   properties:
                     data:
-                      description: Data defines the connection between the Kubernetes Secret keys and the Provider data
+                      description: Data defines the connection between the Kubernetes
+                        Secret keys and the Provider data
                       items:
-                        description: ExternalSecretData defines the connection between the Kubernetes Secret key (spec.data.<key>) and the Provider data.
+                        description: ExternalSecretData defines the connection between
+                          the Kubernetes Secret key (spec.data.<key>) and the Provider
+                          data.
                         properties:
                           remoteRef:
-                            description: RemoteRef points to the remote secret and defines which secret (version/property/..) to fetch.
+                            description: RemoteRef points to the remote secret and
+                              defines which secret (version/property/..) to fetch.
                             properties:
                               conversionStrategy:
                                 default: Default
@@ -78,49 +90,63 @@ spec:
                                 description: Used to define a decoding Strategy
                                 type: string
                               key:
-                                description: Key is the key used in the Provider, mandatory
+                                description: Key is the key used in the Provider,
+                                  mandatory
                                 type: string
                               metadataPolicy:
-                                description: Policy for fetching tags/labels from provider secrets, possible options are Fetch, None. Defaults to None
+                                description: Policy for fetching tags/labels from
+                                  provider secrets, possible options are Fetch, None.
+                                  Defaults to None
                                 type: string
                               property:
-                                description: Used to select a specific property of the Provider value (if a map), if supported
+                                description: Used to select a specific property of
+                                  the Provider value (if a map), if supported
                                 type: string
                               version:
-                                description: Used to select a specific version of the Provider value, if supported
+                                description: Used to select a specific version of
+                                  the Provider value, if supported
                                 type: string
                             required:
                               - key
                             type: object
                           secretKey:
-                            description: SecretKey defines the key in which the controller stores the value. This is the key in the Kind=Secret
+                            description: SecretKey defines the key in which the controller
+                              stores the value. This is the key in the Kind=Secret
                             type: string
                           sourceRef:
-                            description: SourceRef allows you to override the source from which the value will pulled from.
+                            description: SourceRef allows you to override the source
+                              from which the value will pulled from.
                             maxProperties: 1
                             properties:
                               generatorRef:
-                                description: GeneratorRef points to a generator custom resource in
+                                description: GeneratorRef points to a generator custom
+                                  resource in
                                 properties:
                                   apiVersion:
                                     default: generators.external-secrets.io/v1alpha1
-                                    description: Specify the apiVersion of the generator resource
+                                    description: Specify the apiVersion of the generator
+                                      resource
                                     type: string
                                   kind:
-                                    description: Specify the Kind of the resource, e.g. Password, ACRAccessToken etc.
+                                    description: Specify the Kind of the resource,
+                                      e.g. Password, ACRAccessToken etc.
                                     type: string
                                   name:
-                                    description: Specify the name of the generator resource
+                                    description: Specify the name of the generator
+                                      resource
                                     type: string
                                 required:
                                   - kind
                                   - name
                                 type: object
                               storeRef:
-                                description: SecretStoreRef defines which SecretStore to fetch the ExternalSecret data.
+                                description: SecretStoreRef defines which SecretStore
+                                  to fetch the ExternalSecret data.
                                 properties:
                                   kind:
-                                    description: Kind of the SecretStore resource (SecretStore or ClusterSecretStore) Defaults to `SecretStore`
+                                    description: Kind of the SecretStore resource
+                                      (SecretStore or ClusterSecretStore) Defaults
+                                      to `SecretStore`
                                     type: string
                                   name:
                                     description: Name of the SecretStore resource
@@ -135,11 +161,15 @@ spec:
                         type: object
                       type: array
                     dataFrom:
-                      description: DataFrom is used to fetch all properties from a specific Provider data If multiple entries are specified, the Secret keys are merged in the specified order
+                      description: DataFrom is used to fetch all properties from a
+                        specific Provider data If multiple entries are specified,
+                        the Secret keys are merged in the specified order
                       items:
                         properties:
                           extract:
-                            description: 'Used to extract multiple key/value pairs from one secret Note: Extract does not support sourceRef.Generator or sourceRef.GeneratorRef.'
+                            description: 'Used to extract multiple key/value pairs
+                              from one secret Note: Extract does not support sourceRef.Generator
+                              or sourceRef.GeneratorRef.'
                             properties:
                               conversionStrategy:
                                 default: Default
@@ -150,22 +180,29 @@ spec:
                                 description: Used to define a decoding Strategy
                                 type: string
                               key:
-                                description: Key is the key used in the Provider, mandatory
+                                description: Key is the key used in the Provider,
+                                  mandatory
                                 type: string
                               metadataPolicy:
-                                description: Policy for fetching tags/labels from provider secrets, possible options are Fetch, None. Defaults to None
+                                description: Policy for fetching tags/labels from
+                                  provider secrets, possible options are Fetch, None.
+                                  Defaults to None
                                 type: string
                               property:
-                                description: Used to select a specific property of the Provider value (if a map), if supported
+                                description: Used to select a specific property of
+                                  the Provider value (if a map), if supported
                                 type: string
                               version:
-                                description: Used to select a specific version of the Provider value, if supported
+                                description: Used to select a specific version of
+                                  the Provider value, if supported
                                 type: string
                             required:
                               - key
                             type: object
                           find:
-                            description: 'Used to find secrets based on tags or regular expressions Note: Find does not support sourceRef.Generator or sourceRef.GeneratorRef.'
+                            description: 'Used to find secrets based on tags or regular
+                              expressions Note: Find does not support sourceRef.Generator
+                              or sourceRef.GeneratorRef.'
                             properties:
                               conversionStrategy:
                                 default: Default
@@ -192,17 +229,24 @@ spec:
                                 type: object
                             type: object
                           rewrite:
-                            description: Used to rewrite secret Keys after getting them from the secret Provider Multiple Rewrite operations can be provided. They are applied in a layered order (first to last)
+                            description: Used to rewrite secret Keys after getting
+                              them from the secret Provider Multiple Rewrite operations
+                              can be provided. They are applied in a layered order
+                              (first to last)
                             items:
                               properties:
                                 regexp:
-                                  description: Used to rewrite with regular expressions. The resulting key will be the output of a regexp.ReplaceAll operation.
+                                  description: Used to rewrite with regular expressions.
+                                    The resulting key will be the output of a regexp.ReplaceAll
+                                    operation.
                                   properties:
                                     source:
-                                      description: Used to define the regular expression of a re.Compiler.
+                                      description: Used to define the regular expression
+                                        of a re.Compiler.
                                       type: string
                                     target:
-                                      description: Used to define the target pattern of a ReplaceAll operation.
+                                      description: Used to define the target pattern
+                                        of a ReplaceAll operation.
                                       type: string
                                   required:
                                     - source
@@ -211,31 +255,43 @@ spec:
                               type: object
                             type: array
                           sourceRef:
-                            description: SourceRef points to a store or generator which contains secret values ready to use. Use this in combination with Extract or Find pull values out of a specific SecretStore. When sourceRef points to a generator Extract or Find is not supported. The generator returns a static map of values
+                            description: SourceRef points to a store or generator
+                              which contains secret values ready to use. Use this
+                              in combination with Extract or Find pull values out
+                              of a specific SecretStore. When sourceRef points to
+                              a generator Extract or Find is not supported. The generator
+                              returns a static map of values
                             maxProperties: 1
                             properties:
                               generatorRef:
-                                description: GeneratorRef points to a generator custom resource in
+                                description: GeneratorRef points to a generator custom
+                                  resource in
                                 properties:
                                   apiVersion:
                                     default: generators.external-secrets.io/v1alpha1
-                                    description: Specify the apiVersion of the generator resource
+                                    description: Specify the apiVersion of the generator
+                                      resource
                                     type: string
                                   kind:
-                                    description: Specify the Kind of the resource, e.g. Password, ACRAccessToken etc.
+                                    description: Specify the Kind of the resource,
+                                      e.g. Password, ACRAccessToken etc.
                                     type: string
                                   name:
-                                    description: Specify the name of the generator resource
+                                    description: Specify the name of the generator
+                                      resource
                                     type: string
                                 required:
                                   - kind
                                   - name
                                 type: object
                               storeRef:
-                                description: SecretStoreRef defines which SecretStore to fetch the ExternalSecret data.
+                                description: SecretStoreRef defines which SecretStore
+                                  to fetch the ExternalSecret data.
                                 properties:
                                   kind:
-                                    description: Kind of the SecretStore resource (SecretStore or ClusterSecretStore) Defaults to `SecretStore`
+                                    description: Kind of the SecretStore resource
+                                      (SecretStore or ClusterSecretStore) Defaults
+                                      to `SecretStore`
                                     type: string
                                   name:
                                     description: Name of the SecretStore resource
@@ -248,13 +304,18 @@ spec:
                       type: array
                     refreshInterval:
                       default: 1h
-                      description: RefreshInterval is the amount of time before the values are read again from the SecretStore provider Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h" May be set to zero to fetch and create it once. Defaults to 1h.
+                      description: RefreshInterval is the amount of time before the
+                        values are read again from the SecretStore provider Valid
+                        time units are "ns", "us" (or "µs"), "ms", "s", "m", "h" May
+                        be set to zero to fetch and create it once. Defaults to 1h.
                       type: string
                     secretStoreRef:
-                      description: SecretStoreRef defines which SecretStore to fetch the ExternalSecret data.
+                      description: SecretStoreRef defines which SecretStore to fetch
+                        the ExternalSecret data.
                       properties:
                         kind:
-                          description: Kind of the SecretStore resource (SecretStore or ClusterSecretStore) Defaults to `SecretStore`
+                          description: Kind of the SecretStore resource (SecretStore
+                            or ClusterSecretStore) Defaults to `SecretStore`
                           type: string
                         name:
                           description: Name of the SecretStore resource
@@ -266,11 +327,13 @@ spec:
                       default:
                         creationPolicy: Owner
                         deletionPolicy: Retain
-                      description: ExternalSecretTarget defines the Kubernetes Secret to be created There can be only one target per ExternalSecret.
+                      description: ExternalSecretTarget defines the Kubernetes Secret
+                        to be created There can be only one target per ExternalSecret.
                       properties:
                         creationPolicy:
                           default: Owner
-                          description: CreationPolicy defines rules on how to create the resulting Secret Defaults to 'Owner'
+                          description: CreationPolicy defines rules on how to create
+                            the resulting Secret Defaults to 'Owner'
                           enum:
                             - Owner
                             - Orphan
@@ -279,20 +342,25 @@ spec:
                           type: string
                         deletionPolicy:
                           default: Retain
-                          description: DeletionPolicy defines rules on how to delete the resulting Secret Defaults to 'Retain'
+                          description: DeletionPolicy defines rules on how to delete
+                            the resulting Secret Defaults to 'Retain'
                           enum:
                             - Delete
                             - Merge
                             - Retain
                           type: string
                         immutable:
-                          description: Immutable defines if the final secret will be immutable
+                          description: Immutable defines if the final secret will
+                            be immutable
                           type: boolean
                         name:
-                          description: Name defines the name of the Secret resource to be managed This field is immutable Defaults to the .metadata.name of the ExternalSecret resource
+                          description: Name defines the name of the Secret resource
+                            to be managed This field is immutable Defaults to the
+                            .metadata.name of the ExternalSecret resource
                           type: string
                         template:
-                          description: Template defines a blueprint for the created Secret resource.
+                          description: Template defines a blueprint for the created
+                            Secret resource.
                           properties:
                             data:
                               additionalProperties:
@@ -305,7 +373,8 @@ spec:
                               default: Replace
                               type: string
                             metadata:
-                              description: ExternalSecretTemplateMetadata defines metadata fields for the Secret blueprint.
+                              description: ExternalSecretTemplateMetadata defines
+                                metadata fields for the Secret blueprint.
                               properties:
                                 annotations:
                                   additionalProperties:
@@ -372,21 +441,32 @@ spec:
                       type: object
                   type: object
                 namespaceSelector:
-                  description: The labels to select by to find the Namespaces to create the ExternalSecrets in.
+                  description: The labels to select by to find the Namespaces to create
+                    the ExternalSecrets in.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector applies to.
+                            description: key is the label key that the selector applies
+                              to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
                             items:
                               type: string
                             type: array
@@ -398,19 +478,25 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
                       type: object
                   type: object
                   x-kubernetes-map-type: atomic
                 refreshTime:
-                  description: The time in which the controller should reconcile it's objects and recheck namespaces for labels.
+                  description: The time in which the controller should reconcile it's
+                    objects and recheck namespaces for labels.
                   type: string
               required:
                 - externalSecretSpec
                 - namespaceSelector
               type: object
             status:
-              description: ClusterExternalSecretStatus defines the observed state of ClusterExternalSecret.
+              description: ClusterExternalSecretStatus defines the observed state
+                of ClusterExternalSecret.
               properties:
                 conditions:
                   items:
@@ -427,25 +513,31 @@ spec:
                     type: object
                   type: array
                 externalSecretName:
-                  description: ExternalSecretName is the name of the ExternalSecrets created by the ClusterExternalSecret
+                  description: ExternalSecretName is the name of the ExternalSecrets
+                    created by the ClusterExternalSecret
                   type: string
                 failedNamespaces:
-                  description: Failed namespaces are the namespaces that failed to apply an ExternalSecret
+                  description: Failed namespaces are the namespaces that failed to
+                    apply an ExternalSecret
                   items:
-                    description: ClusterExternalSecretNamespaceFailure represents a failed namespace deployment and it's reason.
+                    description: ClusterExternalSecretNamespaceFailure represents
+                      a failed namespace deployment and it's reason.
                     properties:
                       namespace:
-                        description: Namespace is the namespace that failed when trying to apply an ExternalSecret
+                        description: Namespace is the namespace that failed when trying
+                          to apply an ExternalSecret
                         type: string
                       reason:
-                        description: Reason is why the ExternalSecret failed to apply to the namespace
+                        description: Reason is why the ExternalSecret failed to apply
+                          to the namespace
                         type: string
                     required:
                       - namespace
                     type: object
                   type: array
                 provisionedNamespaces:
-                  description: ProvisionedNamespaces are the namespaces where the ClusterExternalSecret has secrets
+                  description: ProvisionedNamespaces are the namespaces where the
+                    ClusterExternalSecret has secrets
                   items:
                     type: string
                   type: array
@@ -496,13 +588,19 @@ spec:
       name: v1alpha1
       schema:
         openAPIV3Schema:
-          description: ClusterSecretStore represents a secure external location for storing secrets, which can be referenced as part of `storeRef` fields.
+          description: ClusterSecretStore represents a secure external location for
+            storing secrets, which can be referenced as part of `storeRef` fields.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
@@ -510,57 +608,91 @@ spec:
               description: SecretStoreSpec defines the desired state of SecretStore.
               properties:
                 controller:
-                  description: 'Used to select the correct ESO controller (think: ingress.ingressClassName) The ESO controller is instantiated with a specific controller name and filters ES based on this property'
+                  description: 'Used to select the correct ESO controller (think:
+                    ingress.ingressClassName) The ESO controller is instantiated with
+                    a specific controller name and filters ES based on this property'
                   type: string
                 provider:
-                  description: Used to configure the provider. Only one provider may be set
+                  description: Used to configure the provider. Only one provider may
+                    be set
                   maxProperties: 1
                   minProperties: 1
                   properties:
                     akeyless:
-                      description: Akeyless configures this store to sync secrets using Akeyless Vault provider
+                      description: Akeyless configures this store to sync secrets
+                        using Akeyless Vault provider
                       properties:
                         akeylessGWApiURL:
-                          description: Akeyless GW API Url from which the secrets to be fetched from.
+                          description: Akeyless GW API Url from which the secrets
+                            to be fetched from.
                           type: string
                         authSecretRef:
-                          description: Auth configures how the operator authenticates with Akeyless.
+                          description: Auth configures how the operator authenticates
+                            with Akeyless.
                           properties:
                             kubernetesAuth:
-                              description: Kubernetes authenticates with Akeyless by passing the ServiceAccount token stored in the named Secret resource.
+                              description: Kubernetes authenticates with Akeyless
+                                by passing the ServiceAccount token stored in the
+                                named Secret resource.
                               properties:
                                 accessID:
-                                  description: the Akeyless Kubernetes auth-method access-id
+                                  description: the Akeyless Kubernetes auth-method
+                                    access-id
                                   type: string
                                 k8sConfName:
-                                  description: Kubernetes-auth configuration name in Akeyless-Gateway
+                                  description: Kubernetes-auth configuration name
+                                    in Akeyless-Gateway
                                   type: string
                                 secretRef:
-                                  description: Optional secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Akeyless. If a name is specified without a key, `token` is the default. If one is not specified, the one bound to the controller will be used.
+                                  description: Optional secret field containing a
+                                    Kubernetes ServiceAccount JWT used for authenticating
+                                    with Akeyless. If a name is specified without
+                                    a key, `token` is the default. If one is not specified,
+                                    the one bound to the controller will be used.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 serviceAccountRef:
-                                  description: Optional service account field containing the name of a kubernetes ServiceAccount. If the service account is specified, the service account secret token JWT will be used for authenticating with Akeyless. If the service account selector is not supplied, the secretRef will be used instead.
+                                  description: Optional service account field containing
+                                    the name of a kubernetes ServiceAccount. If the
+                                    service account is specified, the service account
+                                    secret token JWT will be used for authenticating
+                                    with Akeyless. If the service account selector
+                                    is not supplied, the secretRef will be used instead.
                                   properties:
                                     audiences:
-                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      description: Audience specifies the `aud` claim
+                                        for the service account token If the service
+                                        account uses a well-known annotation for e.g.
+                                        IRSA or GCP Workload Identity then this audiences
+                                        will be appended to the list
                                       items:
                                         type: string
                                       type: array
                                     name:
-                                      description: The name of the ServiceAccount resource being referred to.
+                                      description: The name of the ServiceAccount
+                                        resource being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   required:
                                     - name
@@ -570,67 +702,100 @@ spec:
                                 - k8sConfName
                               type: object
                             secretRef:
-                              description: Reference to a Secret that contains the details to authenticate with Akeyless.
+                              description: Reference to a Secret that contains the
+                                details to authenticate with Akeyless.
                               properties:
                                 accessID:
                                   description: The SecretAccessID is used for authentication
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 accessType:
-                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource, In some instances, `key` is
+                                    a required field.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 accessTypeParam:
-                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource, In some instances, `key` is
+                                    a required field.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               type: object
                           type: object
                         caBundle:
-                          description: PEM/base64 encoded CA bundle used to validate Akeyless Gateway certificate. Only used if the AkeylessGWApiURL URL is using HTTPS protocol. If not set the system root certificates are used to validate the TLS connection.
+                          description: PEM/base64 encoded CA bundle used to validate
+                            Akeyless Gateway certificate. Only used if the AkeylessGWApiURL
+                            URL is using HTTPS protocol. If not set the system root
+                            certificates are used to validate the TLS connection.
                           format: byte
                           type: string
                         caProvider:
-                          description: The provider for the CA bundle to use to validate Akeyless Gateway certificate.
+                          description: The provider for the CA bundle to use to validate
+                            Akeyless Gateway certificate.
                           properties:
                             key:
-                              description: The key the value inside of the provider type to use, only used with "Secret" type
+                              description: The key the value inside of the provider
+                                type to use, only used with "Secret" type
                               type: string
                             name:
-                              description: The name of the object located at the provider type.
+                              description: The name of the object located at the provider
+                                type.
                               type: string
                             namespace:
                               description: The namespace the Provider type is in.
                               type: string
                             type:
-                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              description: The type of provider to use such as "Secret",
+                                or "ConfigMap".
                               enum:
                                 - Secret
                                 - ConfigMap
@@ -644,7 +809,8 @@ spec:
                         - authSecretRef
                       type: object
                     alibaba:
-                      description: Alibaba configures this store to sync secrets using Alibaba Cloud provider
+                      description: Alibaba configures this store to sync secrets using
+                        Alibaba Cloud provider
                       properties:
                         auth:
                           description: AlibabaAuth contains a secretRef for credentials.
@@ -667,32 +833,47 @@ spec:
                                 - sessionName
                               type: object
                             secretRef:
-                              description: AlibabaAuthSecretRef holds secret references for Alibaba credentials.
+                              description: AlibabaAuthSecretRef holds secret references
+                                for Alibaba credentials.
                               properties:
                                 accessKeyIDSecretRef:
                                   description: The AccessKeyID is used for authentication
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 accessKeySecretSecretRef:
                                   description: The AccessKeySecret is used for authentication
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               required:
@@ -708,59 +889,87 @@ spec:
                         - regionID
                       type: object
                     aws:
-                      description: AWS configures this store to sync secrets using AWS Secret Manager provider
+                      description: AWS configures this store to sync secrets using
+                        AWS Secret Manager provider
                       properties:
                         auth:
-                          description: 'Auth defines the information necessary to authenticate against AWS if not set aws sdk will infer credentials from your environment see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                          description: 'Auth defines the information necessary to
+                            authenticate against AWS if not set aws sdk will infer
+                            credentials from your environment see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
                           properties:
                             jwt:
-                              description: Authenticate against AWS using service account tokens.
+                              description: Authenticate against AWS using service
+                                account tokens.
                               properties:
                                 serviceAccountRef:
                                   description: A reference to a ServiceAccount resource.
                                   properties:
                                     audiences:
-                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      description: Audience specifies the `aud` claim
+                                        for the service account token If the service
+                                        account uses a well-known annotation for e.g.
+                                        IRSA or GCP Workload Identity then this audiences
+                                        will be appended to the list
                                       items:
                                         type: string
                                       type: array
                                     name:
-                                      description: The name of the ServiceAccount resource being referred to.
+                                      description: The name of the ServiceAccount
+                                        resource being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   required:
                                     - name
                                   type: object
                               type: object
                             secretRef:
-                              description: AWSAuthSecretRef holds secret references for AWS credentials both AccessKeyID and SecretAccessKey must be defined in order to properly authenticate.
+                              description: AWSAuthSecretRef holds secret references
+                                for AWS credentials both AccessKeyID and SecretAccessKey
+                                must be defined in order to properly authenticate.
                               properties:
                                 accessKeyIDSecretRef:
                                   description: The AccessKeyID is used for authentication
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 secretAccessKeySecretRef:
                                   description: The SecretAccessKey is used for authentication
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               type: object
@@ -769,10 +978,12 @@ spec:
                           description: AWS Region to be used for the provider
                           type: string
                         role:
-                          description: Role is a Role ARN which the SecretManager provider will assume
+                          description: Role is a Role ARN which the SecretManager
+                            provider will assume
                           type: string
                         service:
-                          description: Service defines which service should be used to fetch the secrets
+                          description: Service defines which service should be used
+                            to fetch the secrets
                           enum:
                             - SecretsManager
                             - ParameterStore
@@ -782,71 +993,104 @@ spec:
                         - service
                       type: object
                     azurekv:
-                      description: AzureKV configures this store to sync secrets using Azure Key Vault provider
+                      description: AzureKV configures this store to sync secrets using
+                        Azure Key Vault provider
                       properties:
                         authSecretRef:
-                          description: Auth configures how the operator authenticates with Azure. Required for ServicePrincipal auth type.
+                          description: Auth configures how the operator authenticates
+                            with Azure. Required for ServicePrincipal auth type.
                           properties:
                             clientId:
-                              description: The Azure clientId of the service principle used for authentication.
+                              description: The Azure clientId of the service principle
+                                used for authentication.
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                             clientSecret:
-                              description: The Azure ClientSecret of the service principle used for authentication.
+                              description: The Azure ClientSecret of the service principle
+                                used for authentication.
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                           type: object
                         authType:
                           default: ServicePrincipal
-                          description: 'Auth type defines how to authenticate to the keyvault service. Valid values are: - "ServicePrincipal" (default): Using a service principal (tenantId, clientId, clientSecret) - "ManagedIdentity": Using Managed Identity assigned to the pod (see aad-pod-identity)'
+                          description: 'Auth type defines how to authenticate to the
+                            keyvault service. Valid values are: - "ServicePrincipal"
+                            (default): Using a service principal (tenantId, clientId,
+                            clientSecret) - "ManagedIdentity": Using Managed Identity
+                            assigned to the pod (see aad-pod-identity)'
                           enum:
                             - ServicePrincipal
                             - ManagedIdentity
                             - WorkloadIdentity
                           type: string
                         identityId:
-                          description: If multiple Managed Identity is assigned to the pod, you can select the one to be used
+                          description: If multiple Managed Identity is assigned to
+                            the pod, you can select the one to be used
                           type: string
                         serviceAccountRef:
-                          description: ServiceAccountRef specified the service account that should be used when authenticating with WorkloadIdentity.
+                          description: ServiceAccountRef specified the service account
+                            that should be used when authenticating with WorkloadIdentity.
                           properties:
                             audiences:
-                              description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                              description: Audience specifies the `aud` claim for
+                                the service account token If the service account uses
+                                a well-known annotation for e.g. IRSA or GCP Workload
+                                Identity then this audiences will be appended to the
+                                list
                               items:
                                 type: string
                               type: array
                             name:
-                              description: The name of the ServiceAccount resource being referred to.
+                              description: The name of the ServiceAccount resource
+                                being referred to.
                               type: string
                             namespace:
-                              description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                              description: Namespace of the resource being referred
+                                to. Ignored if referent is not cluster-scoped. cluster-scoped
+                                defaults to the namespace of the referent.
                               type: string
                           required:
                             - name
                           type: object
                         tenantId:
-                          description: TenantID configures the Azure Tenant to send requests to. Required for ServicePrincipal auth type.
+                          description: TenantID configures the Azure Tenant to send
+                            requests to. Required for ServicePrincipal auth type.
                           type: string
                         vaultUrl:
-                          description: Vault Url from which the secrets to be fetched from.
+                          description: Vault Url from which the secrets to be fetched
+                            from.
                           type: string
                       required:
                         - vaultUrl
@@ -875,10 +1119,12 @@ spec:
                         - data
                       type: object
                     gcpsm:
-                      description: GCPSM configures this store to sync secrets using Google Cloud Platform Secret Manager provider
+                      description: GCPSM configures this store to sync secrets using
+                        Google Cloud Platform Secret Manager provider
                       properties:
                         auth:
-                          description: Auth defines the information necessary to authenticate against GCP
+                          description: Auth defines the information necessary to authenticate
+                            against GCP
                           properties:
                             secretRef:
                               properties:
@@ -886,13 +1132,20 @@ spec:
                                   description: The SecretAccessKey is used for authentication
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               type: object
@@ -908,15 +1161,23 @@ spec:
                                   description: A reference to a ServiceAccount resource.
                                   properties:
                                     audiences:
-                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      description: Audience specifies the `aud` claim
+                                        for the service account token If the service
+                                        account uses a well-known annotation for e.g.
+                                        IRSA or GCP Workload Identity then this audiences
+                                        will be appended to the list
                                       items:
                                         type: string
                                       type: array
                                     name:
-                                      description: The name of the ServiceAccount resource being referred to.
+                                      description: The name of the ServiceAccount
+                                        resource being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   required:
                                     - name
@@ -932,10 +1193,12 @@ spec:
                           type: string
                       type: object
                     gitlab:
-                      description: GitLab configures this store to sync secrets using GitLab Variables provider
+                      description: GitLab configures this store to sync secrets using
+                        GitLab Variables provider
                       properties:
                         auth:
-                          description: Auth configures how secret-manager authenticates with a GitLab instance.
+                          description: Auth configures how secret-manager authenticates
+                            with a GitLab instance.
                           properties:
                             SecretRef:
                               properties:
@@ -943,13 +1206,20 @@ spec:
                                   description: AccessToken is used for authentication.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               type: object
@@ -957,19 +1227,23 @@ spec:
                             - SecretRef
                           type: object
                         projectID:
-                          description: ProjectID specifies a project where secrets are located.
+                          description: ProjectID specifies a project where secrets
+                            are located.
                           type: string
                         url:
-                          description: URL configures the GitLab instance URL. Defaults to https://gitlab.com/.
+                          description: URL configures the GitLab instance URL. Defaults
+                            to https://gitlab.com/.
                           type: string
                       required:
                         - auth
                       type: object
                     ibm:
-                      description: IBM configures this store to sync secrets using IBM Cloud provider
+                      description: IBM configures this store to sync secrets using
+                        IBM Cloud provider
                       properties:
                         auth:
-                          description: Auth configures how secret-manager authenticates with the IBM secrets manager.
+                          description: Auth configures how secret-manager authenticates
+                            with the IBM secrets manager.
                           properties:
                             secretRef:
                               properties:
@@ -977,13 +1251,20 @@ spec:
                                   description: The SecretAccessKey is used for authentication
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               type: object
@@ -991,16 +1272,19 @@ spec:
                             - secretRef
                           type: object
                         serviceUrl:
-                          description: ServiceURL is the Endpoint URL that is specific to the Secrets Manager service instance
+                          description: ServiceURL is the Endpoint URL that is specific
+                            to the Secrets Manager service instance
                           type: string
                       required:
                         - auth
                       type: object
                     kubernetes:
-                      description: Kubernetes configures this store to sync secrets using a Kubernetes cluster provider
+                      description: Kubernetes configures this store to sync secrets
+                        using a Kubernetes cluster provider
                       properties:
                         auth:
-                          description: Auth configures how secret-manager authenticates with a Kubernetes instance.
+                          description: Auth configures how secret-manager authenticates
+                            with a Kubernetes instance.
                           maxProperties: 1
                           minProperties: 1
                           properties:
@@ -1008,48 +1292,75 @@ spec:
                               description: has both clientCert and clientKey as secretKeySelector
                               properties:
                                 clientCert:
-                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource, In some instances, `key` is
+                                    a required field.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 clientKey:
-                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource, In some instances, `key` is
+                                    a required field.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               type: object
                             serviceAccount:
-                              description: points to a service account that should be used for authentication
+                              description: points to a service account that should
+                                be used for authentication
                               properties:
                                 serviceAccount:
                                   description: A reference to a ServiceAccount resource.
                                   properties:
                                     audiences:
-                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      description: Audience specifies the `aud` claim
+                                        for the service account token If the service
+                                        account uses a well-known annotation for e.g.
+                                        IRSA or GCP Workload Identity then this audiences
+                                        will be appended to the list
                                       items:
                                         type: string
                                       type: array
                                     name:
-                                      description: The name of the ServiceAccount resource being referred to.
+                                      description: The name of the ServiceAccount
+                                        resource being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   required:
                                     - name
@@ -1059,16 +1370,25 @@ spec:
                               description: use static token to authenticate with
                               properties:
                                 bearerToken:
-                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource, In some instances, `key` is
+                                    a required field.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               type: object
@@ -1088,16 +1408,20 @@ spec:
                               description: 'see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider'
                               properties:
                                 key:
-                                  description: The key the value inside of the provider type to use, only used with "Secret" type
+                                  description: The key the value inside of the provider
+                                    type to use, only used with "Secret" type
                                   type: string
                                 name:
-                                  description: The name of the object located at the provider type.
+                                  description: The name of the object located at the
+                                    provider type.
                                   type: string
                                 namespace:
-                                  description: The namespace the Provider type is in.
+                                  description: The namespace the Provider type is
+                                    in.
                                   type: string
                                 type:
-                                  description: The type of provider to use such as "Secret", or "ConfigMap".
+                                  description: The type of provider to use such as
+                                    "Secret", or "ConfigMap".
                                   enum:
                                     - Secret
                                     - ConfigMap
@@ -1115,38 +1439,57 @@ spec:
                         - auth
                       type: object
                     oracle:
-                      description: Oracle configures this store to sync secrets using Oracle Vault provider
+                      description: Oracle configures this store to sync secrets using
+                        Oracle Vault provider
                       properties:
                         auth:
-                          description: Auth configures how secret-manager authenticates with the Oracle Vault. If empty, use the instance principal, otherwise the user credentials specified in Auth.
+                          description: Auth configures how secret-manager authenticates
+                            with the Oracle Vault. If empty, use the instance principal,
+                            otherwise the user credentials specified in Auth.
                           properties:
                             secretRef:
                               description: SecretRef to pass through sensitive information.
                               properties:
                                 fingerprint:
-                                  description: Fingerprint is the fingerprint of the API private key.
+                                  description: Fingerprint is the fingerprint of the
+                                    API private key.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 privatekey:
-                                  description: PrivateKey is the user's API Signing Key in PEM format, used for authentication.
+                                  description: PrivateKey is the user's API Signing
+                                    Key in PEM format, used for authentication.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               required:
@@ -1154,10 +1497,12 @@ spec:
                                 - privatekey
                               type: object
                             tenancy:
-                              description: Tenancy is the tenancy OCID where user is located.
+                              description: Tenancy is the tenancy OCID where user
+                                is located.
                               type: string
                             user:
-                              description: User is an access OCID specific to the account.
+                              description: User is an access OCID specific to the
+                                account.
                               type: string
                           required:
                             - secretRef
@@ -1168,39 +1513,58 @@ spec:
                           description: Region is the region where vault is located.
                           type: string
                         vault:
-                          description: Vault is the vault's OCID of the specific vault where secret is located.
+                          description: Vault is the vault's OCID of the specific vault
+                            where secret is located.
                           type: string
                       required:
                         - region
                         - vault
                       type: object
                     vault:
-                      description: Vault configures this store to sync secrets using Hashi provider
+                      description: Vault configures this store to sync secrets using
+                        Hashi provider
                       properties:
                         auth:
-                          description: Auth configures how secret-manager authenticates with the Vault server.
+                          description: Auth configures how secret-manager authenticates
+                            with the Vault server.
                           properties:
                             appRole:
-                              description: AppRole authenticates with Vault using the App Role auth mechanism, with the role and secret stored in a Kubernetes Secret resource.
+                              description: AppRole authenticates with Vault using
+                                the App Role auth mechanism, with the role and secret
+                                stored in a Kubernetes Secret resource.
                               properties:
                                 path:
                                   default: approle
-                                  description: 'Path where the App Role authentication backend is mounted in Vault, e.g: "approle"'
+                                  description: 'Path where the App Role authentication
+                                    backend is mounted in Vault, e.g: "approle"'
                                   type: string
                                 roleId:
-                                  description: RoleID configured in the App Role authentication backend when setting up the authentication backend in Vault.
+                                  description: RoleID configured in the App Role authentication
+                                    backend when setting up the authentication backend
+                                    in Vault.
                                   type: string
                                 secretRef:
-                                  description: Reference to a key in a Secret that contains the App Role secret used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role secret.
+                                  description: Reference to a key in a Secret that
+                                    contains the App Role secret used to authenticate
+                                    with Vault. The `key` field must be specified
+                                    and denotes which entry within the Secret resource
+                                    is used as the app role secret.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               required:
@@ -1209,63 +1573,104 @@ spec:
                                 - secretRef
                               type: object
                             cert:
-                              description: Cert authenticates with TLS Certificates by passing client certificate, private key and ca certificate Cert authentication method
+                              description: Cert authenticates with TLS Certificates
+                                by passing client certificate, private key and ca
+                                certificate Cert authentication method
                               properties:
                                 clientCert:
-                                  description: ClientCert is a certificate to authenticate using the Cert Vault authentication method
+                                  description: ClientCert is a certificate to authenticate
+                                    using the Cert Vault authentication method
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 secretRef:
-                                  description: SecretRef to a key in a Secret resource containing client private key to authenticate with Vault using the Cert authentication method
+                                  description: SecretRef to a key in a Secret resource
+                                    containing client private key to authenticate
+                                    with Vault using the Cert authentication method
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               type: object
                             jwt:
-                              description: Jwt authenticates with Vault by passing role and JWT token using the JWT/OIDC authentication method
+                              description: Jwt authenticates with Vault by passing
+                                role and JWT token using the JWT/OIDC authentication
+                                method
                               properties:
                                 kubernetesServiceAccountToken:
-                                  description: Optional ServiceAccountToken specifies the Kubernetes service account for which to request a token for with the `TokenRequest` API.
+                                  description: Optional ServiceAccountToken specifies
+                                    the Kubernetes service account for which to request
+                                    a token for with the `TokenRequest` API.
                                   properties:
                                     audiences:
-                                      description: Optional audiences field that will be used to request a temporary Kubernetes service account token for the service account referenced by `serviceAccountRef`. Defaults to a single audience `vault` it not specified.
+                                      description: Optional audiences field that will
+                                        be used to request a temporary Kubernetes
+                                        service account token for the service account
+                                        referenced by `serviceAccountRef`. Defaults
+                                        to a single audience `vault` it not specified.
                                       items:
                                         type: string
                                       type: array
                                     expirationSeconds:
-                                      description: Optional expiration time in seconds that will be used to request a temporary Kubernetes service account token for the service account referenced by `serviceAccountRef`. Defaults to 10 minutes.
+                                      description: Optional expiration time in seconds
+                                        that will be used to request a temporary Kubernetes
+                                        service account token for the service account
+                                        referenced by `serviceAccountRef`. Defaults
+                                        to 10 minutes.
                                       format: int64
                                       type: integer
                                     serviceAccountRef:
-                                      description: Service account field containing the name of a kubernetes ServiceAccount.
+                                      description: Service account field containing
+                                        the name of a kubernetes ServiceAccount.
                                       properties:
                                         audiences:
-                                          description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                          description: Audience specifies the `aud`
+                                            claim for the service account token If
+                                            the service account uses a well-known
+                                            annotation for e.g. IRSA or GCP Workload
+                                            Identity then this audiences will be appended
+                                            to the list
                                           items:
                                             type: string
                                           type: array
                                         name:
-                                          description: The name of the ServiceAccount resource being referred to.
+                                          description: The name of the ServiceAccount
+                                            resource being referred to.
                                           type: string
                                         namespace:
-                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          description: Namespace of the resource being
+                                            referred to. Ignored if referent is not
+                                            cluster-scoped. cluster-scoped defaults
+                                            to the namespace of the referent.
                                           type: string
                                       required:
                                         - name
@@ -1275,63 +1680,104 @@ spec:
                                   type: object
                                 path:
                                   default: jwt
-                                  description: 'Path where the JWT authentication backend is mounted in Vault, e.g: "jwt"'
+                                  description: 'Path where the JWT authentication
+                                    backend is mounted in Vault, e.g: "jwt"'
                                   type: string
                                 role:
-                                  description: Role is a JWT role to authenticate using the JWT/OIDC Vault authentication method
+                                  description: Role is a JWT role to authenticate
+                                    using the JWT/OIDC Vault authentication method
                                   type: string
                                 secretRef:
-                                  description: Optional SecretRef that refers to a key in a Secret resource containing JWT token to authenticate with Vault using the JWT/OIDC authentication method.
+                                  description: Optional SecretRef that refers to a
+                                    key in a Secret resource containing JWT token
+                                    to authenticate with Vault using the JWT/OIDC
+                                    authentication method.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               required:
                                 - path
                               type: object
                             kubernetes:
-                              description: Kubernetes authenticates with Vault by passing the ServiceAccount token stored in the named Secret resource to the Vault server.
+                              description: Kubernetes authenticates with Vault by
+                                passing the ServiceAccount token stored in the named
+                                Secret resource to the Vault server.
                               properties:
                                 mountPath:
                                   default: kubernetes
-                                  description: 'Path where the Kubernetes authentication backend is mounted in Vault, e.g: "kubernetes"'
+                                  description: 'Path where the Kubernetes authentication
+                                    backend is mounted in Vault, e.g: "kubernetes"'
                                   type: string
                                 role:
-                                  description: A required field containing the Vault Role to assume. A Role binds a Kubernetes ServiceAccount with a set of Vault policies.
+                                  description: A required field containing the Vault
+                                    Role to assume. A Role binds a Kubernetes ServiceAccount
+                                    with a set of Vault policies.
                                   type: string
                                 secretRef:
-                                  description: Optional secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Vault. If a name is specified without a key, `token` is the default. If one is not specified, the one bound to the controller will be used.
+                                  description: Optional secret field containing a
+                                    Kubernetes ServiceAccount JWT used for authenticating
+                                    with Vault. If a name is specified without a key,
+                                    `token` is the default. If one is not specified,
+                                    the one bound to the controller will be used.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 serviceAccountRef:
-                                  description: Optional service account field containing the name of a kubernetes ServiceAccount. If the service account is specified, the service account secret token JWT will be used for authenticating with Vault. If the service account selector is not supplied, the secretRef will be used instead.
+                                  description: Optional service account field containing
+                                    the name of a kubernetes ServiceAccount. If the
+                                    service account is specified, the service account
+                                    secret token JWT will be used for authenticating
+                                    with Vault. If the service account selector is
+                                    not supplied, the secretRef will be used instead.
                                   properties:
                                     audiences:
-                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      description: Audience specifies the `aud` claim
+                                        for the service account token If the service
+                                        account uses a well-known annotation for e.g.
+                                        IRSA or GCP Workload Identity then this audiences
+                                        will be appended to the list
                                       items:
                                         type: string
                                       type: array
                                     name:
-                                      description: The name of the ServiceAccount resource being referred to.
+                                      description: The name of the ServiceAccount
+                                        resource being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   required:
                                     - name
@@ -1341,64 +1787,95 @@ spec:
                                 - role
                               type: object
                             ldap:
-                              description: Ldap authenticates with Vault by passing username/password pair using the LDAP authentication method
+                              description: Ldap authenticates with Vault by passing
+                                username/password pair using the LDAP authentication
+                                method
                               properties:
                                 path:
                                   default: ldap
-                                  description: 'Path where the LDAP authentication backend is mounted in Vault, e.g: "ldap"'
+                                  description: 'Path where the LDAP authentication
+                                    backend is mounted in Vault, e.g: "ldap"'
                                   type: string
                                 secretRef:
-                                  description: SecretRef to a key in a Secret resource containing password for the LDAP user used to authenticate with Vault using the LDAP authentication method
+                                  description: SecretRef to a key in a Secret resource
+                                    containing password for the LDAP user used to
+                                    authenticate with Vault using the LDAP authentication
+                                    method
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 username:
-                                  description: Username is a LDAP user name used to authenticate using the LDAP Vault authentication method
+                                  description: Username is a LDAP user name used to
+                                    authenticate using the LDAP Vault authentication
+                                    method
                                   type: string
                               required:
                                 - path
                                 - username
                               type: object
                             tokenSecretRef:
-                              description: TokenSecretRef authenticates with Vault by presenting a token.
+                              description: TokenSecretRef authenticates with Vault
+                                by presenting a token.
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                           type: object
                         caBundle:
-                          description: PEM encoded CA bundle used to validate Vault server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.
+                          description: PEM encoded CA bundle used to validate Vault
+                            server certificate. Only used if the Server URL is using
+                            HTTPS protocol. This parameter is ignored for plain HTTP
+                            protocol connection. If not set the system root certificates
+                            are used to validate the TLS connection.
                           format: byte
                           type: string
                         caProvider:
-                          description: The provider for the CA bundle to use to validate Vault server certificate.
+                          description: The provider for the CA bundle to use to validate
+                            Vault server certificate.
                           properties:
                             key:
-                              description: The key the value inside of the provider type to use, only used with "Secret" type
+                              description: The key the value inside of the provider
+                                type to use, only used with "Secret" type
                               type: string
                             name:
-                              description: The name of the object located at the provider type.
+                              description: The name of the object located at the provider
+                                type.
                               type: string
                             namespace:
                               description: The namespace the Provider type is in.
                               type: string
                             type:
-                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              description: The type of provider to use such as "Secret",
+                                or "ConfigMap".
                               enum:
                                 - Secret
                                 - ConfigMap
@@ -1408,23 +1885,38 @@ spec:
                             - type
                           type: object
                         forwardInconsistent:
-                          description: ForwardInconsistent tells Vault to forward read-after-write requests to the Vault leader instead of simply retrying within a loop. This can increase performance if the option is enabled serverside. https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header
+                          description: ForwardInconsistent tells Vault to forward
+                            read-after-write requests to the Vault leader instead
+                            of simply retrying within a loop. This can increase performance
+                            if the option is enabled serverside. https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header
                           type: boolean
                         namespace:
-                          description: 'Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1". More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
+                          description: 'Name of the vault namespace. Namespaces is
+                            a set of features within Vault Enterprise that allows
+                            Vault environments to support Secure Multi-tenancy. e.g:
+                            "ns1". More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
                           type: string
                         path:
-                          description: 'Path is the mount path of the Vault KV backend endpoint, e.g: "secret". The v2 KV secret engine version specific "/data" path suffix for fetching secrets from Vault is optional and will be appended if not present in specified path.'
+                          description: 'Path is the mount path of the Vault KV backend
+                            endpoint, e.g: "secret". The v2 KV secret engine version
+                            specific "/data" path suffix for fetching secrets from
+                            Vault is optional and will be appended if not present
+                            in specified path.'
                           type: string
                         readYourWrites:
-                          description: ReadYourWrites ensures isolated read-after-write semantics by providing discovered cluster replication states in each request. More information about eventual consistency in Vault can be found here https://www.vaultproject.io/docs/enterprise/consistency
+                          description: ReadYourWrites ensures isolated read-after-write
+                            semantics by providing discovered cluster replication
+                            states in each request. More information about eventual
+                            consistency in Vault can be found here https://www.vaultproject.io/docs/enterprise/consistency
                           type: boolean
                         server:
-                          description: 'Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".'
+                          description: 'Server is the connection address for the Vault
+                            server, e.g: "https://vault.example.com:8200".'
                           type: string
                         version:
                           default: v2
-                          description: Version is the Vault KV secret engine version. This can be either "v1" or "v2". Version defaults to "v2".
+                          description: Version is the Vault KV secret engine version.
+                            This can be either "v1" or "v2". Version defaults to "v2".
                           enum:
                             - v1
                             - v2
@@ -1434,29 +1926,38 @@ spec:
                         - server
                       type: object
                     webhook:
-                      description: Webhook configures this store to sync secrets using a generic templated webhook
+                      description: Webhook configures this store to sync secrets using
+                        a generic templated webhook
                       properties:
                         body:
                           description: Body
                           type: string
                         caBundle:
-                          description: PEM encoded CA bundle used to validate webhook server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.
+                          description: PEM encoded CA bundle used to validate webhook
+                            server certificate. Only used if the Server URL is using
+                            HTTPS protocol. This parameter is ignored for plain HTTP
+                            protocol connection. If not set the system root certificates
+                            are used to validate the TLS connection.
                           format: byte
                           type: string
                         caProvider:
-                          description: The provider for the CA bundle to use to validate webhook server certificate.
+                          description: The provider for the CA bundle to use to validate
+                            webhook server certificate.
                           properties:
                             key:
-                              description: The key the value inside of the provider type to use, only used with "Secret" type
+                              description: The key the value inside of the provider
+                                type to use, only used with "Secret" type
                               type: string
                             name:
-                              description: The name of the object located at the provider type.
+                              description: The name of the object located at the provider
+                                type.
                               type: string
                             namespace:
                               description: The namespace the Provider type is in.
                               type: string
                             type:
-                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              description: The type of provider to use such as "Secret",
+                                or "ConfigMap".
                               enum:
                                 - Secret
                                 - ConfigMap
@@ -1481,7 +1982,9 @@ spec:
                               type: string
                           type: object
                         secrets:
-                          description: Secrets to fill in templates These secrets will be passed to the templating function as key value pairs under the given name
+                          description: Secrets to fill in templates These secrets
+                            will be passed to the templating function as key value
+                            pairs under the given name
                           items:
                             properties:
                               name:
@@ -1491,13 +1994,20 @@ spec:
                                 description: Secret ref to fill in credentials
                                 properties:
                                   key:
-                                    description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                    description: The key of the entry in the Secret
+                                      resource's `data` field to be used. Some instances
+                                      of this field may be defaulted, in others it
+                                      may be required.
                                     type: string
                                   name:
-                                    description: The name of the Secret resource being referred to.
+                                    description: The name of the Secret resource being
+                                      referred to.
                                     type: string
                                   namespace:
-                                    description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                    description: Namespace of the resource being referred
+                                      to. Ignored if referent is not cluster-scoped.
+                                      cluster-scoped defaults to the namespace of
+                                      the referent.
                                     type: string
                                 type: object
                             required:
@@ -1516,42 +2026,61 @@ spec:
                         - url
                       type: object
                     yandexlockbox:
-                      description: YandexLockbox configures this store to sync secrets using Yandex Lockbox provider
+                      description: YandexLockbox configures this store to sync secrets
+                        using Yandex Lockbox provider
                       properties:
                         apiEndpoint:
                           description: Yandex.Cloud API endpoint (e.g. 'api.cloud.yandex.net:443')
                           type: string
                         auth:
-                          description: Auth defines the information necessary to authenticate against Yandex Lockbox
+                          description: Auth defines the information necessary to authenticate
+                            against Yandex Lockbox
                           properties:
                             authorizedKeySecretRef:
                               description: The authorized key used for authentication
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                           type: object
                         caProvider:
-                          description: The provider for the CA bundle to use to validate Yandex.Cloud server certificate.
+                          description: The provider for the CA bundle to use to validate
+                            Yandex.Cloud server certificate.
                           properties:
                             certSecretRef:
-                              description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                              description: A reference to a specific 'key' within
+                                a Secret resource, In some instances, `key` is a required
+                                field.
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                           type: object
@@ -1615,13 +2144,19 @@ spec:
       name: v1beta1
       schema:
         openAPIV3Schema:
-          description: ClusterSecretStore represents a secure external location for storing secrets, which can be referenced as part of `storeRef` fields.
+          description: ClusterSecretStore represents a secure external location for
+            storing secrets, which can be referenced as part of `storeRef` fields.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
@@ -1629,26 +2164,40 @@ spec:
               description: SecretStoreSpec defines the desired state of SecretStore.
               properties:
                 conditions:
-                  description: Used to constraint a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore
+                  description: Used to constraint a ClusterSecretStore to specific
+                    namespaces. Relevant only to ClusterSecretStore
                   items:
-                    description: ClusterSecretStoreCondition describes a condition by which to choose namespaces to process ExternalSecrets in for a ClusterSecretStore instance.
+                    description: ClusterSecretStoreCondition describes a condition
+                      by which to choose namespaces to process ExternalSecrets in
+                      for a ClusterSecretStore instance.
                     properties:
                       namespaceSelector:
                         description: Choose namespace using a labelSelector
                         properties:
                           matchExpressions:
-                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
                             items:
-                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
                               properties:
                                 key:
-                                  description: key is the label key that the selector applies to.
+                                  description: key is the label key that the selector
+                                    applies to.
                                   type: string
                                 operator:
-                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
                                   type: string
                                 values:
-                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
                                   items:
                                     type: string
                                   type: array
@@ -1660,7 +2209,11 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
-                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
@@ -1672,57 +2225,91 @@ spec:
                     type: object
                   type: array
                 controller:
-                  description: 'Used to select the correct ESO controller (think: ingress.ingressClassName) The ESO controller is instantiated with a specific controller name and filters ES based on this property'
+                  description: 'Used to select the correct ESO controller (think:
+                    ingress.ingressClassName) The ESO controller is instantiated with
+                    a specific controller name and filters ES based on this property'
                   type: string
                 provider:
-                  description: Used to configure the provider. Only one provider may be set
+                  description: Used to configure the provider. Only one provider may
+                    be set
                   maxProperties: 1
                   minProperties: 1
                   properties:
                     akeyless:
-                      description: Akeyless configures this store to sync secrets using Akeyless Vault provider
+                      description: Akeyless configures this store to sync secrets
+                        using Akeyless Vault provider
                       properties:
                         akeylessGWApiURL:
-                          description: Akeyless GW API Url from which the secrets to be fetched from.
+                          description: Akeyless GW API Url from which the secrets
+                            to be fetched from.
                           type: string
                         authSecretRef:
-                          description: Auth configures how the operator authenticates with Akeyless.
+                          description: Auth configures how the operator authenticates
+                            with Akeyless.
                           properties:
                             kubernetesAuth:
-                              description: Kubernetes authenticates with Akeyless by passing the ServiceAccount token stored in the named Secret resource.
+                              description: Kubernetes authenticates with Akeyless
+                                by passing the ServiceAccount token stored in the
+                                named Secret resource.
                               properties:
                                 accessID:
-                                  description: the Akeyless Kubernetes auth-method access-id
+                                  description: the Akeyless Kubernetes auth-method
+                                    access-id
                                   type: string
                                 k8sConfName:
-                                  description: Kubernetes-auth configuration name in Akeyless-Gateway
+                                  description: Kubernetes-auth configuration name
+                                    in Akeyless-Gateway
                                   type: string
                                 secretRef:
-                                  description: Optional secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Akeyless. If a name is specified without a key, `token` is the default. If one is not specified, the one bound to the controller will be used.
+                                  description: Optional secret field containing a
+                                    Kubernetes ServiceAccount JWT used for authenticating
+                                    with Akeyless. If a name is specified without
+                                    a key, `token` is the default. If one is not specified,
+                                    the one bound to the controller will be used.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 serviceAccountRef:
-                                  description: Optional service account field containing the name of a kubernetes ServiceAccount. If the service account is specified, the service account secret token JWT will be used for authenticating with Akeyless. If the service account selector is not supplied, the secretRef will be used instead.
+                                  description: Optional service account field containing
+                                    the name of a kubernetes ServiceAccount. If the
+                                    service account is specified, the service account
+                                    secret token JWT will be used for authenticating
+                                    with Akeyless. If the service account selector
+                                    is not supplied, the secretRef will be used instead.
                                   properties:
                                     audiences:
-                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      description: Audience specifies the `aud` claim
+                                        for the service account token If the service
+                                        account uses a well-known annotation for e.g.
+                                        IRSA or GCP Workload Identity then this audiences
+                                        will be appended to the list
                                       items:
                                         type: string
                                       type: array
                                     name:
-                                      description: The name of the ServiceAccount resource being referred to.
+                                      description: The name of the ServiceAccount
+                                        resource being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   required:
                                     - name
@@ -1732,67 +2319,101 @@ spec:
                                 - k8sConfName
                               type: object
                             secretRef:
-                              description: Reference to a Secret that contains the details to authenticate with Akeyless.
+                              description: Reference to a Secret that contains the
+                                details to authenticate with Akeyless.
                               properties:
                                 accessID:
                                   description: The SecretAccessID is used for authentication
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 accessType:
-                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource, In some instances, `key` is
+                                    a required field.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 accessTypeParam:
-                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource, In some instances, `key` is
+                                    a required field.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               type: object
                           type: object
                         caBundle:
-                          description: PEM/base64 encoded CA bundle used to validate Akeyless Gateway certificate. Only used if the AkeylessGWApiURL URL is using HTTPS protocol. If not set the system root certificates are used to validate the TLS connection.
+                          description: PEM/base64 encoded CA bundle used to validate
+                            Akeyless Gateway certificate. Only used if the AkeylessGWApiURL
+                            URL is using HTTPS protocol. If not set the system root
+                            certificates are used to validate the TLS connection.
                           format: byte
                           type: string
                         caProvider:
-                          description: The provider for the CA bundle to use to validate Akeyless Gateway certificate.
+                          description: The provider for the CA bundle to use to validate
+                            Akeyless Gateway certificate.
                           properties:
                             key:
-                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              description: The key where the CA certificate can be
+                                found in the Secret or ConfigMap.
                               type: string
                             name:
-                              description: The name of the object located at the provider type.
+                              description: The name of the object located at the provider
+                                type.
                               type: string
                             namespace:
-                              description: The namespace the Provider type is in. Can only be defined when used in a ClusterSecretStore.
+                              description: The namespace the Provider type is in.
+                                Can only be defined when used in a ClusterSecretStore.
                               type: string
                             type:
-                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              description: The type of provider to use such as "Secret",
+                                or "ConfigMap".
                               enum:
                                 - Secret
                                 - ConfigMap
@@ -1806,7 +2427,8 @@ spec:
                         - authSecretRef
                       type: object
                     alibaba:
-                      description: Alibaba configures this store to sync secrets using Alibaba Cloud provider
+                      description: Alibaba configures this store to sync secrets using
+                        Alibaba Cloud provider
                       properties:
                         auth:
                           description: AlibabaAuth contains a secretRef for credentials.
@@ -1829,32 +2451,47 @@ spec:
                                 - sessionName
                               type: object
                             secretRef:
-                              description: AlibabaAuthSecretRef holds secret references for Alibaba credentials.
+                              description: AlibabaAuthSecretRef holds secret references
+                                for Alibaba credentials.
                               properties:
                                 accessKeyIDSecretRef:
                                   description: The AccessKeyID is used for authentication
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 accessKeySecretSecretRef:
                                   description: The AccessKeySecret is used for authentication
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               required:
@@ -1870,77 +2507,116 @@ spec:
                         - regionID
                       type: object
                     aws:
-                      description: AWS configures this store to sync secrets using AWS Secret Manager provider
+                      description: AWS configures this store to sync secrets using
+                        AWS Secret Manager provider
                       properties:
                         additionalRoles:
-                          description: AdditionalRoles is a chained list of Role ARNs which the SecretManager provider will sequentially assume before assuming Role
+                          description: AdditionalRoles is a chained list of Role ARNs
+                            which the SecretManager provider will sequentially assume
+                            before assuming Role
                           items:
                             type: string
                           type: array
                         auth:
-                          description: 'Auth defines the information necessary to authenticate against AWS if not set aws sdk will infer credentials from your environment see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                          description: 'Auth defines the information necessary to
+                            authenticate against AWS if not set aws sdk will infer
+                            credentials from your environment see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
                           properties:
                             jwt:
-                              description: Authenticate against AWS using service account tokens.
+                              description: Authenticate against AWS using service
+                                account tokens.
                               properties:
                                 serviceAccountRef:
                                   description: A reference to a ServiceAccount resource.
                                   properties:
                                     audiences:
-                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      description: Audience specifies the `aud` claim
+                                        for the service account token If the service
+                                        account uses a well-known annotation for e.g.
+                                        IRSA or GCP Workload Identity then this audiences
+                                        will be appended to the list
                                       items:
                                         type: string
                                       type: array
                                     name:
-                                      description: The name of the ServiceAccount resource being referred to.
+                                      description: The name of the ServiceAccount
+                                        resource being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   required:
                                     - name
                                   type: object
                               type: object
                             secretRef:
-                              description: AWSAuthSecretRef holds secret references for AWS credentials both AccessKeyID and SecretAccessKey must be defined in order to properly authenticate.
+                              description: AWSAuthSecretRef holds secret references
+                                for AWS credentials both AccessKeyID and SecretAccessKey
+                                must be defined in order to properly authenticate.
                               properties:
                                 accessKeyIDSecretRef:
                                   description: The AccessKeyID is used for authentication
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 secretAccessKeySecretRef:
                                   description: The SecretAccessKey is used for authentication
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 sessionTokenSecretRef:
-                                  description: 'The SessionToken used for authentication This must be defined if AccessKeyID and SecretAccessKey are temporary credentials see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html'
+                                  description: 'The SessionToken used for authentication
+                                    This must be defined if AccessKeyID and SecretAccessKey
+                                    are temporary credentials see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html'
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               type: object
@@ -1952,10 +2628,12 @@ spec:
                           description: AWS Region to be used for the provider
                           type: string
                         role:
-                          description: Role is a Role ARN which the SecretManager provider will assume
+                          description: Role is a Role ARN which the SecretManager
+                            provider will assume
                           type: string
                         service:
-                          description: Service defines which service should be used to fetch the secrets
+                          description: Service defines which service should be used
+                            to fetch the secrets
                           enum:
                             - SecretsManager
                             - ParameterStore
@@ -1974,7 +2652,8 @@ spec:
                             type: object
                           type: array
                         transitiveTagKeys:
-                          description: AWS STS assume role transitive session tags. Required when multiple rules are used with SecretStore
+                          description: AWS STS assume role transitive session tags.
+                            Required when multiple rules are used with SecretStore
                           items:
                             type: string
                           type: array
@@ -1983,41 +2662,63 @@ spec:
                         - service
                       type: object
                     azurekv:
-                      description: AzureKV configures this store to sync secrets using Azure Key Vault provider
+                      description: AzureKV configures this store to sync secrets using
+                        Azure Key Vault provider
                       properties:
                         authSecretRef:
-                          description: Auth configures how the operator authenticates with Azure. Required for ServicePrincipal auth type.
+                          description: Auth configures how the operator authenticates
+                            with Azure. Required for ServicePrincipal auth type.
                           properties:
                             clientId:
-                              description: The Azure clientId of the service principle used for authentication.
+                              description: The Azure clientId of the service principle
+                                used for authentication.
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                             clientSecret:
-                              description: The Azure ClientSecret of the service principle used for authentication.
+                              description: The Azure ClientSecret of the service principle
+                                used for authentication.
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                           type: object
                         authType:
                           default: ServicePrincipal
-                          description: 'Auth type defines how to authenticate to the keyvault service. Valid values are: - "ServicePrincipal" (default): Using a service principal (tenantId, clientId, clientSecret) - "ManagedIdentity": Using Managed Identity assigned to the pod (see aad-pod-identity)'
+                          description: 'Auth type defines how to authenticate to the
+                            keyvault service. Valid values are: - "ServicePrincipal"
+                            (default): Using a service principal (tenantId, clientId,
+                            clientSecret) - "ManagedIdentity": Using Managed Identity
+                            assigned to the pod (see aad-pod-identity)'
                           enum:
                             - ServicePrincipal
                             - ManagedIdentity
@@ -2025,7 +2726,12 @@ spec:
                           type: string
                         environmentType:
                           default: PublicCloud
-                          description: 'EnvironmentType specifies the Azure cloud environment endpoints to use for connecting and authenticating with Azure. By default it points to the public cloud AAD endpoint. The following endpoints are available, also see here: https://github.com/Azure/go-autorest/blob/main/autorest/azure/environments.go#L152 PublicCloud, USGovernmentCloud, ChinaCloud, GermanCloud'
+                          description: 'EnvironmentType specifies the Azure cloud
+                            environment endpoints to use for connecting and authenticating
+                            with Azure. By default it points to the public cloud AAD
+                            endpoint. The following endpoints are available, also
+                            see here: https://github.com/Azure/go-autorest/blob/main/autorest/azure/environments.go#L152
+                            PublicCloud, USGovernmentCloud, ChinaCloud, GermanCloud'
                           enum:
                             - PublicCloud
                             - USGovernmentCloud
@@ -2033,36 +2739,48 @@ spec:
                             - GermanCloud
                           type: string
                         identityId:
-                          description: If multiple Managed Identity is assigned to the pod, you can select the one to be used
+                          description: If multiple Managed Identity is assigned to
+                            the pod, you can select the one to be used
                           type: string
                         serviceAccountRef:
-                          description: ServiceAccountRef specified the service account that should be used when authenticating with WorkloadIdentity.
+                          description: ServiceAccountRef specified the service account
+                            that should be used when authenticating with WorkloadIdentity.
                           properties:
                             audiences:
-                              description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                              description: Audience specifies the `aud` claim for
+                                the service account token If the service account uses
+                                a well-known annotation for e.g. IRSA or GCP Workload
+                                Identity then this audiences will be appended to the
+                                list
                               items:
                                 type: string
                               type: array
                             name:
-                              description: The name of the ServiceAccount resource being referred to.
+                              description: The name of the ServiceAccount resource
+                                being referred to.
                               type: string
                             namespace:
-                              description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                              description: Namespace of the resource being referred
+                                to. Ignored if referent is not cluster-scoped. cluster-scoped
+                                defaults to the namespace of the referent.
                               type: string
                           required:
                             - name
                           type: object
                         tenantId:
-                          description: TenantID configures the Azure Tenant to send requests to. Required for ServicePrincipal auth type.
+                          description: TenantID configures the Azure Tenant to send
+                            requests to. Required for ServicePrincipal auth type.
                           type: string
                         vaultUrl:
-                          description: Vault Url from which the secrets to be fetched from.
+                          description: Vault Url from which the secrets to be fetched
+                            from.
                           type: string
                       required:
                         - vaultUrl
                       type: object
                     conjur:
-                      description: Conjur configures this store to sync secrets using conjur provider
+                      description: Conjur configures this store to sync secrets using
+                        conjur provider
                       properties:
                         auth:
                           properties:
@@ -2071,29 +2789,47 @@ spec:
                                 account:
                                   type: string
                                 apiKeyRef:
-                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource, In some instances, `key` is
+                                    a required field.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 userRef:
-                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource, In some instances, `key` is
+                                    a required field.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               required:
@@ -2106,31 +2842,51 @@ spec:
                                 account:
                                   type: string
                                 secretRef:
-                                  description: Optional SecretRef that refers to a key in a Secret resource containing JWT token to authenticate with Conjur using the JWT authentication method.
+                                  description: Optional SecretRef that refers to a
+                                    key in a Secret resource containing JWT token
+                                    to authenticate with Conjur using the JWT authentication
+                                    method.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 serviceAccountRef:
-                                  description: Optional ServiceAccountRef specifies the Kubernetes service account for which to request a token for with the `TokenRequest` API.
+                                  description: Optional ServiceAccountRef specifies
+                                    the Kubernetes service account for which to request
+                                    a token for with the `TokenRequest` API.
                                   properties:
                                     audiences:
-                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      description: Audience specifies the `aud` claim
+                                        for the service account token If the service
+                                        account uses a well-known annotation for e.g.
+                                        IRSA or GCP Workload Identity then this audiences
+                                        will be appended to the list
                                       items:
                                         type: string
                                       type: array
                                     name:
-                                      description: The name of the ServiceAccount resource being referred to.
+                                      description: The name of the ServiceAccount
+                                        resource being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   required:
                                     - name
@@ -2146,19 +2902,26 @@ spec:
                         caBundle:
                           type: string
                         caProvider:
-                          description: Used to provide custom certificate authority (CA) certificates for a secret store. The CAProvider points to a Secret or ConfigMap resource that contains a PEM-encoded certificate.
+                          description: Used to provide custom certificate authority
+                            (CA) certificates for a secret store. The CAProvider points
+                            to a Secret or ConfigMap resource that contains a PEM-encoded
+                            certificate.
                           properties:
                             key:
-                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              description: The key where the CA certificate can be
+                                found in the Secret or ConfigMap.
                               type: string
                             name:
-                              description: The name of the object located at the provider type.
+                              description: The name of the object located at the provider
+                                type.
                               type: string
                             namespace:
-                              description: The namespace the Provider type is in. Can only be defined when used in a ClusterSecretStore.
+                              description: The namespace the Provider type is in.
+                                Can only be defined when used in a ClusterSecretStore.
                               type: string
                             type:
-                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              description: The type of provider to use such as "Secret",
+                                or "ConfigMap".
                               enum:
                                 - Secret
                                 - ConfigMap
@@ -2180,47 +2943,66 @@ spec:
                           description: ClientID is the non-secret part of the credential.
                           properties:
                             secretRef:
-                              description: SecretRef references a key in a secret that will be used as value.
+                              description: SecretRef references a key in a secret
+                                that will be used as value.
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                             value:
-                              description: Value can be specified directly to set a value without using a secret.
+                              description: Value can be specified directly to set
+                                a value without using a secret.
                               type: string
                           type: object
                         clientSecret:
                           description: ClientSecret is the secret part of the credential.
                           properties:
                             secretRef:
-                              description: SecretRef references a key in a secret that will be used as value.
+                              description: SecretRef references a key in a secret
+                                that will be used as value.
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                             value:
-                              description: Value can be specified directly to set a value without using a secret.
+                              description: Value can be specified directly to set
+                                a value without using a secret.
                               type: string
                           type: object
                         tenant:
                           description: Tenant is the chosen hostname / site name.
                           type: string
                         tld:
-                          description: TLD is based on the server location that was chosen during provisioning. If unset, defaults to "com".
+                          description: TLD is based on the server location that was
+                            chosen during provisioning. If unset, defaults to "com".
                           type: string
                         urlTemplate:
                           description: URLTemplate If unset, defaults to "https://%s.secretsvaultcloud.%s/v1/%s%s".
@@ -2231,24 +3013,36 @@ spec:
                         - tenant
                       type: object
                     doppler:
-                      description: Doppler configures this store to sync secrets using the Doppler provider
+                      description: Doppler configures this store to sync secrets using
+                        the Doppler provider
                       properties:
                         auth:
-                          description: Auth configures how the Operator authenticates with the Doppler API
+                          description: Auth configures how the Operator authenticates
+                            with the Doppler API
                           properties:
                             secretRef:
                               properties:
                                 dopplerToken:
-                                  description: The DopplerToken is used for authentication. See https://docs.doppler.com/reference/api#authentication for auth token types. The Key attribute defaults to dopplerToken if not specified.
+                                  description: The DopplerToken is used for authentication.
+                                    See https://docs.doppler.com/reference/api#authentication
+                                    for auth token types. The Key attribute defaults
+                                    to dopplerToken if not specified.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               required:
@@ -2258,10 +3052,12 @@ spec:
                             - secretRef
                           type: object
                         config:
-                          description: Doppler config (required if not using a Service Token)
+                          description: Doppler config (required if not using a Service
+                            Token)
                           type: string
                         format:
-                          description: Format enables the downloading of secrets as a file (string)
+                          description: Format enables the downloading of secrets as
+                            a file (string)
                           enum:
                             - json
                             - dotnet-json
@@ -2270,7 +3066,8 @@ spec:
                             - docker
                           type: string
                         nameTransformer:
-                          description: Environment variable compatible name transforms that change secret names to a different format
+                          description: Environment variable compatible name transforms
+                            that change secret names to a different format
                           enum:
                             - upper-camel
                             - camel
@@ -2280,7 +3077,8 @@ spec:
                             - lower-kebab
                           type: string
                         project:
-                          description: Doppler project (required if not using a Service Token)
+                          description: Doppler project (required if not using a Service
+                            Token)
                           type: string
                       required:
                         - auth
@@ -2309,10 +3107,12 @@ spec:
                         - data
                       type: object
                     gcpsm:
-                      description: GCPSM configures this store to sync secrets using Google Cloud Platform Secret Manager provider
+                      description: GCPSM configures this store to sync secrets using
+                        Google Cloud Platform Secret Manager provider
                       properties:
                         auth:
-                          description: Auth defines the information necessary to authenticate against GCP
+                          description: Auth defines the information necessary to authenticate
+                            against GCP
                           properties:
                             secretRef:
                               properties:
@@ -2320,13 +3120,20 @@ spec:
                                   description: The SecretAccessKey is used for authentication
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               type: object
@@ -2342,15 +3149,23 @@ spec:
                                   description: A reference to a ServiceAccount resource.
                                   properties:
                                     audiences:
-                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      description: Audience specifies the `aud` claim
+                                        for the service account token If the service
+                                        account uses a well-known annotation for e.g.
+                                        IRSA or GCP Workload Identity then this audiences
+                                        will be appended to the list
                                       items:
                                         type: string
                                       type: array
                                     name:
-                                      description: The name of the ServiceAccount resource being referred to.
+                                      description: The name of the ServiceAccount
+                                        resource being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   required:
                                     - name
@@ -2366,10 +3181,12 @@ spec:
                           type: string
                       type: object
                     gitlab:
-                      description: GitLab configures this store to sync secrets using GitLab Variables provider
+                      description: GitLab configures this store to sync secrets using
+                        GitLab Variables provider
                       properties:
                         auth:
-                          description: Auth configures how secret-manager authenticates with a GitLab instance.
+                          description: Auth configures how secret-manager authenticates
+                            with a GitLab instance.
                           properties:
                             SecretRef:
                               properties:
@@ -2377,13 +3194,20 @@ spec:
                                   description: AccessToken is used for authentication.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               type: object
@@ -2391,35 +3215,45 @@ spec:
                             - SecretRef
                           type: object
                         environment:
-                          description: Environment environment_scope of gitlab CI/CD variables (Please see https://docs.gitlab.com/ee/ci/environments/#create-a-static-environment on how to create environments)
+                          description: Environment environment_scope of gitlab CI/CD
+                            variables (Please see https://docs.gitlab.com/ee/ci/environments/#create-a-static-environment
+                            on how to create environments)
                           type: string
                         groupIDs:
-                          description: GroupIDs specify, which gitlab groups to pull secrets from. Group secrets are read from left to right followed by the project variables.
+                          description: GroupIDs specify, which gitlab groups to pull
+                            secrets from. Group secrets are read from left to right
+                            followed by the project variables.
                           items:
                             type: string
                           type: array
                         inheritFromGroups:
-                          description: InheritFromGroups specifies whether parent groups should be discovered and checked for secrets.
+                          description: InheritFromGroups specifies whether parent
+                            groups should be discovered and checked for secrets.
                           type: boolean
                         projectID:
-                          description: ProjectID specifies a project where secrets are located.
+                          description: ProjectID specifies a project where secrets
+                            are located.
                           type: string
                         url:
-                          description: URL configures the GitLab instance URL. Defaults to https://gitlab.com/.
+                          description: URL configures the GitLab instance URL. Defaults
+                            to https://gitlab.com/.
                           type: string
                       required:
                         - auth
                       type: object
                     ibm:
-                      description: IBM configures this store to sync secrets using IBM Cloud provider
+                      description: IBM configures this store to sync secrets using
+                        IBM Cloud provider
                       properties:
                         auth:
-                          description: Auth configures how secret-manager authenticates with the IBM secrets manager.
+                          description: Auth configures how secret-manager authenticates
+                            with the IBM secrets manager.
                           maxProperties: 1
                           minProperties: 1
                           properties:
                             containerAuth:
-                              description: IBM Container-based auth with IAM Trusted Profile.
+                              description: IBM Container-based auth with IAM Trusted
+                                Profile.
                               properties:
                                 iamEndpoint:
                                   type: string
@@ -2427,7 +3261,8 @@ spec:
                                   description: the IBM Trusted Profile
                                   type: string
                                 tokenLocation:
-                                  description: Location the token is mounted on the pod
+                                  description: Location the token is mounted on the
+                                    pod
                                   type: string
                               required:
                                 - profile
@@ -2438,37 +3273,52 @@ spec:
                                   description: The SecretAccessKey is used for authentication
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               type: object
                           type: object
                         serviceUrl:
-                          description: ServiceURL is the Endpoint URL that is specific to the Secrets Manager service instance
+                          description: ServiceURL is the Endpoint URL that is specific
+                            to the Secrets Manager service instance
                           type: string
                       required:
                         - auth
                       type: object
                     keepersecurity:
-                      description: KeeperSecurity configures this store to sync secrets using the KeeperSecurity provider
+                      description: KeeperSecurity configures this store to sync secrets
+                        using the KeeperSecurity provider
                       properties:
                         authRef:
-                          description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                          description: A reference to a specific 'key' within a Secret
+                            resource, In some instances, `key` is a required field.
                           properties:
                             key:
-                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              description: The key of the entry in the Secret resource's
+                                `data` field to be used. Some instances of this field
+                                may be defaulted, in others it may be required.
                               type: string
                             name:
-                              description: The name of the Secret resource being referred to.
+                              description: The name of the Secret resource being referred
+                                to.
                               type: string
                             namespace:
-                              description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                              description: Namespace of the resource being referred
+                                to. Ignored if referent is not cluster-scoped. cluster-scoped
+                                defaults to the namespace of the referent.
                               type: string
                           type: object
                         folderID:
@@ -2478,10 +3328,12 @@ spec:
                         - folderID
                       type: object
                     kubernetes:
-                      description: Kubernetes configures this store to sync secrets using a Kubernetes cluster provider
+                      description: Kubernetes configures this store to sync secrets
+                        using a Kubernetes cluster provider
                       properties:
                         auth:
-                          description: Auth configures how secret-manager authenticates with a Kubernetes instance.
+                          description: Auth configures how secret-manager authenticates
+                            with a Kubernetes instance.
                           maxProperties: 1
                           minProperties: 1
                           properties:
@@ -2489,45 +3341,72 @@ spec:
                               description: has both clientCert and clientKey as secretKeySelector
                               properties:
                                 clientCert:
-                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource, In some instances, `key` is
+                                    a required field.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 clientKey:
-                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource, In some instances, `key` is
+                                    a required field.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               type: object
                             serviceAccount:
-                              description: points to a service account that should be used for authentication
+                              description: points to a service account that should
+                                be used for authentication
                               properties:
                                 audiences:
-                                  description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                  description: Audience specifies the `aud` claim
+                                    for the service account token If the service account
+                                    uses a well-known annotation for e.g. IRSA or
+                                    GCP Workload Identity then this audiences will
+                                    be appended to the list
                                   items:
                                     type: string
                                   type: array
                                 name:
-                                  description: The name of the ServiceAccount resource being referred to.
+                                  description: The name of the ServiceAccount resource
+                                    being referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               required:
                                 - name
@@ -2536,16 +3415,25 @@ spec:
                               description: use static token to authenticate with
                               properties:
                                 bearerToken:
-                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource, In some instances, `key` is
+                                    a required field.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               type: object
@@ -2565,16 +3453,20 @@ spec:
                               description: 'see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider'
                               properties:
                                 key:
-                                  description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                                  description: The key where the CA certificate can
+                                    be found in the Secret or ConfigMap.
                                   type: string
                                 name:
-                                  description: The name of the object located at the provider type.
+                                  description: The name of the object located at the
+                                    provider type.
                                   type: string
                                 namespace:
-                                  description: The namespace the Provider type is in. Can only be defined when used in a ClusterSecretStore.
+                                  description: The namespace the Provider type is
+                                    in. Can only be defined when used in a ClusterSecretStore.
                                   type: string
                                 type:
-                                  description: The type of provider to use such as "Secret", or "ConfigMap".
+                                  description: The type of provider to use such as
+                                    "Secret", or "ConfigMap".
                                   enum:
                                     - Secret
                                     - ConfigMap
@@ -2592,25 +3484,36 @@ spec:
                         - auth
                       type: object
                     onepassword:
-                      description: OnePassword configures this store to sync secrets using the 1Password Cloud provider
+                      description: OnePassword configures this store to sync secrets
+                        using the 1Password Cloud provider
                       properties:
                         auth:
-                          description: Auth defines the information necessary to authenticate against OnePassword Connect Server
+                          description: Auth defines the information necessary to authenticate
+                            against OnePassword Connect Server
                           properties:
                             secretRef:
-                              description: OnePasswordAuthSecretRef holds secret references for 1Password credentials.
+                              description: OnePasswordAuthSecretRef holds secret references
+                                for 1Password credentials.
                               properties:
                                 connectTokenSecretRef:
-                                  description: The ConnectToken is used for authentication to a 1Password Connect Server.
+                                  description: The ConnectToken is used for authentication
+                                    to a 1Password Connect Server.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               required:
@@ -2620,12 +3523,14 @@ spec:
                             - secretRef
                           type: object
                         connectHost:
-                          description: ConnectHost defines the OnePassword Connect Server to connect to
+                          description: ConnectHost defines the OnePassword Connect
+                            Server to connect to
                           type: string
                         vaults:
                           additionalProperties:
                             type: integer
-                          description: Vaults defines which OnePassword vaults to search in which order
+                          description: Vaults defines which OnePassword vaults to
+                            search in which order
                           type: object
                       required:
                         - auth
@@ -2633,38 +3538,57 @@ spec:
                         - vaults
                       type: object
                     oracle:
-                      description: Oracle configures this store to sync secrets using Oracle Vault provider
+                      description: Oracle configures this store to sync secrets using
+                        Oracle Vault provider
                       properties:
                         auth:
-                          description: Auth configures how secret-manager authenticates with the Oracle Vault. If empty, use the instance principal, otherwise the user credentials specified in Auth.
+                          description: Auth configures how secret-manager authenticates
+                            with the Oracle Vault. If empty, use the instance principal,
+                            otherwise the user credentials specified in Auth.
                           properties:
                             secretRef:
                               description: SecretRef to pass through sensitive information.
                               properties:
                                 fingerprint:
-                                  description: Fingerprint is the fingerprint of the API private key.
+                                  description: Fingerprint is the fingerprint of the
+                                    API private key.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 privatekey:
-                                  description: PrivateKey is the user's API Signing Key in PEM format, used for authentication.
+                                  description: PrivateKey is the user's API Signing
+                                    Key in PEM format, used for authentication.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               required:
@@ -2672,10 +3596,12 @@ spec:
                                 - privatekey
                               type: object
                             tenancy:
-                              description: Tenancy is the tenancy OCID where user is located.
+                              description: Tenancy is the tenancy OCID where user
+                                is located.
                               type: string
                             user:
-                              description: User is an access OCID specific to the account.
+                              description: User is an access OCID specific to the
+                                account.
                               type: string
                           required:
                             - secretRef
@@ -2686,7 +3612,8 @@ spec:
                           description: Region is the region where vault is located.
                           type: string
                         vault:
-                          description: Vault is the vault's OCID of the specific vault where secret is located.
+                          description: Vault is the vault's OCID of the specific vault
+                            where secret is located.
                           type: string
                       required:
                         - region
@@ -2696,52 +3623,74 @@ spec:
                       description: Scaleway
                       properties:
                         accessKey:
-                          description: AccessKey is the non-secret part of the api key.
+                          description: AccessKey is the non-secret part of the api
+                            key.
                           properties:
                             secretRef:
-                              description: SecretRef references a key in a secret that will be used as value.
+                              description: SecretRef references a key in a secret
+                                that will be used as value.
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                             value:
-                              description: Value can be specified directly to set a value without using a secret.
+                              description: Value can be specified directly to set
+                                a value without using a secret.
                               type: string
                           type: object
                         apiUrl:
-                          description: APIURL is the url of the api to use. Defaults to https://api.scaleway.com
+                          description: APIURL is the url of the api to use. Defaults
+                            to https://api.scaleway.com
                           type: string
                         projectId:
-                          description: 'ProjectID is the id of your project, which you can find in the console: https://console.scaleway.com/project/settings'
+                          description: 'ProjectID is the id of your project, which
+                            you can find in the console: https://console.scaleway.com/project/settings'
                           type: string
                         region:
                           description: 'Region where your secrets are located: https://developers.scaleway.com/en/quickstart/#region-and-zone'
                           type: string
                         secretKey:
-                          description: SecretKey is the non-secret part of the api key.
+                          description: SecretKey is the non-secret part of the api
+                            key.
                           properties:
                             secretRef:
-                              description: SecretRef references a key in a secret that will be used as value.
+                              description: SecretRef references a key in a secret
+                                that will be used as value.
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                             value:
-                              description: Value can be specified directly to set a value without using a secret.
+                              description: Value can be specified directly to set
+                                a value without using a secret.
                               type: string
                           type: object
                       required:
@@ -2751,24 +3700,35 @@ spec:
                         - secretKey
                       type: object
                     senhasegura:
-                      description: Senhasegura configures this store to sync secrets using senhasegura provider
+                      description: Senhasegura configures this store to sync secrets
+                        using senhasegura provider
                       properties:
                         auth:
-                          description: Auth defines parameters to authenticate in senhasegura
+                          description: Auth defines parameters to authenticate in
+                            senhasegura
                           properties:
                             clientId:
                               type: string
                             clientSecretSecretRef:
-                              description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                              description: A reference to a specific 'key' within
+                                a Secret resource, In some instances, `key` is a required
+                                field.
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                           required:
@@ -2777,10 +3737,12 @@ spec:
                           type: object
                         ignoreSslCertificate:
                           default: false
-                          description: IgnoreSslCertificate defines if SSL certificate must be ignored
+                          description: IgnoreSslCertificate defines if SSL certificate
+                            must be ignored
                           type: boolean
                         module:
-                          description: Module defines which senhasegura module should be used to get secrets
+                          description: Module defines which senhasegura module should
+                            be used to get secrets
                           type: string
                         url:
                           description: URL of senhasegura
@@ -2791,45 +3753,74 @@ spec:
                         - url
                       type: object
                     vault:
-                      description: Vault configures this store to sync secrets using Hashi provider
+                      description: Vault configures this store to sync secrets using
+                        Hashi provider
                       properties:
                         auth:
-                          description: Auth configures how secret-manager authenticates with the Vault server.
+                          description: Auth configures how secret-manager authenticates
+                            with the Vault server.
                           properties:
                             appRole:
-                              description: AppRole authenticates with Vault using the App Role auth mechanism, with the role and secret stored in a Kubernetes Secret resource.
+                              description: AppRole authenticates with Vault using
+                                the App Role auth mechanism, with the role and secret
+                                stored in a Kubernetes Secret resource.
                               properties:
                                 path:
                                   default: approle
-                                  description: 'Path where the App Role authentication backend is mounted in Vault, e.g: "approle"'
+                                  description: 'Path where the App Role authentication
+                                    backend is mounted in Vault, e.g: "approle"'
                                   type: string
                                 roleId:
-                                  description: RoleID configured in the App Role authentication backend when setting up the authentication backend in Vault.
+                                  description: RoleID configured in the App Role authentication
+                                    backend when setting up the authentication backend
+                                    in Vault.
                                   type: string
                                 roleRef:
-                                  description: Reference to a key in a Secret that contains the App Role ID used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role id.
+                                  description: Reference to a key in a Secret that
+                                    contains the App Role ID used to authenticate
+                                    with Vault. The `key` field must be specified
+                                    and denotes which entry within the Secret resource
+                                    is used as the app role id.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 secretRef:
-                                  description: Reference to a key in a Secret that contains the App Role secret used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role secret.
+                                  description: Reference to a key in a Secret that
+                                    contains the App Role secret used to authenticate
+                                    with Vault. The `key` field must be specified
+                                    and denotes which entry within the Secret resource
+                                    is used as the app role secret.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               required:
@@ -2837,70 +3828,105 @@ spec:
                                 - secretRef
                               type: object
                             cert:
-                              description: Cert authenticates with TLS Certificates by passing client certificate, private key and ca certificate Cert authentication method
+                              description: Cert authenticates with TLS Certificates
+                                by passing client certificate, private key and ca
+                                certificate Cert authentication method
                               properties:
                                 clientCert:
-                                  description: ClientCert is a certificate to authenticate using the Cert Vault authentication method
+                                  description: ClientCert is a certificate to authenticate
+                                    using the Cert Vault authentication method
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 secretRef:
-                                  description: SecretRef to a key in a Secret resource containing client private key to authenticate with Vault using the Cert authentication method
+                                  description: SecretRef to a key in a Secret resource
+                                    containing client private key to authenticate
+                                    with Vault using the Cert authentication method
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               type: object
                             iam:
-                              description: Iam authenticates with vault by passing a special AWS request signed with AWS IAM credentials AWS IAM authentication method
+                              description: Iam authenticates with vault by passing
+                                a special AWS request signed with AWS IAM credentials
+                                AWS IAM authentication method
                               properties:
                                 externalID:
-                                  description: AWS External ID set on assumed IAM roles
+                                  description: AWS External ID set on assumed IAM
+                                    roles
                                   type: string
                                 jwt:
-                                  description: Specify a service account with IRSA enabled
+                                  description: Specify a service account with IRSA
+                                    enabled
                                   properties:
                                     serviceAccountRef:
-                                      description: A reference to a ServiceAccount resource.
+                                      description: A reference to a ServiceAccount
+                                        resource.
                                       properties:
                                         audiences:
-                                          description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                          description: Audience specifies the `aud`
+                                            claim for the service account token If
+                                            the service account uses a well-known
+                                            annotation for e.g. IRSA or GCP Workload
+                                            Identity then this audiences will be appended
+                                            to the list
                                           items:
                                             type: string
                                           type: array
                                         name:
-                                          description: The name of the ServiceAccount resource being referred to.
+                                          description: The name of the ServiceAccount
+                                            resource being referred to.
                                           type: string
                                         namespace:
-                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          description: Namespace of the resource being
+                                            referred to. Ignored if referent is not
+                                            cluster-scoped. cluster-scoped defaults
+                                            to the namespace of the referent.
                                           type: string
                                       required:
                                         - name
                                       type: object
                                   type: object
                                 path:
-                                  description: 'Path where the AWS auth method is enabled in Vault, e.g: "aws"'
+                                  description: 'Path where the AWS auth method is
+                                    enabled in Vault, e.g: "aws"'
                                   type: string
                                 region:
                                   description: AWS region
                                   type: string
                                 role:
-                                  description: This is the AWS role to be assumed before talking to vault
+                                  description: This is the AWS role to be assumed
+                                    before talking to vault
                                   type: string
                                 secretRef:
                                   description: Specify credentials in a Secret object
@@ -2909,79 +3935,134 @@ spec:
                                       description: The AccessKeyID is used for authentication
                                       properties:
                                         key:
-                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          description: The key of the entry in the
+                                            Secret resource's `data` field to be used.
+                                            Some instances of this field may be defaulted,
+                                            in others it may be required.
                                           type: string
                                         name:
-                                          description: The name of the Secret resource being referred to.
+                                          description: The name of the Secret resource
+                                            being referred to.
                                           type: string
                                         namespace:
-                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          description: Namespace of the resource being
+                                            referred to. Ignored if referent is not
+                                            cluster-scoped. cluster-scoped defaults
+                                            to the namespace of the referent.
                                           type: string
                                       type: object
                                     secretAccessKeySecretRef:
-                                      description: The SecretAccessKey is used for authentication
+                                      description: The SecretAccessKey is used for
+                                        authentication
                                       properties:
                                         key:
-                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          description: The key of the entry in the
+                                            Secret resource's `data` field to be used.
+                                            Some instances of this field may be defaulted,
+                                            in others it may be required.
                                           type: string
                                         name:
-                                          description: The name of the Secret resource being referred to.
+                                          description: The name of the Secret resource
+                                            being referred to.
                                           type: string
                                         namespace:
-                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          description: Namespace of the resource being
+                                            referred to. Ignored if referent is not
+                                            cluster-scoped. cluster-scoped defaults
+                                            to the namespace of the referent.
                                           type: string
                                       type: object
                                     sessionTokenSecretRef:
-                                      description: 'The SessionToken used for authentication This must be defined if AccessKeyID and SecretAccessKey are temporary credentials see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html'
+                                      description: 'The SessionToken used for authentication
+                                        This must be defined if AccessKeyID and SecretAccessKey
+                                        are temporary credentials see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html'
                                       properties:
                                         key:
-                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          description: The key of the entry in the
+                                            Secret resource's `data` field to be used.
+                                            Some instances of this field may be defaulted,
+                                            in others it may be required.
                                           type: string
                                         name:
-                                          description: The name of the Secret resource being referred to.
+                                          description: The name of the Secret resource
+                                            being referred to.
                                           type: string
                                         namespace:
-                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          description: Namespace of the resource being
+                                            referred to. Ignored if referent is not
+                                            cluster-scoped. cluster-scoped defaults
+                                            to the namespace of the referent.
                                           type: string
                                       type: object
                                   type: object
                                 vaultAwsIamServerID:
-                                  description: 'X-Vault-AWS-IAM-Server-ID is an additional header used by Vault IAM auth method to mitigate against different types of replay attacks. More details here: https://developer.hashicorp.com/vault/docs/auth/aws'
+                                  description: 'X-Vault-AWS-IAM-Server-ID is an additional
+                                    header used by Vault IAM auth method to mitigate
+                                    against different types of replay attacks. More
+                                    details here: https://developer.hashicorp.com/vault/docs/auth/aws'
                                   type: string
                                 vaultRole:
-                                  description: Vault Role. In vault, a role describes an identity with a set of permissions, groups, or policies you want to attach a user of the secrets engine
+                                  description: Vault Role. In vault, a role describes
+                                    an identity with a set of permissions, groups,
+                                    or policies you want to attach a user of the secrets
+                                    engine
                                   type: string
                               required:
                                 - vaultRole
                               type: object
                             jwt:
-                              description: Jwt authenticates with Vault by passing role and JWT token using the JWT/OIDC authentication method
+                              description: Jwt authenticates with Vault by passing
+                                role and JWT token using the JWT/OIDC authentication
+                                method
                               properties:
                                 kubernetesServiceAccountToken:
-                                  description: Optional ServiceAccountToken specifies the Kubernetes service account for which to request a token for with the `TokenRequest` API.
+                                  description: Optional ServiceAccountToken specifies
+                                    the Kubernetes service account for which to request
+                                    a token for with the `TokenRequest` API.
                                   properties:
                                     audiences:
-                                      description: 'Optional audiences field that will be used to request a temporary Kubernetes service account token for the service account referenced by `serviceAccountRef`. Defaults to a single audience `vault` it not specified. Deprecated: use serviceAccountRef.Audiences instead'
+                                      description: 'Optional audiences field that
+                                        will be used to request a temporary Kubernetes
+                                        service account token for the service account
+                                        referenced by `serviceAccountRef`. Defaults
+                                        to a single audience `vault` it not specified.
+                                        Deprecated: use serviceAccountRef.Audiences
+                                        instead'
                                       items:
                                         type: string
                                       type: array
                                     expirationSeconds:
-                                      description: 'Optional expiration time in seconds that will be used to request a temporary Kubernetes service account token for the service account referenced by `serviceAccountRef`. Deprecated: this will be removed in the future. Defaults to 10 minutes.'
+                                      description: 'Optional expiration time in seconds
+                                        that will be used to request a temporary Kubernetes
+                                        service account token for the service account
+                                        referenced by `serviceAccountRef`. Deprecated:
+                                        this will be removed in the future. Defaults
+                                        to 10 minutes.'
                                       format: int64
                                       type: integer
                                     serviceAccountRef:
-                                      description: Service account field containing the name of a kubernetes ServiceAccount.
+                                      description: Service account field containing
+                                        the name of a kubernetes ServiceAccount.
                                       properties:
                                         audiences:
-                                          description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                          description: Audience specifies the `aud`
+                                            claim for the service account token If
+                                            the service account uses a well-known
+                                            annotation for e.g. IRSA or GCP Workload
+                                            Identity then this audiences will be appended
+                                            to the list
                                           items:
                                             type: string
                                           type: array
                                         name:
-                                          description: The name of the ServiceAccount resource being referred to.
+                                          description: The name of the ServiceAccount
+                                            resource being referred to.
                                           type: string
                                         namespace:
-                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          description: Namespace of the resource being
+                                            referred to. Ignored if referent is not
+                                            cluster-scoped. cluster-scoped defaults
+                                            to the namespace of the referent.
                                           type: string
                                       required:
                                         - name
@@ -2991,63 +4072,104 @@ spec:
                                   type: object
                                 path:
                                   default: jwt
-                                  description: 'Path where the JWT authentication backend is mounted in Vault, e.g: "jwt"'
+                                  description: 'Path where the JWT authentication
+                                    backend is mounted in Vault, e.g: "jwt"'
                                   type: string
                                 role:
-                                  description: Role is a JWT role to authenticate using the JWT/OIDC Vault authentication method
+                                  description: Role is a JWT role to authenticate
+                                    using the JWT/OIDC Vault authentication method
                                   type: string
                                 secretRef:
-                                  description: Optional SecretRef that refers to a key in a Secret resource containing JWT token to authenticate with Vault using the JWT/OIDC authentication method.
+                                  description: Optional SecretRef that refers to a
+                                    key in a Secret resource containing JWT token
+                                    to authenticate with Vault using the JWT/OIDC
+                                    authentication method.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               required:
                                 - path
                               type: object
                             kubernetes:
-                              description: Kubernetes authenticates with Vault by passing the ServiceAccount token stored in the named Secret resource to the Vault server.
+                              description: Kubernetes authenticates with Vault by
+                                passing the ServiceAccount token stored in the named
+                                Secret resource to the Vault server.
                               properties:
                                 mountPath:
                                   default: kubernetes
-                                  description: 'Path where the Kubernetes authentication backend is mounted in Vault, e.g: "kubernetes"'
+                                  description: 'Path where the Kubernetes authentication
+                                    backend is mounted in Vault, e.g: "kubernetes"'
                                   type: string
                                 role:
-                                  description: A required field containing the Vault Role to assume. A Role binds a Kubernetes ServiceAccount with a set of Vault policies.
+                                  description: A required field containing the Vault
+                                    Role to assume. A Role binds a Kubernetes ServiceAccount
+                                    with a set of Vault policies.
                                   type: string
                                 secretRef:
-                                  description: Optional secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Vault. If a name is specified without a key, `token` is the default. If one is not specified, the one bound to the controller will be used.
+                                  description: Optional secret field containing a
+                                    Kubernetes ServiceAccount JWT used for authenticating
+                                    with Vault. If a name is specified without a key,
+                                    `token` is the default. If one is not specified,
+                                    the one bound to the controller will be used.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 serviceAccountRef:
-                                  description: Optional service account field containing the name of a kubernetes ServiceAccount. If the service account is specified, the service account secret token JWT will be used for authenticating with Vault. If the service account selector is not supplied, the secretRef will be used instead.
+                                  description: Optional service account field containing
+                                    the name of a kubernetes ServiceAccount. If the
+                                    service account is specified, the service account
+                                    secret token JWT will be used for authenticating
+                                    with Vault. If the service account selector is
+                                    not supplied, the secretRef will be used instead.
                                   properties:
                                     audiences:
-                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      description: Audience specifies the `aud` claim
+                                        for the service account token If the service
+                                        account uses a well-known annotation for e.g.
+                                        IRSA or GCP Workload Identity then this audiences
+                                        will be appended to the list
                                       items:
                                         type: string
                                       type: array
                                     name:
-                                      description: The name of the ServiceAccount resource being referred to.
+                                      description: The name of the ServiceAccount
+                                        resource being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   required:
                                     - name
@@ -3057,67 +4179,102 @@ spec:
                                 - role
                               type: object
                             ldap:
-                              description: Ldap authenticates with Vault by passing username/password pair using the LDAP authentication method
+                              description: Ldap authenticates with Vault by passing
+                                username/password pair using the LDAP authentication
+                                method
                               properties:
                                 path:
                                   default: ldap
-                                  description: 'Path where the LDAP authentication backend is mounted in Vault, e.g: "ldap"'
+                                  description: 'Path where the LDAP authentication
+                                    backend is mounted in Vault, e.g: "ldap"'
                                   type: string
                                 secretRef:
-                                  description: SecretRef to a key in a Secret resource containing password for the LDAP user used to authenticate with Vault using the LDAP authentication method
+                                  description: SecretRef to a key in a Secret resource
+                                    containing password for the LDAP user used to
+                                    authenticate with Vault using the LDAP authentication
+                                    method
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 username:
-                                  description: Username is a LDAP user name used to authenticate using the LDAP Vault authentication method
+                                  description: Username is a LDAP user name used to
+                                    authenticate using the LDAP Vault authentication
+                                    method
                                   type: string
                               required:
                                 - path
                                 - username
                               type: object
                             tokenSecretRef:
-                              description: TokenSecretRef authenticates with Vault by presenting a token.
+                              description: TokenSecretRef authenticates with Vault
+                                by presenting a token.
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                             userPass:
-                              description: UserPass authenticates with Vault by passing username/password pair
+                              description: UserPass authenticates with Vault by passing
+                                username/password pair
                               properties:
                                 path:
                                   default: user
-                                  description: 'Path where the UserPassword authentication backend is mounted in Vault, e.g: "user"'
+                                  description: 'Path where the UserPassword authentication
+                                    backend is mounted in Vault, e.g: "user"'
                                   type: string
                                 secretRef:
-                                  description: SecretRef to a key in a Secret resource containing password for the user used to authenticate with Vault using the UserPass authentication method
+                                  description: SecretRef to a key in a Secret resource
+                                    containing password for the user used to authenticate
+                                    with Vault using the UserPass authentication method
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 username:
-                                  description: Username is a user name used to authenticate using the UserPass Vault authentication method
+                                  description: Username is a user name used to authenticate
+                                    using the UserPass Vault authentication method
                                   type: string
                               required:
                                 - path
@@ -3125,23 +4282,32 @@ spec:
                               type: object
                           type: object
                         caBundle:
-                          description: PEM encoded CA bundle used to validate Vault server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.
+                          description: PEM encoded CA bundle used to validate Vault
+                            server certificate. Only used if the Server URL is using
+                            HTTPS protocol. This parameter is ignored for plain HTTP
+                            protocol connection. If not set the system root certificates
+                            are used to validate the TLS connection.
                           format: byte
                           type: string
                         caProvider:
-                          description: The provider for the CA bundle to use to validate Vault server certificate.
+                          description: The provider for the CA bundle to use to validate
+                            Vault server certificate.
                           properties:
                             key:
-                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              description: The key where the CA certificate can be
+                                found in the Secret or ConfigMap.
                               type: string
                             name:
-                              description: The name of the object located at the provider type.
+                              description: The name of the object located at the provider
+                                type.
                               type: string
                             namespace:
-                              description: The namespace the Provider type is in. Can only be defined when used in a ClusterSecretStore.
+                              description: The namespace the Provider type is in.
+                                Can only be defined when used in a ClusterSecretStore.
                               type: string
                             type:
-                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              description: The type of provider to use such as "Secret",
+                                or "ConfigMap".
                               enum:
                                 - Secret
                                 - ConfigMap
@@ -3151,23 +4317,38 @@ spec:
                             - type
                           type: object
                         forwardInconsistent:
-                          description: ForwardInconsistent tells Vault to forward read-after-write requests to the Vault leader instead of simply retrying within a loop. This can increase performance if the option is enabled serverside. https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header
+                          description: ForwardInconsistent tells Vault to forward
+                            read-after-write requests to the Vault leader instead
+                            of simply retrying within a loop. This can increase performance
+                            if the option is enabled serverside. https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header
                           type: boolean
                         namespace:
-                          description: 'Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1". More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
+                          description: 'Name of the vault namespace. Namespaces is
+                            a set of features within Vault Enterprise that allows
+                            Vault environments to support Secure Multi-tenancy. e.g:
+                            "ns1". More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
                           type: string
                         path:
-                          description: 'Path is the mount path of the Vault KV backend endpoint, e.g: "secret". The v2 KV secret engine version specific "/data" path suffix for fetching secrets from Vault is optional and will be appended if not present in specified path.'
+                          description: 'Path is the mount path of the Vault KV backend
+                            endpoint, e.g: "secret". The v2 KV secret engine version
+                            specific "/data" path suffix for fetching secrets from
+                            Vault is optional and will be appended if not present
+                            in specified path.'
                           type: string
                         readYourWrites:
-                          description: ReadYourWrites ensures isolated read-after-write semantics by providing discovered cluster replication states in each request. More information about eventual consistency in Vault can be found here https://www.vaultproject.io/docs/enterprise/consistency
+                          description: ReadYourWrites ensures isolated read-after-write
+                            semantics by providing discovered cluster replication
+                            states in each request. More information about eventual
+                            consistency in Vault can be found here https://www.vaultproject.io/docs/enterprise/consistency
                           type: boolean
                         server:
-                          description: 'Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".'
+                          description: 'Server is the connection address for the Vault
+                            server, e.g: "https://vault.example.com:8200".'
                           type: string
                         version:
                           default: v2
-                          description: Version is the Vault KV secret engine version. This can be either "v1" or "v2". Version defaults to "v2".
+                          description: Version is the Vault KV secret engine version.
+                            This can be either "v1" or "v2". Version defaults to "v2".
                           enum:
                             - v1
                             - v2
@@ -3177,29 +4358,38 @@ spec:
                         - server
                       type: object
                     webhook:
-                      description: Webhook configures this store to sync secrets using a generic templated webhook
+                      description: Webhook configures this store to sync secrets using
+                        a generic templated webhook
                       properties:
                         body:
                           description: Body
                           type: string
                         caBundle:
-                          description: PEM encoded CA bundle used to validate webhook server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.
+                          description: PEM encoded CA bundle used to validate webhook
+                            server certificate. Only used if the Server URL is using
+                            HTTPS protocol. This parameter is ignored for plain HTTP
+                            protocol connection. If not set the system root certificates
+                            are used to validate the TLS connection.
                           format: byte
                           type: string
                         caProvider:
-                          description: The provider for the CA bundle to use to validate webhook server certificate.
+                          description: The provider for the CA bundle to use to validate
+                            webhook server certificate.
                           properties:
                             key:
-                              description: The key the value inside of the provider type to use, only used with "Secret" type
+                              description: The key the value inside of the provider
+                                type to use, only used with "Secret" type
                               type: string
                             name:
-                              description: The name of the object located at the provider type.
+                              description: The name of the object located at the provider
+                                type.
                               type: string
                             namespace:
                               description: The namespace the Provider type is in.
                               type: string
                             type:
-                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              description: The type of provider to use such as "Secret",
+                                or "ConfigMap".
                               enum:
                                 - Secret
                                 - ConfigMap
@@ -3224,7 +4414,9 @@ spec:
                               type: string
                           type: object
                         secrets:
-                          description: Secrets to fill in templates These secrets will be passed to the templating function as key value pairs under the given name
+                          description: Secrets to fill in templates These secrets
+                            will be passed to the templating function as key value
+                            pairs under the given name
                           items:
                             properties:
                               name:
@@ -3234,13 +4426,20 @@ spec:
                                 description: Secret ref to fill in credentials
                                 properties:
                                   key:
-                                    description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                    description: The key of the entry in the Secret
+                                      resource's `data` field to be used. Some instances
+                                      of this field may be defaulted, in others it
+                                      may be required.
                                     type: string
                                   name:
-                                    description: The name of the Secret resource being referred to.
+                                    description: The name of the Secret resource being
+                                      referred to.
                                     type: string
                                   namespace:
-                                    description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                    description: Namespace of the resource being referred
+                                      to. Ignored if referent is not cluster-scoped.
+                                      cluster-scoped defaults to the namespace of
+                                      the referent.
                                     type: string
                                 type: object
                             required:
@@ -3259,42 +4458,61 @@ spec:
                         - url
                       type: object
                     yandexcertificatemanager:
-                      description: YandexCertificateManager configures this store to sync secrets using Yandex Certificate Manager provider
+                      description: YandexCertificateManager configures this store
+                        to sync secrets using Yandex Certificate Manager provider
                       properties:
                         apiEndpoint:
                           description: Yandex.Cloud API endpoint (e.g. 'api.cloud.yandex.net:443')
                           type: string
                         auth:
-                          description: Auth defines the information necessary to authenticate against Yandex Certificate Manager
+                          description: Auth defines the information necessary to authenticate
+                            against Yandex Certificate Manager
                           properties:
                             authorizedKeySecretRef:
                               description: The authorized key used for authentication
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                           type: object
                         caProvider:
-                          description: The provider for the CA bundle to use to validate Yandex.Cloud server certificate.
+                          description: The provider for the CA bundle to use to validate
+                            Yandex.Cloud server certificate.
                           properties:
                             certSecretRef:
-                              description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                              description: A reference to a specific 'key' within
+                                a Secret resource, In some instances, `key` is a required
+                                field.
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                           type: object
@@ -3302,42 +4520,61 @@ spec:
                         - auth
                       type: object
                     yandexlockbox:
-                      description: YandexLockbox configures this store to sync secrets using Yandex Lockbox provider
+                      description: YandexLockbox configures this store to sync secrets
+                        using Yandex Lockbox provider
                       properties:
                         apiEndpoint:
                           description: Yandex.Cloud API endpoint (e.g. 'api.cloud.yandex.net:443')
                           type: string
                         auth:
-                          description: Auth defines the information necessary to authenticate against Yandex Lockbox
+                          description: Auth defines the information necessary to authenticate
+                            against Yandex Lockbox
                           properties:
                             authorizedKeySecretRef:
                               description: The authorized key used for authentication
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                           type: object
                         caProvider:
-                          description: The provider for the CA bundle to use to validate Yandex.Cloud server certificate.
+                          description: The provider for the CA bundle to use to validate
+                            Yandex.Cloud server certificate.
                           properties:
                             certSecretRef:
-                              description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                              description: A reference to a specific 'key' within
+                                a Secret resource, In some instances, `key` is a required
+                                field.
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                           type: object
@@ -3346,7 +4583,8 @@ spec:
                       type: object
                   type: object
                 refreshInterval:
-                  description: Used to configure store refresh interval in seconds. Empty or 0 will default to the controller config.
+                  description: Used to configure store refresh interval in seconds.
+                    Empty or 0 will default to the controller config.
                   type: integer
                 retrySettings:
                   description: Used to configure http retries if failed
@@ -3364,7 +4602,8 @@ spec:
               description: SecretStoreStatus defines the observed state of the SecretStore.
               properties:
                 capabilities:
-                  description: SecretStoreCapabilities defines the possible operations a SecretStore can do.
+                  description: SecretStoreCapabilities defines the possible operations
+                    a SecretStore can do.
                   type: string
                 conditions:
                   items:
@@ -3438,10 +4677,15 @@ spec:
           description: ExternalSecret is the Schema for the external-secrets API.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
@@ -3449,12 +4693,16 @@ spec:
               description: ExternalSecretSpec defines the desired state of ExternalSecret.
               properties:
                 data:
-                  description: Data defines the connection between the Kubernetes Secret keys and the Provider data
+                  description: Data defines the connection between the Kubernetes
+                    Secret keys and the Provider data
                   items:
-                    description: ExternalSecretData defines the connection between the Kubernetes Secret key (spec.data.<key>) and the Provider data.
+                    description: ExternalSecretData defines the connection between
+                      the Kubernetes Secret key (spec.data.<key>) and the Provider
+                      data.
                     properties:
                       remoteRef:
-                        description: ExternalSecretDataRemoteRef defines Provider data location.
+                        description: ExternalSecretDataRemoteRef defines Provider
+                          data location.
                         properties:
                           conversionStrategy:
                             default: Default
@@ -3464,10 +4712,12 @@ spec:
                             description: Key is the key used in the Provider, mandatory
                             type: string
                           property:
-                            description: Used to select a specific property of the Provider value (if a map), if supported
+                            description: Used to select a specific property of the
+                              Provider value (if a map), if supported
                             type: string
                           version:
-                            description: Used to select a specific version of the Provider value, if supported
+                            description: Used to select a specific version of the
+                              Provider value, if supported
                             type: string
                         required:
                           - key
@@ -3480,9 +4730,12 @@ spec:
                     type: object
                   type: array
                 dataFrom:
-                  description: DataFrom is used to fetch all properties from a specific Provider data If multiple entries are specified, the Secret keys are merged in the specified order
+                  description: DataFrom is used to fetch all properties from a specific
+                    Provider data If multiple entries are specified, the Secret keys
+                    are merged in the specified order
                   items:
-                    description: ExternalSecretDataRemoteRef defines Provider data location.
+                    description: ExternalSecretDataRemoteRef defines Provider data
+                      location.
                     properties:
                       conversionStrategy:
                         default: Default
@@ -3492,10 +4745,12 @@ spec:
                         description: Key is the key used in the Provider, mandatory
                         type: string
                       property:
-                        description: Used to select a specific property of the Provider value (if a map), if supported
+                        description: Used to select a specific property of the Provider
+                          value (if a map), if supported
                         type: string
                       version:
-                        description: Used to select a specific version of the Provider value, if supported
+                        description: Used to select a specific version of the Provider
+                          value, if supported
                         type: string
                     required:
                       - key
@@ -3503,13 +4758,18 @@ spec:
                   type: array
                 refreshInterval:
                   default: 1h
-                  description: RefreshInterval is the amount of time before the values are read again from the SecretStore provider Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h" May be set to zero to fetch and create it once. Defaults to 1h.
+                  description: RefreshInterval is the amount of time before the values
+                    are read again from the SecretStore provider Valid time units
+                    are "ns", "us" (or "µs"), "ms", "s", "m", "h" May be set to zero
+                    to fetch and create it once. Defaults to 1h.
                   type: string
                 secretStoreRef:
-                  description: SecretStoreRef defines which SecretStore to fetch the ExternalSecret data.
+                  description: SecretStoreRef defines which SecretStore to fetch the
+                    ExternalSecret data.
                   properties:
                     kind:
-                      description: Kind of the SecretStore resource (SecretStore or ClusterSecretStore) Defaults to `SecretStore`
+                      description: Kind of the SecretStore resource (SecretStore or
+                        ClusterSecretStore) Defaults to `SecretStore`
                       type: string
                     name:
                       description: Name of the SecretStore resource
@@ -3518,20 +4778,25 @@ spec:
                     - name
                   type: object
                 target:
-                  description: ExternalSecretTarget defines the Kubernetes Secret to be created There can be only one target per ExternalSecret.
+                  description: ExternalSecretTarget defines the Kubernetes Secret
+                    to be created There can be only one target per ExternalSecret.
                   properties:
                     creationPolicy:
                       default: Owner
-                      description: CreationPolicy defines rules on how to create the resulting Secret Defaults to 'Owner'
+                      description: CreationPolicy defines rules on how to create the
+                        resulting Secret Defaults to 'Owner'
                       type: string
                     immutable:
                       description: Immutable defines if the final secret will be immutable
                       type: boolean
                     name:
-                      description: Name defines the name of the Secret resource to be managed This field is immutable Defaults to the .metadata.name of the ExternalSecret resource
+                      description: Name defines the name of the Secret resource to
+                        be managed This field is immutable Defaults to the .metadata.name
+                        of the ExternalSecret resource
                       type: string
                     template:
-                      description: Template defines a blueprint for the created Secret resource.
+                      description: Template defines a blueprint for the created Secret
+                        resource.
                       properties:
                         data:
                           additionalProperties:
@@ -3539,10 +4804,13 @@ spec:
                           type: object
                         engineVersion:
                           default: v1
-                          description: EngineVersion specifies the template engine version that should be used to compile/execute the template specified in .data and .templateFrom[].
+                          description: EngineVersion specifies the template engine
+                            version that should be used to compile/execute the template
+                            specified in .data and .templateFrom[].
                           type: string
                         metadata:
-                          description: ExternalSecretTemplateMetadata defines metadata fields for the Secret blueprint.
+                          description: ExternalSecretTemplateMetadata defines metadata
+                            fields for the Secret blueprint.
                           properties:
                             annotations:
                               additionalProperties:
@@ -3605,10 +4873,12 @@ spec:
             status:
               properties:
                 binding:
-                  description: Binding represents a servicebinding.io Provisioned Service reference to the secret
+                  description: Binding represents a servicebinding.io Provisioned
+                    Service reference to the secret
                   properties:
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
@@ -3632,12 +4902,14 @@ spec:
                     type: object
                   type: array
                 refreshTime:
-                  description: refreshTime is the time and date the external secret was fetched and the target secret updated
+                  description: refreshTime is the time and date the external secret
+                    was fetched and the target secret updated
                   format: date-time
                   nullable: true
                   type: string
                 syncedResourceVersion:
-                  description: SyncedResourceVersion keeps track of the last synced version
+                  description: SyncedResourceVersion keeps track of the last synced
+                    version
                   type: string
               type: object
           type: object
@@ -3664,10 +4936,15 @@ spec:
           description: ExternalSecret is the Schema for the external-secrets API.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
@@ -3675,12 +4952,16 @@ spec:
               description: ExternalSecretSpec defines the desired state of ExternalSecret.
               properties:
                 data:
-                  description: Data defines the connection between the Kubernetes Secret keys and the Provider data
+                  description: Data defines the connection between the Kubernetes
+                    Secret keys and the Provider data
                   items:
-                    description: ExternalSecretData defines the connection between the Kubernetes Secret key (spec.data.<key>) and the Provider data.
+                    description: ExternalSecretData defines the connection between
+                      the Kubernetes Secret key (spec.data.<key>) and the Provider
+                      data.
                     properties:
                       remoteRef:
-                        description: RemoteRef points to the remote secret and defines which secret (version/property/..) to fetch.
+                        description: RemoteRef points to the remote secret and defines
+                          which secret (version/property/..) to fetch.
                         properties:
                           conversionStrategy:
                             default: Default
@@ -3694,33 +4975,42 @@ spec:
                             description: Key is the key used in the Provider, mandatory
                             type: string
                           metadataPolicy:
-                            description: Policy for fetching tags/labels from provider secrets, possible options are Fetch, None. Defaults to None
+                            description: Policy for fetching tags/labels from provider
+                              secrets, possible options are Fetch, None. Defaults
+                              to None
                             type: string
                           property:
-                            description: Used to select a specific property of the Provider value (if a map), if supported
+                            description: Used to select a specific property of the
+                              Provider value (if a map), if supported
                             type: string
                           version:
-                            description: Used to select a specific version of the Provider value, if supported
+                            description: Used to select a specific version of the
+                              Provider value, if supported
                             type: string
                         required:
                           - key
                         type: object
                       secretKey:
-                        description: SecretKey defines the key in which the controller stores the value. This is the key in the Kind=Secret
+                        description: SecretKey defines the key in which the controller
+                          stores the value. This is the key in the Kind=Secret
                         type: string
                       sourceRef:
-                        description: SourceRef allows you to override the source from which the value will pulled from.
+                        description: SourceRef allows you to override the source from
+                          which the value will pulled from.
                         maxProperties: 1
                         properties:
                           generatorRef:
-                            description: GeneratorRef points to a generator custom resource in
+                            description: GeneratorRef points to a generator custom
+                              resource in
                             properties:
                               apiVersion:
                                 default: generators.external-secrets.io/v1alpha1
-                                description: Specify the apiVersion of the generator resource
+                                description: Specify the apiVersion of the generator
+                                  resource
                                 type: string
                               kind:
-                                description: Specify the Kind of the resource, e.g. Password, ACRAccessToken etc.
+                                description: Specify the Kind of the resource, e.g.
+                                  Password, ACRAccessToken etc.
                                 type: string
                               name:
                                 description: Specify the name of the generator resource
@@ -3730,10 +5020,12 @@ spec:
                               - name
                             type: object
                           storeRef:
-                            description: SecretStoreRef defines which SecretStore to fetch the ExternalSecret data.
+                            description: SecretStoreRef defines which SecretStore
+                              to fetch the ExternalSecret data.
                             properties:
                               kind:
-                                description: Kind of the SecretStore resource (SecretStore or ClusterSecretStore) Defaults to `SecretStore`
+                                description: Kind of the SecretStore resource (SecretStore
+                                  or ClusterSecretStore) Defaults to `SecretStore`
                                 type: string
                               name:
                                 description: Name of the SecretStore resource
@@ -3748,11 +5040,15 @@ spec:
                     type: object
                   type: array
                 dataFrom:
-                  description: DataFrom is used to fetch all properties from a specific Provider data If multiple entries are specified, the Secret keys are merged in the specified order
+                  description: DataFrom is used to fetch all properties from a specific
+                    Provider data If multiple entries are specified, the Secret keys
+                    are merged in the specified order
                   items:
                     properties:
                       extract:
-                        description: 'Used to extract multiple key/value pairs from one secret Note: Extract does not support sourceRef.Generator or sourceRef.GeneratorRef.'
+                        description: 'Used to extract multiple key/value pairs from
+                          one secret Note: Extract does not support sourceRef.Generator
+                          or sourceRef.GeneratorRef.'
                         properties:
                           conversionStrategy:
                             default: Default
@@ -3766,19 +5062,25 @@ spec:
                             description: Key is the key used in the Provider, mandatory
                             type: string
                           metadataPolicy:
-                            description: Policy for fetching tags/labels from provider secrets, possible options are Fetch, None. Defaults to None
+                            description: Policy for fetching tags/labels from provider
+                              secrets, possible options are Fetch, None. Defaults
+                              to None
                             type: string
                           property:
-                            description: Used to select a specific property of the Provider value (if a map), if supported
+                            description: Used to select a specific property of the
+                              Provider value (if a map), if supported
                             type: string
                           version:
-                            description: Used to select a specific version of the Provider value, if supported
+                            description: Used to select a specific version of the
+                              Provider value, if supported
                             type: string
                         required:
                           - key
                         type: object
                       find:
-                        description: 'Used to find secrets based on tags or regular expressions Note: Find does not support sourceRef.Generator or sourceRef.GeneratorRef.'
+                        description: 'Used to find secrets based on tags or regular
+                          expressions Note: Find does not support sourceRef.Generator
+                          or sourceRef.GeneratorRef.'
                         properties:
                           conversionStrategy:
                             default: Default
@@ -3805,17 +5107,24 @@ spec:
                             type: object
                         type: object
                       rewrite:
-                        description: Used to rewrite secret Keys after getting them from the secret Provider Multiple Rewrite operations can be provided. They are applied in a layered order (first to last)
+                        description: Used to rewrite secret Keys after getting them
+                          from the secret Provider Multiple Rewrite operations can
+                          be provided. They are applied in a layered order (first
+                          to last)
                         items:
                           properties:
                             regexp:
-                              description: Used to rewrite with regular expressions. The resulting key will be the output of a regexp.ReplaceAll operation.
+                              description: Used to rewrite with regular expressions.
+                                The resulting key will be the output of a regexp.ReplaceAll
+                                operation.
                               properties:
                                 source:
-                                  description: Used to define the regular expression of a re.Compiler.
+                                  description: Used to define the regular expression
+                                    of a re.Compiler.
                                   type: string
                                 target:
-                                  description: Used to define the target pattern of a ReplaceAll operation.
+                                  description: Used to define the target pattern of
+                                    a ReplaceAll operation.
                                   type: string
                               required:
                                 - source
@@ -3824,18 +5133,25 @@ spec:
                           type: object
                         type: array
                       sourceRef:
-                        description: SourceRef points to a store or generator which contains secret values ready to use. Use this in combination with Extract or Find pull values out of a specific SecretStore. When sourceRef points to a generator Extract or Find is not supported. The generator returns a static map of values
+                        description: SourceRef points to a store or generator which
+                          contains secret values ready to use. Use this in combination
+                          with Extract or Find pull values out of a specific SecretStore.
+                          When sourceRef points to a generator Extract or Find is
+                          not supported. The generator returns a static map of values
                         maxProperties: 1
                         properties:
                           generatorRef:
-                            description: GeneratorRef points to a generator custom resource in
+                            description: GeneratorRef points to a generator custom
+                              resource in
                             properties:
                               apiVersion:
                                 default: generators.external-secrets.io/v1alpha1
-                                description: Specify the apiVersion of the generator resource
+                                description: Specify the apiVersion of the generator
+                                  resource
                                 type: string
                               kind:
-                                description: Specify the Kind of the resource, e.g. Password, ACRAccessToken etc.
+                                description: Specify the Kind of the resource, e.g.
+                                  Password, ACRAccessToken etc.
                                 type: string
                               name:
                                 description: Specify the name of the generator resource
@@ -3845,10 +5161,12 @@ spec:
                               - name
                             type: object
                           storeRef:
-                            description: SecretStoreRef defines which SecretStore to fetch the ExternalSecret data.
+                            description: SecretStoreRef defines which SecretStore
+                              to fetch the ExternalSecret data.
                             properties:
                               kind:
-                                description: Kind of the SecretStore resource (SecretStore or ClusterSecretStore) Defaults to `SecretStore`
+                                description: Kind of the SecretStore resource (SecretStore
+                                  or ClusterSecretStore) Defaults to `SecretStore`
                                 type: string
                               name:
                                 description: Name of the SecretStore resource
@@ -3861,13 +5179,18 @@ spec:
                   type: array
                 refreshInterval:
                   default: 1h
-                  description: RefreshInterval is the amount of time before the values are read again from the SecretStore provider Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h" May be set to zero to fetch and create it once. Defaults to 1h.
+                  description: RefreshInterval is the amount of time before the values
+                    are read again from the SecretStore provider Valid time units
+                    are "ns", "us" (or "µs"), "ms", "s", "m", "h" May be set to zero
+                    to fetch and create it once. Defaults to 1h.
                   type: string
                 secretStoreRef:
-                  description: SecretStoreRef defines which SecretStore to fetch the ExternalSecret data.
+                  description: SecretStoreRef defines which SecretStore to fetch the
+                    ExternalSecret data.
                   properties:
                     kind:
-                      description: Kind of the SecretStore resource (SecretStore or ClusterSecretStore) Defaults to `SecretStore`
+                      description: Kind of the SecretStore resource (SecretStore or
+                        ClusterSecretStore) Defaults to `SecretStore`
                       type: string
                     name:
                       description: Name of the SecretStore resource
@@ -3879,11 +5202,13 @@ spec:
                   default:
                     creationPolicy: Owner
                     deletionPolicy: Retain
-                  description: ExternalSecretTarget defines the Kubernetes Secret to be created There can be only one target per ExternalSecret.
+                  description: ExternalSecretTarget defines the Kubernetes Secret
+                    to be created There can be only one target per ExternalSecret.
                   properties:
                     creationPolicy:
                       default: Owner
-                      description: CreationPolicy defines rules on how to create the resulting Secret Defaults to 'Owner'
+                      description: CreationPolicy defines rules on how to create the
+                        resulting Secret Defaults to 'Owner'
                       enum:
                         - Owner
                         - Orphan
@@ -3892,7 +5217,8 @@ spec:
                       type: string
                     deletionPolicy:
                       default: Retain
-                      description: DeletionPolicy defines rules on how to delete the resulting Secret Defaults to 'Retain'
+                      description: DeletionPolicy defines rules on how to delete the
+                        resulting Secret Defaults to 'Retain'
                       enum:
                         - Delete
                         - Merge
@@ -3902,10 +5228,13 @@ spec:
                       description: Immutable defines if the final secret will be immutable
                       type: boolean
                     name:
-                      description: Name defines the name of the Secret resource to be managed This field is immutable Defaults to the .metadata.name of the ExternalSecret resource
+                      description: Name defines the name of the Secret resource to
+                        be managed This field is immutable Defaults to the .metadata.name
+                        of the ExternalSecret resource
                       type: string
                     template:
-                      description: Template defines a blueprint for the created Secret resource.
+                      description: Template defines a blueprint for the created Secret
+                        resource.
                       properties:
                         data:
                           additionalProperties:
@@ -3918,7 +5247,8 @@ spec:
                           default: Replace
                           type: string
                         metadata:
-                          description: ExternalSecretTemplateMetadata defines metadata fields for the Secret blueprint.
+                          description: ExternalSecretTemplateMetadata defines metadata
+                            fields for the Secret blueprint.
                           properties:
                             annotations:
                               additionalProperties:
@@ -3987,10 +5317,12 @@ spec:
             status:
               properties:
                 binding:
-                  description: Binding represents a servicebinding.io Provisioned Service reference to the secret
+                  description: Binding represents a servicebinding.io Provisioned
+                    Service reference to the secret
                   properties:
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
@@ -4014,12 +5346,14 @@ spec:
                     type: object
                   type: array
                 refreshTime:
-                  description: refreshTime is the time and date the external secret was fetched and the target secret updated
+                  description: refreshTime is the time and date the external secret
+                    was fetched and the target secret updated
                   format: date-time
                   nullable: true
                   type: string
                 syncedResourceVersion:
-                  description: SyncedResourceVersion keeps track of the last synced version
+                  description: SyncedResourceVersion keeps track of the last synced
+                    version
                   type: string
               type: object
           type: object
@@ -4067,10 +5401,15 @@ spec:
         openAPIV3Schema:
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
@@ -4082,13 +5421,15 @@ spec:
                   items:
                     properties:
                       match:
-                        description: Match a given Secret Key to be pushed to the provider.
+                        description: Match a given Secret Key to be pushed to the
+                          provider.
                         properties:
                           remoteRef:
                             description: Remote Refs to push to providers.
                             properties:
                               property:
-                                description: Name of the property in the resulting secret
+                                description: Name of the property in the resulting
+                                  secret
                                 type: string
                               remoteKey:
                                 description: Name of the resulting provider secret.
@@ -4104,7 +5445,9 @@ spec:
                           - secretKey
                         type: object
                       metadata:
-                        description: Metadata is metadata attached to the secret. The structure of metadata is provider specific, please look it up in the provider documentation.
+                        description: Metadata is metadata attached to the secret.
+                          The structure of metadata is provider specific, please look
+                          it up in the provider documentation.
                         x-kubernetes-preserve-unknown-fields: true
                     required:
                       - match
@@ -4112,34 +5455,49 @@ spec:
                   type: array
                 deletionPolicy:
                   default: None
-                  description: 'Deletion Policy to handle Secrets in the provider. Possible Values: "Delete/None". Defaults to "None".'
+                  description: 'Deletion Policy to handle Secrets in the provider.
+                    Possible Values: "Delete/None". Defaults to "None".'
                   type: string
                 refreshInterval:
-                  description: The Interval to which External Secrets will try to push a secret definition
+                  description: The Interval to which External Secrets will try to
+                    push a secret definition
                   type: string
                 secretStoreRefs:
                   items:
                     properties:
                       kind:
                         default: SecretStore
-                        description: Kind of the SecretStore resource (SecretStore or ClusterSecretStore) Defaults to `SecretStore`
+                        description: Kind of the SecretStore resource (SecretStore
+                          or ClusterSecretStore) Defaults to `SecretStore`
                         type: string
                       labelSelector:
-                        description: Optionally, sync to secret stores with label selector
+                        description: Optionally, sync to secret stores with label
+                          selector
                         properties:
                           matchExpressions:
-                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
                             items:
-                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
                               properties:
                                 key:
-                                  description: key is the label key that the selector applies to.
+                                  description: key is the label key that the selector
+                                    applies to.
                                   type: string
                                 operator:
-                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
                                   type: string
                                 values:
-                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
                                   items:
                                     type: string
                                   type: array
@@ -4151,12 +5509,17 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
-                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
                       name:
-                        description: Optionally, sync to the SecretStore of the given name
+                        description: Optionally, sync to the SecretStore of the given
+                          name
                         type: string
                     type: object
                   type: array
@@ -4167,7 +5530,8 @@ spec:
                       description: Select a Secret to Push.
                       properties:
                         name:
-                          description: Name of the Secret. The Secret must exist in the same namespace as the PushSecret manifest.
+                          description: Name of the Secret. The Secret must exist in
+                            the same namespace as the PushSecret manifest.
                           type: string
                       required:
                         - name
@@ -4180,11 +5544,13 @@ spec:
                 - selector
               type: object
             status:
-              description: PushSecretStatus indicates the history of the status of PushSecret.
+              description: PushSecretStatus indicates the history of the status of
+                PushSecret.
               properties:
                 conditions:
                   items:
-                    description: PushSecretStatusCondition indicates the status of the PushSecret.
+                    description: PushSecretStatusCondition indicates the status of
+                      the PushSecret.
                     properties:
                       lastTransitionTime:
                         format: date-time
@@ -4196,7 +5562,8 @@ spec:
                       status:
                         type: string
                       type:
-                        description: PushSecretConditionType indicates the condition of the PushSecret.
+                        description: PushSecretConditionType indicates the condition
+                          of the PushSecret.
                         type: string
                     required:
                       - status
@@ -4204,7 +5571,8 @@ spec:
                     type: object
                   type: array
                 refreshTime:
-                  description: refreshTime is the time and date the external secret was fetched and the target secret updated
+                  description: refreshTime is the time and date the external secret
+                    was fetched and the target secret updated
                   format: date-time
                   nullable: true
                   type: string
@@ -4213,13 +5581,15 @@ spec:
                     additionalProperties:
                       properties:
                         match:
-                          description: Match a given Secret Key to be pushed to the provider.
+                          description: Match a given Secret Key to be pushed to the
+                            provider.
                           properties:
                             remoteRef:
                               description: Remote Refs to push to providers.
                               properties:
                                 property:
-                                  description: Name of the property in the resulting secret
+                                  description: Name of the property in the resulting
+                                    secret
                                   type: string
                                 remoteKey:
                                   description: Name of the resulting provider secret.
@@ -4235,16 +5605,20 @@ spec:
                             - secretKey
                           type: object
                         metadata:
-                          description: Metadata is metadata attached to the secret. The structure of metadata is provider specific, please look it up in the provider documentation.
+                          description: Metadata is metadata attached to the secret.
+                            The structure of metadata is provider specific, please
+                            look it up in the provider documentation.
                           x-kubernetes-preserve-unknown-fields: true
                       required:
                         - match
                       type: object
                     type: object
-                  description: Synced Push Secrets for later deletion. Matches Secret Stores to PushSecretData that was stored to that secretStore.
+                  description: Synced Push Secrets for later deletion. Matches Secret
+                    Stores to PushSecretData that was stored to that secretStore.
                   type: object
                 syncedResourceVersion:
-                  description: SyncedResourceVersion keeps track of the last synced version.
+                  description: SyncedResourceVersion keeps track of the last synced
+                    version.
                   type: string
               type: object
           type: object
@@ -4293,13 +5667,19 @@ spec:
       name: v1alpha1
       schema:
         openAPIV3Schema:
-          description: SecretStore represents a secure external location for storing secrets, which can be referenced as part of `storeRef` fields.
+          description: SecretStore represents a secure external location for storing
+            secrets, which can be referenced as part of `storeRef` fields.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
@@ -4307,57 +5687,91 @@ spec:
               description: SecretStoreSpec defines the desired state of SecretStore.
               properties:
                 controller:
-                  description: 'Used to select the correct ESO controller (think: ingress.ingressClassName) The ESO controller is instantiated with a specific controller name and filters ES based on this property'
+                  description: 'Used to select the correct ESO controller (think:
+                    ingress.ingressClassName) The ESO controller is instantiated with
+                    a specific controller name and filters ES based on this property'
                   type: string
                 provider:
-                  description: Used to configure the provider. Only one provider may be set
+                  description: Used to configure the provider. Only one provider may
+                    be set
                   maxProperties: 1
                   minProperties: 1
                   properties:
                     akeyless:
-                      description: Akeyless configures this store to sync secrets using Akeyless Vault provider
+                      description: Akeyless configures this store to sync secrets
+                        using Akeyless Vault provider
                       properties:
                         akeylessGWApiURL:
-                          description: Akeyless GW API Url from which the secrets to be fetched from.
+                          description: Akeyless GW API Url from which the secrets
+                            to be fetched from.
                           type: string
                         authSecretRef:
-                          description: Auth configures how the operator authenticates with Akeyless.
+                          description: Auth configures how the operator authenticates
+                            with Akeyless.
                           properties:
                             kubernetesAuth:
-                              description: Kubernetes authenticates with Akeyless by passing the ServiceAccount token stored in the named Secret resource.
+                              description: Kubernetes authenticates with Akeyless
+                                by passing the ServiceAccount token stored in the
+                                named Secret resource.
                               properties:
                                 accessID:
-                                  description: the Akeyless Kubernetes auth-method access-id
+                                  description: the Akeyless Kubernetes auth-method
+                                    access-id
                                   type: string
                                 k8sConfName:
-                                  description: Kubernetes-auth configuration name in Akeyless-Gateway
+                                  description: Kubernetes-auth configuration name
+                                    in Akeyless-Gateway
                                   type: string
                                 secretRef:
-                                  description: Optional secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Akeyless. If a name is specified without a key, `token` is the default. If one is not specified, the one bound to the controller will be used.
+                                  description: Optional secret field containing a
+                                    Kubernetes ServiceAccount JWT used for authenticating
+                                    with Akeyless. If a name is specified without
+                                    a key, `token` is the default. If one is not specified,
+                                    the one bound to the controller will be used.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 serviceAccountRef:
-                                  description: Optional service account field containing the name of a kubernetes ServiceAccount. If the service account is specified, the service account secret token JWT will be used for authenticating with Akeyless. If the service account selector is not supplied, the secretRef will be used instead.
+                                  description: Optional service account field containing
+                                    the name of a kubernetes ServiceAccount. If the
+                                    service account is specified, the service account
+                                    secret token JWT will be used for authenticating
+                                    with Akeyless. If the service account selector
+                                    is not supplied, the secretRef will be used instead.
                                   properties:
                                     audiences:
-                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      description: Audience specifies the `aud` claim
+                                        for the service account token If the service
+                                        account uses a well-known annotation for e.g.
+                                        IRSA or GCP Workload Identity then this audiences
+                                        will be appended to the list
                                       items:
                                         type: string
                                       type: array
                                     name:
-                                      description: The name of the ServiceAccount resource being referred to.
+                                      description: The name of the ServiceAccount
+                                        resource being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   required:
                                     - name
@@ -4367,67 +5781,100 @@ spec:
                                 - k8sConfName
                               type: object
                             secretRef:
-                              description: Reference to a Secret that contains the details to authenticate with Akeyless.
+                              description: Reference to a Secret that contains the
+                                details to authenticate with Akeyless.
                               properties:
                                 accessID:
                                   description: The SecretAccessID is used for authentication
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 accessType:
-                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource, In some instances, `key` is
+                                    a required field.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 accessTypeParam:
-                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource, In some instances, `key` is
+                                    a required field.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               type: object
                           type: object
                         caBundle:
-                          description: PEM/base64 encoded CA bundle used to validate Akeyless Gateway certificate. Only used if the AkeylessGWApiURL URL is using HTTPS protocol. If not set the system root certificates are used to validate the TLS connection.
+                          description: PEM/base64 encoded CA bundle used to validate
+                            Akeyless Gateway certificate. Only used if the AkeylessGWApiURL
+                            URL is using HTTPS protocol. If not set the system root
+                            certificates are used to validate the TLS connection.
                           format: byte
                           type: string
                         caProvider:
-                          description: The provider for the CA bundle to use to validate Akeyless Gateway certificate.
+                          description: The provider for the CA bundle to use to validate
+                            Akeyless Gateway certificate.
                           properties:
                             key:
-                              description: The key the value inside of the provider type to use, only used with "Secret" type
+                              description: The key the value inside of the provider
+                                type to use, only used with "Secret" type
                               type: string
                             name:
-                              description: The name of the object located at the provider type.
+                              description: The name of the object located at the provider
+                                type.
                               type: string
                             namespace:
                               description: The namespace the Provider type is in.
                               type: string
                             type:
-                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              description: The type of provider to use such as "Secret",
+                                or "ConfigMap".
                               enum:
                                 - Secret
                                 - ConfigMap
@@ -4441,7 +5888,8 @@ spec:
                         - authSecretRef
                       type: object
                     alibaba:
-                      description: Alibaba configures this store to sync secrets using Alibaba Cloud provider
+                      description: Alibaba configures this store to sync secrets using
+                        Alibaba Cloud provider
                       properties:
                         auth:
                           description: AlibabaAuth contains a secretRef for credentials.
@@ -4464,32 +5912,47 @@ spec:
                                 - sessionName
                               type: object
                             secretRef:
-                              description: AlibabaAuthSecretRef holds secret references for Alibaba credentials.
+                              description: AlibabaAuthSecretRef holds secret references
+                                for Alibaba credentials.
                               properties:
                                 accessKeyIDSecretRef:
                                   description: The AccessKeyID is used for authentication
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 accessKeySecretSecretRef:
                                   description: The AccessKeySecret is used for authentication
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               required:
@@ -4505,59 +5968,87 @@ spec:
                         - regionID
                       type: object
                     aws:
-                      description: AWS configures this store to sync secrets using AWS Secret Manager provider
+                      description: AWS configures this store to sync secrets using
+                        AWS Secret Manager provider
                       properties:
                         auth:
-                          description: 'Auth defines the information necessary to authenticate against AWS if not set aws sdk will infer credentials from your environment see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                          description: 'Auth defines the information necessary to
+                            authenticate against AWS if not set aws sdk will infer
+                            credentials from your environment see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
                           properties:
                             jwt:
-                              description: Authenticate against AWS using service account tokens.
+                              description: Authenticate against AWS using service
+                                account tokens.
                               properties:
                                 serviceAccountRef:
                                   description: A reference to a ServiceAccount resource.
                                   properties:
                                     audiences:
-                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      description: Audience specifies the `aud` claim
+                                        for the service account token If the service
+                                        account uses a well-known annotation for e.g.
+                                        IRSA or GCP Workload Identity then this audiences
+                                        will be appended to the list
                                       items:
                                         type: string
                                       type: array
                                     name:
-                                      description: The name of the ServiceAccount resource being referred to.
+                                      description: The name of the ServiceAccount
+                                        resource being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   required:
                                     - name
                                   type: object
                               type: object
                             secretRef:
-                              description: AWSAuthSecretRef holds secret references for AWS credentials both AccessKeyID and SecretAccessKey must be defined in order to properly authenticate.
+                              description: AWSAuthSecretRef holds secret references
+                                for AWS credentials both AccessKeyID and SecretAccessKey
+                                must be defined in order to properly authenticate.
                               properties:
                                 accessKeyIDSecretRef:
                                   description: The AccessKeyID is used for authentication
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 secretAccessKeySecretRef:
                                   description: The SecretAccessKey is used for authentication
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               type: object
@@ -4566,10 +6057,12 @@ spec:
                           description: AWS Region to be used for the provider
                           type: string
                         role:
-                          description: Role is a Role ARN which the SecretManager provider will assume
+                          description: Role is a Role ARN which the SecretManager
+                            provider will assume
                           type: string
                         service:
-                          description: Service defines which service should be used to fetch the secrets
+                          description: Service defines which service should be used
+                            to fetch the secrets
                           enum:
                             - SecretsManager
                             - ParameterStore
@@ -4579,71 +6072,104 @@ spec:
                         - service
                       type: object
                     azurekv:
-                      description: AzureKV configures this store to sync secrets using Azure Key Vault provider
+                      description: AzureKV configures this store to sync secrets using
+                        Azure Key Vault provider
                       properties:
                         authSecretRef:
-                          description: Auth configures how the operator authenticates with Azure. Required for ServicePrincipal auth type.
+                          description: Auth configures how the operator authenticates
+                            with Azure. Required for ServicePrincipal auth type.
                           properties:
                             clientId:
-                              description: The Azure clientId of the service principle used for authentication.
+                              description: The Azure clientId of the service principle
+                                used for authentication.
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                             clientSecret:
-                              description: The Azure ClientSecret of the service principle used for authentication.
+                              description: The Azure ClientSecret of the service principle
+                                used for authentication.
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                           type: object
                         authType:
                           default: ServicePrincipal
-                          description: 'Auth type defines how to authenticate to the keyvault service. Valid values are: - "ServicePrincipal" (default): Using a service principal (tenantId, clientId, clientSecret) - "ManagedIdentity": Using Managed Identity assigned to the pod (see aad-pod-identity)'
+                          description: 'Auth type defines how to authenticate to the
+                            keyvault service. Valid values are: - "ServicePrincipal"
+                            (default): Using a service principal (tenantId, clientId,
+                            clientSecret) - "ManagedIdentity": Using Managed Identity
+                            assigned to the pod (see aad-pod-identity)'
                           enum:
                             - ServicePrincipal
                             - ManagedIdentity
                             - WorkloadIdentity
                           type: string
                         identityId:
-                          description: If multiple Managed Identity is assigned to the pod, you can select the one to be used
+                          description: If multiple Managed Identity is assigned to
+                            the pod, you can select the one to be used
                           type: string
                         serviceAccountRef:
-                          description: ServiceAccountRef specified the service account that should be used when authenticating with WorkloadIdentity.
+                          description: ServiceAccountRef specified the service account
+                            that should be used when authenticating with WorkloadIdentity.
                           properties:
                             audiences:
-                              description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                              description: Audience specifies the `aud` claim for
+                                the service account token If the service account uses
+                                a well-known annotation for e.g. IRSA or GCP Workload
+                                Identity then this audiences will be appended to the
+                                list
                               items:
                                 type: string
                               type: array
                             name:
-                              description: The name of the ServiceAccount resource being referred to.
+                              description: The name of the ServiceAccount resource
+                                being referred to.
                               type: string
                             namespace:
-                              description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                              description: Namespace of the resource being referred
+                                to. Ignored if referent is not cluster-scoped. cluster-scoped
+                                defaults to the namespace of the referent.
                               type: string
                           required:
                             - name
                           type: object
                         tenantId:
-                          description: TenantID configures the Azure Tenant to send requests to. Required for ServicePrincipal auth type.
+                          description: TenantID configures the Azure Tenant to send
+                            requests to. Required for ServicePrincipal auth type.
                           type: string
                         vaultUrl:
-                          description: Vault Url from which the secrets to be fetched from.
+                          description: Vault Url from which the secrets to be fetched
+                            from.
                           type: string
                       required:
                         - vaultUrl
@@ -4672,10 +6198,12 @@ spec:
                         - data
                       type: object
                     gcpsm:
-                      description: GCPSM configures this store to sync secrets using Google Cloud Platform Secret Manager provider
+                      description: GCPSM configures this store to sync secrets using
+                        Google Cloud Platform Secret Manager provider
                       properties:
                         auth:
-                          description: Auth defines the information necessary to authenticate against GCP
+                          description: Auth defines the information necessary to authenticate
+                            against GCP
                           properties:
                             secretRef:
                               properties:
@@ -4683,13 +6211,20 @@ spec:
                                   description: The SecretAccessKey is used for authentication
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               type: object
@@ -4705,15 +6240,23 @@ spec:
                                   description: A reference to a ServiceAccount resource.
                                   properties:
                                     audiences:
-                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      description: Audience specifies the `aud` claim
+                                        for the service account token If the service
+                                        account uses a well-known annotation for e.g.
+                                        IRSA or GCP Workload Identity then this audiences
+                                        will be appended to the list
                                       items:
                                         type: string
                                       type: array
                                     name:
-                                      description: The name of the ServiceAccount resource being referred to.
+                                      description: The name of the ServiceAccount
+                                        resource being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   required:
                                     - name
@@ -4729,10 +6272,12 @@ spec:
                           type: string
                       type: object
                     gitlab:
-                      description: GitLab configures this store to sync secrets using GitLab Variables provider
+                      description: GitLab configures this store to sync secrets using
+                        GitLab Variables provider
                       properties:
                         auth:
-                          description: Auth configures how secret-manager authenticates with a GitLab instance.
+                          description: Auth configures how secret-manager authenticates
+                            with a GitLab instance.
                           properties:
                             SecretRef:
                               properties:
@@ -4740,13 +6285,20 @@ spec:
                                   description: AccessToken is used for authentication.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               type: object
@@ -4754,19 +6306,23 @@ spec:
                             - SecretRef
                           type: object
                         projectID:
-                          description: ProjectID specifies a project where secrets are located.
+                          description: ProjectID specifies a project where secrets
+                            are located.
                           type: string
                         url:
-                          description: URL configures the GitLab instance URL. Defaults to https://gitlab.com/.
+                          description: URL configures the GitLab instance URL. Defaults
+                            to https://gitlab.com/.
                           type: string
                       required:
                         - auth
                       type: object
                     ibm:
-                      description: IBM configures this store to sync secrets using IBM Cloud provider
+                      description: IBM configures this store to sync secrets using
+                        IBM Cloud provider
                       properties:
                         auth:
-                          description: Auth configures how secret-manager authenticates with the IBM secrets manager.
+                          description: Auth configures how secret-manager authenticates
+                            with the IBM secrets manager.
                           properties:
                             secretRef:
                               properties:
@@ -4774,13 +6330,20 @@ spec:
                                   description: The SecretAccessKey is used for authentication
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               type: object
@@ -4788,16 +6351,19 @@ spec:
                             - secretRef
                           type: object
                         serviceUrl:
-                          description: ServiceURL is the Endpoint URL that is specific to the Secrets Manager service instance
+                          description: ServiceURL is the Endpoint URL that is specific
+                            to the Secrets Manager service instance
                           type: string
                       required:
                         - auth
                       type: object
                     kubernetes:
-                      description: Kubernetes configures this store to sync secrets using a Kubernetes cluster provider
+                      description: Kubernetes configures this store to sync secrets
+                        using a Kubernetes cluster provider
                       properties:
                         auth:
-                          description: Auth configures how secret-manager authenticates with a Kubernetes instance.
+                          description: Auth configures how secret-manager authenticates
+                            with a Kubernetes instance.
                           maxProperties: 1
                           minProperties: 1
                           properties:
@@ -4805,48 +6371,75 @@ spec:
                               description: has both clientCert and clientKey as secretKeySelector
                               properties:
                                 clientCert:
-                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource, In some instances, `key` is
+                                    a required field.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 clientKey:
-                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource, In some instances, `key` is
+                                    a required field.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               type: object
                             serviceAccount:
-                              description: points to a service account that should be used for authentication
+                              description: points to a service account that should
+                                be used for authentication
                               properties:
                                 serviceAccount:
                                   description: A reference to a ServiceAccount resource.
                                   properties:
                                     audiences:
-                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      description: Audience specifies the `aud` claim
+                                        for the service account token If the service
+                                        account uses a well-known annotation for e.g.
+                                        IRSA or GCP Workload Identity then this audiences
+                                        will be appended to the list
                                       items:
                                         type: string
                                       type: array
                                     name:
-                                      description: The name of the ServiceAccount resource being referred to.
+                                      description: The name of the ServiceAccount
+                                        resource being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   required:
                                     - name
@@ -4856,16 +6449,25 @@ spec:
                               description: use static token to authenticate with
                               properties:
                                 bearerToken:
-                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource, In some instances, `key` is
+                                    a required field.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               type: object
@@ -4885,16 +6487,20 @@ spec:
                               description: 'see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider'
                               properties:
                                 key:
-                                  description: The key the value inside of the provider type to use, only used with "Secret" type
+                                  description: The key the value inside of the provider
+                                    type to use, only used with "Secret" type
                                   type: string
                                 name:
-                                  description: The name of the object located at the provider type.
+                                  description: The name of the object located at the
+                                    provider type.
                                   type: string
                                 namespace:
-                                  description: The namespace the Provider type is in.
+                                  description: The namespace the Provider type is
+                                    in.
                                   type: string
                                 type:
-                                  description: The type of provider to use such as "Secret", or "ConfigMap".
+                                  description: The type of provider to use such as
+                                    "Secret", or "ConfigMap".
                                   enum:
                                     - Secret
                                     - ConfigMap
@@ -4912,38 +6518,57 @@ spec:
                         - auth
                       type: object
                     oracle:
-                      description: Oracle configures this store to sync secrets using Oracle Vault provider
+                      description: Oracle configures this store to sync secrets using
+                        Oracle Vault provider
                       properties:
                         auth:
-                          description: Auth configures how secret-manager authenticates with the Oracle Vault. If empty, use the instance principal, otherwise the user credentials specified in Auth.
+                          description: Auth configures how secret-manager authenticates
+                            with the Oracle Vault. If empty, use the instance principal,
+                            otherwise the user credentials specified in Auth.
                           properties:
                             secretRef:
                               description: SecretRef to pass through sensitive information.
                               properties:
                                 fingerprint:
-                                  description: Fingerprint is the fingerprint of the API private key.
+                                  description: Fingerprint is the fingerprint of the
+                                    API private key.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 privatekey:
-                                  description: PrivateKey is the user's API Signing Key in PEM format, used for authentication.
+                                  description: PrivateKey is the user's API Signing
+                                    Key in PEM format, used for authentication.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               required:
@@ -4951,10 +6576,12 @@ spec:
                                 - privatekey
                               type: object
                             tenancy:
-                              description: Tenancy is the tenancy OCID where user is located.
+                              description: Tenancy is the tenancy OCID where user
+                                is located.
                               type: string
                             user:
-                              description: User is an access OCID specific to the account.
+                              description: User is an access OCID specific to the
+                                account.
                               type: string
                           required:
                             - secretRef
@@ -4965,39 +6592,58 @@ spec:
                           description: Region is the region where vault is located.
                           type: string
                         vault:
-                          description: Vault is the vault's OCID of the specific vault where secret is located.
+                          description: Vault is the vault's OCID of the specific vault
+                            where secret is located.
                           type: string
                       required:
                         - region
                         - vault
                       type: object
                     vault:
-                      description: Vault configures this store to sync secrets using Hashi provider
+                      description: Vault configures this store to sync secrets using
+                        Hashi provider
                       properties:
                         auth:
-                          description: Auth configures how secret-manager authenticates with the Vault server.
+                          description: Auth configures how secret-manager authenticates
+                            with the Vault server.
                           properties:
                             appRole:
-                              description: AppRole authenticates with Vault using the App Role auth mechanism, with the role and secret stored in a Kubernetes Secret resource.
+                              description: AppRole authenticates with Vault using
+                                the App Role auth mechanism, with the role and secret
+                                stored in a Kubernetes Secret resource.
                               properties:
                                 path:
                                   default: approle
-                                  description: 'Path where the App Role authentication backend is mounted in Vault, e.g: "approle"'
+                                  description: 'Path where the App Role authentication
+                                    backend is mounted in Vault, e.g: "approle"'
                                   type: string
                                 roleId:
-                                  description: RoleID configured in the App Role authentication backend when setting up the authentication backend in Vault.
+                                  description: RoleID configured in the App Role authentication
+                                    backend when setting up the authentication backend
+                                    in Vault.
                                   type: string
                                 secretRef:
-                                  description: Reference to a key in a Secret that contains the App Role secret used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role secret.
+                                  description: Reference to a key in a Secret that
+                                    contains the App Role secret used to authenticate
+                                    with Vault. The `key` field must be specified
+                                    and denotes which entry within the Secret resource
+                                    is used as the app role secret.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               required:
@@ -5006,63 +6652,104 @@ spec:
                                 - secretRef
                               type: object
                             cert:
-                              description: Cert authenticates with TLS Certificates by passing client certificate, private key and ca certificate Cert authentication method
+                              description: Cert authenticates with TLS Certificates
+                                by passing client certificate, private key and ca
+                                certificate Cert authentication method
                               properties:
                                 clientCert:
-                                  description: ClientCert is a certificate to authenticate using the Cert Vault authentication method
+                                  description: ClientCert is a certificate to authenticate
+                                    using the Cert Vault authentication method
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 secretRef:
-                                  description: SecretRef to a key in a Secret resource containing client private key to authenticate with Vault using the Cert authentication method
+                                  description: SecretRef to a key in a Secret resource
+                                    containing client private key to authenticate
+                                    with Vault using the Cert authentication method
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               type: object
                             jwt:
-                              description: Jwt authenticates with Vault by passing role and JWT token using the JWT/OIDC authentication method
+                              description: Jwt authenticates with Vault by passing
+                                role and JWT token using the JWT/OIDC authentication
+                                method
                               properties:
                                 kubernetesServiceAccountToken:
-                                  description: Optional ServiceAccountToken specifies the Kubernetes service account for which to request a token for with the `TokenRequest` API.
+                                  description: Optional ServiceAccountToken specifies
+                                    the Kubernetes service account for which to request
+                                    a token for with the `TokenRequest` API.
                                   properties:
                                     audiences:
-                                      description: Optional audiences field that will be used to request a temporary Kubernetes service account token for the service account referenced by `serviceAccountRef`. Defaults to a single audience `vault` it not specified.
+                                      description: Optional audiences field that will
+                                        be used to request a temporary Kubernetes
+                                        service account token for the service account
+                                        referenced by `serviceAccountRef`. Defaults
+                                        to a single audience `vault` it not specified.
                                       items:
                                         type: string
                                       type: array
                                     expirationSeconds:
-                                      description: Optional expiration time in seconds that will be used to request a temporary Kubernetes service account token for the service account referenced by `serviceAccountRef`. Defaults to 10 minutes.
+                                      description: Optional expiration time in seconds
+                                        that will be used to request a temporary Kubernetes
+                                        service account token for the service account
+                                        referenced by `serviceAccountRef`. Defaults
+                                        to 10 minutes.
                                       format: int64
                                       type: integer
                                     serviceAccountRef:
-                                      description: Service account field containing the name of a kubernetes ServiceAccount.
+                                      description: Service account field containing
+                                        the name of a kubernetes ServiceAccount.
                                       properties:
                                         audiences:
-                                          description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                          description: Audience specifies the `aud`
+                                            claim for the service account token If
+                                            the service account uses a well-known
+                                            annotation for e.g. IRSA or GCP Workload
+                                            Identity then this audiences will be appended
+                                            to the list
                                           items:
                                             type: string
                                           type: array
                                         name:
-                                          description: The name of the ServiceAccount resource being referred to.
+                                          description: The name of the ServiceAccount
+                                            resource being referred to.
                                           type: string
                                         namespace:
-                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          description: Namespace of the resource being
+                                            referred to. Ignored if referent is not
+                                            cluster-scoped. cluster-scoped defaults
+                                            to the namespace of the referent.
                                           type: string
                                       required:
                                         - name
@@ -5072,63 +6759,104 @@ spec:
                                   type: object
                                 path:
                                   default: jwt
-                                  description: 'Path where the JWT authentication backend is mounted in Vault, e.g: "jwt"'
+                                  description: 'Path where the JWT authentication
+                                    backend is mounted in Vault, e.g: "jwt"'
                                   type: string
                                 role:
-                                  description: Role is a JWT role to authenticate using the JWT/OIDC Vault authentication method
+                                  description: Role is a JWT role to authenticate
+                                    using the JWT/OIDC Vault authentication method
                                   type: string
                                 secretRef:
-                                  description: Optional SecretRef that refers to a key in a Secret resource containing JWT token to authenticate with Vault using the JWT/OIDC authentication method.
+                                  description: Optional SecretRef that refers to a
+                                    key in a Secret resource containing JWT token
+                                    to authenticate with Vault using the JWT/OIDC
+                                    authentication method.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               required:
                                 - path
                               type: object
                             kubernetes:
-                              description: Kubernetes authenticates with Vault by passing the ServiceAccount token stored in the named Secret resource to the Vault server.
+                              description: Kubernetes authenticates with Vault by
+                                passing the ServiceAccount token stored in the named
+                                Secret resource to the Vault server.
                               properties:
                                 mountPath:
                                   default: kubernetes
-                                  description: 'Path where the Kubernetes authentication backend is mounted in Vault, e.g: "kubernetes"'
+                                  description: 'Path where the Kubernetes authentication
+                                    backend is mounted in Vault, e.g: "kubernetes"'
                                   type: string
                                 role:
-                                  description: A required field containing the Vault Role to assume. A Role binds a Kubernetes ServiceAccount with a set of Vault policies.
+                                  description: A required field containing the Vault
+                                    Role to assume. A Role binds a Kubernetes ServiceAccount
+                                    with a set of Vault policies.
                                   type: string
                                 secretRef:
-                                  description: Optional secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Vault. If a name is specified without a key, `token` is the default. If one is not specified, the one bound to the controller will be used.
+                                  description: Optional secret field containing a
+                                    Kubernetes ServiceAccount JWT used for authenticating
+                                    with Vault. If a name is specified without a key,
+                                    `token` is the default. If one is not specified,
+                                    the one bound to the controller will be used.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 serviceAccountRef:
-                                  description: Optional service account field containing the name of a kubernetes ServiceAccount. If the service account is specified, the service account secret token JWT will be used for authenticating with Vault. If the service account selector is not supplied, the secretRef will be used instead.
+                                  description: Optional service account field containing
+                                    the name of a kubernetes ServiceAccount. If the
+                                    service account is specified, the service account
+                                    secret token JWT will be used for authenticating
+                                    with Vault. If the service account selector is
+                                    not supplied, the secretRef will be used instead.
                                   properties:
                                     audiences:
-                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      description: Audience specifies the `aud` claim
+                                        for the service account token If the service
+                                        account uses a well-known annotation for e.g.
+                                        IRSA or GCP Workload Identity then this audiences
+                                        will be appended to the list
                                       items:
                                         type: string
                                       type: array
                                     name:
-                                      description: The name of the ServiceAccount resource being referred to.
+                                      description: The name of the ServiceAccount
+                                        resource being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   required:
                                     - name
@@ -5138,64 +6866,95 @@ spec:
                                 - role
                               type: object
                             ldap:
-                              description: Ldap authenticates with Vault by passing username/password pair using the LDAP authentication method
+                              description: Ldap authenticates with Vault by passing
+                                username/password pair using the LDAP authentication
+                                method
                               properties:
                                 path:
                                   default: ldap
-                                  description: 'Path where the LDAP authentication backend is mounted in Vault, e.g: "ldap"'
+                                  description: 'Path where the LDAP authentication
+                                    backend is mounted in Vault, e.g: "ldap"'
                                   type: string
                                 secretRef:
-                                  description: SecretRef to a key in a Secret resource containing password for the LDAP user used to authenticate with Vault using the LDAP authentication method
+                                  description: SecretRef to a key in a Secret resource
+                                    containing password for the LDAP user used to
+                                    authenticate with Vault using the LDAP authentication
+                                    method
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 username:
-                                  description: Username is a LDAP user name used to authenticate using the LDAP Vault authentication method
+                                  description: Username is a LDAP user name used to
+                                    authenticate using the LDAP Vault authentication
+                                    method
                                   type: string
                               required:
                                 - path
                                 - username
                               type: object
                             tokenSecretRef:
-                              description: TokenSecretRef authenticates with Vault by presenting a token.
+                              description: TokenSecretRef authenticates with Vault
+                                by presenting a token.
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                           type: object
                         caBundle:
-                          description: PEM encoded CA bundle used to validate Vault server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.
+                          description: PEM encoded CA bundle used to validate Vault
+                            server certificate. Only used if the Server URL is using
+                            HTTPS protocol. This parameter is ignored for plain HTTP
+                            protocol connection. If not set the system root certificates
+                            are used to validate the TLS connection.
                           format: byte
                           type: string
                         caProvider:
-                          description: The provider for the CA bundle to use to validate Vault server certificate.
+                          description: The provider for the CA bundle to use to validate
+                            Vault server certificate.
                           properties:
                             key:
-                              description: The key the value inside of the provider type to use, only used with "Secret" type
+                              description: The key the value inside of the provider
+                                type to use, only used with "Secret" type
                               type: string
                             name:
-                              description: The name of the object located at the provider type.
+                              description: The name of the object located at the provider
+                                type.
                               type: string
                             namespace:
                               description: The namespace the Provider type is in.
                               type: string
                             type:
-                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              description: The type of provider to use such as "Secret",
+                                or "ConfigMap".
                               enum:
                                 - Secret
                                 - ConfigMap
@@ -5205,23 +6964,38 @@ spec:
                             - type
                           type: object
                         forwardInconsistent:
-                          description: ForwardInconsistent tells Vault to forward read-after-write requests to the Vault leader instead of simply retrying within a loop. This can increase performance if the option is enabled serverside. https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header
+                          description: ForwardInconsistent tells Vault to forward
+                            read-after-write requests to the Vault leader instead
+                            of simply retrying within a loop. This can increase performance
+                            if the option is enabled serverside. https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header
                           type: boolean
                         namespace:
-                          description: 'Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1". More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
+                          description: 'Name of the vault namespace. Namespaces is
+                            a set of features within Vault Enterprise that allows
+                            Vault environments to support Secure Multi-tenancy. e.g:
+                            "ns1". More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
                           type: string
                         path:
-                          description: 'Path is the mount path of the Vault KV backend endpoint, e.g: "secret". The v2 KV secret engine version specific "/data" path suffix for fetching secrets from Vault is optional and will be appended if not present in specified path.'
+                          description: 'Path is the mount path of the Vault KV backend
+                            endpoint, e.g: "secret". The v2 KV secret engine version
+                            specific "/data" path suffix for fetching secrets from
+                            Vault is optional and will be appended if not present
+                            in specified path.'
                           type: string
                         readYourWrites:
-                          description: ReadYourWrites ensures isolated read-after-write semantics by providing discovered cluster replication states in each request. More information about eventual consistency in Vault can be found here https://www.vaultproject.io/docs/enterprise/consistency
+                          description: ReadYourWrites ensures isolated read-after-write
+                            semantics by providing discovered cluster replication
+                            states in each request. More information about eventual
+                            consistency in Vault can be found here https://www.vaultproject.io/docs/enterprise/consistency
                           type: boolean
                         server:
-                          description: 'Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".'
+                          description: 'Server is the connection address for the Vault
+                            server, e.g: "https://vault.example.com:8200".'
                           type: string
                         version:
                           default: v2
-                          description: Version is the Vault KV secret engine version. This can be either "v1" or "v2". Version defaults to "v2".
+                          description: Version is the Vault KV secret engine version.
+                            This can be either "v1" or "v2". Version defaults to "v2".
                           enum:
                             - v1
                             - v2
@@ -5231,29 +7005,38 @@ spec:
                         - server
                       type: object
                     webhook:
-                      description: Webhook configures this store to sync secrets using a generic templated webhook
+                      description: Webhook configures this store to sync secrets using
+                        a generic templated webhook
                       properties:
                         body:
                           description: Body
                           type: string
                         caBundle:
-                          description: PEM encoded CA bundle used to validate webhook server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.
+                          description: PEM encoded CA bundle used to validate webhook
+                            server certificate. Only used if the Server URL is using
+                            HTTPS protocol. This parameter is ignored for plain HTTP
+                            protocol connection. If not set the system root certificates
+                            are used to validate the TLS connection.
                           format: byte
                           type: string
                         caProvider:
-                          description: The provider for the CA bundle to use to validate webhook server certificate.
+                          description: The provider for the CA bundle to use to validate
+                            webhook server certificate.
                           properties:
                             key:
-                              description: The key the value inside of the provider type to use, only used with "Secret" type
+                              description: The key the value inside of the provider
+                                type to use, only used with "Secret" type
                               type: string
                             name:
-                              description: The name of the object located at the provider type.
+                              description: The name of the object located at the provider
+                                type.
                               type: string
                             namespace:
                               description: The namespace the Provider type is in.
                               type: string
                             type:
-                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              description: The type of provider to use such as "Secret",
+                                or "ConfigMap".
                               enum:
                                 - Secret
                                 - ConfigMap
@@ -5278,7 +7061,9 @@ spec:
                               type: string
                           type: object
                         secrets:
-                          description: Secrets to fill in templates These secrets will be passed to the templating function as key value pairs under the given name
+                          description: Secrets to fill in templates These secrets
+                            will be passed to the templating function as key value
+                            pairs under the given name
                           items:
                             properties:
                               name:
@@ -5288,13 +7073,20 @@ spec:
                                 description: Secret ref to fill in credentials
                                 properties:
                                   key:
-                                    description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                    description: The key of the entry in the Secret
+                                      resource's `data` field to be used. Some instances
+                                      of this field may be defaulted, in others it
+                                      may be required.
                                     type: string
                                   name:
-                                    description: The name of the Secret resource being referred to.
+                                    description: The name of the Secret resource being
+                                      referred to.
                                     type: string
                                   namespace:
-                                    description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                    description: Namespace of the resource being referred
+                                      to. Ignored if referent is not cluster-scoped.
+                                      cluster-scoped defaults to the namespace of
+                                      the referent.
                                     type: string
                                 type: object
                             required:
@@ -5313,42 +7105,61 @@ spec:
                         - url
                       type: object
                     yandexlockbox:
-                      description: YandexLockbox configures this store to sync secrets using Yandex Lockbox provider
+                      description: YandexLockbox configures this store to sync secrets
+                        using Yandex Lockbox provider
                       properties:
                         apiEndpoint:
                           description: Yandex.Cloud API endpoint (e.g. 'api.cloud.yandex.net:443')
                           type: string
                         auth:
-                          description: Auth defines the information necessary to authenticate against Yandex Lockbox
+                          description: Auth defines the information necessary to authenticate
+                            against Yandex Lockbox
                           properties:
                             authorizedKeySecretRef:
                               description: The authorized key used for authentication
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                           type: object
                         caProvider:
-                          description: The provider for the CA bundle to use to validate Yandex.Cloud server certificate.
+                          description: The provider for the CA bundle to use to validate
+                            Yandex.Cloud server certificate.
                           properties:
                             certSecretRef:
-                              description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                              description: A reference to a specific 'key' within
+                                a Secret resource, In some instances, `key` is a required
+                                field.
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                           type: object
@@ -5412,13 +7223,19 @@ spec:
       name: v1beta1
       schema:
         openAPIV3Schema:
-          description: SecretStore represents a secure external location for storing secrets, which can be referenced as part of `storeRef` fields.
+          description: SecretStore represents a secure external location for storing
+            secrets, which can be referenced as part of `storeRef` fields.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
@@ -5426,26 +7243,40 @@ spec:
               description: SecretStoreSpec defines the desired state of SecretStore.
               properties:
                 conditions:
-                  description: Used to constraint a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore
+                  description: Used to constraint a ClusterSecretStore to specific
+                    namespaces. Relevant only to ClusterSecretStore
                   items:
-                    description: ClusterSecretStoreCondition describes a condition by which to choose namespaces to process ExternalSecrets in for a ClusterSecretStore instance.
+                    description: ClusterSecretStoreCondition describes a condition
+                      by which to choose namespaces to process ExternalSecrets in
+                      for a ClusterSecretStore instance.
                     properties:
                       namespaceSelector:
                         description: Choose namespace using a labelSelector
                         properties:
                           matchExpressions:
-                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
                             items:
-                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
                               properties:
                                 key:
-                                  description: key is the label key that the selector applies to.
+                                  description: key is the label key that the selector
+                                    applies to.
                                   type: string
                                 operator:
-                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
                                   type: string
                                 values:
-                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
                                   items:
                                     type: string
                                   type: array
@@ -5457,7 +7288,11 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
-                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
@@ -5469,57 +7304,91 @@ spec:
                     type: object
                   type: array
                 controller:
-                  description: 'Used to select the correct ESO controller (think: ingress.ingressClassName) The ESO controller is instantiated with a specific controller name and filters ES based on this property'
+                  description: 'Used to select the correct ESO controller (think:
+                    ingress.ingressClassName) The ESO controller is instantiated with
+                    a specific controller name and filters ES based on this property'
                   type: string
                 provider:
-                  description: Used to configure the provider. Only one provider may be set
+                  description: Used to configure the provider. Only one provider may
+                    be set
                   maxProperties: 1
                   minProperties: 1
                   properties:
                     akeyless:
-                      description: Akeyless configures this store to sync secrets using Akeyless Vault provider
+                      description: Akeyless configures this store to sync secrets
+                        using Akeyless Vault provider
                       properties:
                         akeylessGWApiURL:
-                          description: Akeyless GW API Url from which the secrets to be fetched from.
+                          description: Akeyless GW API Url from which the secrets
+                            to be fetched from.
                           type: string
                         authSecretRef:
-                          description: Auth configures how the operator authenticates with Akeyless.
+                          description: Auth configures how the operator authenticates
+                            with Akeyless.
                           properties:
                             kubernetesAuth:
-                              description: Kubernetes authenticates with Akeyless by passing the ServiceAccount token stored in the named Secret resource.
+                              description: Kubernetes authenticates with Akeyless
+                                by passing the ServiceAccount token stored in the
+                                named Secret resource.
                               properties:
                                 accessID:
-                                  description: the Akeyless Kubernetes auth-method access-id
+                                  description: the Akeyless Kubernetes auth-method
+                                    access-id
                                   type: string
                                 k8sConfName:
-                                  description: Kubernetes-auth configuration name in Akeyless-Gateway
+                                  description: Kubernetes-auth configuration name
+                                    in Akeyless-Gateway
                                   type: string
                                 secretRef:
-                                  description: Optional secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Akeyless. If a name is specified without a key, `token` is the default. If one is not specified, the one bound to the controller will be used.
+                                  description: Optional secret field containing a
+                                    Kubernetes ServiceAccount JWT used for authenticating
+                                    with Akeyless. If a name is specified without
+                                    a key, `token` is the default. If one is not specified,
+                                    the one bound to the controller will be used.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 serviceAccountRef:
-                                  description: Optional service account field containing the name of a kubernetes ServiceAccount. If the service account is specified, the service account secret token JWT will be used for authenticating with Akeyless. If the service account selector is not supplied, the secretRef will be used instead.
+                                  description: Optional service account field containing
+                                    the name of a kubernetes ServiceAccount. If the
+                                    service account is specified, the service account
+                                    secret token JWT will be used for authenticating
+                                    with Akeyless. If the service account selector
+                                    is not supplied, the secretRef will be used instead.
                                   properties:
                                     audiences:
-                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      description: Audience specifies the `aud` claim
+                                        for the service account token If the service
+                                        account uses a well-known annotation for e.g.
+                                        IRSA or GCP Workload Identity then this audiences
+                                        will be appended to the list
                                       items:
                                         type: string
                                       type: array
                                     name:
-                                      description: The name of the ServiceAccount resource being referred to.
+                                      description: The name of the ServiceAccount
+                                        resource being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   required:
                                     - name
@@ -5529,67 +7398,101 @@ spec:
                                 - k8sConfName
                               type: object
                             secretRef:
-                              description: Reference to a Secret that contains the details to authenticate with Akeyless.
+                              description: Reference to a Secret that contains the
+                                details to authenticate with Akeyless.
                               properties:
                                 accessID:
                                   description: The SecretAccessID is used for authentication
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 accessType:
-                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource, In some instances, `key` is
+                                    a required field.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 accessTypeParam:
-                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource, In some instances, `key` is
+                                    a required field.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               type: object
                           type: object
                         caBundle:
-                          description: PEM/base64 encoded CA bundle used to validate Akeyless Gateway certificate. Only used if the AkeylessGWApiURL URL is using HTTPS protocol. If not set the system root certificates are used to validate the TLS connection.
+                          description: PEM/base64 encoded CA bundle used to validate
+                            Akeyless Gateway certificate. Only used if the AkeylessGWApiURL
+                            URL is using HTTPS protocol. If not set the system root
+                            certificates are used to validate the TLS connection.
                           format: byte
                           type: string
                         caProvider:
-                          description: The provider for the CA bundle to use to validate Akeyless Gateway certificate.
+                          description: The provider for the CA bundle to use to validate
+                            Akeyless Gateway certificate.
                           properties:
                             key:
-                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              description: The key where the CA certificate can be
+                                found in the Secret or ConfigMap.
                               type: string
                             name:
-                              description: The name of the object located at the provider type.
+                              description: The name of the object located at the provider
+                                type.
                               type: string
                             namespace:
-                              description: The namespace the Provider type is in. Can only be defined when used in a ClusterSecretStore.
+                              description: The namespace the Provider type is in.
+                                Can only be defined when used in a ClusterSecretStore.
                               type: string
                             type:
-                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              description: The type of provider to use such as "Secret",
+                                or "ConfigMap".
                               enum:
                                 - Secret
                                 - ConfigMap
@@ -5603,7 +7506,8 @@ spec:
                         - authSecretRef
                       type: object
                     alibaba:
-                      description: Alibaba configures this store to sync secrets using Alibaba Cloud provider
+                      description: Alibaba configures this store to sync secrets using
+                        Alibaba Cloud provider
                       properties:
                         auth:
                           description: AlibabaAuth contains a secretRef for credentials.
@@ -5626,32 +7530,47 @@ spec:
                                 - sessionName
                               type: object
                             secretRef:
-                              description: AlibabaAuthSecretRef holds secret references for Alibaba credentials.
+                              description: AlibabaAuthSecretRef holds secret references
+                                for Alibaba credentials.
                               properties:
                                 accessKeyIDSecretRef:
                                   description: The AccessKeyID is used for authentication
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 accessKeySecretSecretRef:
                                   description: The AccessKeySecret is used for authentication
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               required:
@@ -5667,77 +7586,116 @@ spec:
                         - regionID
                       type: object
                     aws:
-                      description: AWS configures this store to sync secrets using AWS Secret Manager provider
+                      description: AWS configures this store to sync secrets using
+                        AWS Secret Manager provider
                       properties:
                         additionalRoles:
-                          description: AdditionalRoles is a chained list of Role ARNs which the SecretManager provider will sequentially assume before assuming Role
+                          description: AdditionalRoles is a chained list of Role ARNs
+                            which the SecretManager provider will sequentially assume
+                            before assuming Role
                           items:
                             type: string
                           type: array
                         auth:
-                          description: 'Auth defines the information necessary to authenticate against AWS if not set aws sdk will infer credentials from your environment see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                          description: 'Auth defines the information necessary to
+                            authenticate against AWS if not set aws sdk will infer
+                            credentials from your environment see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
                           properties:
                             jwt:
-                              description: Authenticate against AWS using service account tokens.
+                              description: Authenticate against AWS using service
+                                account tokens.
                               properties:
                                 serviceAccountRef:
                                   description: A reference to a ServiceAccount resource.
                                   properties:
                                     audiences:
-                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      description: Audience specifies the `aud` claim
+                                        for the service account token If the service
+                                        account uses a well-known annotation for e.g.
+                                        IRSA or GCP Workload Identity then this audiences
+                                        will be appended to the list
                                       items:
                                         type: string
                                       type: array
                                     name:
-                                      description: The name of the ServiceAccount resource being referred to.
+                                      description: The name of the ServiceAccount
+                                        resource being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   required:
                                     - name
                                   type: object
                               type: object
                             secretRef:
-                              description: AWSAuthSecretRef holds secret references for AWS credentials both AccessKeyID and SecretAccessKey must be defined in order to properly authenticate.
+                              description: AWSAuthSecretRef holds secret references
+                                for AWS credentials both AccessKeyID and SecretAccessKey
+                                must be defined in order to properly authenticate.
                               properties:
                                 accessKeyIDSecretRef:
                                   description: The AccessKeyID is used for authentication
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 secretAccessKeySecretRef:
                                   description: The SecretAccessKey is used for authentication
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 sessionTokenSecretRef:
-                                  description: 'The SessionToken used for authentication This must be defined if AccessKeyID and SecretAccessKey are temporary credentials see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html'
+                                  description: 'The SessionToken used for authentication
+                                    This must be defined if AccessKeyID and SecretAccessKey
+                                    are temporary credentials see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html'
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               type: object
@@ -5749,10 +7707,12 @@ spec:
                           description: AWS Region to be used for the provider
                           type: string
                         role:
-                          description: Role is a Role ARN which the SecretManager provider will assume
+                          description: Role is a Role ARN which the SecretManager
+                            provider will assume
                           type: string
                         service:
-                          description: Service defines which service should be used to fetch the secrets
+                          description: Service defines which service should be used
+                            to fetch the secrets
                           enum:
                             - SecretsManager
                             - ParameterStore
@@ -5771,7 +7731,8 @@ spec:
                             type: object
                           type: array
                         transitiveTagKeys:
-                          description: AWS STS assume role transitive session tags. Required when multiple rules are used with SecretStore
+                          description: AWS STS assume role transitive session tags.
+                            Required when multiple rules are used with SecretStore
                           items:
                             type: string
                           type: array
@@ -5780,41 +7741,63 @@ spec:
                         - service
                       type: object
                     azurekv:
-                      description: AzureKV configures this store to sync secrets using Azure Key Vault provider
+                      description: AzureKV configures this store to sync secrets using
+                        Azure Key Vault provider
                       properties:
                         authSecretRef:
-                          description: Auth configures how the operator authenticates with Azure. Required for ServicePrincipal auth type.
+                          description: Auth configures how the operator authenticates
+                            with Azure. Required for ServicePrincipal auth type.
                           properties:
                             clientId:
-                              description: The Azure clientId of the service principle used for authentication.
+                              description: The Azure clientId of the service principle
+                                used for authentication.
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                             clientSecret:
-                              description: The Azure ClientSecret of the service principle used for authentication.
+                              description: The Azure ClientSecret of the service principle
+                                used for authentication.
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                           type: object
                         authType:
                           default: ServicePrincipal
-                          description: 'Auth type defines how to authenticate to the keyvault service. Valid values are: - "ServicePrincipal" (default): Using a service principal (tenantId, clientId, clientSecret) - "ManagedIdentity": Using Managed Identity assigned to the pod (see aad-pod-identity)'
+                          description: 'Auth type defines how to authenticate to the
+                            keyvault service. Valid values are: - "ServicePrincipal"
+                            (default): Using a service principal (tenantId, clientId,
+                            clientSecret) - "ManagedIdentity": Using Managed Identity
+                            assigned to the pod (see aad-pod-identity)'
                           enum:
                             - ServicePrincipal
                             - ManagedIdentity
@@ -5822,7 +7805,12 @@ spec:
                           type: string
                         environmentType:
                           default: PublicCloud
-                          description: 'EnvironmentType specifies the Azure cloud environment endpoints to use for connecting and authenticating with Azure. By default it points to the public cloud AAD endpoint. The following endpoints are available, also see here: https://github.com/Azure/go-autorest/blob/main/autorest/azure/environments.go#L152 PublicCloud, USGovernmentCloud, ChinaCloud, GermanCloud'
+                          description: 'EnvironmentType specifies the Azure cloud
+                            environment endpoints to use for connecting and authenticating
+                            with Azure. By default it points to the public cloud AAD
+                            endpoint. The following endpoints are available, also
+                            see here: https://github.com/Azure/go-autorest/blob/main/autorest/azure/environments.go#L152
+                            PublicCloud, USGovernmentCloud, ChinaCloud, GermanCloud'
                           enum:
                             - PublicCloud
                             - USGovernmentCloud
@@ -5830,36 +7818,48 @@ spec:
                             - GermanCloud
                           type: string
                         identityId:
-                          description: If multiple Managed Identity is assigned to the pod, you can select the one to be used
+                          description: If multiple Managed Identity is assigned to
+                            the pod, you can select the one to be used
                           type: string
                         serviceAccountRef:
-                          description: ServiceAccountRef specified the service account that should be used when authenticating with WorkloadIdentity.
+                          description: ServiceAccountRef specified the service account
+                            that should be used when authenticating with WorkloadIdentity.
                           properties:
                             audiences:
-                              description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                              description: Audience specifies the `aud` claim for
+                                the service account token If the service account uses
+                                a well-known annotation for e.g. IRSA or GCP Workload
+                                Identity then this audiences will be appended to the
+                                list
                               items:
                                 type: string
                               type: array
                             name:
-                              description: The name of the ServiceAccount resource being referred to.
+                              description: The name of the ServiceAccount resource
+                                being referred to.
                               type: string
                             namespace:
-                              description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                              description: Namespace of the resource being referred
+                                to. Ignored if referent is not cluster-scoped. cluster-scoped
+                                defaults to the namespace of the referent.
                               type: string
                           required:
                             - name
                           type: object
                         tenantId:
-                          description: TenantID configures the Azure Tenant to send requests to. Required for ServicePrincipal auth type.
+                          description: TenantID configures the Azure Tenant to send
+                            requests to. Required for ServicePrincipal auth type.
                           type: string
                         vaultUrl:
-                          description: Vault Url from which the secrets to be fetched from.
+                          description: Vault Url from which the secrets to be fetched
+                            from.
                           type: string
                       required:
                         - vaultUrl
                       type: object
                     conjur:
-                      description: Conjur configures this store to sync secrets using conjur provider
+                      description: Conjur configures this store to sync secrets using
+                        conjur provider
                       properties:
                         auth:
                           properties:
@@ -5868,29 +7868,47 @@ spec:
                                 account:
                                   type: string
                                 apiKeyRef:
-                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource, In some instances, `key` is
+                                    a required field.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 userRef:
-                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource, In some instances, `key` is
+                                    a required field.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               required:
@@ -5903,31 +7921,51 @@ spec:
                                 account:
                                   type: string
                                 secretRef:
-                                  description: Optional SecretRef that refers to a key in a Secret resource containing JWT token to authenticate with Conjur using the JWT authentication method.
+                                  description: Optional SecretRef that refers to a
+                                    key in a Secret resource containing JWT token
+                                    to authenticate with Conjur using the JWT authentication
+                                    method.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 serviceAccountRef:
-                                  description: Optional ServiceAccountRef specifies the Kubernetes service account for which to request a token for with the `TokenRequest` API.
+                                  description: Optional ServiceAccountRef specifies
+                                    the Kubernetes service account for which to request
+                                    a token for with the `TokenRequest` API.
                                   properties:
                                     audiences:
-                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      description: Audience specifies the `aud` claim
+                                        for the service account token If the service
+                                        account uses a well-known annotation for e.g.
+                                        IRSA or GCP Workload Identity then this audiences
+                                        will be appended to the list
                                       items:
                                         type: string
                                       type: array
                                     name:
-                                      description: The name of the ServiceAccount resource being referred to.
+                                      description: The name of the ServiceAccount
+                                        resource being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   required:
                                     - name
@@ -5943,19 +7981,26 @@ spec:
                         caBundle:
                           type: string
                         caProvider:
-                          description: Used to provide custom certificate authority (CA) certificates for a secret store. The CAProvider points to a Secret or ConfigMap resource that contains a PEM-encoded certificate.
+                          description: Used to provide custom certificate authority
+                            (CA) certificates for a secret store. The CAProvider points
+                            to a Secret or ConfigMap resource that contains a PEM-encoded
+                            certificate.
                           properties:
                             key:
-                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              description: The key where the CA certificate can be
+                                found in the Secret or ConfigMap.
                               type: string
                             name:
-                              description: The name of the object located at the provider type.
+                              description: The name of the object located at the provider
+                                type.
                               type: string
                             namespace:
-                              description: The namespace the Provider type is in. Can only be defined when used in a ClusterSecretStore.
+                              description: The namespace the Provider type is in.
+                                Can only be defined when used in a ClusterSecretStore.
                               type: string
                             type:
-                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              description: The type of provider to use such as "Secret",
+                                or "ConfigMap".
                               enum:
                                 - Secret
                                 - ConfigMap
@@ -5977,47 +8022,66 @@ spec:
                           description: ClientID is the non-secret part of the credential.
                           properties:
                             secretRef:
-                              description: SecretRef references a key in a secret that will be used as value.
+                              description: SecretRef references a key in a secret
+                                that will be used as value.
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                             value:
-                              description: Value can be specified directly to set a value without using a secret.
+                              description: Value can be specified directly to set
+                                a value without using a secret.
                               type: string
                           type: object
                         clientSecret:
                           description: ClientSecret is the secret part of the credential.
                           properties:
                             secretRef:
-                              description: SecretRef references a key in a secret that will be used as value.
+                              description: SecretRef references a key in a secret
+                                that will be used as value.
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                             value:
-                              description: Value can be specified directly to set a value without using a secret.
+                              description: Value can be specified directly to set
+                                a value without using a secret.
                               type: string
                           type: object
                         tenant:
                           description: Tenant is the chosen hostname / site name.
                           type: string
                         tld:
-                          description: TLD is based on the server location that was chosen during provisioning. If unset, defaults to "com".
+                          description: TLD is based on the server location that was
+                            chosen during provisioning. If unset, defaults to "com".
                           type: string
                         urlTemplate:
                           description: URLTemplate If unset, defaults to "https://%s.secretsvaultcloud.%s/v1/%s%s".
@@ -6028,24 +8092,36 @@ spec:
                         - tenant
                       type: object
                     doppler:
-                      description: Doppler configures this store to sync secrets using the Doppler provider
+                      description: Doppler configures this store to sync secrets using
+                        the Doppler provider
                       properties:
                         auth:
-                          description: Auth configures how the Operator authenticates with the Doppler API
+                          description: Auth configures how the Operator authenticates
+                            with the Doppler API
                           properties:
                             secretRef:
                               properties:
                                 dopplerToken:
-                                  description: The DopplerToken is used for authentication. See https://docs.doppler.com/reference/api#authentication for auth token types. The Key attribute defaults to dopplerToken if not specified.
+                                  description: The DopplerToken is used for authentication.
+                                    See https://docs.doppler.com/reference/api#authentication
+                                    for auth token types. The Key attribute defaults
+                                    to dopplerToken if not specified.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               required:
@@ -6055,10 +8131,12 @@ spec:
                             - secretRef
                           type: object
                         config:
-                          description: Doppler config (required if not using a Service Token)
+                          description: Doppler config (required if not using a Service
+                            Token)
                           type: string
                         format:
-                          description: Format enables the downloading of secrets as a file (string)
+                          description: Format enables the downloading of secrets as
+                            a file (string)
                           enum:
                             - json
                             - dotnet-json
@@ -6067,7 +8145,8 @@ spec:
                             - docker
                           type: string
                         nameTransformer:
-                          description: Environment variable compatible name transforms that change secret names to a different format
+                          description: Environment variable compatible name transforms
+                            that change secret names to a different format
                           enum:
                             - upper-camel
                             - camel
@@ -6077,7 +8156,8 @@ spec:
                             - lower-kebab
                           type: string
                         project:
-                          description: Doppler project (required if not using a Service Token)
+                          description: Doppler project (required if not using a Service
+                            Token)
                           type: string
                       required:
                         - auth
@@ -6106,10 +8186,12 @@ spec:
                         - data
                       type: object
                     gcpsm:
-                      description: GCPSM configures this store to sync secrets using Google Cloud Platform Secret Manager provider
+                      description: GCPSM configures this store to sync secrets using
+                        Google Cloud Platform Secret Manager provider
                       properties:
                         auth:
-                          description: Auth defines the information necessary to authenticate against GCP
+                          description: Auth defines the information necessary to authenticate
+                            against GCP
                           properties:
                             secretRef:
                               properties:
@@ -6117,13 +8199,20 @@ spec:
                                   description: The SecretAccessKey is used for authentication
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               type: object
@@ -6139,15 +8228,23 @@ spec:
                                   description: A reference to a ServiceAccount resource.
                                   properties:
                                     audiences:
-                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      description: Audience specifies the `aud` claim
+                                        for the service account token If the service
+                                        account uses a well-known annotation for e.g.
+                                        IRSA or GCP Workload Identity then this audiences
+                                        will be appended to the list
                                       items:
                                         type: string
                                       type: array
                                     name:
-                                      description: The name of the ServiceAccount resource being referred to.
+                                      description: The name of the ServiceAccount
+                                        resource being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   required:
                                     - name
@@ -6163,10 +8260,12 @@ spec:
                           type: string
                       type: object
                     gitlab:
-                      description: GitLab configures this store to sync secrets using GitLab Variables provider
+                      description: GitLab configures this store to sync secrets using
+                        GitLab Variables provider
                       properties:
                         auth:
-                          description: Auth configures how secret-manager authenticates with a GitLab instance.
+                          description: Auth configures how secret-manager authenticates
+                            with a GitLab instance.
                           properties:
                             SecretRef:
                               properties:
@@ -6174,13 +8273,20 @@ spec:
                                   description: AccessToken is used for authentication.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               type: object
@@ -6188,35 +8294,45 @@ spec:
                             - SecretRef
                           type: object
                         environment:
-                          description: Environment environment_scope of gitlab CI/CD variables (Please see https://docs.gitlab.com/ee/ci/environments/#create-a-static-environment on how to create environments)
+                          description: Environment environment_scope of gitlab CI/CD
+                            variables (Please see https://docs.gitlab.com/ee/ci/environments/#create-a-static-environment
+                            on how to create environments)
                           type: string
                         groupIDs:
-                          description: GroupIDs specify, which gitlab groups to pull secrets from. Group secrets are read from left to right followed by the project variables.
+                          description: GroupIDs specify, which gitlab groups to pull
+                            secrets from. Group secrets are read from left to right
+                            followed by the project variables.
                           items:
                             type: string
                           type: array
                         inheritFromGroups:
-                          description: InheritFromGroups specifies whether parent groups should be discovered and checked for secrets.
+                          description: InheritFromGroups specifies whether parent
+                            groups should be discovered and checked for secrets.
                           type: boolean
                         projectID:
-                          description: ProjectID specifies a project where secrets are located.
+                          description: ProjectID specifies a project where secrets
+                            are located.
                           type: string
                         url:
-                          description: URL configures the GitLab instance URL. Defaults to https://gitlab.com/.
+                          description: URL configures the GitLab instance URL. Defaults
+                            to https://gitlab.com/.
                           type: string
                       required:
                         - auth
                       type: object
                     ibm:
-                      description: IBM configures this store to sync secrets using IBM Cloud provider
+                      description: IBM configures this store to sync secrets using
+                        IBM Cloud provider
                       properties:
                         auth:
-                          description: Auth configures how secret-manager authenticates with the IBM secrets manager.
+                          description: Auth configures how secret-manager authenticates
+                            with the IBM secrets manager.
                           maxProperties: 1
                           minProperties: 1
                           properties:
                             containerAuth:
-                              description: IBM Container-based auth with IAM Trusted Profile.
+                              description: IBM Container-based auth with IAM Trusted
+                                Profile.
                               properties:
                                 iamEndpoint:
                                   type: string
@@ -6224,7 +8340,8 @@ spec:
                                   description: the IBM Trusted Profile
                                   type: string
                                 tokenLocation:
-                                  description: Location the token is mounted on the pod
+                                  description: Location the token is mounted on the
+                                    pod
                                   type: string
                               required:
                                 - profile
@@ -6235,37 +8352,52 @@ spec:
                                   description: The SecretAccessKey is used for authentication
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               type: object
                           type: object
                         serviceUrl:
-                          description: ServiceURL is the Endpoint URL that is specific to the Secrets Manager service instance
+                          description: ServiceURL is the Endpoint URL that is specific
+                            to the Secrets Manager service instance
                           type: string
                       required:
                         - auth
                       type: object
                     keepersecurity:
-                      description: KeeperSecurity configures this store to sync secrets using the KeeperSecurity provider
+                      description: KeeperSecurity configures this store to sync secrets
+                        using the KeeperSecurity provider
                       properties:
                         authRef:
-                          description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                          description: A reference to a specific 'key' within a Secret
+                            resource, In some instances, `key` is a required field.
                           properties:
                             key:
-                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              description: The key of the entry in the Secret resource's
+                                `data` field to be used. Some instances of this field
+                                may be defaulted, in others it may be required.
                               type: string
                             name:
-                              description: The name of the Secret resource being referred to.
+                              description: The name of the Secret resource being referred
+                                to.
                               type: string
                             namespace:
-                              description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                              description: Namespace of the resource being referred
+                                to. Ignored if referent is not cluster-scoped. cluster-scoped
+                                defaults to the namespace of the referent.
                               type: string
                           type: object
                         folderID:
@@ -6275,10 +8407,12 @@ spec:
                         - folderID
                       type: object
                     kubernetes:
-                      description: Kubernetes configures this store to sync secrets using a Kubernetes cluster provider
+                      description: Kubernetes configures this store to sync secrets
+                        using a Kubernetes cluster provider
                       properties:
                         auth:
-                          description: Auth configures how secret-manager authenticates with a Kubernetes instance.
+                          description: Auth configures how secret-manager authenticates
+                            with a Kubernetes instance.
                           maxProperties: 1
                           minProperties: 1
                           properties:
@@ -6286,45 +8420,72 @@ spec:
                               description: has both clientCert and clientKey as secretKeySelector
                               properties:
                                 clientCert:
-                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource, In some instances, `key` is
+                                    a required field.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 clientKey:
-                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource, In some instances, `key` is
+                                    a required field.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               type: object
                             serviceAccount:
-                              description: points to a service account that should be used for authentication
+                              description: points to a service account that should
+                                be used for authentication
                               properties:
                                 audiences:
-                                  description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                  description: Audience specifies the `aud` claim
+                                    for the service account token If the service account
+                                    uses a well-known annotation for e.g. IRSA or
+                                    GCP Workload Identity then this audiences will
+                                    be appended to the list
                                   items:
                                     type: string
                                   type: array
                                 name:
-                                  description: The name of the ServiceAccount resource being referred to.
+                                  description: The name of the ServiceAccount resource
+                                    being referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               required:
                                 - name
@@ -6333,16 +8494,25 @@ spec:
                               description: use static token to authenticate with
                               properties:
                                 bearerToken:
-                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource, In some instances, `key` is
+                                    a required field.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               type: object
@@ -6362,16 +8532,20 @@ spec:
                               description: 'see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider'
                               properties:
                                 key:
-                                  description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                                  description: The key where the CA certificate can
+                                    be found in the Secret or ConfigMap.
                                   type: string
                                 name:
-                                  description: The name of the object located at the provider type.
+                                  description: The name of the object located at the
+                                    provider type.
                                   type: string
                                 namespace:
-                                  description: The namespace the Provider type is in. Can only be defined when used in a ClusterSecretStore.
+                                  description: The namespace the Provider type is
+                                    in. Can only be defined when used in a ClusterSecretStore.
                                   type: string
                                 type:
-                                  description: The type of provider to use such as "Secret", or "ConfigMap".
+                                  description: The type of provider to use such as
+                                    "Secret", or "ConfigMap".
                                   enum:
                                     - Secret
                                     - ConfigMap
@@ -6389,25 +8563,36 @@ spec:
                         - auth
                       type: object
                     onepassword:
-                      description: OnePassword configures this store to sync secrets using the 1Password Cloud provider
+                      description: OnePassword configures this store to sync secrets
+                        using the 1Password Cloud provider
                       properties:
                         auth:
-                          description: Auth defines the information necessary to authenticate against OnePassword Connect Server
+                          description: Auth defines the information necessary to authenticate
+                            against OnePassword Connect Server
                           properties:
                             secretRef:
-                              description: OnePasswordAuthSecretRef holds secret references for 1Password credentials.
+                              description: OnePasswordAuthSecretRef holds secret references
+                                for 1Password credentials.
                               properties:
                                 connectTokenSecretRef:
-                                  description: The ConnectToken is used for authentication to a 1Password Connect Server.
+                                  description: The ConnectToken is used for authentication
+                                    to a 1Password Connect Server.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               required:
@@ -6417,12 +8602,14 @@ spec:
                             - secretRef
                           type: object
                         connectHost:
-                          description: ConnectHost defines the OnePassword Connect Server to connect to
+                          description: ConnectHost defines the OnePassword Connect
+                            Server to connect to
                           type: string
                         vaults:
                           additionalProperties:
                             type: integer
-                          description: Vaults defines which OnePassword vaults to search in which order
+                          description: Vaults defines which OnePassword vaults to
+                            search in which order
                           type: object
                       required:
                         - auth
@@ -6430,38 +8617,57 @@ spec:
                         - vaults
                       type: object
                     oracle:
-                      description: Oracle configures this store to sync secrets using Oracle Vault provider
+                      description: Oracle configures this store to sync secrets using
+                        Oracle Vault provider
                       properties:
                         auth:
-                          description: Auth configures how secret-manager authenticates with the Oracle Vault. If empty, use the instance principal, otherwise the user credentials specified in Auth.
+                          description: Auth configures how secret-manager authenticates
+                            with the Oracle Vault. If empty, use the instance principal,
+                            otherwise the user credentials specified in Auth.
                           properties:
                             secretRef:
                               description: SecretRef to pass through sensitive information.
                               properties:
                                 fingerprint:
-                                  description: Fingerprint is the fingerprint of the API private key.
+                                  description: Fingerprint is the fingerprint of the
+                                    API private key.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 privatekey:
-                                  description: PrivateKey is the user's API Signing Key in PEM format, used for authentication.
+                                  description: PrivateKey is the user's API Signing
+                                    Key in PEM format, used for authentication.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               required:
@@ -6469,10 +8675,12 @@ spec:
                                 - privatekey
                               type: object
                             tenancy:
-                              description: Tenancy is the tenancy OCID where user is located.
+                              description: Tenancy is the tenancy OCID where user
+                                is located.
                               type: string
                             user:
-                              description: User is an access OCID specific to the account.
+                              description: User is an access OCID specific to the
+                                account.
                               type: string
                           required:
                             - secretRef
@@ -6483,7 +8691,8 @@ spec:
                           description: Region is the region where vault is located.
                           type: string
                         vault:
-                          description: Vault is the vault's OCID of the specific vault where secret is located.
+                          description: Vault is the vault's OCID of the specific vault
+                            where secret is located.
                           type: string
                       required:
                         - region
@@ -6493,52 +8702,74 @@ spec:
                       description: Scaleway
                       properties:
                         accessKey:
-                          description: AccessKey is the non-secret part of the api key.
+                          description: AccessKey is the non-secret part of the api
+                            key.
                           properties:
                             secretRef:
-                              description: SecretRef references a key in a secret that will be used as value.
+                              description: SecretRef references a key in a secret
+                                that will be used as value.
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                             value:
-                              description: Value can be specified directly to set a value without using a secret.
+                              description: Value can be specified directly to set
+                                a value without using a secret.
                               type: string
                           type: object
                         apiUrl:
-                          description: APIURL is the url of the api to use. Defaults to https://api.scaleway.com
+                          description: APIURL is the url of the api to use. Defaults
+                            to https://api.scaleway.com
                           type: string
                         projectId:
-                          description: 'ProjectID is the id of your project, which you can find in the console: https://console.scaleway.com/project/settings'
+                          description: 'ProjectID is the id of your project, which
+                            you can find in the console: https://console.scaleway.com/project/settings'
                           type: string
                         region:
                           description: 'Region where your secrets are located: https://developers.scaleway.com/en/quickstart/#region-and-zone'
                           type: string
                         secretKey:
-                          description: SecretKey is the non-secret part of the api key.
+                          description: SecretKey is the non-secret part of the api
+                            key.
                           properties:
                             secretRef:
-                              description: SecretRef references a key in a secret that will be used as value.
+                              description: SecretRef references a key in a secret
+                                that will be used as value.
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                             value:
-                              description: Value can be specified directly to set a value without using a secret.
+                              description: Value can be specified directly to set
+                                a value without using a secret.
                               type: string
                           type: object
                       required:
@@ -6548,24 +8779,35 @@ spec:
                         - secretKey
                       type: object
                     senhasegura:
-                      description: Senhasegura configures this store to sync secrets using senhasegura provider
+                      description: Senhasegura configures this store to sync secrets
+                        using senhasegura provider
                       properties:
                         auth:
-                          description: Auth defines parameters to authenticate in senhasegura
+                          description: Auth defines parameters to authenticate in
+                            senhasegura
                           properties:
                             clientId:
                               type: string
                             clientSecretSecretRef:
-                              description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                              description: A reference to a specific 'key' within
+                                a Secret resource, In some instances, `key` is a required
+                                field.
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                           required:
@@ -6574,10 +8816,12 @@ spec:
                           type: object
                         ignoreSslCertificate:
                           default: false
-                          description: IgnoreSslCertificate defines if SSL certificate must be ignored
+                          description: IgnoreSslCertificate defines if SSL certificate
+                            must be ignored
                           type: boolean
                         module:
-                          description: Module defines which senhasegura module should be used to get secrets
+                          description: Module defines which senhasegura module should
+                            be used to get secrets
                           type: string
                         url:
                           description: URL of senhasegura
@@ -6588,45 +8832,74 @@ spec:
                         - url
                       type: object
                     vault:
-                      description: Vault configures this store to sync secrets using Hashi provider
+                      description: Vault configures this store to sync secrets using
+                        Hashi provider
                       properties:
                         auth:
-                          description: Auth configures how secret-manager authenticates with the Vault server.
+                          description: Auth configures how secret-manager authenticates
+                            with the Vault server.
                           properties:
                             appRole:
-                              description: AppRole authenticates with Vault using the App Role auth mechanism, with the role and secret stored in a Kubernetes Secret resource.
+                              description: AppRole authenticates with Vault using
+                                the App Role auth mechanism, with the role and secret
+                                stored in a Kubernetes Secret resource.
                               properties:
                                 path:
                                   default: approle
-                                  description: 'Path where the App Role authentication backend is mounted in Vault, e.g: "approle"'
+                                  description: 'Path where the App Role authentication
+                                    backend is mounted in Vault, e.g: "approle"'
                                   type: string
                                 roleId:
-                                  description: RoleID configured in the App Role authentication backend when setting up the authentication backend in Vault.
+                                  description: RoleID configured in the App Role authentication
+                                    backend when setting up the authentication backend
+                                    in Vault.
                                   type: string
                                 roleRef:
-                                  description: Reference to a key in a Secret that contains the App Role ID used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role id.
+                                  description: Reference to a key in a Secret that
+                                    contains the App Role ID used to authenticate
+                                    with Vault. The `key` field must be specified
+                                    and denotes which entry within the Secret resource
+                                    is used as the app role id.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 secretRef:
-                                  description: Reference to a key in a Secret that contains the App Role secret used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role secret.
+                                  description: Reference to a key in a Secret that
+                                    contains the App Role secret used to authenticate
+                                    with Vault. The `key` field must be specified
+                                    and denotes which entry within the Secret resource
+                                    is used as the app role secret.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               required:
@@ -6634,70 +8907,105 @@ spec:
                                 - secretRef
                               type: object
                             cert:
-                              description: Cert authenticates with TLS Certificates by passing client certificate, private key and ca certificate Cert authentication method
+                              description: Cert authenticates with TLS Certificates
+                                by passing client certificate, private key and ca
+                                certificate Cert authentication method
                               properties:
                                 clientCert:
-                                  description: ClientCert is a certificate to authenticate using the Cert Vault authentication method
+                                  description: ClientCert is a certificate to authenticate
+                                    using the Cert Vault authentication method
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 secretRef:
-                                  description: SecretRef to a key in a Secret resource containing client private key to authenticate with Vault using the Cert authentication method
+                                  description: SecretRef to a key in a Secret resource
+                                    containing client private key to authenticate
+                                    with Vault using the Cert authentication method
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               type: object
                             iam:
-                              description: Iam authenticates with vault by passing a special AWS request signed with AWS IAM credentials AWS IAM authentication method
+                              description: Iam authenticates with vault by passing
+                                a special AWS request signed with AWS IAM credentials
+                                AWS IAM authentication method
                               properties:
                                 externalID:
-                                  description: AWS External ID set on assumed IAM roles
+                                  description: AWS External ID set on assumed IAM
+                                    roles
                                   type: string
                                 jwt:
-                                  description: Specify a service account with IRSA enabled
+                                  description: Specify a service account with IRSA
+                                    enabled
                                   properties:
                                     serviceAccountRef:
-                                      description: A reference to a ServiceAccount resource.
+                                      description: A reference to a ServiceAccount
+                                        resource.
                                       properties:
                                         audiences:
-                                          description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                          description: Audience specifies the `aud`
+                                            claim for the service account token If
+                                            the service account uses a well-known
+                                            annotation for e.g. IRSA or GCP Workload
+                                            Identity then this audiences will be appended
+                                            to the list
                                           items:
                                             type: string
                                           type: array
                                         name:
-                                          description: The name of the ServiceAccount resource being referred to.
+                                          description: The name of the ServiceAccount
+                                            resource being referred to.
                                           type: string
                                         namespace:
-                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          description: Namespace of the resource being
+                                            referred to. Ignored if referent is not
+                                            cluster-scoped. cluster-scoped defaults
+                                            to the namespace of the referent.
                                           type: string
                                       required:
                                         - name
                                       type: object
                                   type: object
                                 path:
-                                  description: 'Path where the AWS auth method is enabled in Vault, e.g: "aws"'
+                                  description: 'Path where the AWS auth method is
+                                    enabled in Vault, e.g: "aws"'
                                   type: string
                                 region:
                                   description: AWS region
                                   type: string
                                 role:
-                                  description: This is the AWS role to be assumed before talking to vault
+                                  description: This is the AWS role to be assumed
+                                    before talking to vault
                                   type: string
                                 secretRef:
                                   description: Specify credentials in a Secret object
@@ -6706,79 +9014,134 @@ spec:
                                       description: The AccessKeyID is used for authentication
                                       properties:
                                         key:
-                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          description: The key of the entry in the
+                                            Secret resource's `data` field to be used.
+                                            Some instances of this field may be defaulted,
+                                            in others it may be required.
                                           type: string
                                         name:
-                                          description: The name of the Secret resource being referred to.
+                                          description: The name of the Secret resource
+                                            being referred to.
                                           type: string
                                         namespace:
-                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          description: Namespace of the resource being
+                                            referred to. Ignored if referent is not
+                                            cluster-scoped. cluster-scoped defaults
+                                            to the namespace of the referent.
                                           type: string
                                       type: object
                                     secretAccessKeySecretRef:
-                                      description: The SecretAccessKey is used for authentication
+                                      description: The SecretAccessKey is used for
+                                        authentication
                                       properties:
                                         key:
-                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          description: The key of the entry in the
+                                            Secret resource's `data` field to be used.
+                                            Some instances of this field may be defaulted,
+                                            in others it may be required.
                                           type: string
                                         name:
-                                          description: The name of the Secret resource being referred to.
+                                          description: The name of the Secret resource
+                                            being referred to.
                                           type: string
                                         namespace:
-                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          description: Namespace of the resource being
+                                            referred to. Ignored if referent is not
+                                            cluster-scoped. cluster-scoped defaults
+                                            to the namespace of the referent.
                                           type: string
                                       type: object
                                     sessionTokenSecretRef:
-                                      description: 'The SessionToken used for authentication This must be defined if AccessKeyID and SecretAccessKey are temporary credentials see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html'
+                                      description: 'The SessionToken used for authentication
+                                        This must be defined if AccessKeyID and SecretAccessKey
+                                        are temporary credentials see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html'
                                       properties:
                                         key:
-                                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                          description: The key of the entry in the
+                                            Secret resource's `data` field to be used.
+                                            Some instances of this field may be defaulted,
+                                            in others it may be required.
                                           type: string
                                         name:
-                                          description: The name of the Secret resource being referred to.
+                                          description: The name of the Secret resource
+                                            being referred to.
                                           type: string
                                         namespace:
-                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          description: Namespace of the resource being
+                                            referred to. Ignored if referent is not
+                                            cluster-scoped. cluster-scoped defaults
+                                            to the namespace of the referent.
                                           type: string
                                       type: object
                                   type: object
                                 vaultAwsIamServerID:
-                                  description: 'X-Vault-AWS-IAM-Server-ID is an additional header used by Vault IAM auth method to mitigate against different types of replay attacks. More details here: https://developer.hashicorp.com/vault/docs/auth/aws'
+                                  description: 'X-Vault-AWS-IAM-Server-ID is an additional
+                                    header used by Vault IAM auth method to mitigate
+                                    against different types of replay attacks. More
+                                    details here: https://developer.hashicorp.com/vault/docs/auth/aws'
                                   type: string
                                 vaultRole:
-                                  description: Vault Role. In vault, a role describes an identity with a set of permissions, groups, or policies you want to attach a user of the secrets engine
+                                  description: Vault Role. In vault, a role describes
+                                    an identity with a set of permissions, groups,
+                                    or policies you want to attach a user of the secrets
+                                    engine
                                   type: string
                               required:
                                 - vaultRole
                               type: object
                             jwt:
-                              description: Jwt authenticates with Vault by passing role and JWT token using the JWT/OIDC authentication method
+                              description: Jwt authenticates with Vault by passing
+                                role and JWT token using the JWT/OIDC authentication
+                                method
                               properties:
                                 kubernetesServiceAccountToken:
-                                  description: Optional ServiceAccountToken specifies the Kubernetes service account for which to request a token for with the `TokenRequest` API.
+                                  description: Optional ServiceAccountToken specifies
+                                    the Kubernetes service account for which to request
+                                    a token for with the `TokenRequest` API.
                                   properties:
                                     audiences:
-                                      description: 'Optional audiences field that will be used to request a temporary Kubernetes service account token for the service account referenced by `serviceAccountRef`. Defaults to a single audience `vault` it not specified. Deprecated: use serviceAccountRef.Audiences instead'
+                                      description: 'Optional audiences field that
+                                        will be used to request a temporary Kubernetes
+                                        service account token for the service account
+                                        referenced by `serviceAccountRef`. Defaults
+                                        to a single audience `vault` it not specified.
+                                        Deprecated: use serviceAccountRef.Audiences
+                                        instead'
                                       items:
                                         type: string
                                       type: array
                                     expirationSeconds:
-                                      description: 'Optional expiration time in seconds that will be used to request a temporary Kubernetes service account token for the service account referenced by `serviceAccountRef`. Deprecated: this will be removed in the future. Defaults to 10 minutes.'
+                                      description: 'Optional expiration time in seconds
+                                        that will be used to request a temporary Kubernetes
+                                        service account token for the service account
+                                        referenced by `serviceAccountRef`. Deprecated:
+                                        this will be removed in the future. Defaults
+                                        to 10 minutes.'
                                       format: int64
                                       type: integer
                                     serviceAccountRef:
-                                      description: Service account field containing the name of a kubernetes ServiceAccount.
+                                      description: Service account field containing
+                                        the name of a kubernetes ServiceAccount.
                                       properties:
                                         audiences:
-                                          description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                          description: Audience specifies the `aud`
+                                            claim for the service account token If
+                                            the service account uses a well-known
+                                            annotation for e.g. IRSA or GCP Workload
+                                            Identity then this audiences will be appended
+                                            to the list
                                           items:
                                             type: string
                                           type: array
                                         name:
-                                          description: The name of the ServiceAccount resource being referred to.
+                                          description: The name of the ServiceAccount
+                                            resource being referred to.
                                           type: string
                                         namespace:
-                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          description: Namespace of the resource being
+                                            referred to. Ignored if referent is not
+                                            cluster-scoped. cluster-scoped defaults
+                                            to the namespace of the referent.
                                           type: string
                                       required:
                                         - name
@@ -6788,63 +9151,104 @@ spec:
                                   type: object
                                 path:
                                   default: jwt
-                                  description: 'Path where the JWT authentication backend is mounted in Vault, e.g: "jwt"'
+                                  description: 'Path where the JWT authentication
+                                    backend is mounted in Vault, e.g: "jwt"'
                                   type: string
                                 role:
-                                  description: Role is a JWT role to authenticate using the JWT/OIDC Vault authentication method
+                                  description: Role is a JWT role to authenticate
+                                    using the JWT/OIDC Vault authentication method
                                   type: string
                                 secretRef:
-                                  description: Optional SecretRef that refers to a key in a Secret resource containing JWT token to authenticate with Vault using the JWT/OIDC authentication method.
+                                  description: Optional SecretRef that refers to a
+                                    key in a Secret resource containing JWT token
+                                    to authenticate with Vault using the JWT/OIDC
+                                    authentication method.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               required:
                                 - path
                               type: object
                             kubernetes:
-                              description: Kubernetes authenticates with Vault by passing the ServiceAccount token stored in the named Secret resource to the Vault server.
+                              description: Kubernetes authenticates with Vault by
+                                passing the ServiceAccount token stored in the named
+                                Secret resource to the Vault server.
                               properties:
                                 mountPath:
                                   default: kubernetes
-                                  description: 'Path where the Kubernetes authentication backend is mounted in Vault, e.g: "kubernetes"'
+                                  description: 'Path where the Kubernetes authentication
+                                    backend is mounted in Vault, e.g: "kubernetes"'
                                   type: string
                                 role:
-                                  description: A required field containing the Vault Role to assume. A Role binds a Kubernetes ServiceAccount with a set of Vault policies.
+                                  description: A required field containing the Vault
+                                    Role to assume. A Role binds a Kubernetes ServiceAccount
+                                    with a set of Vault policies.
                                   type: string
                                 secretRef:
-                                  description: Optional secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Vault. If a name is specified without a key, `token` is the default. If one is not specified, the one bound to the controller will be used.
+                                  description: Optional secret field containing a
+                                    Kubernetes ServiceAccount JWT used for authenticating
+                                    with Vault. If a name is specified without a key,
+                                    `token` is the default. If one is not specified,
+                                    the one bound to the controller will be used.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 serviceAccountRef:
-                                  description: Optional service account field containing the name of a kubernetes ServiceAccount. If the service account is specified, the service account secret token JWT will be used for authenticating with Vault. If the service account selector is not supplied, the secretRef will be used instead.
+                                  description: Optional service account field containing
+                                    the name of a kubernetes ServiceAccount. If the
+                                    service account is specified, the service account
+                                    secret token JWT will be used for authenticating
+                                    with Vault. If the service account selector is
+                                    not supplied, the secretRef will be used instead.
                                   properties:
                                     audiences:
-                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      description: Audience specifies the `aud` claim
+                                        for the service account token If the service
+                                        account uses a well-known annotation for e.g.
+                                        IRSA or GCP Workload Identity then this audiences
+                                        will be appended to the list
                                       items:
                                         type: string
                                       type: array
                                     name:
-                                      description: The name of the ServiceAccount resource being referred to.
+                                      description: The name of the ServiceAccount
+                                        resource being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   required:
                                     - name
@@ -6854,67 +9258,102 @@ spec:
                                 - role
                               type: object
                             ldap:
-                              description: Ldap authenticates with Vault by passing username/password pair using the LDAP authentication method
+                              description: Ldap authenticates with Vault by passing
+                                username/password pair using the LDAP authentication
+                                method
                               properties:
                                 path:
                                   default: ldap
-                                  description: 'Path where the LDAP authentication backend is mounted in Vault, e.g: "ldap"'
+                                  description: 'Path where the LDAP authentication
+                                    backend is mounted in Vault, e.g: "ldap"'
                                   type: string
                                 secretRef:
-                                  description: SecretRef to a key in a Secret resource containing password for the LDAP user used to authenticate with Vault using the LDAP authentication method
+                                  description: SecretRef to a key in a Secret resource
+                                    containing password for the LDAP user used to
+                                    authenticate with Vault using the LDAP authentication
+                                    method
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 username:
-                                  description: Username is a LDAP user name used to authenticate using the LDAP Vault authentication method
+                                  description: Username is a LDAP user name used to
+                                    authenticate using the LDAP Vault authentication
+                                    method
                                   type: string
                               required:
                                 - path
                                 - username
                               type: object
                             tokenSecretRef:
-                              description: TokenSecretRef authenticates with Vault by presenting a token.
+                              description: TokenSecretRef authenticates with Vault
+                                by presenting a token.
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                             userPass:
-                              description: UserPass authenticates with Vault by passing username/password pair
+                              description: UserPass authenticates with Vault by passing
+                                username/password pair
                               properties:
                                 path:
                                   default: user
-                                  description: 'Path where the UserPassword authentication backend is mounted in Vault, e.g: "user"'
+                                  description: 'Path where the UserPassword authentication
+                                    backend is mounted in Vault, e.g: "user"'
                                   type: string
                                 secretRef:
-                                  description: SecretRef to a key in a Secret resource containing password for the user used to authenticate with Vault using the UserPass authentication method
+                                  description: SecretRef to a key in a Secret resource
+                                    containing password for the user used to authenticate
+                                    with Vault using the UserPass authentication method
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 username:
-                                  description: Username is a user name used to authenticate using the UserPass Vault authentication method
+                                  description: Username is a user name used to authenticate
+                                    using the UserPass Vault authentication method
                                   type: string
                               required:
                                 - path
@@ -6922,23 +9361,32 @@ spec:
                               type: object
                           type: object
                         caBundle:
-                          description: PEM encoded CA bundle used to validate Vault server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.
+                          description: PEM encoded CA bundle used to validate Vault
+                            server certificate. Only used if the Server URL is using
+                            HTTPS protocol. This parameter is ignored for plain HTTP
+                            protocol connection. If not set the system root certificates
+                            are used to validate the TLS connection.
                           format: byte
                           type: string
                         caProvider:
-                          description: The provider for the CA bundle to use to validate Vault server certificate.
+                          description: The provider for the CA bundle to use to validate
+                            Vault server certificate.
                           properties:
                             key:
-                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              description: The key where the CA certificate can be
+                                found in the Secret or ConfigMap.
                               type: string
                             name:
-                              description: The name of the object located at the provider type.
+                              description: The name of the object located at the provider
+                                type.
                               type: string
                             namespace:
-                              description: The namespace the Provider type is in. Can only be defined when used in a ClusterSecretStore.
+                              description: The namespace the Provider type is in.
+                                Can only be defined when used in a ClusterSecretStore.
                               type: string
                             type:
-                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              description: The type of provider to use such as "Secret",
+                                or "ConfigMap".
                               enum:
                                 - Secret
                                 - ConfigMap
@@ -6948,23 +9396,38 @@ spec:
                             - type
                           type: object
                         forwardInconsistent:
-                          description: ForwardInconsistent tells Vault to forward read-after-write requests to the Vault leader instead of simply retrying within a loop. This can increase performance if the option is enabled serverside. https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header
+                          description: ForwardInconsistent tells Vault to forward
+                            read-after-write requests to the Vault leader instead
+                            of simply retrying within a loop. This can increase performance
+                            if the option is enabled serverside. https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header
                           type: boolean
                         namespace:
-                          description: 'Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1". More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
+                          description: 'Name of the vault namespace. Namespaces is
+                            a set of features within Vault Enterprise that allows
+                            Vault environments to support Secure Multi-tenancy. e.g:
+                            "ns1". More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
                           type: string
                         path:
-                          description: 'Path is the mount path of the Vault KV backend endpoint, e.g: "secret". The v2 KV secret engine version specific "/data" path suffix for fetching secrets from Vault is optional and will be appended if not present in specified path.'
+                          description: 'Path is the mount path of the Vault KV backend
+                            endpoint, e.g: "secret". The v2 KV secret engine version
+                            specific "/data" path suffix for fetching secrets from
+                            Vault is optional and will be appended if not present
+                            in specified path.'
                           type: string
                         readYourWrites:
-                          description: ReadYourWrites ensures isolated read-after-write semantics by providing discovered cluster replication states in each request. More information about eventual consistency in Vault can be found here https://www.vaultproject.io/docs/enterprise/consistency
+                          description: ReadYourWrites ensures isolated read-after-write
+                            semantics by providing discovered cluster replication
+                            states in each request. More information about eventual
+                            consistency in Vault can be found here https://www.vaultproject.io/docs/enterprise/consistency
                           type: boolean
                         server:
-                          description: 'Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".'
+                          description: 'Server is the connection address for the Vault
+                            server, e.g: "https://vault.example.com:8200".'
                           type: string
                         version:
                           default: v2
-                          description: Version is the Vault KV secret engine version. This can be either "v1" or "v2". Version defaults to "v2".
+                          description: Version is the Vault KV secret engine version.
+                            This can be either "v1" or "v2". Version defaults to "v2".
                           enum:
                             - v1
                             - v2
@@ -6974,29 +9437,38 @@ spec:
                         - server
                       type: object
                     webhook:
-                      description: Webhook configures this store to sync secrets using a generic templated webhook
+                      description: Webhook configures this store to sync secrets using
+                        a generic templated webhook
                       properties:
                         body:
                           description: Body
                           type: string
                         caBundle:
-                          description: PEM encoded CA bundle used to validate webhook server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.
+                          description: PEM encoded CA bundle used to validate webhook
+                            server certificate. Only used if the Server URL is using
+                            HTTPS protocol. This parameter is ignored for plain HTTP
+                            protocol connection. If not set the system root certificates
+                            are used to validate the TLS connection.
                           format: byte
                           type: string
                         caProvider:
-                          description: The provider for the CA bundle to use to validate webhook server certificate.
+                          description: The provider for the CA bundle to use to validate
+                            webhook server certificate.
                           properties:
                             key:
-                              description: The key the value inside of the provider type to use, only used with "Secret" type
+                              description: The key the value inside of the provider
+                                type to use, only used with "Secret" type
                               type: string
                             name:
-                              description: The name of the object located at the provider type.
+                              description: The name of the object located at the provider
+                                type.
                               type: string
                             namespace:
                               description: The namespace the Provider type is in.
                               type: string
                             type:
-                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              description: The type of provider to use such as "Secret",
+                                or "ConfigMap".
                               enum:
                                 - Secret
                                 - ConfigMap
@@ -7021,7 +9493,9 @@ spec:
                               type: string
                           type: object
                         secrets:
-                          description: Secrets to fill in templates These secrets will be passed to the templating function as key value pairs under the given name
+                          description: Secrets to fill in templates These secrets
+                            will be passed to the templating function as key value
+                            pairs under the given name
                           items:
                             properties:
                               name:
@@ -7031,13 +9505,20 @@ spec:
                                 description: Secret ref to fill in credentials
                                 properties:
                                   key:
-                                    description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                    description: The key of the entry in the Secret
+                                      resource's `data` field to be used. Some instances
+                                      of this field may be defaulted, in others it
+                                      may be required.
                                     type: string
                                   name:
-                                    description: The name of the Secret resource being referred to.
+                                    description: The name of the Secret resource being
+                                      referred to.
                                     type: string
                                   namespace:
-                                    description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                    description: Namespace of the resource being referred
+                                      to. Ignored if referent is not cluster-scoped.
+                                      cluster-scoped defaults to the namespace of
+                                      the referent.
                                     type: string
                                 type: object
                             required:
@@ -7056,42 +9537,61 @@ spec:
                         - url
                       type: object
                     yandexcertificatemanager:
-                      description: YandexCertificateManager configures this store to sync secrets using Yandex Certificate Manager provider
+                      description: YandexCertificateManager configures this store
+                        to sync secrets using Yandex Certificate Manager provider
                       properties:
                         apiEndpoint:
                           description: Yandex.Cloud API endpoint (e.g. 'api.cloud.yandex.net:443')
                           type: string
                         auth:
-                          description: Auth defines the information necessary to authenticate against Yandex Certificate Manager
+                          description: Auth defines the information necessary to authenticate
+                            against Yandex Certificate Manager
                           properties:
                             authorizedKeySecretRef:
                               description: The authorized key used for authentication
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                           type: object
                         caProvider:
-                          description: The provider for the CA bundle to use to validate Yandex.Cloud server certificate.
+                          description: The provider for the CA bundle to use to validate
+                            Yandex.Cloud server certificate.
                           properties:
                             certSecretRef:
-                              description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                              description: A reference to a specific 'key' within
+                                a Secret resource, In some instances, `key` is a required
+                                field.
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                           type: object
@@ -7099,42 +9599,61 @@ spec:
                         - auth
                       type: object
                     yandexlockbox:
-                      description: YandexLockbox configures this store to sync secrets using Yandex Lockbox provider
+                      description: YandexLockbox configures this store to sync secrets
+                        using Yandex Lockbox provider
                       properties:
                         apiEndpoint:
                           description: Yandex.Cloud API endpoint (e.g. 'api.cloud.yandex.net:443')
                           type: string
                         auth:
-                          description: Auth defines the information necessary to authenticate against Yandex Lockbox
+                          description: Auth defines the information necessary to authenticate
+                            against Yandex Lockbox
                           properties:
                             authorizedKeySecretRef:
                               description: The authorized key used for authentication
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                           type: object
                         caProvider:
-                          description: The provider for the CA bundle to use to validate Yandex.Cloud server certificate.
+                          description: The provider for the CA bundle to use to validate
+                            Yandex.Cloud server certificate.
                           properties:
                             certSecretRef:
-                              description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                              description: A reference to a specific 'key' within
+                                a Secret resource, In some instances, `key` is a required
+                                field.
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                           type: object
@@ -7143,7 +9662,8 @@ spec:
                       type: object
                   type: object
                 refreshInterval:
-                  description: Used to configure store refresh interval in seconds. Empty or 0 will default to the controller config.
+                  description: Used to configure store refresh interval in seconds.
+                    Empty or 0 will default to the controller config.
                   type: integer
                 retrySettings:
                   description: Used to configure http retries if failed
@@ -7161,7 +9681,8 @@ spec:
               description: SecretStoreStatus defines the observed state of the SecretStore.
               properties:
                 capabilities:
-                  description: SecretStoreCapabilities defines the possible operations a SecretStore can do.
+                  description: SecretStoreCapabilities defines the possible operations
+                    a SecretStore can do.
                   type: string
                 conditions:
                   items:
@@ -7221,58 +9742,88 @@ spec:
     - name: v1alpha1
       schema:
         openAPIV3Schema:
-          description: "ACRAccessToken returns a Azure Container Registry token that can be used for pushing/pulling images. Note: by default it will return an ACR Refresh Token with full access (depending on the identity). This can be scoped down to the repository level using .spec.scope. In case scope is defined it will return an ACR Access Token. \n See docs: https://github.com/Azure/acr/blob/main/docs/AAD-OAuth.md"
+          description: "ACRAccessToken returns a Azure Container Registry token that\
+            \ can be used for pushing/pulling images. Note: by default it will return\
+            \ an ACR Refresh Token with full access (depending on the identity). This\
+            \ can be scoped down to the repository level using .spec.scope. In case\
+            \ scope is defined it will return an ACR Access Token. \n See docs: https://github.com/Azure/acr/blob/main/docs/AAD-OAuth.md"
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
             spec:
-              description: 'ACRAccessTokenSpec defines how to generate the access token e.g. how to authenticate and which registry to use. see: https://github.com/Azure/acr/blob/main/docs/AAD-OAuth.md#overview'
+              description: 'ACRAccessTokenSpec defines how to generate the access
+                token e.g. how to authenticate and which registry to use. see: https://github.com/Azure/acr/blob/main/docs/AAD-OAuth.md#overview'
               properties:
                 auth:
                   properties:
                     managedIdentity:
-                      description: ManagedIdentity uses Azure Managed Identity to authenticate with Azure.
+                      description: ManagedIdentity uses Azure Managed Identity to
+                        authenticate with Azure.
                       properties:
                         identityId:
-                          description: If multiple Managed Identity is assigned to the pod, you can select the one to be used
+                          description: If multiple Managed Identity is assigned to
+                            the pod, you can select the one to be used
                           type: string
                       type: object
                     servicePrincipal:
-                      description: ServicePrincipal uses Azure Service Principal credentials to authenticate with Azure.
+                      description: ServicePrincipal uses Azure Service Principal credentials
+                        to authenticate with Azure.
                       properties:
                         secretRef:
-                          description: Configuration used to authenticate with Azure using static credentials stored in a Kind=Secret.
+                          description: Configuration used to authenticate with Azure
+                            using static credentials stored in a Kind=Secret.
                           properties:
                             clientId:
-                              description: The Azure clientId of the service principle used for authentication.
+                              description: The Azure clientId of the service principle
+                                used for authentication.
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                             clientSecret:
-                              description: The Azure ClientSecret of the service principle used for authentication.
+                              description: The Azure ClientSecret of the service principle
+                                used for authentication.
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                           type: object
@@ -7280,21 +9831,30 @@ spec:
                         - secretRef
                       type: object
                     workloadIdentity:
-                      description: WorkloadIdentity uses Azure Workload Identity to authenticate with Azure.
+                      description: WorkloadIdentity uses Azure Workload Identity to
+                        authenticate with Azure.
                       properties:
                         serviceAccountRef:
-                          description: ServiceAccountRef specified the service account that should be used when authenticating with WorkloadIdentity.
+                          description: ServiceAccountRef specified the service account
+                            that should be used when authenticating with WorkloadIdentity.
                           properties:
                             audiences:
-                              description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                              description: Audience specifies the `aud` claim for
+                                the service account token If the service account uses
+                                a well-known annotation for e.g. IRSA or GCP Workload
+                                Identity then this audiences will be appended to the
+                                list
                               items:
                                 type: string
                               type: array
                             name:
-                              description: The name of the ServiceAccount resource being referred to.
+                              description: The name of the ServiceAccount resource
+                                being referred to.
                               type: string
                             namespace:
-                              description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                              description: Namespace of the resource being referred
+                                to. Ignored if referent is not cluster-scoped. cluster-scoped
+                                defaults to the namespace of the referent.
                               type: string
                           required:
                             - name
@@ -7303,7 +9863,11 @@ spec:
                   type: object
                 environmentType:
                   default: PublicCloud
-                  description: 'EnvironmentType specifies the Azure cloud environment endpoints to use for connecting and authenticating with Azure. By default it points to the public cloud AAD endpoint. The following endpoints are available, also see here: https://github.com/Azure/go-autorest/blob/main/autorest/azure/environments.go#L152 PublicCloud, USGovernmentCloud, ChinaCloud, GermanCloud'
+                  description: 'EnvironmentType specifies the Azure cloud environment
+                    endpoints to use for connecting and authenticating with Azure.
+                    By default it points to the public cloud AAD endpoint. The following
+                    endpoints are available, also see here: https://github.com/Azure/go-autorest/blob/main/autorest/azure/environments.go#L152
+                    PublicCloud, USGovernmentCloud, ChinaCloud, GermanCloud'
                   enum:
                     - PublicCloud
                     - USGovernmentCloud
@@ -7314,10 +9878,16 @@ spec:
                   description: the domain name of the ACR registry e.g. foobarexample.azurecr.io
                   type: string
                 scope:
-                  description: "Define the scope for the access token, e.g. pull/push access for a repository. if not provided it will return a refresh token that has full scope. Note: you need to pin it down to the repository level, there is no wildcard available. \n examples: repository:my-repository:pull,push repository:my-repository:pull \n see docs for details: https://docs.docker.com/registry/spec/auth/scope/"
+                  description: "Define the scope for the access token, e.g. pull/push\
+                    \ access for a repository. if not provided it will return a refresh\
+                    \ token that has full scope. Note: you need to pin it down to\
+                    \ the repository level, there is no wildcard available. \n examples:\
+                    \ repository:my-repository:pull,push repository:my-repository:pull\
+                    \ \n see docs for details: https://docs.docker.com/registry/spec/auth/scope/"
                   type: string
                 tenantId:
-                  description: TenantID configures the Azure Tenant to send requests to. Required for ServicePrincipal auth type.
+                  description: TenantID configures the Azure Tenant to send requests
+                    to. Required for ServicePrincipal auth type.
                   type: string
               required:
                 - auth
@@ -7361,13 +9931,23 @@ spec:
     - name: v1alpha1
       schema:
         openAPIV3Schema:
-          description: ECRAuthorizationTokenSpec uses the GetAuthorizationToken API to retrieve an authorization token. The authorization token is valid for 12 hours. The authorizationToken returned is a base64 encoded string that can be decoded and used in a docker login command to authenticate to a registry. For more information, see Registry authentication (https://docs.aws.amazon.com/AmazonECR/latest/userguide/Registries.html#registry_auth) in the Amazon Elastic Container Registry User Guide.
+          description: ECRAuthorizationTokenSpec uses the GetAuthorizationToken API
+            to retrieve an authorization token. The authorization token is valid for
+            12 hours. The authorizationToken returned is a base64 encoded string that
+            can be decoded and used in a docker login command to authenticate to a
+            registry. For more information, see Registry authentication (https://docs.aws.amazon.com/AmazonECR/latest/userguide/Registries.html#registry_auth)
+            in the Amazon Elastic Container Registry User Guide.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
@@ -7377,66 +9957,93 @@ spec:
                   description: Auth defines how to authenticate with AWS
                   properties:
                     jwt:
-                      description: Authenticate against AWS using service account tokens.
+                      description: Authenticate against AWS using service account
+                        tokens.
                       properties:
                         serviceAccountRef:
                           description: A reference to a ServiceAccount resource.
                           properties:
                             audiences:
-                              description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                              description: Audience specifies the `aud` claim for
+                                the service account token If the service account uses
+                                a well-known annotation for e.g. IRSA or GCP Workload
+                                Identity then this audiences will be appended to the
+                                list
                               items:
                                 type: string
                               type: array
                             name:
-                              description: The name of the ServiceAccount resource being referred to.
+                              description: The name of the ServiceAccount resource
+                                being referred to.
                               type: string
                             namespace:
-                              description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                              description: Namespace of the resource being referred
+                                to. Ignored if referent is not cluster-scoped. cluster-scoped
+                                defaults to the namespace of the referent.
                               type: string
                           required:
                             - name
                           type: object
                       type: object
                     secretRef:
-                      description: AWSAuthSecretRef holds secret references for AWS credentials both AccessKeyID and SecretAccessKey must be defined in order to properly authenticate.
+                      description: AWSAuthSecretRef holds secret references for AWS
+                        credentials both AccessKeyID and SecretAccessKey must be defined
+                        in order to properly authenticate.
                       properties:
                         accessKeyIDSecretRef:
                           description: The AccessKeyID is used for authentication
                           properties:
                             key:
-                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              description: The key of the entry in the Secret resource's
+                                `data` field to be used. Some instances of this field
+                                may be defaulted, in others it may be required.
                               type: string
                             name:
-                              description: The name of the Secret resource being referred to.
+                              description: The name of the Secret resource being referred
+                                to.
                               type: string
                             namespace:
-                              description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                              description: Namespace of the resource being referred
+                                to. Ignored if referent is not cluster-scoped. cluster-scoped
+                                defaults to the namespace of the referent.
                               type: string
                           type: object
                         secretAccessKeySecretRef:
                           description: The SecretAccessKey is used for authentication
                           properties:
                             key:
-                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              description: The key of the entry in the Secret resource's
+                                `data` field to be used. Some instances of this field
+                                may be defaulted, in others it may be required.
                               type: string
                             name:
-                              description: The name of the Secret resource being referred to.
+                              description: The name of the Secret resource being referred
+                                to.
                               type: string
                             namespace:
-                              description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                              description: Namespace of the resource being referred
+                                to. Ignored if referent is not cluster-scoped. cluster-scoped
+                                defaults to the namespace of the referent.
                               type: string
                           type: object
                         sessionTokenSecretRef:
-                          description: 'The SessionToken used for authentication This must be defined if AccessKeyID and SecretAccessKey are temporary credentials see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html'
+                          description: 'The SessionToken used for authentication This
+                            must be defined if AccessKeyID and SecretAccessKey are
+                            temporary credentials see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html'
                           properties:
                             key:
-                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              description: The key of the entry in the Secret resource's
+                                `data` field to be used. Some instances of this field
+                                may be defaulted, in others it may be required.
                               type: string
                             name:
-                              description: The name of the Secret resource being referred to.
+                              description: The name of the Secret resource being referred
+                                to.
                               type: string
                             namespace:
-                              description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                              description: Namespace of the resource being referred
+                                to. Ignored if referent is not cluster-scoped. cluster-scoped
+                                defaults to the namespace of the referent.
                               type: string
                           type: object
                       type: object
@@ -7445,7 +10052,8 @@ spec:
                   description: Region specifies the region to operate in.
                   type: string
                 role:
-                  description: You can assume a role before making calls to the desired AWS service.
+                  description: You can assume a role before making calls to the desired
+                    AWS service.
                   type: string
               required:
                 - region
@@ -7488,13 +10096,19 @@ spec:
     - name: v1alpha1
       schema:
         openAPIV3Schema:
-          description: Fake generator is used for testing. It lets you define a static set of credentials that is always returned.
+          description: Fake generator is used for testing. It lets you define a static
+            set of credentials that is always returned.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
@@ -7502,7 +10116,9 @@ spec:
               description: FakeSpec contains the static data.
               properties:
                 controller:
-                  description: 'Used to select the correct ESO controller (think: ingress.ingressClassName) The ESO controller is instantiated with a specific controller name and filters VDS based on this property'
+                  description: 'Used to select the correct ESO controller (think:
+                    ingress.ingressClassName) The ESO controller is instantiated with
+                    a specific controller name and filters VDS based on this property'
                   type: string
                 data:
                   additionalProperties:
@@ -7548,13 +10164,19 @@ spec:
     - name: v1alpha1
       schema:
         openAPIV3Schema:
-          description: GCRAccessToken generates an GCP access token that can be used to authenticate with GCR.
+          description: GCRAccessToken generates an GCP access token that can be used
+            to authenticate with GCR.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
@@ -7569,13 +10191,18 @@ spec:
                           description: The SecretAccessKey is used for authentication
                           properties:
                             key:
-                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              description: The key of the entry in the Secret resource's
+                                `data` field to be used. Some instances of this field
+                                may be defaulted, in others it may be required.
                               type: string
                             name:
-                              description: The name of the Secret resource being referred to.
+                              description: The name of the Secret resource being referred
+                                to.
                               type: string
                             namespace:
-                              description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                              description: Namespace of the resource being referred
+                                to. Ignored if referent is not cluster-scoped. cluster-scoped
+                                defaults to the namespace of the referent.
                               type: string
                           type: object
                       type: object
@@ -7591,15 +10218,22 @@ spec:
                           description: A reference to a ServiceAccount resource.
                           properties:
                             audiences:
-                              description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                              description: Audience specifies the `aud` claim for
+                                the service account token If the service account uses
+                                a well-known annotation for e.g. IRSA or GCP Workload
+                                Identity then this audiences will be appended to the
+                                list
                               items:
                                 type: string
                               type: array
                             name:
-                              description: The name of the ServiceAccount resource being referred to.
+                              description: The name of the ServiceAccount resource
+                                being referred to.
                               type: string
                             namespace:
-                              description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                              description: Namespace of the resource being referred
+                                to. Ignored if referent is not cluster-scoped. cluster-scoped
+                                defaults to the namespace of the referent.
                               type: string
                           required:
                             - name
@@ -7611,7 +10245,8 @@ spec:
                       type: object
                   type: object
                 projectID:
-                  description: ProjectID defines which project to use to authenticate with
+                  description: ProjectID defines which project to use to authenticate
+                    with
                   type: string
               required:
                 - auth
@@ -7655,13 +10290,20 @@ spec:
     - name: v1alpha1
       schema:
         openAPIV3Schema:
-          description: Password generates a random password based on the configuration parameters in spec. You can specify the length, characterset and other attributes.
+          description: Password generates a random password based on the configuration
+            parameters in spec. You can specify the length, characterset and other
+            attributes.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
@@ -7673,21 +10315,26 @@ spec:
                   description: set AllowRepeat to true to allow repeating characters.
                   type: boolean
                 digits:
-                  description: Digits specifies the number of digits in the generated password. If omitted it defaults to 25% of the length of the password
+                  description: Digits specifies the number of digits in the generated
+                    password. If omitted it defaults to 25% of the length of the password
                   type: integer
                 length:
                   default: 24
-                  description: Length of the password to be generated. Defaults to 24
+                  description: Length of the password to be generated. Defaults to
+                    24
                   type: integer
                 noUpper:
                   default: false
                   description: Set NoUpper to disable uppercase characters
                   type: boolean
                 symbolCharacters:
-                  description: SymbolCharacters specifies the special characters that should be used in the generated password.
+                  description: SymbolCharacters specifies the special characters that
+                    should be used in the generated password.
                   type: string
                 symbols:
-                  description: Symbols specifies the number of symbol characters in the generated password. If omitted it defaults to 25% of the length of the password
+                  description: Symbols specifies the number of symbol characters in
+                    the generated password. If omitted it defaults to 25% of the length
+                    of the password
                   type: integer
               required:
                 - allowRepeat
@@ -7734,17 +10381,24 @@ spec:
         openAPIV3Schema:
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
             spec:
               properties:
                 controller:
-                  description: 'Used to select the correct ESO controller (think: ingress.ingressClassName) The ESO controller is instantiated with a specific controller name and filters VDS based on this property'
+                  description: 'Used to select the correct ESO controller (think:
+                    ingress.ingressClassName) The ESO controller is instantiated with
+                    a specific controller name and filters VDS based on this property'
                   type: string
                 method:
                   description: Vault API method to use (GET/POST/other)
@@ -7759,42 +10413,70 @@ spec:
                   description: Vault provider common spec
                   properties:
                     auth:
-                      description: Auth configures how secret-manager authenticates with the Vault server.
+                      description: Auth configures how secret-manager authenticates
+                        with the Vault server.
                       properties:
                         appRole:
-                          description: AppRole authenticates with Vault using the App Role auth mechanism, with the role and secret stored in a Kubernetes Secret resource.
+                          description: AppRole authenticates with Vault using the
+                            App Role auth mechanism, with the role and secret stored
+                            in a Kubernetes Secret resource.
                           properties:
                             path:
                               default: approle
-                              description: 'Path where the App Role authentication backend is mounted in Vault, e.g: "approle"'
+                              description: 'Path where the App Role authentication
+                                backend is mounted in Vault, e.g: "approle"'
                               type: string
                             roleId:
-                              description: RoleID configured in the App Role authentication backend when setting up the authentication backend in Vault.
+                              description: RoleID configured in the App Role authentication
+                                backend when setting up the authentication backend
+                                in Vault.
                               type: string
                             roleRef:
-                              description: Reference to a key in a Secret that contains the App Role ID used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role id.
+                              description: Reference to a key in a Secret that contains
+                                the App Role ID used to authenticate with Vault. The
+                                `key` field must be specified and denotes which entry
+                                within the Secret resource is used as the app role
+                                id.
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                             secretRef:
-                              description: Reference to a key in a Secret that contains the App Role secret used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role secret.
+                              description: Reference to a key in a Secret that contains
+                                the App Role secret used to authenticate with Vault.
+                                The `key` field must be specified and denotes which
+                                entry within the Secret resource is used as the app
+                                role secret.
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                           required:
@@ -7802,37 +10484,58 @@ spec:
                             - secretRef
                           type: object
                         cert:
-                          description: Cert authenticates with TLS Certificates by passing client certificate, private key and ca certificate Cert authentication method
+                          description: Cert authenticates with TLS Certificates by
+                            passing client certificate, private key and ca certificate
+                            Cert authentication method
                           properties:
                             clientCert:
-                              description: ClientCert is a certificate to authenticate using the Cert Vault authentication method
+                              description: ClientCert is a certificate to authenticate
+                                using the Cert Vault authentication method
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                             secretRef:
-                              description: SecretRef to a key in a Secret resource containing client private key to authenticate with Vault using the Cert authentication method
+                              description: SecretRef to a key in a Secret resource
+                                containing client private key to authenticate with
+                                Vault using the Cert authentication method
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                           type: object
                         iam:
-                          description: Iam authenticates with vault by passing a special AWS request signed with AWS IAM credentials AWS IAM authentication method
+                          description: Iam authenticates with vault by passing a special
+                            AWS request signed with AWS IAM credentials AWS IAM authentication
+                            method
                           properties:
                             externalID:
                               description: AWS External ID set on assumed IAM roles
@@ -7844,28 +10547,38 @@ spec:
                                   description: A reference to a ServiceAccount resource.
                                   properties:
                                     audiences:
-                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      description: Audience specifies the `aud` claim
+                                        for the service account token If the service
+                                        account uses a well-known annotation for e.g.
+                                        IRSA or GCP Workload Identity then this audiences
+                                        will be appended to the list
                                       items:
                                         type: string
                                       type: array
                                     name:
-                                      description: The name of the ServiceAccount resource being referred to.
+                                      description: The name of the ServiceAccount
+                                        resource being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   required:
                                     - name
                                   type: object
                               type: object
                             path:
-                              description: 'Path where the AWS auth method is enabled in Vault, e.g: "aws"'
+                              description: 'Path where the AWS auth method is enabled
+                                in Vault, e.g: "aws"'
                               type: string
                             region:
                               description: AWS region
                               type: string
                             role:
-                              description: This is the AWS role to be assumed before talking to vault
+                              description: This is the AWS role to be assumed before
+                                talking to vault
                               type: string
                             secretRef:
                               description: Specify credentials in a Secret object
@@ -7874,79 +10587,130 @@ spec:
                                   description: The AccessKeyID is used for authentication
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 secretAccessKeySecretRef:
                                   description: The SecretAccessKey is used for authentication
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                                 sessionTokenSecretRef:
-                                  description: 'The SessionToken used for authentication This must be defined if AccessKeyID and SecretAccessKey are temporary credentials see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html'
+                                  description: 'The SessionToken used for authentication
+                                    This must be defined if AccessKeyID and SecretAccessKey
+                                    are temporary credentials see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html'
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
                                       type: string
                                     name:
-                                      description: The name of the Secret resource being referred to.
+                                      description: The name of the Secret resource
+                                        being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   type: object
                               type: object
                             vaultAwsIamServerID:
-                              description: 'X-Vault-AWS-IAM-Server-ID is an additional header used by Vault IAM auth method to mitigate against different types of replay attacks. More details here: https://developer.hashicorp.com/vault/docs/auth/aws'
+                              description: 'X-Vault-AWS-IAM-Server-ID is an additional
+                                header used by Vault IAM auth method to mitigate against
+                                different types of replay attacks. More details here:
+                                https://developer.hashicorp.com/vault/docs/auth/aws'
                               type: string
                             vaultRole:
-                              description: Vault Role. In vault, a role describes an identity with a set of permissions, groups, or policies you want to attach a user of the secrets engine
+                              description: Vault Role. In vault, a role describes
+                                an identity with a set of permissions, groups, or
+                                policies you want to attach a user of the secrets
+                                engine
                               type: string
                           required:
                             - vaultRole
                           type: object
                         jwt:
-                          description: Jwt authenticates with Vault by passing role and JWT token using the JWT/OIDC authentication method
+                          description: Jwt authenticates with Vault by passing role
+                            and JWT token using the JWT/OIDC authentication method
                           properties:
                             kubernetesServiceAccountToken:
-                              description: Optional ServiceAccountToken specifies the Kubernetes service account for which to request a token for with the `TokenRequest` API.
+                              description: Optional ServiceAccountToken specifies
+                                the Kubernetes service account for which to request
+                                a token for with the `TokenRequest` API.
                               properties:
                                 audiences:
-                                  description: 'Optional audiences field that will be used to request a temporary Kubernetes service account token for the service account referenced by `serviceAccountRef`. Defaults to a single audience `vault` it not specified. Deprecated: use serviceAccountRef.Audiences instead'
+                                  description: 'Optional audiences field that will
+                                    be used to request a temporary Kubernetes service
+                                    account token for the service account referenced
+                                    by `serviceAccountRef`. Defaults to a single audience
+                                    `vault` it not specified. Deprecated: use serviceAccountRef.Audiences
+                                    instead'
                                   items:
                                     type: string
                                   type: array
                                 expirationSeconds:
-                                  description: 'Optional expiration time in seconds that will be used to request a temporary Kubernetes service account token for the service account referenced by `serviceAccountRef`. Deprecated: this will be removed in the future. Defaults to 10 minutes.'
+                                  description: 'Optional expiration time in seconds
+                                    that will be used to request a temporary Kubernetes
+                                    service account token for the service account
+                                    referenced by `serviceAccountRef`. Deprecated:
+                                    this will be removed in the future. Defaults to
+                                    10 minutes.'
                                   format: int64
                                   type: integer
                                 serviceAccountRef:
-                                  description: Service account field containing the name of a kubernetes ServiceAccount.
+                                  description: Service account field containing the
+                                    name of a kubernetes ServiceAccount.
                                   properties:
                                     audiences:
-                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      description: Audience specifies the `aud` claim
+                                        for the service account token If the service
+                                        account uses a well-known annotation for e.g.
+                                        IRSA or GCP Workload Identity then this audiences
+                                        will be appended to the list
                                       items:
                                         type: string
                                       type: array
                                     name:
-                                      description: The name of the ServiceAccount resource being referred to.
+                                      description: The name of the ServiceAccount
+                                        resource being referred to.
                                       type: string
                                     namespace:
-                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      description: Namespace of the resource being
+                                        referred to. Ignored if referent is not cluster-scoped.
+                                        cluster-scoped defaults to the namespace of
+                                        the referent.
                                       type: string
                                   required:
                                     - name
@@ -7956,63 +10720,103 @@ spec:
                               type: object
                             path:
                               default: jwt
-                              description: 'Path where the JWT authentication backend is mounted in Vault, e.g: "jwt"'
+                              description: 'Path where the JWT authentication backend
+                                is mounted in Vault, e.g: "jwt"'
                               type: string
                             role:
-                              description: Role is a JWT role to authenticate using the JWT/OIDC Vault authentication method
+                              description: Role is a JWT role to authenticate using
+                                the JWT/OIDC Vault authentication method
                               type: string
                             secretRef:
-                              description: Optional SecretRef that refers to a key in a Secret resource containing JWT token to authenticate with Vault using the JWT/OIDC authentication method.
+                              description: Optional SecretRef that refers to a key
+                                in a Secret resource containing JWT token to authenticate
+                                with Vault using the JWT/OIDC authentication method.
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                           required:
                             - path
                           type: object
                         kubernetes:
-                          description: Kubernetes authenticates with Vault by passing the ServiceAccount token stored in the named Secret resource to the Vault server.
+                          description: Kubernetes authenticates with Vault by passing
+                            the ServiceAccount token stored in the named Secret resource
+                            to the Vault server.
                           properties:
                             mountPath:
                               default: kubernetes
-                              description: 'Path where the Kubernetes authentication backend is mounted in Vault, e.g: "kubernetes"'
+                              description: 'Path where the Kubernetes authentication
+                                backend is mounted in Vault, e.g: "kubernetes"'
                               type: string
                             role:
-                              description: A required field containing the Vault Role to assume. A Role binds a Kubernetes ServiceAccount with a set of Vault policies.
+                              description: A required field containing the Vault Role
+                                to assume. A Role binds a Kubernetes ServiceAccount
+                                with a set of Vault policies.
                               type: string
                             secretRef:
-                              description: Optional secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Vault. If a name is specified without a key, `token` is the default. If one is not specified, the one bound to the controller will be used.
+                              description: Optional secret field containing a Kubernetes
+                                ServiceAccount JWT used for authenticating with Vault.
+                                If a name is specified without a key, `token` is the
+                                default. If one is not specified, the one bound to
+                                the controller will be used.
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                             serviceAccountRef:
-                              description: Optional service account field containing the name of a kubernetes ServiceAccount. If the service account is specified, the service account secret token JWT will be used for authenticating with Vault. If the service account selector is not supplied, the secretRef will be used instead.
+                              description: Optional service account field containing
+                                the name of a kubernetes ServiceAccount. If the service
+                                account is specified, the service account secret token
+                                JWT will be used for authenticating with Vault. If
+                                the service account selector is not supplied, the
+                                secretRef will be used instead.
                               properties:
                                 audiences:
-                                  description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                  description: Audience specifies the `aud` claim
+                                    for the service account token If the service account
+                                    uses a well-known annotation for e.g. IRSA or
+                                    GCP Workload Identity then this audiences will
+                                    be appended to the list
                                   items:
                                     type: string
                                   type: array
                                 name:
-                                  description: The name of the ServiceAccount resource being referred to.
+                                  description: The name of the ServiceAccount resource
+                                    being referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               required:
                                 - name
@@ -8022,67 +10826,97 @@ spec:
                             - role
                           type: object
                         ldap:
-                          description: Ldap authenticates with Vault by passing username/password pair using the LDAP authentication method
+                          description: Ldap authenticates with Vault by passing username/password
+                            pair using the LDAP authentication method
                           properties:
                             path:
                               default: ldap
-                              description: 'Path where the LDAP authentication backend is mounted in Vault, e.g: "ldap"'
+                              description: 'Path where the LDAP authentication backend
+                                is mounted in Vault, e.g: "ldap"'
                               type: string
                             secretRef:
-                              description: SecretRef to a key in a Secret resource containing password for the LDAP user used to authenticate with Vault using the LDAP authentication method
+                              description: SecretRef to a key in a Secret resource
+                                containing password for the LDAP user used to authenticate
+                                with Vault using the LDAP authentication method
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                             username:
-                              description: Username is a LDAP user name used to authenticate using the LDAP Vault authentication method
+                              description: Username is a LDAP user name used to authenticate
+                                using the LDAP Vault authentication method
                               type: string
                           required:
                             - path
                             - username
                           type: object
                         tokenSecretRef:
-                          description: TokenSecretRef authenticates with Vault by presenting a token.
+                          description: TokenSecretRef authenticates with Vault by
+                            presenting a token.
                           properties:
                             key:
-                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              description: The key of the entry in the Secret resource's
+                                `data` field to be used. Some instances of this field
+                                may be defaulted, in others it may be required.
                               type: string
                             name:
-                              description: The name of the Secret resource being referred to.
+                              description: The name of the Secret resource being referred
+                                to.
                               type: string
                             namespace:
-                              description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                              description: Namespace of the resource being referred
+                                to. Ignored if referent is not cluster-scoped. cluster-scoped
+                                defaults to the namespace of the referent.
                               type: string
                           type: object
                         userPass:
-                          description: UserPass authenticates with Vault by passing username/password pair
+                          description: UserPass authenticates with Vault by passing
+                            username/password pair
                           properties:
                             path:
                               default: user
-                              description: 'Path where the UserPassword authentication backend is mounted in Vault, e.g: "user"'
+                              description: 'Path where the UserPassword authentication
+                                backend is mounted in Vault, e.g: "user"'
                               type: string
                             secretRef:
-                              description: SecretRef to a key in a Secret resource containing password for the user used to authenticate with Vault using the UserPass authentication method
+                              description: SecretRef to a key in a Secret resource
+                                containing password for the user used to authenticate
+                                with Vault using the UserPass authentication method
                               properties:
                                 key:
-                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  description: The key of the entry in the Secret
+                                    resource's `data` field to be used. Some instances
+                                    of this field may be defaulted, in others it may
+                                    be required.
                                   type: string
                                 name:
-                                  description: The name of the Secret resource being referred to.
+                                  description: The name of the Secret resource being
+                                    referred to.
                                   type: string
                                 namespace:
-                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  description: Namespace of the resource being referred
+                                    to. Ignored if referent is not cluster-scoped.
+                                    cluster-scoped defaults to the namespace of the
+                                    referent.
                                   type: string
                               type: object
                             username:
-                              description: Username is a user name used to authenticate using the UserPass Vault authentication method
+                              description: Username is a user name used to authenticate
+                                using the UserPass Vault authentication method
                               type: string
                           required:
                             - path
@@ -8090,23 +10924,32 @@ spec:
                           type: object
                       type: object
                     caBundle:
-                      description: PEM encoded CA bundle used to validate Vault server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.
+                      description: PEM encoded CA bundle used to validate Vault server
+                        certificate. Only used if the Server URL is using HTTPS protocol.
+                        This parameter is ignored for plain HTTP protocol connection.
+                        If not set the system root certificates are used to validate
+                        the TLS connection.
                       format: byte
                       type: string
                     caProvider:
-                      description: The provider for the CA bundle to use to validate Vault server certificate.
+                      description: The provider for the CA bundle to use to validate
+                        Vault server certificate.
                       properties:
                         key:
-                          description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                          description: The key where the CA certificate can be found
+                            in the Secret or ConfigMap.
                           type: string
                         name:
-                          description: The name of the object located at the provider type.
+                          description: The name of the object located at the provider
+                            type.
                           type: string
                         namespace:
-                          description: The namespace the Provider type is in. Can only be defined when used in a ClusterSecretStore.
+                          description: The namespace the Provider type is in. Can
+                            only be defined when used in a ClusterSecretStore.
                           type: string
                         type:
-                          description: The type of provider to use such as "Secret", or "ConfigMap".
+                          description: The type of provider to use such as "Secret",
+                            or "ConfigMap".
                           enum:
                             - Secret
                             - ConfigMap
@@ -8116,23 +10959,37 @@ spec:
                         - type
                       type: object
                     forwardInconsistent:
-                      description: ForwardInconsistent tells Vault to forward read-after-write requests to the Vault leader instead of simply retrying within a loop. This can increase performance if the option is enabled serverside. https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header
+                      description: ForwardInconsistent tells Vault to forward read-after-write
+                        requests to the Vault leader instead of simply retrying within
+                        a loop. This can increase performance if the option is enabled
+                        serverside. https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header
                       type: boolean
                     namespace:
-                      description: 'Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1". More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
+                      description: 'Name of the vault namespace. Namespaces is a set
+                        of features within Vault Enterprise that allows Vault environments
+                        to support Secure Multi-tenancy. e.g: "ns1". More about namespaces
+                        can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
                       type: string
                     path:
-                      description: 'Path is the mount path of the Vault KV backend endpoint, e.g: "secret". The v2 KV secret engine version specific "/data" path suffix for fetching secrets from Vault is optional and will be appended if not present in specified path.'
+                      description: 'Path is the mount path of the Vault KV backend
+                        endpoint, e.g: "secret". The v2 KV secret engine version specific
+                        "/data" path suffix for fetching secrets from Vault is optional
+                        and will be appended if not present in specified path.'
                       type: string
                     readYourWrites:
-                      description: ReadYourWrites ensures isolated read-after-write semantics by providing discovered cluster replication states in each request. More information about eventual consistency in Vault can be found here https://www.vaultproject.io/docs/enterprise/consistency
+                      description: ReadYourWrites ensures isolated read-after-write
+                        semantics by providing discovered cluster replication states
+                        in each request. More information about eventual consistency
+                        in Vault can be found here https://www.vaultproject.io/docs/enterprise/consistency
                       type: boolean
                     server:
-                      description: 'Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".'
+                      description: 'Server is the connection address for the Vault
+                        server, e.g: "https://vault.example.com:8200".'
                       type: string
                     version:
                       default: v2
-                      description: Version is the Vault KV secret engine version. This can be either "v1" or "v2". Version defaults to "v2".
+                      description: Version is the Vault KV secret engine version.
+                        This can be either "v1" or "v2". Version defaults to "v2".
                       enum:
                         - v1
                         - v2
@@ -8143,7 +11000,11 @@ spec:
                   type: object
                 resultType:
                   default: Data
-                  description: Result type defines which data is returned from the generator. By default it is the "data" section of the Vault API response. When using e.g. /auth/token/create the "data" section is empty but the "auth" section contains the generated token. Please refer to the vault docs regarding the result data structure.
+                  description: Result type defines which data is returned from the
+                    generator. By default it is the "data" section of the Vault API
+                    response. When using e.g. /auth/token/create the "data" section
+                    is empty but the "auth" section contains the generated token.
+                    Please refer to the vault docs regarding the result data structure.
                   type: string
               required:
                 - path

--- a/hack/crd.generate.sh
+++ b/hack/crd.generate.sh
@@ -28,6 +28,6 @@ for f in "${CRD_DIR}"/bases/*.yaml; do
 done
 
 shopt -s extglob
-yq e \
+yq -ey \
     '.spec.conversion.strategy = "Webhook" | .spec.conversion.webhook.conversionReviewVersions = ["v1"] | .spec.conversion.webhook.clientConfig.service.name = "kubernetes" | .spec.conversion.webhook.clientConfig.service.namespace = "default" |	.spec.conversion.webhook.clientConfig.service.path = "/convert"' \
     "${CRD_DIR}"/bases/!(kustomization).yaml > "${BUNDLE_YAML}"

--- a/pkg/provider/aws/provider.go
+++ b/pkg/provider/aws/provider.go
@@ -152,11 +152,9 @@ func newClient(ctx context.Context, store esv1beta1.GenericStore, kube client.Cl
 		}
 
 		if storeSpec.RetrySettings.RetryInterval != nil {
-			retryDuration, err = time.ParseDuration(*storeSpec.RetrySettings.RetryInterval)
+			retryDuration = storeSpec.RetrySettings.RetryInterval.Duration
 		}
-		if err != nil {
-			return nil, fmt.Errorf(errInitAWSProvider, err)
-		}
+
 		awsRetryer := awsclient.DefaultRetryer{
 			NumMaxRetries:    retryAmount,
 			MinRetryDelay:    retryDuration,

--- a/pkg/provider/ibm/provider.go
+++ b/pkg/provider/ibm/provider.go
@@ -733,7 +733,7 @@ func (ibm *providerIBM) NewClient(ctx context.Context, store esv1beta1.GenericSt
 		}
 
 		if storeSpec.RetrySettings.RetryInterval != nil {
-			retryDuration, err = time.ParseDuration(*storeSpec.RetrySettings.RetryInterval)
+			retryDuration = storeSpec.RetrySettings.RetryInterval.Duration
 		} else {
 			retryDuration = 5 * time.Second
 		}

--- a/pkg/provider/ibm/provider_test.go
+++ b/pkg/provider/ibm/provider_test.go
@@ -25,15 +25,11 @@ import (
 
 	"github.com/IBM/go-sdk-core/v5/core"
 	sm "github.com/IBM/secrets-manager-go-sdk/v2/secretsmanagerv2"
-	"github.com/go-openapi/strfmt"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilpointer "k8s.io/utils/ptr"
-	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
-
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 	v1 "github.com/external-secrets/external-secrets/apis/meta/v1"
 	fakesm "github.com/external-secrets/external-secrets/pkg/provider/ibm/fake"
+	"github.com/go-openapi/strfmt"
+	utilpointer "k8s.io/utils/ptr"
 )
 
 const (
@@ -1167,52 +1163,6 @@ func TestGetSecretMap(t *testing.T) {
 				t.Errorf("unexpected secret data: expected:\n%+v\ngot:\n%+v", v.expectedData, out)
 			}
 		})
-	}
-}
-
-func TestValidRetryInput(t *testing.T) {
-	sm := providerIBM{}
-
-	invalid := "Invalid"
-	serviceURL := "http://fake-service-url.cool"
-
-	spec := &esv1beta1.SecretStore{
-		Spec: esv1beta1.SecretStoreSpec{
-			Provider: &esv1beta1.SecretStoreProvider{
-				IBM: &esv1beta1.IBMProvider{
-					Auth: esv1beta1.IBMAuth{
-						SecretRef: &esv1beta1.IBMAuthSecretRef{
-							SecretAPIKey: v1.SecretKeySelector{
-								Name: "fake-secret",
-								Key:  "fake-key",
-							},
-						},
-					},
-					ServiceURL: &serviceURL,
-				},
-			},
-			RetrySettings: &esv1beta1.SecretStoreRetrySettings{
-				RetryInterval: &invalid,
-			},
-		},
-	}
-
-	expected := fmt.Sprintf("cannot setup new ibm client: time: invalid duration %q", invalid)
-	ctx := context.TODO()
-	kube := clientfake.NewClientBuilder().WithObjects(&corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "fake-secret",
-			Namespace: "default",
-		},
-		Data: map[string][]byte{
-			"fake-key": []byte("ImAFakeApiKey"),
-		},
-	}).Build()
-
-	_, err := sm.NewClient(ctx, spec, kube, "default")
-
-	if !ErrorContains(err, expected) {
-		t.Errorf("CheckValidRetryInput unexpected error: %s, expected: '%s'", err.Error(), expected)
 	}
 }
 

--- a/pkg/provider/oracle/oracle.go
+++ b/pkg/provider/oracle/oracle.go
@@ -18,8 +18,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"time"
-
 	"github.com/oracle/oci-go-sdk/v56/common"
 	"github.com/oracle/oci-go-sdk/v56/common/auth"
 	"github.com/oracle/oci-go-sdk/v56/keymanagement"
@@ -194,10 +192,7 @@ func (vms *VaultManagementService) NewClient(ctx context.Context, store esv1beta
 		}
 
 		if ri := storeSpec.RetrySettings.RetryInterval; ri != nil {
-			i, err := time.ParseDuration(*storeSpec.RetrySettings.RetryInterval)
-			if err != nil {
-				return nil, fmt.Errorf(errOracleClient, err)
-			}
+			i := storeSpec.RetrySettings.RetryInterval.Duration
 			opts = append(opts, common.WithFixedBackoff(i))
 		}
 

--- a/pkg/provider/oracle/oracle_test.go
+++ b/pkg/provider/oracle/oracle_test.go
@@ -24,6 +24,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/oracle/oci-go-sdk/v56/secrets"
 	corev1 "k8s.io/api/core/v1"
@@ -365,7 +366,7 @@ func TestVaultManagementService_NewClient(t *testing.T) {
 						},
 					},
 					RetrySettings: &esv1beta1.SecretStoreRetrySettings{
-						RetryInterval: ptr.To("1s"),
+						RetryInterval: &metav1.Duration{Duration: 1 * time.Second},
 						MaxRetries:    ptr.To(int32(5)),
 					},
 				},
@@ -383,7 +384,7 @@ func TestVaultManagementService_NewClient(t *testing.T) {
 						},
 					},
 					RetrySettings: &esv1beta1.SecretStoreRetrySettings{
-						RetryInterval: ptr.To("1s"),
+						RetryInterval: &metav1.Duration{Duration: 1 * time.Second},
 					},
 				},
 			},
@@ -430,29 +431,11 @@ func TestVaultManagementService_NewClient(t *testing.T) {
 						},
 					},
 					RetrySettings: &esv1beta1.SecretStoreRetrySettings{
-						RetryInterval: ptr.To("invalid"),
+						RetryInterval: &metav1.Duration{Duration: 1 * time.Second},
 					},
 				},
 			},
 			expectedErr: `could not fetch SecretAccessKey secret: secrets "non-existing-secret"`,
-		},
-		{
-			desc: "invalid retry interval",
-			secretStore: &esv1beta1.SecretStore{
-				Spec: esv1beta1.SecretStoreSpec{
-					Provider: &esv1beta1.SecretStoreProvider{
-						Oracle: &esv1beta1.OracleProvider{
-							Vault:  vaultOCID,
-							Region: region,
-							Auth:   auth,
-						},
-					},
-					RetrySettings: &esv1beta1.SecretStoreRetrySettings{
-						RetryInterval: ptr.To("invalid"),
-					},
-				},
-			},
-			expectedErr: "cannot setup new oracle client: time: invalid duration",
 		},
 	}
 

--- a/pkg/provider/vault/vault.go
+++ b/pkg/provider/vault/vault.go
@@ -27,7 +27,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -292,12 +291,9 @@ func (c *Connector) prepareConfig(kube kclient.Client, corev1 typedcorev1.CoreV1
 		}
 
 		if retrySettings.RetryInterval != nil {
-			retryWait, err := time.ParseDuration(*retrySettings.RetryInterval)
-			if err != nil {
-				return nil, nil, err
-			}
-			cfg.MinRetryWait = retryWait
-			cfg.MaxRetryWait = retryWait
+			retryWait := *retrySettings.RetryInterval
+			cfg.MinRetryWait = retryWait.Duration
+			cfg.MaxRetryWait = retryWait.Duration
 		}
 	}
 

--- a/pkg/provider/vault/vault_test.go
+++ b/pkg/provider/vault/vault_test.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	vault "github.com/hashicorp/vault/api"
@@ -250,27 +251,13 @@ MIIFkTCCA3mgAwIBAgIUBEUg3m/WqAsWHG4Q/II3IePFfuowDQYJKoZIhvcNAQELBQAwWDELMAkGA1UE
 				err: errors.New(errVaultStore),
 			},
 		},
-		"InvalidRetrySettings": {
-			reason: "Should return error if given an invalid Retry Interval.",
-			args: args{
-				store: makeSecretStore(func(s *esv1beta1.SecretStore) {
-					s.Spec.RetrySettings = &esv1beta1.SecretStoreRetrySettings{
-						MaxRetries:    pointer.To(int32(3)),
-						RetryInterval: pointer.To("not-an-interval"),
-					}
-				}),
-			},
-			want: want{
-				err: errors.New("time: invalid duration \"not-an-interval\""),
-			},
-		},
 		"ValidRetrySettings": {
 			reason: "Should return a Vault provider with custom retry settings",
 			args: args{
 				store: makeSecretStore(func(s *esv1beta1.SecretStore) {
 					s.Spec.RetrySettings = &esv1beta1.SecretStoreRetrySettings{
 						MaxRetries:    pointer.To(int32(3)),
-						RetryInterval: pointer.To("10m"),
+						RetryInterval: &metav1.Duration{Duration: 10 * time.Minute},
 					}
 				}),
 				ns:            "default",


### PR DESCRIPTION
## Problem Statement

[SecretStoreRetrySettings.RetryInterval](https://github.com/external-secrets/external-secrets/blob/bdf437c2e1a1a441955b1036b84eed5f63bda5d9/apis/externalsecrets/v1beta1/secretstore_types.go#L176) is currently a pointer of string, but it should have been *metav1.Duration to avoid unnecessary conversion in the first place.

## Related Issue
[#2761](https://github.com/external-secrets/external-secrets/issues/2761)

## Proposed Changes

Change type of [SecretStoreRetrySettings.RetryInterval](https://github.com/external-secrets/external-secrets/blob/bdf437c2e1a1a441955b1036b84eed5f63bda5d9/apis/externalsecrets/v1beta1/secretstore_types.go#L176) from string to *metav1.Duration.
Refactor code for the new type.
Refactor test cases to match the new changes.

## Checklist

- [X ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] My changes have reasonable test coverage
- [X] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
