### PR TITLE
feat: fix cert-controller readiness probe

### DIFF
--- a/cmd/certcontroller.go
+++ b/cmd/certcontroller.go
@@ -87,7 +87,8 @@ var certcontrollerCmd = &cobra.Command{
 			setupLog.Error(err, "unable to start manager")
 			os.Exit(1)
 		}
-		crdctrl := crds.New(mgr.GetClient(), mgr.GetScheme(),
+
+		crdctrl := crds.New(mgr.GetClient(), mgr.GetScheme(), mgr.Elected(),
 			ctrl.Log.WithName("controllers").WithName("webhook-certs-updater"),
 			crdRequeueInterval, serviceName, serviceNamespace, secretName, secretNamespace, crdNames)
 		if err := crdctrl.SetupWithManager(mgr, controller.Options{
@@ -97,7 +98,7 @@ var certcontrollerCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		whc := webhookconfig.New(mgr.GetClient(), mgr.GetScheme(),
+		whc := webhookconfig.New(mgr.GetClient(), mgr.GetScheme(), mgr.Elected(),
 			ctrl.Log.WithName("controllers").WithName("webhook-certs-updater"),
 			serviceName, serviceNamespace,
 			secretName, secretNamespace, crdRequeueInterval)

--- a/pkg/controllers/crds/suite_test.go
+++ b/pkg/controllers/crds/suite_test.go
@@ -77,7 +77,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).ToNot(BeNil())
 
-	rec := New(k8sClient, k8sManager.GetScheme(), log, time.Second*1,
+	leaderChan := make(chan struct{})
+	close(leaderChan)
+	rec := New(k8sClient, k8sManager.GetScheme(), leaderChan, log, time.Second*1,
 		"foo", "default", "foo", "default", []string{
 			"secretstores.test.io",
 		})

--- a/pkg/controllers/webhookconfig/suite_test.go
+++ b/pkg/controllers/webhookconfig/suite_test.go
@@ -84,8 +84,9 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).ToNot(BeNil())
-
-	reconciler = New(k8sClient, k8sManager.GetScheme(), ctrl.Log, ctrlSvcName, ctrlSvcNamespace, ctrlSecretName, ctrlSecretNamespace, time.Second)
+	leaderChan := make(chan struct{})
+	close(leaderChan)
+	reconciler = New(k8sClient, k8sManager.GetScheme(), leaderChan, ctrl.Log, ctrlSvcName, ctrlSvcNamespace, ctrlSecretName, ctrlSecretNamespace, time.Second)
 	reconciler.SetupWithManager(k8sManager, controller.Options{})
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
In `controller-runtime`, readiness probes are being executed independently from the leader election status. The current implementation depends on leader election (client cache etc.) to run properly. This commit fixes that by short-circuiting the readiness probes when the mgr is not the leader.

This bug surfaces when leader-election=true and cert-controller replicas>=2.

Proof of work:

cert-controller runs with leader-election and multiple replicas:
![2023-11-06T20:38:19,609635351+01:00](https://github.com/external-secrets/external-secrets/assets/1709030/258a7f45-0e4d-4124-aab0-dbb1c63015de)
