### PR TITLE
Add validations for the enum values

### DIFF
--- a/apis/externalsecrets/v1alpha1/externalsecret_types.go
+++ b/apis/externalsecrets/v1alpha1/externalsecret_types.go
@@ -31,6 +31,7 @@ type SecretStoreRef struct {
 }
 
 // ExternalSecretCreationPolicy defines rules on how to create the resulting Secret.
+// +kubebuilder:validation:Enum=Owner;Merge;None
 type ExternalSecretCreationPolicy string
 
 const (
@@ -75,6 +76,7 @@ type ExternalSecretTemplate struct {
 	TemplateFrom []TemplateFrom `json:"templateFrom,omitempty"`
 }
 
+// +kubebuilder:validation:Enum=v1;v2
 type TemplateEngineVersion string
 
 const (
@@ -147,6 +149,7 @@ type ExternalSecretDataRemoteRef struct {
 	ConversionStrategy ExternalSecretConversionStrategy `json:"conversionStrategy,omitempty"`
 }
 
+// +kubebuilder:validation:Enum=Default;Unicode
 type ExternalSecretConversionStrategy string
 
 const (

--- a/apis/externalsecrets/v1alpha1/pushsecret_types.go
+++ b/apis/externalsecrets/v1alpha1/pushsecret_types.go
@@ -39,6 +39,7 @@ type PushSecretStoreRef struct {
 	Kind string `json:"kind,omitempty"`
 }
 
+// +kubebuilder:validation:Enum=Delete;None
 type PushSecretDeletionPolicy string
 
 const (

--- a/apis/externalsecrets/v1beta1/externalsecret_types.go
+++ b/apis/externalsecrets/v1beta1/externalsecret_types.go
@@ -91,7 +91,6 @@ type ExternalSecretTemplate struct {
 	// that should be used to compile/execute the
 	// template specified in .data and .templateFrom[].
 	// +kubebuilder:default="v2"
-
 	EngineVersion TemplateEngineVersion `json:"engineVersion,omitempty"`
 	// +optional
 	Metadata ExternalSecretTemplateMetadata `json:"metadata,omitempty"`
@@ -103,6 +102,7 @@ type ExternalSecretTemplate struct {
 	TemplateFrom []TemplateFrom `json:"templateFrom,omitempty"`
 }
 
+// +kubebuilder:validation:Enum=Replace;Merge
 type TemplateMergePolicy string
 
 const (
@@ -110,6 +110,7 @@ const (
 	MergePolicyMerge   TemplateMergePolicy = "Merge"
 )
 
+// +kubebuilder:validation:Enum=v1;v2
 type TemplateEngineVersion string
 
 const (
@@ -128,6 +129,7 @@ type TemplateFrom struct {
 	Literal *string `json:"literal,omitempty"`
 }
 
+// +kubebuilder:validation:Enum=Values;KeysAndValues
 type TemplateScope string
 
 const (
@@ -135,6 +137,7 @@ const (
 	TemplateScopeKeysAndValues TemplateScope = "KeysAndValues"
 )
 
+// +kubebuilder:validation:Enum=Data;Annotations;Labels
 type TemplateTarget string
 
 const (
@@ -204,6 +207,7 @@ type ExternalSecretDataRemoteRef struct {
 
 	// +optional
 	// Policy for fetching tags/labels from provider secrets, possible options are Fetch, None. Defaults to None
+	// +kubebuilder:default="None"
 	MetadataPolicy ExternalSecretMetadataPolicy `json:"metadataPolicy,omitempty"`
 
 	// +optional
@@ -225,6 +229,7 @@ type ExternalSecretDataRemoteRef struct {
 	DecodingStrategy ExternalSecretDecodingStrategy `json:"decodingStrategy,omitempty"`
 }
 
+// +kubebuilder:validation:Enum=None;Fetch
 type ExternalSecretMetadataPolicy string
 
 const (
@@ -232,6 +237,7 @@ const (
 	ExternalSecretMetadataPolicyFetch ExternalSecretMetadataPolicy = "Fetch"
 )
 
+// +kubebuilder:validation:Enum=Default;Unicode
 type ExternalSecretConversionStrategy string
 
 const (
@@ -239,6 +245,7 @@ const (
 	ExternalSecretConversionUnicode ExternalSecretConversionStrategy = "Unicode"
 )
 
+// +kubebuilder:validation:Enum=Auto;Base64;Base64URL;None
 type ExternalSecretDecodingStrategy string
 
 const (

--- a/config/crds/bases/external-secrets.io_clusterexternalsecrets.yaml
+++ b/config/crds/bases/external-secrets.io_clusterexternalsecrets.yaml
@@ -82,18 +82,30 @@ spec:
                             conversionStrategy:
                               default: Default
                               description: Used to define a conversion Strategy
+                              enum:
+                              - Default
+                              - Unicode
                               type: string
                             decodingStrategy:
                               default: None
                               description: Used to define a decoding Strategy
+                              enum:
+                              - Auto
+                              - Base64
+                              - Base64URL
+                              - None
                               type: string
                             key:
                               description: Key is the key used in the Provider, mandatory
                               type: string
                             metadataPolicy:
+                              default: None
                               description: Policy for fetching tags/labels from provider
                                 secrets, possible options are Fetch, None. Defaults
                                 to None
+                              enum:
+                              - None
+                              - Fetch
                               type: string
                             property:
                               description: Used to select a specific property of the
@@ -169,18 +181,30 @@ spec:
                             conversionStrategy:
                               default: Default
                               description: Used to define a conversion Strategy
+                              enum:
+                              - Default
+                              - Unicode
                               type: string
                             decodingStrategy:
                               default: None
                               description: Used to define a decoding Strategy
+                              enum:
+                              - Auto
+                              - Base64
+                              - Base64URL
+                              - None
                               type: string
                             key:
                               description: Key is the key used in the Provider, mandatory
                               type: string
                             metadataPolicy:
+                              default: None
                               description: Policy for fetching tags/labels from provider
                                 secrets, possible options are Fetch, None. Defaults
                                 to None
+                              enum:
+                              - None
+                              - Fetch
                               type: string
                             property:
                               description: Used to select a specific property of the
@@ -201,10 +225,18 @@ spec:
                             conversionStrategy:
                               default: Default
                               description: Used to define a conversion Strategy
+                              enum:
+                              - Default
+                              - Unicode
                               type: string
                             decodingStrategy:
                               default: None
                               description: Used to define a decoding Strategy
+                              enum:
+                              - Auto
+                              - Base64
+                              - Base64URL
+                              - None
                               type: string
                             name:
                               description: Finds secrets based on the name.
@@ -372,9 +404,18 @@ spec:
                             type: object
                           engineVersion:
                             default: v2
+                            description: EngineVersion specifies the template engine
+                              version that should be used to compile/execute the template
+                              specified in .data and .templateFrom[].
+                            enum:
+                            - v1
+                            - v2
                             type: string
                           mergePolicy:
                             default: Replace
+                            enum:
+                            - Replace
+                            - Merge
                             type: string
                           metadata:
                             description: ExternalSecretTemplateMetadata defines metadata
@@ -401,6 +442,9 @@ spec:
                                             type: string
                                           templateAs:
                                             default: Values
+                                            enum:
+                                            - Values
+                                            - KeysAndValues
                                             type: string
                                         required:
                                         - key
@@ -423,6 +467,9 @@ spec:
                                             type: string
                                           templateAs:
                                             default: Values
+                                            enum:
+                                            - Values
+                                            - KeysAndValues
                                             type: string
                                         required:
                                         - key
@@ -436,6 +483,10 @@ spec:
                                   type: object
                                 target:
                                   default: Data
+                                  enum:
+                                  - Data
+                                  - Annotations
+                                  - Labels
                                   type: string
                               type: object
                             type: array

--- a/config/crds/bases/external-secrets.io_externalsecrets.yaml
+++ b/config/crds/bases/external-secrets.io_externalsecrets.yaml
@@ -62,6 +62,9 @@ spec:
                         conversionStrategy:
                           default: Default
                           description: Used to define a conversion Strategy
+                          enum:
+                          - Default
+                          - Unicode
                           type: string
                         key:
                           description: Key is the key used in the Provider, mandatory
@@ -94,6 +97,9 @@ spec:
                     conversionStrategy:
                       default: Default
                       description: Used to define a conversion Strategy
+                      enum:
+                      - Default
+                      - Unicode
                       type: string
                     key:
                       description: Key is the key used in the Provider, mandatory
@@ -139,6 +145,10 @@ spec:
                     default: Owner
                     description: CreationPolicy defines rules on how to create the
                       resulting Secret Defaults to 'Owner'
+                    enum:
+                    - Owner
+                    - Merge
+                    - None
                     type: string
                   immutable:
                     description: Immutable defines if the final secret will be immutable
@@ -161,6 +171,9 @@ spec:
                         description: EngineVersion specifies the template engine version
                           that should be used to compile/execute the template specified
                           in .data and .templateFrom[].
+                        enum:
+                        - v1
+                        - v2
                         type: string
                       metadata:
                         description: ExternalSecretTemplateMetadata defines metadata
@@ -318,18 +331,30 @@ spec:
                         conversionStrategy:
                           default: Default
                           description: Used to define a conversion Strategy
+                          enum:
+                          - Default
+                          - Unicode
                           type: string
                         decodingStrategy:
                           default: None
                           description: Used to define a decoding Strategy
+                          enum:
+                          - Auto
+                          - Base64
+                          - Base64URL
+                          - None
                           type: string
                         key:
                           description: Key is the key used in the Provider, mandatory
                           type: string
                         metadataPolicy:
+                          default: None
                           description: Policy for fetching tags/labels from provider
                             secrets, possible options are Fetch, None. Defaults to
                             None
+                          enum:
+                          - None
+                          - Fetch
                           type: string
                         property:
                           description: Used to select a specific property of the Provider
@@ -405,18 +430,30 @@ spec:
                         conversionStrategy:
                           default: Default
                           description: Used to define a conversion Strategy
+                          enum:
+                          - Default
+                          - Unicode
                           type: string
                         decodingStrategy:
                           default: None
                           description: Used to define a decoding Strategy
+                          enum:
+                          - Auto
+                          - Base64
+                          - Base64URL
+                          - None
                           type: string
                         key:
                           description: Key is the key used in the Provider, mandatory
                           type: string
                         metadataPolicy:
+                          default: None
                           description: Policy for fetching tags/labels from provider
                             secrets, possible options are Fetch, None. Defaults to
                             None
+                          enum:
+                          - None
+                          - Fetch
                           type: string
                         property:
                           description: Used to select a specific property of the Provider
@@ -437,10 +474,18 @@ spec:
                         conversionStrategy:
                           default: Default
                           description: Used to define a conversion Strategy
+                          enum:
+                          - Default
+                          - Unicode
                           type: string
                         decodingStrategy:
                           default: None
                           description: Used to define a decoding Strategy
+                          enum:
+                          - Auto
+                          - Base64
+                          - Base64URL
+                          - None
                           type: string
                         name:
                           description: Finds secrets based on the name.
@@ -606,9 +651,18 @@ spec:
                         type: object
                       engineVersion:
                         default: v2
+                        description: EngineVersion specifies the template engine version
+                          that should be used to compile/execute the template specified
+                          in .data and .templateFrom[].
+                        enum:
+                        - v1
+                        - v2
                         type: string
                       mergePolicy:
                         default: Replace
+                        enum:
+                        - Replace
+                        - Merge
                         type: string
                       metadata:
                         description: ExternalSecretTemplateMetadata defines metadata
@@ -635,6 +689,9 @@ spec:
                                         type: string
                                       templateAs:
                                         default: Values
+                                        enum:
+                                        - Values
+                                        - KeysAndValues
                                         type: string
                                     required:
                                     - key
@@ -657,6 +714,9 @@ spec:
                                         type: string
                                       templateAs:
                                         default: Values
+                                        enum:
+                                        - Values
+                                        - KeysAndValues
                                         type: string
                                     required:
                                     - key
@@ -670,6 +730,10 @@ spec:
                               type: object
                             target:
                               default: Data
+                              enum:
+                              - Data
+                              - Annotations
+                              - Labels
                               type: string
                           type: object
                         type: array

--- a/config/crds/bases/external-secrets.io_pushsecrets.yaml
+++ b/config/crds/bases/external-secrets.io_pushsecrets.yaml
@@ -80,6 +80,9 @@ spec:
                 default: None
                 description: 'Deletion Policy to handle Secrets in the provider. Possible
                   Values: "Delete/None". Defaults to "None".'
+                enum:
+                - Delete
+                - None
                 type: string
               refreshInterval:
                 description: The Interval to which External Secrets will try to push

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -72,16 +72,28 @@ spec:
                               conversionStrategy:
                                 default: Default
                                 description: Used to define a conversion Strategy
+                                enum:
+                                  - Default
+                                  - Unicode
                                 type: string
                               decodingStrategy:
                                 default: None
                                 description: Used to define a decoding Strategy
+                                enum:
+                                  - Auto
+                                  - Base64
+                                  - Base64URL
+                                  - None
                                 type: string
                               key:
                                 description: Key is the key used in the Provider, mandatory
                                 type: string
                               metadataPolicy:
+                                default: None
                                 description: Policy for fetching tags/labels from provider secrets, possible options are Fetch, None. Defaults to None
+                                enum:
+                                  - None
+                                  - Fetch
                                 type: string
                               property:
                                 description: Used to select a specific property of the Provider value (if a map), if supported
@@ -144,16 +156,28 @@ spec:
                               conversionStrategy:
                                 default: Default
                                 description: Used to define a conversion Strategy
+                                enum:
+                                  - Default
+                                  - Unicode
                                 type: string
                               decodingStrategy:
                                 default: None
                                 description: Used to define a decoding Strategy
+                                enum:
+                                  - Auto
+                                  - Base64
+                                  - Base64URL
+                                  - None
                                 type: string
                               key:
                                 description: Key is the key used in the Provider, mandatory
                                 type: string
                               metadataPolicy:
+                                default: None
                                 description: Policy for fetching tags/labels from provider secrets, possible options are Fetch, None. Defaults to None
+                                enum:
+                                  - None
+                                  - Fetch
                                 type: string
                               property:
                                 description: Used to select a specific property of the Provider value (if a map), if supported
@@ -170,10 +194,18 @@ spec:
                               conversionStrategy:
                                 default: Default
                                 description: Used to define a conversion Strategy
+                                enum:
+                                  - Default
+                                  - Unicode
                                 type: string
                               decodingStrategy:
                                 default: None
                                 description: Used to define a decoding Strategy
+                                enum:
+                                  - Auto
+                                  - Base64
+                                  - Base64URL
+                                  - None
                                 type: string
                               name:
                                 description: Finds secrets based on the name.
@@ -309,9 +341,16 @@ spec:
                               type: object
                             engineVersion:
                               default: v2
+                              description: EngineVersion specifies the template engine version that should be used to compile/execute the template specified in .data and .templateFrom[].
+                              enum:
+                                - v1
+                                - v2
                               type: string
                             mergePolicy:
                               default: Replace
+                              enum:
+                                - Replace
+                                - Merge
                               type: string
                             metadata:
                               description: ExternalSecretTemplateMetadata defines metadata fields for the Secret blueprint.
@@ -337,6 +376,9 @@ spec:
                                               type: string
                                             templateAs:
                                               default: Values
+                                              enum:
+                                                - Values
+                                                - KeysAndValues
                                               type: string
                                           required:
                                             - key
@@ -359,6 +401,9 @@ spec:
                                               type: string
                                             templateAs:
                                               default: Values
+                                              enum:
+                                                - Values
+                                                - KeysAndValues
                                               type: string
                                           required:
                                             - key
@@ -372,6 +417,10 @@ spec:
                                     type: object
                                   target:
                                     default: Data
+                                    enum:
+                                      - Data
+                                      - Annotations
+                                      - Labels
                                     type: string
                                 type: object
                               type: array
@@ -3478,6 +3527,9 @@ spec:
                           conversionStrategy:
                             default: Default
                             description: Used to define a conversion Strategy
+                            enum:
+                              - Default
+                              - Unicode
                             type: string
                           key:
                             description: Key is the key used in the Provider, mandatory
@@ -3506,6 +3558,9 @@ spec:
                       conversionStrategy:
                         default: Default
                         description: Used to define a conversion Strategy
+                        enum:
+                          - Default
+                          - Unicode
                         type: string
                       key:
                         description: Key is the key used in the Provider, mandatory
@@ -3542,6 +3597,10 @@ spec:
                     creationPolicy:
                       default: Owner
                       description: CreationPolicy defines rules on how to create the resulting Secret Defaults to 'Owner'
+                      enum:
+                        - Owner
+                        - Merge
+                        - None
                       type: string
                     immutable:
                       description: Immutable defines if the final secret will be immutable
@@ -3559,6 +3618,9 @@ spec:
                         engineVersion:
                           default: v1
                           description: EngineVersion specifies the template engine version that should be used to compile/execute the template specified in .data and .templateFrom[].
+                          enum:
+                            - v1
+                            - v2
                           type: string
                         metadata:
                           description: ExternalSecretTemplateMetadata defines metadata fields for the Secret blueprint.
@@ -3704,16 +3766,28 @@ spec:
                           conversionStrategy:
                             default: Default
                             description: Used to define a conversion Strategy
+                            enum:
+                              - Default
+                              - Unicode
                             type: string
                           decodingStrategy:
                             default: None
                             description: Used to define a decoding Strategy
+                            enum:
+                              - Auto
+                              - Base64
+                              - Base64URL
+                              - None
                             type: string
                           key:
                             description: Key is the key used in the Provider, mandatory
                             type: string
                           metadataPolicy:
+                            default: None
                             description: Policy for fetching tags/labels from provider secrets, possible options are Fetch, None. Defaults to None
+                            enum:
+                              - None
+                              - Fetch
                             type: string
                           property:
                             description: Used to select a specific property of the Provider value (if a map), if supported
@@ -3776,16 +3850,28 @@ spec:
                           conversionStrategy:
                             default: Default
                             description: Used to define a conversion Strategy
+                            enum:
+                              - Default
+                              - Unicode
                             type: string
                           decodingStrategy:
                             default: None
                             description: Used to define a decoding Strategy
+                            enum:
+                              - Auto
+                              - Base64
+                              - Base64URL
+                              - None
                             type: string
                           key:
                             description: Key is the key used in the Provider, mandatory
                             type: string
                           metadataPolicy:
+                            default: None
                             description: Policy for fetching tags/labels from provider secrets, possible options are Fetch, None. Defaults to None
+                            enum:
+                              - None
+                              - Fetch
                             type: string
                           property:
                             description: Used to select a specific property of the Provider value (if a map), if supported
@@ -3802,10 +3888,18 @@ spec:
                           conversionStrategy:
                             default: Default
                             description: Used to define a conversion Strategy
+                            enum:
+                              - Default
+                              - Unicode
                             type: string
                           decodingStrategy:
                             default: None
                             description: Used to define a decoding Strategy
+                            enum:
+                              - Auto
+                              - Base64
+                              - Base64URL
+                              - None
                             type: string
                           name:
                             description: Finds secrets based on the name.
@@ -3941,9 +4035,16 @@ spec:
                           type: object
                         engineVersion:
                           default: v2
+                          description: EngineVersion specifies the template engine version that should be used to compile/execute the template specified in .data and .templateFrom[].
+                          enum:
+                            - v1
+                            - v2
                           type: string
                         mergePolicy:
                           default: Replace
+                          enum:
+                            - Replace
+                            - Merge
                           type: string
                         metadata:
                           description: ExternalSecretTemplateMetadata defines metadata fields for the Secret blueprint.
@@ -3969,6 +4070,9 @@ spec:
                                           type: string
                                         templateAs:
                                           default: Values
+                                          enum:
+                                            - Values
+                                            - KeysAndValues
                                           type: string
                                       required:
                                         - key
@@ -3991,6 +4095,9 @@ spec:
                                           type: string
                                         templateAs:
                                           default: Values
+                                          enum:
+                                            - Values
+                                            - KeysAndValues
                                           type: string
                                       required:
                                         - key
@@ -4004,6 +4111,10 @@ spec:
                                 type: object
                               target:
                                 default: Data
+                                enum:
+                                  - Data
+                                  - Annotations
+                                  - Labels
                                 type: string
                             type: object
                           type: array
@@ -4141,6 +4252,9 @@ spec:
                 deletionPolicy:
                   default: None
                   description: 'Deletion Policy to handle Secrets in the provider. Possible Values: "Delete/None". Defaults to "None".'
+                  enum:
+                    - Delete
+                    - None
                   type: string
                 refreshInterval:
                   description: The Interval to which External Secrets will try to push a secret definition

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -3306,6 +3306,9 @@ TemplateEngineVersion
 </em>
 </td>
 <td>
+<p>EngineVersion specifies the template engine version
+that should be used to compile/execute the
+template specified in .data and .templateFrom[].</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
## Problem Statement

I noticed some enum fields do not have validation markers and users could put wrong values accidentally. To improve usability, it would be better if we set validations to those enum fields. Thank you for your review!

## Related Issue

None

## Proposed Changes

Put `+kubebuilder:validation:Enum` markers to the enum fields.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
