### PR TITLE
fix: update the linter so that it runs latest and disable debguard

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -46,7 +46,6 @@ linters:
   enable:
     - asciicheck
     - bodyclose
-    - depguard
     - dogsled
     - dupl
     - errcheck

--- a/Makefile
+++ b/Makefile
@@ -303,7 +303,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
-GOLANGCI_VERSION := 1.52.2
+GOLANGCI_VERSION := 1.54.2
 KUBERNETES_VERSION := 1.28.x
 
 .PHONY: envtest


### PR DESCRIPTION
## Problem Statement

golangci-lint is outdated and doesn't run.

Further, depguard is set, but without configuration it's almost useless. It throws too many errors.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
