### PR TITLE
Support GetAllSecrets for the fake provider

### DIFF
--- a/apis/externalsecrets/v1beta1/externalsecret_types.go
+++ b/apis/externalsecrets/v1beta1/externalsecret_types.go
@@ -308,6 +308,7 @@ type ExternalSecretFind struct {
 	// A root path to start the find operations.
 	// +optional
 	Path *string `json:"path,omitempty"`
+
 	// Finds secrets based on the name.
 	// +optional
 	Name *FindName `json:"name,omitempty"`

--- a/pkg/provider/fake/fake.go
+++ b/pkg/provider/fake/fake.go
@@ -138,20 +138,20 @@ func (p *Provider) GetAllSecrets(_ context.Context, ref esv1beta1.ExternalSecret
 
 		latestDataMap := make(map[string]*Data)
 		for key, data := range p.config {
-			// Reconstruct the "true" key without the version suffix
+			// Reconstruct the original key without the version suffix
 			// See the mapKey function to know how the provider generates keys
-			key = strings.TrimSuffix(key, data.Version)
-			if !matcher.MatchName(key) {
+			originalKey := strings.TrimSuffix(key, data.Version)
+			if !matcher.MatchName(originalKey) {
 				continue
 			}
 
-			if d, ok := latestDataMap[key]; ok {
+			if d, ok := latestDataMap[originalKey]; ok {
 				// Need to get only the latest version
 				if d.Version < data.Version {
-					latestDataMap[key] = data
+					latestDataMap[originalKey] = data
 				}
 			} else {
-				latestDataMap[key] = data
+				latestDataMap[originalKey] = data
 			}
 		}
 

--- a/pkg/provider/fake/fake.go
+++ b/pkg/provider/fake/fake.go
@@ -17,6 +17,7 @@ package fake
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/tidwall/gjson"
 	corev1 "k8s.io/api/core/v1"
@@ -24,6 +25,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
+	"github.com/external-secrets/external-secrets/pkg/find"
+	"github.com/external-secrets/external-secrets/pkg/utils"
 )
 
 var (
@@ -77,14 +80,14 @@ func (p *Provider) NewClient(_ context.Context, store esv1beta1.GenericStore, _ 
 		}
 	}
 	for _, data := range c.Data {
-		mapKey := fmt.Sprintf("%v%v", data.Key, data.Version)
-		cfg[mapKey] = &Data{
+		key := mapKey(data.Key, data.Version)
+		cfg[key] = &Data{
 			Value:   data.Value,
 			Version: data.Version,
 			Origin:  FakeSecretStore,
 		}
 		if data.ValueMap != nil {
-			cfg[mapKey].ValueMap = data.ValueMap
+			cfg[key].ValueMap = data.ValueMap
 		}
 	}
 	p.database[store.GetName()] = cfg
@@ -124,16 +127,47 @@ func (p *Provider) PushSecret(_ context.Context, value []byte, _ corev1.SecretTy
 	return nil
 }
 
-// Empty GetAllSecrets.
-func (p *Provider) GetAllSecrets(_ context.Context, _ esv1beta1.ExternalSecretFind) (map[string][]byte, error) {
-	// TO be implemented
-	return nil, fmt.Errorf("GetAllSecrets not implemented")
+// GetAllSecrets returns multiple secrets from the given ExternalSecretFind
+// Currently, only the Name operator is supported.
+func (p *Provider) GetAllSecrets(_ context.Context, ref esv1beta1.ExternalSecretFind) (map[string][]byte, error) {
+	if ref.Name != nil {
+		matcher, err := find.New(*ref.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		latestDataMap := make(map[string]*Data)
+		for key, data := range p.config {
+			// Reconstruct the "true" key without the version suffix
+			// See the mapKey function to know how the provider generates keys
+			key = strings.TrimSuffix(key, data.Version)
+			if !matcher.MatchName(key) {
+				continue
+			}
+
+			if d, ok := latestDataMap[key]; ok {
+				// Need to get only the latest version
+				if d.Version < data.Version {
+					latestDataMap[key] = data
+				}
+			} else {
+				latestDataMap[key] = data
+			}
+		}
+
+		dataMap := make(map[string][]byte)
+		for key, data := range latestDataMap {
+			dataMap[key] = []byte(data.Value)
+		}
+
+		return utils.ConvertKeys(ref.ConversionStrategy, dataMap)
+	}
+	return nil, fmt.Errorf("unsupported find operator: %#v", ref)
 }
 
 // GetSecret returns a single secret from the provider.
 func (p *Provider) GetSecret(_ context.Context, ref esv1beta1.ExternalSecretDataRemoteRef) ([]byte, error) {
-	mapKey := fmt.Sprintf("%v%v", ref.Key, ref.Version)
-	data, ok := p.config[mapKey]
+	data, ok := p.config[mapKey(ref.Key, ref.Version)]
 	if !ok || data.Version != ref.Version {
 		return nil, esv1beta1.NoSecretErr
 	}
@@ -152,8 +186,7 @@ func (p *Provider) GetSecret(_ context.Context, ref esv1beta1.ExternalSecretData
 
 // GetSecretMap returns multiple k/v pairs from the provider.
 func (p *Provider) GetSecretMap(_ context.Context, ref esv1beta1.ExternalSecretDataRemoteRef) (map[string][]byte, error) {
-	mapKey := fmt.Sprintf("%v%v", ref.Key, ref.Version)
-	data, ok := p.config[mapKey]
+	data, ok := p.config[mapKey(ref.Key, ref.Version)]
 	if !ok || data.Version != ref.Version || data.ValueMap == nil {
 		return nil, esv1beta1.NoSecretErr
 	}
@@ -190,6 +223,11 @@ func (p *Provider) ValidateStore(store esv1beta1.GenericStore) error {
 		}
 	}
 	return nil
+}
+
+func mapKey(key, version string) string {
+	// Add the version suffix to preserve entries with the old versions as well.
+	return fmt.Sprintf("%v%v", key, version)
 }
 
 func init() {

--- a/pkg/provider/fake/fake_test.go
+++ b/pkg/provider/fake/fake_test.go
@@ -17,10 +17,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	esv1alpha1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
@@ -85,6 +88,154 @@ type testCase struct {
 	request  esv1beta1.ExternalSecretDataRemoteRef
 	expValue string
 	expErr   string
+}
+
+func TestGetAllSecrets(t *testing.T) {
+	cases := []struct {
+		desc        string
+		data        []esv1beta1.FakeProviderData
+		ref         esv1beta1.ExternalSecretFind
+		expected    map[string][]byte
+		expectedErr string
+	}{
+		{
+			desc: "no matches",
+			data: []esv1beta1.FakeProviderData{},
+			ref: esv1beta1.ExternalSecretFind{
+				Name: &esv1beta1.FindName{
+					RegExp: "some-key",
+				},
+			},
+			expected: map[string][]byte{},
+		},
+		{
+			desc: "matches",
+			data: []esv1beta1.FakeProviderData{
+				{
+					Key:   "some-key1",
+					Value: "some-value1",
+				},
+				{
+					Key:   "some-key2",
+					Value: "some-value2",
+				},
+				{
+					Key:   "another-key1",
+					Value: "another-value1",
+				},
+			},
+			ref: esv1beta1.ExternalSecretFind{
+				Name: &esv1beta1.FindName{
+					RegExp: "some-key.*",
+				},
+			},
+			expected: map[string][]byte{
+				"some-key1": []byte("some-value1"),
+				"some-key2": []byte("some-value2"),
+			},
+		},
+		{
+			desc: "matches with version",
+			data: []esv1beta1.FakeProviderData{
+				{
+					Key:     "some-key1",
+					Value:   "some-value1-version1",
+					Version: "1",
+				},
+				{
+					Key:     "some-key1",
+					Value:   "some-value1-version2",
+					Version: "2",
+				},
+				{
+					Key:     "some-key2",
+					Value:   "some-value2-version1",
+					Version: "1",
+				},
+				{
+					Key:     "some-key2",
+					Value:   "some-value2-version2",
+					Version: "2",
+				},
+				{
+					Key:     "some-key2",
+					Value:   "some-value2-version3",
+					Version: "3",
+				},
+				{
+					Key:     "another-key1",
+					Value:   "another-value1-version1",
+					Version: "1",
+				},
+				{
+					Key:     "another-key1",
+					Value:   "another-value1-version2",
+					Version: "2",
+				},
+			},
+			ref: esv1beta1.ExternalSecretFind{
+				Name: &esv1beta1.FindName{
+					RegExp: "some-key.*",
+				},
+			},
+			expected: map[string][]byte{
+				"some-key1": []byte("some-value1-version2"),
+				"some-key2": []byte("some-value2-version3"),
+			},
+		},
+		{
+			desc: "unsupported operator",
+			data: []esv1beta1.FakeProviderData{},
+			ref: esv1beta1.ExternalSecretFind{
+				Path: ptr.To("some-path"),
+			},
+			expectedErr: "unsupported find operator",
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			ctx := context.Background()
+			p := Provider{}
+
+			client, err := p.NewClient(ctx, &esv1beta1.SecretStore{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: fmt.Sprintf("secret-store-%v", i),
+				},
+				Spec: esv1beta1.SecretStoreSpec{
+					Provider: &esv1beta1.SecretStoreProvider{
+						Fake: &esv1beta1.FakeProvider{
+							Data: tc.data,
+						},
+					},
+				},
+			}, nil, "")
+			if err != nil {
+				t.Fatalf("failed to create a client: %v", err)
+			}
+
+			got, err := client.GetAllSecrets(ctx, tc.ref)
+			if err != nil {
+				if tc.expectedErr == "" {
+					t.Fatalf("failed to call GetAllSecrets: %v", err)
+				}
+
+				if !strings.Contains(err.Error(), tc.expectedErr) {
+					t.Fatalf("%q expected to contain substring %q", err.Error(), tc.expectedErr)
+				}
+
+				return
+			}
+
+			if tc.expectedErr != "" {
+				t.Fatal("expected to receive an error but got nil")
+			}
+
+			if diff := cmp.Diff(tc.expected, got); diff != "" {
+				t.Fatalf("(-got, +want)\n%s", diff)
+			}
+		})
+	}
 }
 
 func TestGetSecret(t *testing.T) {


### PR DESCRIPTION
## Problem Statement

SSIA. I've added the GetAllSecrets method to the fake provider to support `dataFrom.find`.

## Related Issue

Closes https://github.com/external-secrets/external-secrets/issues/2835

## Proposed Changes

Add the GetAllSecrets method to the fake provider.

## For Reviews
Feel free to use the following manifests to check the behavior locally 🙂 

```
apiVersion: external-secrets.io/v1beta1
kind: ClusterSecretStore
metadata:
  name: fake
spec:
  provider:
    fake:
      data:
      - key: "some-key1"
        value: "HELLO1V1"
        version: "v1"
      - key: "some-key2"
        value: "HELLO2V1"
        version: "v1"
      - key: "some-key2"
        value: "HELLO2V2"
        version: "v2"
      - key: "another-key"
        value: "Hi"
```

```
apiVersion: external-secrets.io/v1beta1
kind: ExternalSecret
metadata:
  name: example
spec:
  refreshInterval: 1h
  secretStoreRef:
    name: fake
    kind: ClusterSecretStore
  target:
    name: secret-to-be-created
  dataFrom:
  - find:
      name:
        regexp: some-key.*
```

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
