### PR TITLE
Refactor the PushSecret interface

### DIFF
--- a/apis/externalsecrets/v1alpha1/pushsecret_types.go
+++ b/apis/externalsecrets/v1alpha1/pushsecret_types.go
@@ -105,6 +105,22 @@ type PushSecretData struct {
 	Metadata *apiextensionsv1.JSON `json:"metadata,omitempty"`
 }
 
+func (d PushSecretData) GetMetadata() *apiextensionsv1.JSON {
+	return d.Metadata
+}
+
+func (d PushSecretData) GetSecretKey() string {
+	return d.Match.SecretKey
+}
+
+func (d PushSecretData) GetRemoteKey() string {
+	return d.Match.RemoteRef.RemoteKey
+}
+
+func (d PushSecretData) GetProperty() string {
+	return d.Match.RemoteRef.Property
+}
+
 // PushSecretConditionType indicates the condition of the PushSecret.
 type PushSecretConditionType string
 

--- a/apis/externalsecrets/v1beta1/fakes/pushremoteref.go
+++ b/apis/externalsecrets/v1beta1/fakes/pushremoteref.go
@@ -103,4 +103,4 @@ func (fake *PushRemoteRef) recordInvocation(key string, args []interface{}) {
 	fake.invocations[key] = append(fake.invocations[key], args)
 }
 
-var _ v1beta1.PushRemoteRef = new(PushRemoteRef)
+var _ v1beta1.PushSecretRemoteRef = new(PushRemoteRef)

--- a/apis/externalsecrets/v1beta1/provider.go
+++ b/apis/externalsecrets/v1beta1/provider.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -70,10 +69,10 @@ type SecretsClient interface {
 	GetSecret(ctx context.Context, ref ExternalSecretDataRemoteRef) ([]byte, error)
 
 	// PushSecret will write a single secret into the provider
-	PushSecret(ctx context.Context, value []byte, typed corev1.SecretType, metadata *apiextensionsv1.JSON, remoteRef PushRemoteRef) error
+	PushSecret(ctx context.Context, secret *corev1.Secret, data PushSecretData) error
 
 	// DeleteSecret will delete the secret from a provider
-	DeleteSecret(ctx context.Context, remoteRef PushRemoteRef) error
+	DeleteSecret(ctx context.Context, remoteRef PushSecretRemoteRef) error
 
 	// Validate checks if the client is configured correctly
 	// and is able to retrieve secrets from the provider.

--- a/apis/externalsecrets/v1beta1/provider_schema_test.go
+++ b/apis/externalsecrets/v1beta1/provider_schema_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -37,12 +36,12 @@ func (p *PP) NewClient(_ context.Context, _ GenericStore, _ client.Client, _ str
 }
 
 // PushSecret writes a single secret into a provider.
-func (p *PP) PushSecret(_ context.Context, _ []byte, _ corev1.SecretType, _ *apiextensionsv1.JSON, _ PushRemoteRef) error {
+func (p *PP) PushSecret(_ context.Context, _ *corev1.Secret, _ PushSecretData) error {
 	return nil
 }
 
 // DeleteSecret deletes a single secret from a provider.
-func (p *PP) DeleteSecret(_ context.Context, _ PushRemoteRef) error {
+func (p *PP) DeleteSecret(_ context.Context, _ PushSecretRemoteRef) error {
 	return nil
 }
 

--- a/apis/externalsecrets/v1beta1/pushsecret_interfaces.go
+++ b/apis/externalsecrets/v1beta1/pushsecret_interfaces.go
@@ -13,13 +13,28 @@ limitations under the License.
 */
 package v1beta1
 
+import apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
 // +kubebuilder:object:root=false
 // +kubebuilder:object:generate:false
 // +k8s:deepcopy-gen:interfaces=nil
 // +k8s:deepcopy-gen=nil
 
-// This interface is to allow using v1alpha1 content in Provider registered in v1beta1.
-type PushRemoteRef interface {
+// PushSecretData is an interface to allow using v1alpha1.PushSecretData content in Provider registered in v1beta1.
+type PushSecretData interface {
+	GetMetadata() *apiextensionsv1.JSON
+	GetSecretKey() string
+	GetRemoteKey() string
+	GetProperty() string
+}
+
+// +kubebuilder:object:root=false
+// +kubebuilder:object:generate:false
+// +k8s:deepcopy-gen:interfaces=nil
+// +k8s:deepcopy-gen=nil
+
+// PushSecretRemoteRef is an interface to allow using v1alpha1.PushSecretRemoteRef in Provider registered in v1beta1.
+type PushSecretRemoteRef interface {
 	GetRemoteKey() string
 	GetProperty() string
 }

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -4664,10 +4664,15 @@ External Secrets meta/v1.SecretKeySelector
 <p>
 <p>Provider is a common interface for interacting with secret backends.</p>
 </p>
-<h3 id="external-secrets.io/v1beta1.PushRemoteRef">PushRemoteRef
+<h3 id="external-secrets.io/v1beta1.PushSecretData">PushSecretData
 </h3>
 <p>
-<p>This interface is to allow using v1alpha1 content in Provider registered in v1beta1.</p>
+<p>PushSecretData is an interface to allow using v1alpha1.PushSecretData content in Provider registered in v1beta1.</p>
+</p>
+<h3 id="external-secrets.io/v1beta1.PushSecretRemoteRef">PushSecretRemoteRef
+</h3>
+<p>
+<p>PushSecretRemoteRef is an interface to allow using v1alpha1.PushSecretRemoteRef in Provider registered in v1beta1.</p>
 </p>
 <h3 id="external-secrets.io/v1beta1.ScalewayProvider">ScalewayProvider
 </h3>

--- a/pkg/controllers/pushsecret/pushsecret_controller.go
+++ b/pkg/controllers/pushsecret/pushsecret_controller.go
@@ -275,21 +275,20 @@ func (r *Reconciler) PushSecretToProviders(ctx context.Context, stores map[esapi
 			Name: store.GetName(),
 			Kind: ref.Kind,
 		}
-		client, err := mgr.Get(ctx, storeRef, ps.GetNamespace(), nil)
+		secretClient, err := mgr.Get(ctx, storeRef, ps.GetNamespace(), nil)
 		if err != nil {
 			return out, fmt.Errorf("could not get secrets client for store %v: %w", store.GetName(), err)
 		}
 		for _, data := range ps.Spec.Data {
-			secretValue, ok := secret.Data[data.Match.SecretKey]
-			if !ok {
+			if _, ok := secret.Data[data.Match.SecretKey]; !ok {
 				return out, fmt.Errorf("secret key %v does not exist", data.Match.SecretKey)
 			}
 
-			err := client.PushSecret(ctx, secretValue, secret.Type, data.Metadata, data.Match.RemoteRef)
+			err := secretClient.PushSecret(ctx, secret, data)
 			if err != nil {
 				return out, fmt.Errorf(errSetSecretFailed, data.Match.SecretKey, store.GetName(), err)
 			}
-			out[storeKey][statusRef(data.Match.RemoteRef)] = data
+			out[storeKey][statusRef(data)] = data
 		}
 	}
 	return out, nil
@@ -423,7 +422,7 @@ func getPushSecretCondition(status esapi.PushSecretStatus, condType esapi.PushSe
 	return nil
 }
 
-func statusRef(ref v1beta1.PushRemoteRef) string {
+func statusRef(ref v1beta1.PushSecretData) string {
 	if ref.GetProperty() != "" {
 		return ref.GetRemoteKey() + "/" + ref.GetProperty()
 	}

--- a/pkg/controllers/secretstore/client_manager_test.go
+++ b/pkg/controllers/secretstore/client_manager_test.go
@@ -340,11 +340,11 @@ type MockFakeClient struct {
 	closeCalled bool
 }
 
-func (c *MockFakeClient) PushSecret(_ context.Context, _ []byte, _ corev1.SecretType, _ *apiextensionsv1.JSON, _ esv1beta1.PushRemoteRef) error {
+func (c *MockFakeClient) PushSecret(_ context.Context, _ *corev1.Secret, _ esv1beta1.PushSecretData) error {
 	return nil
 }
 
-func (c *MockFakeClient) DeleteSecret(_ context.Context, _ esv1beta1.PushRemoteRef) error {
+func (c *MockFakeClient) DeleteSecret(_ context.Context, _ esv1beta1.PushSecretRemoteRef) error {
 	return nil
 }
 

--- a/pkg/provider/akeyless/akeyless.go
+++ b/pkg/provider/akeyless/akeyless.go
@@ -30,7 +30,6 @@ import (
 	"github.com/akeylesslabs/akeyless-go/v3"
 	"github.com/tidwall/gjson"
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/client-go/kubernetes"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -228,11 +227,11 @@ func (a *Akeyless) Validate() (esv1beta1.ValidationResult, error) {
 	return esv1beta1.ValidationResultReady, nil
 }
 
-func (a *Akeyless) PushSecret(_ context.Context, _ []byte, _ corev1.SecretType, _ *apiextensionsv1.JSON, _ esv1beta1.PushRemoteRef) error {
+func (a *Akeyless) PushSecret(_ context.Context, _ *corev1.Secret, _ esv1beta1.PushSecretData) error {
 	return fmt.Errorf("not implemented")
 }
 
-func (a *Akeyless) DeleteSecret(_ context.Context, _ esv1beta1.PushRemoteRef) error {
+func (a *Akeyless) DeleteSecret(_ context.Context, _ esv1beta1.PushSecretRemoteRef) error {
 	return fmt.Errorf("not implemented")
 }
 

--- a/pkg/provider/alibaba/kms.go
+++ b/pkg/provider/alibaba/kms.go
@@ -26,7 +26,6 @@ import (
 	"github.com/avast/retry-go/v4"
 	"github.com/tidwall/gjson"
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/types"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -59,11 +58,11 @@ type SMInterface interface {
 	Endpoint() string
 }
 
-func (kms *KeyManagementService) PushSecret(_ context.Context, _ []byte, _ corev1.SecretType, _ *apiextensionsv1.JSON, _ esv1beta1.PushRemoteRef) error {
+func (kms *KeyManagementService) PushSecret(_ context.Context, _ *corev1.Secret, _ esv1beta1.PushSecretData) error {
 	return fmt.Errorf("not implemented")
 }
 
-func (kms *KeyManagementService) DeleteSecret(_ context.Context, _ esv1beta1.PushRemoteRef) error {
+func (kms *KeyManagementService) DeleteSecret(_ context.Context, _ esv1beta1.PushSecretRemoteRef) error {
 	return fmt.Errorf("not implemented")
 }
 

--- a/pkg/provider/aws/parameterstore/parameterstore.go
+++ b/pkg/provider/aws/parameterstore/parameterstore.go
@@ -27,7 +27,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/tidwall/gjson"
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	utilpointer "k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -95,7 +94,7 @@ func (pm *ParameterStore) getTagsByName(ctx aws.Context, ref *ssm.GetParameterOu
 	return data.TagList, nil
 }
 
-func (pm *ParameterStore) DeleteSecret(ctx context.Context, remoteRef esv1beta1.PushRemoteRef) error {
+func (pm *ParameterStore) DeleteSecret(ctx context.Context, remoteRef esv1beta1.PushSecretRemoteRef) error {
 	secretName := remoteRef.GetRemoteKey()
 	secretValue := ssm.GetParameterInput{
 		Name: &secretName,
@@ -132,12 +131,13 @@ func (pm *ParameterStore) DeleteSecret(ctx context.Context, remoteRef esv1beta1.
 	return nil
 }
 
-func (pm *ParameterStore) PushSecret(ctx context.Context, value []byte, _ corev1.SecretType, _ *apiextensionsv1.JSON, remoteRef esv1beta1.PushRemoteRef) error {
+func (pm *ParameterStore) PushSecret(ctx context.Context, secret *corev1.Secret, data esv1beta1.PushSecretData) error {
 	parameterType := "String"
 	overwrite := true
 
+	value := secret.Data[data.GetSecretKey()]
 	stringValue := string(value)
-	secretName := remoteRef.GetRemoteKey()
+	secretName := data.GetRemoteKey()
 
 	secretRequest := ssm.PutParameterInput{
 		Name:      &secretName,

--- a/pkg/provider/aws/parameterstore/parameterstore_test.go
+++ b/pkg/provider/aws/parameterstore/parameterstore_test.go
@@ -24,11 +24,13 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 	fakeps "github.com/external-secrets/external-secrets/pkg/provider/aws/parameterstore/fake"
 	"github.com/external-secrets/external-secrets/pkg/provider/aws/util"
+	"github.com/external-secrets/external-secrets/pkg/provider/testing/fake"
 )
 
 const (
@@ -45,18 +47,6 @@ type parameterstoreTestCase struct {
 	expectError    string
 	expectedSecret string
 	expectedData   map[string][]byte
-}
-
-type fakeRef struct {
-	key string
-}
-
-func (f fakeRef) GetRemoteKey() string {
-	return f.key
-}
-
-func (f fakeRef) GetProperty() string {
-	return ""
 }
 
 func makeValidParameterStoreTestCase() *parameterstoreTestCase {
@@ -247,7 +237,7 @@ func TestDeleteSecret(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			ref := fakeRef{key: "fake-key"}
+			ref := fake.PushSecretData{RemoteKey: "fake-key"}
 			ps := ParameterStore{
 				client: &tc.args.client,
 			}
@@ -273,7 +263,13 @@ func TestDeleteSecret(t *testing.T) {
 func TestPushSecret(t *testing.T) {
 	invalidParameters := errors.New(ssm.ErrCodeInvalidParameters)
 	alreadyExistsError := errors.New(ssm.ErrCodeAlreadyExistsException)
+	fakeSecretKey := "fakeSecretKey"
 	fakeValue := "fakeValue"
+	fakeSecret := &corev1.Secret{
+		Data: map[string][]byte{
+			fakeSecretKey: []byte(fakeValue),
+		},
+	}
 
 	managedByESO := ssm.Tag{
 		Key:   &managedBy,
@@ -431,11 +427,11 @@ func TestPushSecret(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			ref := fakeRef{key: "fake-key"}
+			psd := fake.PushSecretData{SecretKey: "fake-secret-key", RemoteKey: "fake-key"}
 			ps := ParameterStore{
 				client: &tc.args.client,
 			}
-			err := ps.PushSecret(context.TODO(), []byte(fakeValue), "", nil, ref)
+			err := ps.PushSecret(context.TODO(), fakeSecret, psd)
 
 			// Error nil XOR tc.want.err nil
 			if ((err == nil) || (tc.want.err == nil)) && !((err == nil) && (tc.want.err == nil)) {

--- a/pkg/provider/aws/secretsmanager/secretsmanager_test.go
+++ b/pkg/provider/aws/secretsmanager/secretsmanager_test.go
@@ -25,11 +25,13 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	awssm "github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 	fakesm "github.com/external-secrets/external-secrets/pkg/provider/aws/secretsmanager/fake"
 	"github.com/external-secrets/external-secrets/pkg/provider/aws/util"
+	"github.com/external-secrets/external-secrets/pkg/provider/testing/fake"
 )
 
 type secretsManagerTestCase struct {
@@ -365,23 +367,16 @@ func ErrorContains(out error, want string) bool {
 	return strings.Contains(out.Error(), want)
 }
 
-type fakeRef struct {
-	key      string
-	property string
-}
-
-func (f fakeRef) GetRemoteKey() string {
-	return f.key
-}
-
-func (f fakeRef) GetProperty() string {
-	return f.property
-}
-
 func TestSetSecret(t *testing.T) {
 	managedBy := managedBy
 	notManagedBy := "not-managed-by"
+	secretKey := "fake-secret-key"
 	secretValue := []byte("fake-value")
+	fakeSecret := &corev1.Secret{
+		Data: map[string][]byte{
+			secretKey: secretValue,
+		},
+	}
 	externalSecrets := externalSecrets
 	noPermission := errors.New("no permission")
 	arn := "arn:aws:secretsmanager:us-east-1:702902267788:secret:foo-bar5-Robbgh"
@@ -461,13 +456,13 @@ func TestSetSecret(t *testing.T) {
 		ARN: &arn,
 	}
 
-	remoteRefWithoutProperty := fakeRef{key: "fake-key", property: ""}
-	remoteRefWithProperty := fakeRef{key: "fake-key", property: "other-fake-property"}
+	pushSecretDataWithoutProperty := fake.PushSecretData{SecretKey: secretKey, RemoteKey: "fake-key", Property: ""}
+	pushSecretDataWithProperty := fake.PushSecretData{SecretKey: secretKey, RemoteKey: "fake-key", Property: "other-fake-property"}
 
 	type args struct {
-		store     *esv1beta1.AWSProvider
-		client    fakesm.Client
-		remoteRef fakeRef
+		store          *esv1beta1.AWSProvider
+		client         fakesm.Client
+		pushSecretData fake.PushSecretData
 	}
 
 	type want struct {
@@ -488,7 +483,7 @@ func TestSetSecret(t *testing.T) {
 					PutSecretValueWithContextFn: fakesm.NewPutSecretValueWithContextFn(putSecretOutput, nil),
 					DescribeSecretWithContextFn: fakesm.NewDescribeSecretWithContextFn(tagSecretOutput, nil),
 				},
-				remoteRef: remoteRefWithoutProperty,
+				pushSecretData: pushSecretDataWithoutProperty,
 			},
 			want: want{
 				err: nil,
@@ -502,28 +497,28 @@ func TestSetSecret(t *testing.T) {
 					GetSecretValueWithContextFn: fakesm.NewGetSecretValueWithContextFn(blankSecretValueOutput, &getSecretCorrectErr),
 					CreateSecretWithContextFn:   fakesm.NewCreateSecretWithContextFn(secretOutput, nil),
 				},
-				remoteRef: remoteRefWithoutProperty,
+				pushSecretData: pushSecretDataWithoutProperty,
 			},
 			want: want{
 				err: nil,
 			},
 		},
 		"SetSecretWithPropertySucceedsWithNewSecret": {
-			reason: "if a new secret is pushed to aws sm and a remoteRef property is specified, create a json secret with the remoteRef property as a key",
+			reason: "if a new secret is pushed to aws sm and a pushSecretData property is specified, create a json secret with the pushSecretData property as a key",
 			args: args{
 				store: makeValidSecretStore().Spec.Provider.AWS,
 				client: fakesm.Client{
 					GetSecretValueWithContextFn: fakesm.NewGetSecretValueWithContextFn(blankSecretValueOutput, &getSecretCorrectErr),
 					CreateSecretWithContextFn:   fakesm.NewCreateSecretWithContextFn(secretOutput, nil, []byte(`{"other-fake-property":"fake-value"}`)),
 				},
-				remoteRef: remoteRefWithProperty,
+				pushSecretData: pushSecretDataWithProperty,
 			},
 			want: want{
 				err: nil,
 			},
 		},
 		"SetSecretWithPropertySucceedsWithExistingSecretAndNewPropertyBinary": {
-			reason: "when a remoteRef property is specified, this property will be added to the sm secret if it is currently absent (sm secret is binary)",
+			reason: "when a pushSecretData property is specified, this property will be added to the sm secret if it is currently absent (sm secret is binary)",
 			args: args{
 				store: makeValidSecretStore().Spec.Provider.AWS,
 				client: fakesm.Client{
@@ -534,7 +529,7 @@ func TestSetSecret(t *testing.T) {
 						Version:      &defaultUpdatedVersion,
 					}),
 				},
-				remoteRef: remoteRefWithProperty,
+				pushSecretData: pushSecretDataWithProperty,
 			},
 			want: want{
 				err: nil,
@@ -555,7 +550,7 @@ func TestSetSecret(t *testing.T) {
 						Version:      &randomUUIDVersionIncremented,
 					}),
 				},
-				remoteRef: remoteRefWithProperty,
+				pushSecretData: pushSecretDataWithProperty,
 			},
 			want: want{
 				err: nil,
@@ -576,7 +571,7 @@ func TestSetSecret(t *testing.T) {
 						Version:      &initialVersion,
 					}),
 				},
-				remoteRef: remoteRefWithProperty,
+				pushSecretData: pushSecretDataWithProperty,
 			},
 			want: want{
 				err: fmt.Errorf("expected secret version in AWS SSM to be a UUID but got '%s'", unparsableVersion),
@@ -597,14 +592,14 @@ func TestSetSecret(t *testing.T) {
 						Version:      &initialVersion,
 					}),
 				},
-				remoteRef: remoteRefWithProperty,
+				pushSecretData: pushSecretDataWithProperty,
 			},
 			want: want{
 				err: nil,
 			},
 		},
 		"SetSecretWithPropertySucceedsWithExistingSecretAndNewPropertyString": {
-			reason: "when a remoteRef property is specified, this property will be added to the sm secret if it is currently absent (sm secret is a string)",
+			reason: "when a pushSecretData property is specified, this property will be added to the sm secret if it is currently absent (sm secret is a string)",
 			args: args{
 				store: makeValidSecretStore().Spec.Provider.AWS,
 				client: fakesm.Client{
@@ -615,14 +610,14 @@ func TestSetSecret(t *testing.T) {
 						Version:      &defaultUpdatedVersion,
 					}),
 				},
-				remoteRef: remoteRefWithProperty,
+				pushSecretData: pushSecretDataWithProperty,
 			},
 			want: want{
 				err: nil,
 			},
 		},
 		"SetSecretWithPropertySucceedsWithExistingSecretAndNewPropertyWithDot": {
-			reason: "when a remoteRef property is specified, this property will be added to the sm secret if it is currently absent (remoteRef property is a sub-object)",
+			reason: "when a pushSecretData property is specified, this property will be added to the sm secret if it is currently absent (pushSecretData property is a sub-object)",
 			args: args{
 				store: makeValidSecretStore().Spec.Provider.AWS,
 				client: fakesm.Client{
@@ -633,24 +628,24 @@ func TestSetSecret(t *testing.T) {
 						Version:      &defaultUpdatedVersion,
 					}),
 				},
-				remoteRef: fakeRef{key: "fake-key", property: "fake-property.other-fake-property"},
+				pushSecretData: fake.PushSecretData{SecretKey: secretKey, RemoteKey: "fake-key", Property: "fake-property.other-fake-property"},
 			},
 			want: want{
 				err: nil,
 			},
 		},
 		"SetSecretWithPropertyFailsExistingNonJsonSecret": {
-			reason: "setting a remoteRef property is only supported for json secrets",
+			reason: "setting a pushSecretData property is only supported for json secrets",
 			args: args{
 				store: makeValidSecretStore().Spec.Provider.AWS,
 				client: fakesm.Client{
 					GetSecretValueWithContextFn: fakesm.NewGetSecretValueWithContextFn(secretValueOutputFrom(params{s: `non-json-secret`}), nil),
 					DescribeSecretWithContextFn: fakesm.NewDescribeSecretWithContextFn(tagSecretOutput, nil),
 				},
-				remoteRef: remoteRefWithProperty,
+				pushSecretData: pushSecretDataWithProperty,
 			},
 			want: want{
-				err: errors.New("PushSecret for aws secrets manager with a remoteRef property requires a json secret"),
+				err: errors.New("PushSecret for aws secrets manager with a pushSecretData property requires a json secret"),
 			},
 		},
 		"SetSecretCreateSecretFails": {
@@ -661,7 +656,7 @@ func TestSetSecret(t *testing.T) {
 					GetSecretValueWithContextFn: fakesm.NewGetSecretValueWithContextFn(blankSecretValueOutput, &getSecretCorrectErr),
 					CreateSecretWithContextFn:   fakesm.NewCreateSecretWithContextFn(nil, noPermission),
 				},
-				remoteRef: remoteRefWithoutProperty,
+				pushSecretData: pushSecretDataWithoutProperty,
 			},
 			want: want{
 				err: noPermission,
@@ -674,7 +669,7 @@ func TestSetSecret(t *testing.T) {
 				client: fakesm.Client{
 					GetSecretValueWithContextFn: fakesm.NewGetSecretValueWithContextFn(blankSecretValueOutput, noPermission),
 				},
-				remoteRef: remoteRefWithoutProperty,
+				pushSecretData: pushSecretDataWithoutProperty,
 			},
 			want: want{
 				err: noPermission,
@@ -688,7 +683,7 @@ func TestSetSecret(t *testing.T) {
 					GetSecretValueWithContextFn: fakesm.NewGetSecretValueWithContextFn(secretValueOutput2, nil),
 					DescribeSecretWithContextFn: fakesm.NewDescribeSecretWithContextFn(tagSecretOutput, nil),
 				},
-				remoteRef: remoteRefWithoutProperty,
+				pushSecretData: pushSecretDataWithoutProperty,
 			},
 			want: want{
 				err: nil,
@@ -703,7 +698,7 @@ func TestSetSecret(t *testing.T) {
 					PutSecretValueWithContextFn: fakesm.NewPutSecretValueWithContextFn(nil, noPermission),
 					DescribeSecretWithContextFn: fakesm.NewDescribeSecretWithContextFn(tagSecretOutput, nil),
 				},
-				remoteRef: remoteRefWithoutProperty,
+				pushSecretData: pushSecretDataWithoutProperty,
 			},
 			want: want{
 				err: noPermission,
@@ -716,7 +711,7 @@ func TestSetSecret(t *testing.T) {
 				client: fakesm.Client{
 					GetSecretValueWithContextFn: fakesm.NewGetSecretValueWithContextFn(blankSecretValueOutput, &getSecretWrongErr),
 				},
-				remoteRef: remoteRefWithoutProperty,
+				pushSecretData: pushSecretDataWithoutProperty,
 			},
 			want: want{
 				err: &getSecretWrongErr,
@@ -730,7 +725,7 @@ func TestSetSecret(t *testing.T) {
 					GetSecretValueWithContextFn: fakesm.NewGetSecretValueWithContextFn(secretValueOutput, nil),
 					DescribeSecretWithContextFn: fakesm.NewDescribeSecretWithContextFn(nil, noPermission),
 				},
-				remoteRef: remoteRefWithoutProperty,
+				pushSecretData: pushSecretDataWithoutProperty,
 			},
 			want: want{
 				err: noPermission,
@@ -744,7 +739,7 @@ func TestSetSecret(t *testing.T) {
 					GetSecretValueWithContextFn: fakesm.NewGetSecretValueWithContextFn(secretValueOutput, nil),
 					DescribeSecretWithContextFn: fakesm.NewDescribeSecretWithContextFn(tagSecretOutputFaulty, nil),
 				},
-				remoteRef: remoteRefWithoutProperty,
+				pushSecretData: pushSecretDataWithoutProperty,
 			},
 			want: want{
 				err: fmt.Errorf("secret not managed by external-secrets"),
@@ -757,7 +752,7 @@ func TestSetSecret(t *testing.T) {
 			sm := SecretsManager{
 				client: &tc.args.client,
 			}
-			err := sm.PushSecret(context.Background(), []byte("fake-value"), "", nil, tc.args.remoteRef)
+			err := sm.PushSecret(context.Background(), fakeSecret, tc.args.pushSecretData)
 
 			// Error nil XOR tc.want.err nil
 			if ((err == nil) || (tc.want.err == nil)) && !((err == nil) && (tc.want.err == nil)) {
@@ -897,7 +892,7 @@ func TestDeleteSecret(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			ref := fakeRef{key: "fake-key"}
+			ref := fake.PushSecretData{RemoteKey: "fake-key"}
 			sm := SecretsManager{
 				client: &tc.args.client,
 			}

--- a/pkg/provider/azure/keyvault/keyvault.go
+++ b/pkg/provider/azure/keyvault/keyvault.go
@@ -39,7 +39,6 @@ import (
 	"golang.org/x/crypto/sha3"
 	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -296,7 +295,7 @@ func (a *Azure) deleteKeyVaultCertificate(ctx context.Context, certName string) 
 	return nil
 }
 
-func (a *Azure) DeleteSecret(ctx context.Context, remoteRef esv1beta1.PushRemoteRef) error {
+func (a *Azure) DeleteSecret(ctx context.Context, remoteRef esv1beta1.PushSecretRemoteRef) error {
 	objectType, secretName := getObjType(esv1beta1.ExternalSecretDataRemoteRef{Key: remoteRef.GetRemoteKey()})
 	switch objectType {
 	case defaultObjType:
@@ -497,8 +496,9 @@ func (a *Azure) setKeyVaultKey(ctx context.Context, secretName string, value []b
 }
 
 // PushSecret stores secrets into a Key vault instance.
-func (a *Azure) PushSecret(ctx context.Context, value []byte, _ corev1.SecretType, _ *apiextensionsv1.JSON, remoteRef esv1beta1.PushRemoteRef) error {
-	objectType, secretName := getObjType(esv1beta1.ExternalSecretDataRemoteRef{Key: remoteRef.GetRemoteKey()})
+func (a *Azure) PushSecret(ctx context.Context, secret *corev1.Secret, data esv1beta1.PushSecretData) error {
+	objectType, secretName := getObjType(esv1beta1.ExternalSecretDataRemoteRef{Key: data.GetRemoteKey()})
+	value := secret.Data[data.GetSecretKey()]
 	switch objectType {
 	case defaultObjType:
 		return a.setKeyVaultSecret(ctx, secretName, value)

--- a/pkg/provider/azure/keyvault/keyvault_test.go
+++ b/pkg/provider/azure/keyvault/keyvault_test.go
@@ -25,12 +25,14 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/2016-10-01/keyvault"
 	"github.com/Azure/go-autorest/autorest"
+	corev1 "k8s.io/api/core/v1"
 	pointer "k8s.io/utils/ptr"
 
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 	v1 "github.com/external-secrets/external-secrets/apis/meta/v1"
-	fake "github.com/external-secrets/external-secrets/pkg/provider/azure/keyvault/fake"
-	utils "github.com/external-secrets/external-secrets/pkg/utils"
+	"github.com/external-secrets/external-secrets/pkg/provider/azure/keyvault/fake"
+	testingfake "github.com/external-secrets/external-secrets/pkg/provider/testing/fake"
+	"github.com/external-secrets/external-secrets/pkg/utils"
 )
 
 type secretManagerTestCase struct {
@@ -43,7 +45,7 @@ type secretManagerTestCase struct {
 	apiErr                  error
 	setErr                  error
 	deleteErr               error
-	pushRef                 esv1beta1.PushRemoteRef
+	pushData                esv1beta1.PushSecretData
 	secretOutput            keyvault.SecretBundle
 	setSecretOutput         keyvault.SecretBundle
 	keyOutput               keyvault.KeyBundle
@@ -150,29 +152,17 @@ func newKVJWK(b []byte) *keyvault.JSONWebKey {
 	return &key
 }
 
-type fakeRef struct {
-	key string
-}
-
-func (f fakeRef) GetRemoteKey() string {
-	return f.key
-}
-
-func (f fakeRef) GetProperty() string {
-	return ""
-}
-
 func TestAzureKeyVaultDeleteSecret(t *testing.T) {
 	unsupportedType := func(smtc *secretManagerTestCase) {
-		smtc.pushRef = fakeRef{
-			key: "yadayada/foo",
+		smtc.pushData = testingfake.PushSecretData{
+			RemoteKey: "yadayada/foo",
 		}
 		smtc.expectError = "secret type 'yadayada' is not supported"
 	}
 
 	secretSuccess := func(smtc *secretManagerTestCase) {
-		smtc.pushRef = fakeRef{
-			key: secretName,
+		smtc.pushData = testingfake.PushSecretData{
+			RemoteKey: secretName,
 		}
 		smtc.secretOutput = keyvault.SecretBundle{
 			Tags: map[string]*string{
@@ -184,16 +174,16 @@ func TestAzureKeyVaultDeleteSecret(t *testing.T) {
 	}
 
 	secretNotFound := func(smtc *secretManagerTestCase) {
-		smtc.pushRef = fakeRef{
-			key: secretName,
+		smtc.pushData = testingfake.PushSecretData{
+			RemoteKey: secretName,
 		}
 		smtc.apiErr = autorest.DetailedError{StatusCode: 404, Method: "GET", Message: "Not Found"}
 		smtc.deleteErr = autorest.DetailedError{StatusCode: 404, Method: "DELETE", Message: "Not Found"}
 	}
 
 	secretNotManaged := func(smtc *secretManagerTestCase) {
-		smtc.pushRef = fakeRef{
-			key: secretName,
+		smtc.pushData = testingfake.PushSecretData{
+			RemoteKey: secretName,
 		}
 		smtc.secretOutput = keyvault.SecretBundle{
 			Value: pointer.To("foo"),
@@ -203,16 +193,16 @@ func TestAzureKeyVaultDeleteSecret(t *testing.T) {
 	}
 
 	secretUnexpectedError := func(smtc *secretManagerTestCase) {
-		smtc.pushRef = fakeRef{
-			key: secretName,
+		smtc.pushData = testingfake.PushSecretData{
+			RemoteKey: secretName,
 		}
 		smtc.expectError = "boom"
 		smtc.apiErr = fmt.Errorf("boom")
 	}
 
 	secretNoDeletePermissions := func(smtc *secretManagerTestCase) {
-		smtc.pushRef = fakeRef{
-			key: secretName,
+		smtc.pushData = testingfake.PushSecretData{
+			RemoteKey: secretName,
 		}
 		smtc.secretOutput = keyvault.SecretBundle{
 			Tags: map[string]*string{
@@ -225,16 +215,16 @@ func TestAzureKeyVaultDeleteSecret(t *testing.T) {
 	}
 
 	secretNoGetPermissions := func(smtc *secretManagerTestCase) {
-		smtc.pushRef = fakeRef{
-			key: secretName,
+		smtc.pushData = testingfake.PushSecretData{
+			RemoteKey: secretName,
 		}
 		smtc.expectError = errNoPermission
 		smtc.apiErr = autorest.DetailedError{StatusCode: 403, Method: "GET", Message: errNoPermission}
 	}
 
 	certificateSuccess := func(smtc *secretManagerTestCase) {
-		smtc.pushRef = fakeRef{
-			key: certName,
+		smtc.pushData = testingfake.PushSecretData{
+			RemoteKey: certName,
 		}
 		smtc.certOutput = keyvault.CertificateBundle{
 			Tags: map[string]*string{
@@ -244,16 +234,16 @@ func TestAzureKeyVaultDeleteSecret(t *testing.T) {
 		smtc.deleteCertificateOutput = keyvault.DeletedCertificateBundle{}
 	}
 	certNotFound := func(smtc *secretManagerTestCase) {
-		smtc.pushRef = fakeRef{
-			key: certName,
+		smtc.pushData = testingfake.PushSecretData{
+			RemoteKey: certName,
 		}
 		smtc.apiErr = autorest.DetailedError{StatusCode: 404, Method: "GET", Message: "Certificate Not Found"}
 		smtc.deleteErr = autorest.DetailedError{StatusCode: 404, Method: "DELETE", Message: "Not Found"}
 	}
 
 	certNotManaged := func(smtc *secretManagerTestCase) {
-		smtc.pushRef = fakeRef{
-			key: certName,
+		smtc.pushData = testingfake.PushSecretData{
+			RemoteKey: certName,
 		}
 		smtc.certOutput = keyvault.CertificateBundle{}
 		smtc.expectError = errNotManaged
@@ -261,16 +251,16 @@ func TestAzureKeyVaultDeleteSecret(t *testing.T) {
 	}
 
 	certUnexpectedError := func(smtc *secretManagerTestCase) {
-		smtc.pushRef = fakeRef{
-			key: certName,
+		smtc.pushData = testingfake.PushSecretData{
+			RemoteKey: certName,
 		}
 		smtc.expectError = "crash"
 		smtc.apiErr = fmt.Errorf("crash")
 	}
 
 	certNoDeletePermissions := func(smtc *secretManagerTestCase) {
-		smtc.pushRef = fakeRef{
-			key: certName,
+		smtc.pushData = testingfake.PushSecretData{
+			RemoteKey: certName,
 		}
 		smtc.certOutput = keyvault.CertificateBundle{
 			Tags: map[string]*string{
@@ -282,16 +272,16 @@ func TestAzureKeyVaultDeleteSecret(t *testing.T) {
 	}
 
 	certNoGetPermissions := func(smtc *secretManagerTestCase) {
-		smtc.pushRef = fakeRef{
-			key: certName,
+		smtc.pushData = testingfake.PushSecretData{
+			RemoteKey: certName,
 		}
 		smtc.expectError = "No certificate get Permissions"
 		smtc.apiErr = autorest.DetailedError{StatusCode: 403, Method: "GET", Message: "No certificate get Permissions"}
 	}
 
 	keySuccess := func(smtc *secretManagerTestCase) {
-		smtc.pushRef = fakeRef{
-			key: keyName,
+		smtc.pushData = testingfake.PushSecretData{
+			RemoteKey: keyName,
 		}
 		smtc.keyOutput = keyvault.KeyBundle{
 			Tags: map[string]*string{
@@ -301,16 +291,16 @@ func TestAzureKeyVaultDeleteSecret(t *testing.T) {
 		smtc.deleteKeyOutput = keyvault.DeletedKeyBundle{}
 	}
 	keyNotFound := func(smtc *secretManagerTestCase) {
-		smtc.pushRef = fakeRef{
-			key: keyName,
+		smtc.pushData = testingfake.PushSecretData{
+			RemoteKey: keyName,
 		}
 		smtc.apiErr = autorest.DetailedError{StatusCode: 404, Method: "GET", Message: "Not Found"}
 		smtc.deleteErr = autorest.DetailedError{StatusCode: 404, Method: "DELETE", Message: "Not Found"}
 	}
 
 	keyNotManaged := func(smtc *secretManagerTestCase) {
-		smtc.pushRef = fakeRef{
-			key: keyName,
+		smtc.pushData = testingfake.PushSecretData{
+			RemoteKey: keyName,
 		}
 		smtc.keyOutput = keyvault.KeyBundle{}
 		smtc.expectError = errNotManaged
@@ -318,16 +308,16 @@ func TestAzureKeyVaultDeleteSecret(t *testing.T) {
 	}
 
 	keyUnexpectedError := func(smtc *secretManagerTestCase) {
-		smtc.pushRef = fakeRef{
-			key: keyName,
+		smtc.pushData = testingfake.PushSecretData{
+			RemoteKey: keyName,
 		}
 		smtc.expectError = "tls timeout"
 		smtc.apiErr = fmt.Errorf("tls timeout")
 	}
 
 	keyNoDeletePermissions := func(smtc *secretManagerTestCase) {
-		smtc.pushRef = fakeRef{
-			key: keyName,
+		smtc.pushData = testingfake.PushSecretData{
+			RemoteKey: keyName,
 		}
 		smtc.keyOutput = keyvault.KeyBundle{
 			Tags: map[string]*string{
@@ -339,8 +329,8 @@ func TestAzureKeyVaultDeleteSecret(t *testing.T) {
 	}
 
 	keyNoGetPermissions := func(smtc *secretManagerTestCase) {
-		smtc.pushRef = fakeRef{
-			key: keyName,
+		smtc.pushData = testingfake.PushSecretData{
+			RemoteKey: keyName,
 		}
 		smtc.expectError = errNoPermission
 		smtc.apiErr = autorest.DetailedError{StatusCode: 403, Method: "GET", Message: errNoPermission}
@@ -373,7 +363,7 @@ func TestAzureKeyVaultDeleteSecret(t *testing.T) {
 	}
 	for k, v := range successCases {
 		sm.baseClient = v.mockClient
-		err := sm.DeleteSecret(context.Background(), v.pushRef)
+		err := sm.DeleteSecret(context.Background(), v.pushData)
 		if !utils.ErrorContains(err, v.expectError) {
 			if err == nil {
 				t.Errorf("[%d] unexpected error: <nil>, expected: '%s'", k, v.expectError)
@@ -387,16 +377,19 @@ func TestAzureKeyVaultPushSecret(t *testing.T) {
 	p12Cert, _ := base64.StdEncoding.DecodeString("MIIQaQIBAzCCEC8GCSqGSIb3DQEHAaCCECAEghAcMIIQGDCCBk8GCSqGSIb3DQEHBqCCBkAwggY8AgEAMIIGNQYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQYwDgQIoJ3l+zBtWI8CAggAgIIGCBqkhjPsUaowPQrDumYb2OySFN7Jt91IbIeCt1W3Lk99ueJbZ4+xNUiOD+ZDLLJJI/EDtq+0b+TgWHjx92q/IEUj2woQV2rg1W8EW815MmstyD0YRnw7KvoEKBH+CsWiR/JcC/IVoiV1od0dWFfWGSBtWY5xLiaBWUX6xV8zcBVz1fkB+pHOofkStW2up6G2sQos1WwIptAvz6VpS16xLUmZ1whZZvPhqz1GPfexJSavBWEe7YcoxVd/q8LLGQmQCfV7zXwyUX3WnHATkesYPMSTDPuRWXMOrJRjy2zinQP5XweNY2DeZ2bRV6y3v8eQlQNmKBXteNj5H5lJFkOD7BA6xwYlzj3KGB37Qf7kl6R46liT2tlYp/T9eX1ejC0GqICOroPrAy1J5/r9Jlst/39K20omD7M7DGbnqhEWNUeXoXpT6m/UiXLA+0ns5TBZqt4gwC8n8qgjYVvuxvn5tY3gERzkCa6PYzxBfasjM47hHEbsQ1gQORan7OQqTBjbwjeFC4ObMc4u48qxi/cyzMsPgbgE9pQoz2eF5BC6qcJr5mxL/0RWK+Zpn0or9tK4vqf2czLKrWsMcl5sfShSELXY3+jAsUscMbo0LfRgTwsVZGPgOC1cKJlGky734WFj2l9dHVxiRInz6yuWobIT/fmlvPUhjEXNPc0p7vrPvU3/susH+zilbSrp0rY9Y8t70ixGsHPbSHTk8MapukoFnKy2RxcYZQ4cLLMRBo0BA+ugAO7/pa2qGYawzl+U6ydmBftSxTs2gm4SjDnKWoe67r0Q1FHQEWd6rCA40dzAEiCmClCSqzggDKJYnxqub3sqh3Z2Ap9EEZdWBb/Qxryw5h5H3HAOblwudftsyaXsNPf6nDrknANHZyuwkWuh5XYSkKfG8mz6B8+l5A217nYWn0P4i1+WYgnyojJ+m/ZnaNy1+pWXHy1IugoRkfZaVp3NDmwgjK+dnu6rL3/XhJbXlrOk3UEYImX1yMzIWDv/urdWr3bR/cfwM3XwVUy55QUayLIzxRWfWOLuZ8+ZKw8cJ5YGNUa9AgQ3Fs6Lfp7Qn11SdG4adCEJl6DhsugwZokfy6JqBAv0ywbZ94LKvRc1ItM/crfy/5Io1+GsinnF7lsybsZJFGB6tVNWzgZh92dluzUKIRppMG1ZhUmq/4yaJgZsXYDkAxuPWQ2iSpldijmeuBnr/Oct1BpTwM5ogUS3WCHyZajfS/vIGTzz/q8+VnR9W57hvBKulSCS7G06QsFOvr6yOexb9bJJtgsu1sGjqXqyw0SKbFU9AMRunRVezp/r1LwJ+O/8O4ZCB40o3kSJM4tFvj80zVIz8VoWME7JjwAt04v+o9evavxt6p5yaSpH6pzHbvP6cT6YnJqQbYA9J/sDyLt5caq3/OeiJe4tb1pXmJ6dtwFxFygobKnGZjHsL+yRHrIPvNaqztGRzTu5gwEddMZ38nE0IGOhPVnE6WQC1admI/KUUdVOOATD6kJxSwGYGxpsWXX0KOcy9vb3ykeafmHoJU2S64KpxClH8BfOn7Bn4ypab7rNHs76FmqZYmTV9rjHdCgMqI62pB0TKK925q/RQuX+Rn/8J4mMOOjbDQwlndYbljWq0b9tbcTHpZntnmN/KZbydggrKwb0A9PonIGxqoPs+/MrJtCmlgjhjjHE8N3a10apN/NmN/B4TlfBAr47a/2eelTX642kU2DJ2f00mEeDvwY1lkRCjx+80EiY7nUj9cFfPptNdyQbiVDthkS0rXSbyobDgt53g7KU6/UvTdaRWK5Ks9Q5NZ9c44RaHJ/Y7ukWFrsZDCpcQ2v3gn0A9mQPoZGvziMd1Mh7pOJNR2jrpmodGA9j6MMVuYFKu0GbheEhf++UrDOti40GXcPO+o1NAbTClXeIhDEl81cE1rrK+pPvZEB9m/FV7Osp8NmHQDY+z2rPKa5luO6g77/HM9fJrEGBv19ByQcOFuvOQi0RICUp5sIJD+GO3TBGO7WANpUZvB2cezkBbTa/sVAINTXSD007tOo4WfJTBrQbXAbpQ+04B/2yolFvtbYL4rOcMIIJwQYJKoZIhvcNAQcBoIIJsgSCCa4wggmqMIIJpgYLKoZIhvcNAQwKAQKgggluMIIJajAcBgoqhkiG9w0BDAEDMA4ECM7kJUu/1hDPAgIIAASCCUgs+wJaAYsjcSK7oETqGlVmKzCLwkqvstEYmYlJDihNrj0MWHQqmMP/sfdrnqIHVrLnl3vWRN0CBEtzPZGIM5BqYW1puS8mHXowz+8epz6TLRDpiKM2M29+BfAmTkZwlppfuKpu2MoXgd3LLspAQT10pLjoP66OSj+PfUpCbU82+YjjK7PSxog5OrYmuf4Tfohl8bWcFj6mIiaUYiVuF7mRLq3oUY5mE61EjMGp118JKVCG/8sS4MRZ69ulowDZEdrPOCvXzG+gK3bjeMW4aboIaIZ7UxoUy/AYQNdcYjAiUIRWrZx3s7UMa90R7ZvpWRYEEenko95WEUezaing2vVdImMphmjOIpP0Fkm+WTIQHoznE2+ppET1MtIwLyB0PjLptjFtK5orXNqplFWsN6+X5B6ATG0KCwKcsX7fmrkbDpO3B/suVAGk4SdQsV4xrlHhUneUl4hiZ6v2M9MIC+ZMRuGxmuej7znRxV6IRuVVIOqWuwGVVOQpGC4sCOc2Ej0WQeHQCxVK4EWlGL7JE9ux4Ds//40LC2mUihJXiG01ZI/v6eez1GrPeoOeTtHU7+5N7eU4f00S0XSVQGOhUwlp1E9c7DkSPA4lJ7MfTYUFLeP4R+ITpXXbdco65mwH2WFWPbTAKG1rabHj2D5DvHEoBZEsgcD4klhPnZIEBh6gFg67MZB9XNiofSiLzeSKDgfyeTG1MCctUWTa+vy1mrue4rREuRQMC4h0NMyPJ4LlVYutFfEncH2iGmB8t4CVM5CzZ0hXqDxHEgddU02ix/aIzizXqWgpPN0vkHp/Hv+/wyRvjwuiljmE8otRRFMinoIigmLKQKueJQpLWAZAvBjmCZdKTG8sjJAeo0ufOJQdi/EuCmDWR3YkXKi/RX7ub6cnc9hFb+zDGiplLPTyYqOnEPVut8fdA0kmUuAkelLpSbJcv6h3/tS/IJzH2vMCz26J152UaY6Zh0AqD1hl+wA5q5qgDER0jeFY11KypNfEgYxNhr/BcvuNYvN1/1T/wuvEIviMYhJPaSXXbtqpBzIjpkvxOzm9LeC9wqRM1Gq1HrSHwUUeRl8AeMpsRmcmRRy222ZM7p6b0T90l/AKcPLmNxQVYTy5+DeWMC/YaBFHPVMiakKEmPZjeR3Vbb63EJ5DCoAN3xh6NmpANXmXAl7z6ID0hVjNV/Ji8Y+tuJczh0IyMQncDBRw76cdup9QIk2D/pKcj9M7ul2Jx2xwBqntJbvFQqjhIhaSzLKMQtaC+qgcL/C/ANFey8IN5zUUver9RdYyEnRNf4OPl/mq7kUs8znnu5wGGOyxHuvHMFUtJfuII3P7YDSltK2QP1uhefhMfEvNYL9QqosN3740nQ8TCPvZFzzoBC8Psn6OvNXnWipz3WCZ+5u+fOXzawpNKvPHWz/D4O4dmMu9/DpxKb8UOLv/+YFEkqkGNDhS91dgyI672JqC4TQ9ijmNwtdgQt+OtOmllUO3cRP5I4nxCLjAJ5bBYmFV7kSdfWJEjkeCUGMKmwP88sXxeAV0D7qGFG0kdNgMow7WE8AI+lKo8bgBpmR8LQlD0Zt/LBlgGk1uOXolXTNaEGXUMj7h3zS46C3qR/UraHTq+vaNrLqY3qYJaVXdvhhShVDEhH6jLFFYJYCBtWCnhZ3lKkFJnIY+n+25lEQNMwR4sNOLxmUP+kzkt6qSjTRj+u1gK4NptkhFck7lFigAlHozlzg1mnKPvXcD2w3B+Qt6smAQb31rxD6P/byFVEjMFFH1LHNaSrmJNt2/Hmlgd1+2lmVieHF0OnptCDt/MxGjlZYD9/MHBDvWC6LgyGAGL3hub/C/wX5ngOYNq7SZJ1xPsonppKsWD/ixwlzXKu0MQS05CjMqnJCUW7YWl8F+2c2WcAnKA8MN4oONJbv29afj35I/mInT20PptaUH3vJg1VrbU4gWyJWw2/ap63Y2mTMwF2MRuuvIZQTlSwAXHaSZT1weqNX37NFVQLEx1GIiMSBXu+ogZEZWuKwlzB2F2OQ4DuhWgxmTA8Fh0md/IG0sc96wBb3E1Jj80UOeIMIsOO3nCA5Wa5+btUaVueIqGHM9L3IGn2jk/PdidEW5Anp7aT8f8korjBKNF/qc7Hk0V0QDvzxXbuHIE2neoZVemgPteu4tFFI5N/wtXAp3BBQi1ozdqWaBBT/fbYiWesp6fe83f6KNaVXTnjGUnkv4ougvZDi99e+plpSFgjMv180/kfyC57PfX/KLbuK6M6nmVykZSzBdxGqe7V2JUR32dYNRZeiNI6PZO2HumyM7/h8adcP2yw9NseW9D4M2wihsY/ozcU/N+Fv+/WDMd+p7Ekl7oN/PERRZcL5bpjq+Oh7cv5mIH443K/tUni1wVrs8Njft/VQfubU2HY0UcFuX0IHc8/yp9NhqFgdMVTLQWTW9RRkl/9XleMco7qqEdhJCK8dHFBAwsK6SB6aUtY4rpopltVKbgnmAmCwkMcg9Q3Bx9DFJ0SVgqQdrNnJ0koJE9BWG96SreVBW+BOCqYED9sZI7DBFc/Hnb3pDwmqV2gr4gl+bzzHfOQwADVDIe6OcT0b3t4iOVhpd6G1LT/df4IdZLxcXi5PPbpwvjFmo8jJpT8DKya0KjW3E25Q6+qQQ9vZzc4d31yUog30tGJun1HHg1A+3KSo67awfgxG7er/viMe+Nx1dLPVlj+wi3X1JJvZlBXJ4yhfaSnzOa5u1ZxAGTz1OuHYkz7USuyJlf5qYV/oCyyypwaQ5DUpzcISgQGdOe4HVA6gTMLHWbX05MCHdfBFRa64c92/nxA0OS4m8xruRgsZwxwLDtG2IHXxcA/Tfam0Rqd5+UfWWyxLSHF3/u5gpLARwPsH59Tb28MhFmVFsELOHt1VoTntQU0qJ4ZljyUwP7Y3u0TmGhj0bEv3s7eqntKUz7zpGnLyxbu1tef4EJvFMYLBNIkkB3bb68i2HCXkoLJRyRH6VT3j9ahea/acgt5U8WASlMH41jURGFdCBWHdk+aIkyqDrJ9KtZFT6h88vUWt9iiAgJInLTL+tJ2j3dMHVvT0WkcAt8w6uXLYT7AGAbKjetqwLiU6JEXfCdZfUVQG50ztLwcfuTlzCO4d9vhkiuy/NIpH9NoONGwCYSfYyx+ycxZjMnLSsJcgys2aANdLGpLnQhy3WY8QxJTAjBgkqhkiG9w0BCRUxFgQUilZxcWgYWs3WodyrZQAAsliFtB4wMTAhMAkGBSsOAwIaBQAEFLCnG3FfSE655zJaBGibla7sAnVEBAguHlNaj8V3VQICCAA=")
 	goodKey, _ := base64.StdEncoding.DecodeString("LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUpRZ0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQ1N3d2dna29BZ0VBQW9JQ0FRQ1pITzRvNkpteU9aZGYKQXQ3RFdqR2tHdzdENVVIU1BHZXQyTjg2cnBGWXcrZThnL3dSeDBnZDBzRk9pelBBREdjcnpmdWE5Z3ZFcDRWcwpXb2FHbmN3UXhqdnMrZ1orWmQ2UkVPNHRLNzRURmYxaWZibmowUHE2OENlQlFpaG8xbDNwM2UwQy8yemVJMjNiCnZWRHZlMm13VXE5aDY4UTFFUmdWMU1LaWJHU1Naak5DQzdkRGFQWmpKazViMFlWVFdxREViemREVnh2ZVVMNVIKcUZnL0RKQTMzVnE2VFQzQ2U5RjBIcEorb3graSs4cUxmWU5qZExSUDZlbEtLTU5naVhhNTFvdnQ5MjF4UkVGdgpYRXYvTUtqWTlhNkppNndIRSs0NmdvbFY4V2puK2xMRkRKVHh6WEFEN2p2NzVzaHY0WEczdFlaQ2J4cTMzZ2JtCm96c0VQZ3lTRGtCMm5zc0tIUEFhSVNPaWpjNDhiSXhwbDVocFJPWUZFblJDWnhablhQNjdLZVF1VWZXQkpoVWcKYWltc0JRK3p6cFB6ZjVUbjRnVExkWll2NU41V1V2djJJdUF5Qktha0ZhR1ZYTzFpZ2FDeVQvUTNBcEE2ZGx4Sgo1VW44SzY4dS9KSGFmWWZ5engwVnVoZk5zbmtiWkxWSEZsR2Rxd3JrU0tCWSs1eS9WWlpkeC9hSHNWWndVN3ZECmNlaGxlWlFNNGV2cm5tMUY3dk5xSHBUK3BHSnpNVWVUNGZMVFpabTBra1Y3ZXl5RGRMMDFEWXRXQk1TM2NEb1EKdU5vWElBMCtDeFZPOHcxcC9wbXF2UFQ3cmpad2pwYkVMUkp3MWs4R3ozU2FKb2VqaFBzWC9xNzNGWWdBc09PRApwTXJuK3ZpU2U0ZnJmR0VmZlEvYXJUVE5qK1BUb3dJREFRQUJBb0lDQUM3ek1CUmJQc1huNHdLL1hvK0ltTEE1Cm04MTEvemo0VE5LQ0xmRlFsa0VoMFcxOUMwNW9UVFRYNjI2cVFMUWpHWC9WS2RIYW9NRXNuVDBjaFNQQ1AxRGwKZUhxeU1FdVI4UzJLZzM1V2EzSnV5OFBueVppUi9GQldVOGJQQXBVakpxa1A1QjJITlZyb2drZGZSZklwWmI4cgptNXZyTDc4Vi9zeXk4UHZkUVBtalhSUmpnMDZvWU9VR1dnRE52cFJRdGZ1R0h1d0hTZ1JodmZwTUpNTXdsd2lLClY4Zkk1NmM3VUg3SzRTRHo1RCtWOWdYUDl2b0lUMEl4OTlkRnFLTnhnM1o0MDIrazcycE1BOFNpQ0t1M3dBN0gKUnozbUZsb1ZRbmV1ajI1TEdHQUo0bGVLQkNJaFhMZlgxWXpvdDQyWEU4ZkJZZW45SjdRNTRPUFlLY0NqUmpjSgp1M2NkamtIbmFWVFc1dDdLTDFuYVAxRmF0S0ZxSjY1V1Y0c3pxWDhPVkpzbWhLalNsNUhqTk1VeERuaFUraWRTCmsxaGNaa00zOWd2RGR1ekRHeHF0L2hHMWNJS3VtamxZb01WNDV4VWFoVHdhTjZnamlrTUxNdFgrb2c0MVAxU3cKa09hZTZ4enJFQmU1eXhqSnVDWFJzK2FFOXZhTmpIWmpnSTNKREJ0enNjeCtvRFZBMXoxWVBpR2t1NXBNYmxYUQpFMWlRQnlJOVRjeHMrazN0NWdIQ0d3Z2lOcXVnOVZJaXY1cTQ2R2VGRVdnQS8wZ2hEZ0hIRnNRSDJ4VEpGU2d6ClluTkRVNlZtQ1RYZEQ0QU5jS085Z0loQzdxYk9iazlUeS9zZkZIQjBrYUdCVjFFZGZ3a0R4LytYdXRacHNUN3IKdkl6SUVDd2JPTEUzZCtLb1grUUJBb0lCQVFESG9SVU42U1VmQ3I4Z2FsOFM3UDhscU1kZnhsQVNRcWRqOHY2WAp3V1o1MFJKVE9TRmxqN3dlb2FnTStDT3pEUHpoU3pMbE4vcVdnK2h1RFJGcXBWb08xTmlrZVdvZEVwajFyZG5qCmlLeFlEVUJKNjFCMk5GT3R6Qm9CZUgyOFpDR3dRUW93clZSNUh5dUlqOTRhTzBiRlNUWEJTdWx2d3NQeDZhR2cKaTV2Q0VITHB6ODZKV1BzcjYwSmxVSDk2Z2U3NXJNZEFuRTJ1UE5JVlRnR2grMHpOenZ2a21yZHRYRVR4QXpFZwo5d0RaNVFZTUNYTGVjV0RxaWtmQUpoaUFJTjdVWEtvajN0b1ZMMzh6Sm95WmNWT3ZLaVRIQXY1MCtyNGhVTzhiCjJmL1J2VllKMngybnJuSVR4L0s2Y2N3UUttb1dFNmJRdmg4SXJGTEI3aWN2cVJzUEFvSUJBUURFV1VGemRyRHgKN2w4VGg2bVV5ZlBIWWtOUU0vdDBqM3l3RDROQ2JuSlEvZGd2OGNqMVhGWTNkOWptdWZreGtrQ01WVC8rcVNrOQp1cm1JVVJDeGo5ZDJZcUtMYXZVcUVFWCtNVStIZ0VDOW4yTHluN0xXdVNyK2dFWVdkNllXUVNSVXpoS0xaN2RUCnliTnhmcnNtczNFSVJEZTkwcFV4ZGJ0eWpJSTlZd1NaRDdMUHVOQmc1cWNaTW1xWG9vSnQxdnJld1JINncwam8KM1pxTWMrVGFtNGxYc0xmU0pqTlAzd2IzZEE0ZDFvWWFIb29WWTVyK0dER1F5YnVKYllQZSt6d01NTkJhZ2dTVQpCL3J5NlBldVBTWVJnby9kTlR2TERDamJjbytXdFpncjRJaWxCVmpCbmwycEhzakVHYjZDV2Q2bXZCdlk3SWM5ClM3cXJLUGQrWE00dEFvSUJBR08wRkN2cWNkdmJKakl1Ym1XcGNKV0NnbkZYUHM2Zjg3Sjd2cVJVdDdYSHNmdFcKNFZNMFFxU1o0TEQ1amZyelZhbkFRUjh5b2psaWtFZkd4eGdZbGE0cXFEa2RXdDVDVjVyOHhZSmExSmoxcFZKRgo4TjNZcktKMCtkZ2FNZEpSd0hHalNrK2RnajhzVGpYYWhQZGMrNisxTE4vcFprV25aTzRCM2ZPdFJwSGFYVXBoCnU2bmxneTBnUnYwTEEyQlFYT2JlWUhYb212T1c5T1luRzdHbkxXanRJK205VERlV2llaEZ5OWZIQmVuTjlRTTIKQk9VTWczY2dzVTFLdVpuazBPWUhrZ0p3WDBPTmdWNHV0ckk4WTZ0c3hRbVFlVDQ3clpJK05lNFhKeW0rQXFiUgpoVEltY2x0bTFkaEExY2FOS0liMk1hNjRCZy95NFRKeW02ZTJNZ2tDZ2dFQkFKTGt5NmljVllqSjh1dGpoU1ZCCmFWWHpWN1M3RHhhRytwdWxIMmdseFBSKzFLd1owV1J1N2ptVk9mcHppOURnUDlZOU9TRkdZUXBEbGVZNzc2ZEgKbThSL3ltZFBYNWRXa1dhNGNXMUlNQ2N0QlJQTEVqcStVVUlScVYzSnFjSGdmbFBMeitmbmNpb0hMbTVzaDR0TwpsL085Ulk2SDZ3SVR1R2JjWTl1VkpxMTBKeXhzY2NqdEJubzlVNjJaOE1aSUhXdGxPaFJHNFZjRjQwZk10Snd2CjNMSjBEVEgxVGxJazRzdGlVZVZVeHdMbmNocktaL3hORVZmbTlKeStCL2hjTVBKVjJxcTd0cjBnczBmanJ0ajEKK25NRElLbzMxMEh6R09ZRWNSUXBTMjBZRUdLVSsyL3ZFTmNqcHNPL0Z0M2lha2FIV0xZVFRxSTI4N0oxZGFOZAp2d2tDZ2dFQUNqWTJIc0ErSlQvWlU1Q0k1NlFRNmlMTkdJeFNUYkxUMGJNbGNWTDJraGFFNTRMVGtld0I5enFTCk5xNVFacUhxbGk2anZiKzM4Q1FPUWxPWmd6clVtZlhIemNWQ1FwMUk1RjRmSGkyWUVVa3FJL2dWdlVGMUxCNUUKZE1KR1FZa3Jick83Qjc0eE50RUV3Mmh3UFUwcTRmby92eFZXV0pFdTNoMGpSL0llMDA3UGtPZ0p1K1R5ZWZBNwpQVkM4OFlQbmsyZ3ArUFpRdDljanhOL0V4enRweDZ4cUJzT0MvQWZIYU5BdFA0azM5MVc5NjN3eHVwbUE5SkdiCk4yM0NCRmVIZDJmTUViTWJuWDk1Q1NYNjNJVWNaNVRhZTdwQS9OZ094YkdzaGRSMHdFZldTMGNyT1VTdGt6aE0KT3lCekNZSk53d3Bld3cyOFpIMGgybHh6VVRHWStRPT0KLS0tLS1FTkQgUFJJVkFURSBLRVktLS0tLQo=")
 	goodSecret := "old"
+	secretKey := "fakeSecretKey"
 	typeNotSupported := func(smtc *secretManagerTestCase) {
-		smtc.pushRef = fakeRef{
-			key: "badtype/secret",
+		smtc.pushData = testingfake.PushSecretData{
+			SecretKey: secretKey,
+			RemoteKey: "badtype/secret",
 		}
 		smtc.expectError = "secret type badtype not supported"
 	}
 	secretSuccess := func(smtc *secretManagerTestCase) {
 		smtc.setValue = []byte("secret")
-		smtc.pushRef = fakeRef{
-			key: secretName,
+		smtc.pushData = testingfake.PushSecretData{
+			SecretKey: secretKey,
+			RemoteKey: secretName,
 		}
 		smtc.secretOutput = keyvault.SecretBundle{
 			Tags: map[string]*string{
@@ -407,8 +400,9 @@ func TestAzureKeyVaultPushSecret(t *testing.T) {
 	}
 	secretNoChange := func(smtc *secretManagerTestCase) {
 		smtc.setValue = []byte(goodSecret)
-		smtc.pushRef = fakeRef{
-			key: secretName,
+		smtc.pushData = testingfake.PushSecretData{
+			SecretKey: secretKey,
+			RemoteKey: secretName,
 		}
 		smtc.secretOutput = keyvault.SecretBundle{
 			Tags: map[string]*string{
@@ -419,8 +413,9 @@ func TestAzureKeyVaultPushSecret(t *testing.T) {
 	}
 	secretWrongTags := func(smtc *secretManagerTestCase) {
 		smtc.setValue = []byte(goodSecret)
-		smtc.pushRef = fakeRef{
-			key: secretName,
+		smtc.pushData = testingfake.PushSecretData{
+			SecretKey: secretKey,
+			RemoteKey: secretName,
 		}
 		smtc.secretOutput = keyvault.SecretBundle{
 			Tags: map[string]*string{
@@ -432,8 +427,9 @@ func TestAzureKeyVaultPushSecret(t *testing.T) {
 	}
 	secretNoTags := func(smtc *secretManagerTestCase) {
 		smtc.setValue = []byte(goodSecret)
-		smtc.pushRef = fakeRef{
-			key: secretName,
+		smtc.pushData = testingfake.PushSecretData{
+			SecretKey: secretKey,
+			RemoteKey: secretName,
 		}
 		smtc.secretOutput = keyvault.SecretBundle{
 			Tags:  map[string]*string{},
@@ -443,31 +439,35 @@ func TestAzureKeyVaultPushSecret(t *testing.T) {
 	}
 	secretNotFound := func(smtc *secretManagerTestCase) {
 		smtc.setValue = []byte(goodSecret)
-		smtc.pushRef = fakeRef{
-			key: secretName,
+		smtc.pushData = testingfake.PushSecretData{
+			SecretKey: secretKey,
+			RemoteKey: secretName,
 		}
 		smtc.apiErr = autorest.DetailedError{StatusCode: 404, Method: "GET", Message: "Not Found"}
 	}
 	failedGetSecret := func(smtc *secretManagerTestCase) {
 		smtc.setValue = []byte(goodSecret)
-		smtc.pushRef = fakeRef{
-			key: secretName,
+		smtc.pushData = testingfake.PushSecretData{
+			SecretKey: secretKey,
+			RemoteKey: secretName,
 		}
 		smtc.apiErr = autorest.DetailedError{StatusCode: 403, Method: "GET", Message: "Forbidden"}
 		smtc.expectError = errAPI
 	}
 	failedNotParseableError := func(smtc *secretManagerTestCase) {
 		smtc.setValue = []byte(goodSecret)
-		smtc.pushRef = fakeRef{
-			key: secretName,
+		smtc.pushData = testingfake.PushSecretData{
+			SecretKey: secretKey,
+			RemoteKey: secretName,
 		}
 		smtc.apiErr = fmt.Errorf("crash")
 		smtc.expectError = "crash"
 	}
 	failedSetSecret := func(smtc *secretManagerTestCase) {
 		smtc.setValue = []byte(goodSecret)
-		smtc.pushRef = fakeRef{
-			key: secretName,
+		smtc.pushData = testingfake.PushSecretData{
+			SecretKey: secretKey,
+			RemoteKey: secretName,
 		}
 		smtc.apiErr = autorest.DetailedError{StatusCode: 404, Method: "GET", Message: "Not Found"}
 		smtc.setErr = autorest.DetailedError{StatusCode: 403, Method: "POST", Message: "Forbidden"}
@@ -475,8 +475,9 @@ func TestAzureKeyVaultPushSecret(t *testing.T) {
 	}
 	keySuccess := func(smtc *secretManagerTestCase) {
 		smtc.setValue = goodKey
-		smtc.pushRef = fakeRef{
-			key: keyName,
+		smtc.pushData = testingfake.PushSecretData{
+			SecretKey: secretKey,
+			RemoteKey: keyName,
 		}
 		smtc.keyOutput = keyvault.KeyBundle{
 			Tags: map[string]*string{
@@ -487,8 +488,9 @@ func TestAzureKeyVaultPushSecret(t *testing.T) {
 	}
 	symmetricKeySuccess := func(smtc *secretManagerTestCase) {
 		smtc.setValue = []byte("secret")
-		smtc.pushRef = fakeRef{
-			key: keyName,
+		smtc.pushData = testingfake.PushSecretData{
+			SecretKey: secretKey,
+			RemoteKey: keyName,
 		}
 		smtc.keyOutput = keyvault.KeyBundle{
 			Tags: map[string]*string{
@@ -499,8 +501,9 @@ func TestAzureKeyVaultPushSecret(t *testing.T) {
 	}
 	RSAKeySuccess := func(smtc *secretManagerTestCase) {
 		smtc.setValue, _ = base64.StdEncoding.DecodeString("LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlKS1FJQkFBS0NBZ0VBdmIxYjM2YlpyaFNFYm5YWGtRL1pjR3VLY05HMDBGa2U1SkVOaWU4UzFHTG1uK1N0CndmdittVFRUN2xyVkdpVkplV3ZhQnRkMUVLRll0aWdlVlhJQjA0MllzeHRmMlM5WkNzNlUxaFZDWFZQc3BobEUKOUVyOHNHa0Ewa1lKdmxWejR2eFA2NTNzNjFGYTBpclRvUGlJTFZwMU1jdGRxVnB0VnJFV1JadzQ2NEF4MzhNNgpCMjFvN2NaUmlZN3VGZTA4UEllbEd3VGc0cHJRdEg2VXVuK09BV3MrNFNDTU5xT2xDRkNzSDBLK0NZZUMyZmpXClplaURsbjBTUDdkZ3puMmJsbk9VQzZ0Z3VtQ3grdW1ISVdmV1hzUDVQR0hoWFBwYlpGbDA4ZktaelNqbytCOWkKVzVsbWhrRE1HM0dsU0JPMmEvcEtjck1uTFVWbE15OVdWLy9LUmw3ZWFtdmJ5dWFzSnZHbVJ4L3d1NXlpYVhwSwprZG4xL0E2VFhBRnVvbU4xb3NvaGVyMjR2MHZ0YzBGZmxJM3h4WVpVTXIwazhLV0VlM1Nhdk83NkdrZTJhbEppCnVtZ20wTmhtK2pqNmlXajl1V1ZzV215MmFDMHc0aTRDS1d2YU56K0NDek5kWk8vcFpPTmlmTzVSSUZpZ2RzTVgKUHgvWU5nSkVKdmEyUVZ2MU9kcWZTdW1CMS8zRldFYmg5V2tFYXRGOElJRDI5TS9qVktiRm9BaktYeVZhUTI5eQpOOFRWR3Axc2pzOW5sSWdjN0JRUFhBZTVPQUExdnc5SWV4N09QZjhPZENBbDluQzlEaDdaK3MyV2lOVlRxb2dwCk1VbE1GUWxGVXpMWGVCUmp0ay9rL3lWT20yWkhBT2RuR1k4bSthRWlTV0ExYXhpa0RYMG9HWjhjbHFzQ0F3RUEKQVFLQ0FnRUFwZDZBRG9pQ0M1aU1IVFNQZXBUc2RVYk9BOHFQMHdQVjZlS1VmMXlzalZiWVhqYy9Yekc0Wko2MgpGc3o1TnA0YUdUZWJwaGQ4azBrNWtDU0tRQkFtWUphTVF5ZFBKMElwQ1RXSEQ1QU9NQ0JKNVBwNk9VWEVtVU55CklHQng3QjR2N09LOXl6Q0lDVDlac2hrV1lNWmo1YUlLaWJsSzY5M05iOWZuckhyaGw1NjkrdXRrTTFJR1JMYjIKV05iR2RBeXNlQTNzM0Mzcm1xM1VmYldhdDE4QytXS1QyYUxtY0cybXZCb3FIam51Zjg0aktnSkxDMU8wbFQ1SgpVY0l4c3RKRHpjYkVTVjlNZENKTDlSbHB0RjVlSFFJZFJCZ2ROM2IxcGtnOTM3VkJsd1NJaFVDS2I2RXU2M2FCCitBdmxmWmtlQkU4Ti9pOTN0Qy9TUkdqQmhyUnFVcEVOOVYrOHBJczVxTE5keC9RanF4TEpMMUtwMXQ0L0hVTkEKOVVTZVNrVDZTZ09OZ1NnQktCemFCYzUyTXRoWWYrZDk2YTJkN0N0dCt1amJBT0JKTkdKMytGenJoc3pzUTMzWQpkalBWTGQxSzBQSHZ0WDNrSWRKbFNWSmYxS3d5bDVKVm1Cck1wb2ZDQ2dsNnhyR0puYVJPb1A3bDZNb1BFZ21hClNRWWFIQVIvVGIzM2lBeTNLdlBuUkNMQlM2MEJCYitIcVd3c0RhczM0Uk9WUE05bUI2ZldkTUo0TG5kZmVpZm0KTGZ3Sy9GMXpRdFRaczNpYUYyMGEvY0EvdjRENWJCUldYSEQvTDA3Mks5TGxoMGNRRFVZY1V1ZUdwRWUycEZHRApxa1pCL08wSXNBOXAyTnNCekdvRWl1eHJwd0JBaXpiOUdCcU9DZUlGS1hKeU5heGU3YUVDZ2dFQkFOeG9zQ2cyCngwTWQzajRtWVhvWVpMMVBOUklwNlpuN2VLbThzK0tIRFdMUTlXWmtFbUwyODNXNzJFd2dDbmc2VjdsUHVYVlEKVTJXR0xjNDNvUU95U3JlNEZXbnZhTVhnWk42Wis2T0wvQ1J2VHZSbFhVNXJlYVNCT2tyZUJYK1g2dFo2Q1dORgpLWjkxTERvVVR5TlJVTTFUL3lwbS85SlE4MTJ1VUxnYUlQZGl5cCtPYmRoZWdBUE5CS0lxR3Nva0tKRlpjRDNyCjRwSVdHT0U3RVJrbU14MnFZMk54VGtuUGxOVUJzR01jS25qeTdycER5WmpDR0U3eldoRE5XRGdMUkJOc1liaHIKa0p4ZlNVVlBOb2RLaE8xVHQ3bDJRMnplcWxlV05pcktRbWdMY3JJRU9MRUdYcEY3U250eEx3N1pvYWlQU0FWWApQMTVqNXNkZlUzV1ZOdzhDZ2dFQkFOeGcyOGw5TllHUmwwU1JCZFJEakJhV21IK0pWYWdpdG0zNnorcnB1MWdZClZ4dFJ0N0FGTzF1QVphTys1aWd1d0JKcFhSUWJXVmZUcWppaTM1bUV2UENkZjhPcTZBQVlzeXg5WXVmUUdOUnEKZG1VNlcvdWhCMnVURDBrL0dQdjVFb2hBTlRjQmkyS1ROS2p0S1Z2bHFtbWZ4Tis5YTl4NjVEdWRHWUFRNGplNwpGaHZJSlU5WFA5VnRUc0ZGL1dqbE54enJNQURqSzNJekRvQTMwaU1XQXZkeTFjUDgxUzJzeGtwa0ZoL1QrNVVFCjYwZkNOSGFFemtQWWhKUmxYaUZtWXpqc3AyWjZpUERyMllHd1FWbURoMFFGeFVqZnoxdk1ONFdnVlVVeDlmNnUKR3QxeDdHblZFSGhzQ0VjQlFCUkhFbzJRcXY0VDVXbmNTNUVTN2hqK1JxVUNnZ0VBRDVUVEJ6VEFKMjJBSFpLbgpCM09jQTRvSzdXckxHZGllTWhtbCtkaWtTSjBQREJyODljUVJkL3c4a1QwZW9GczNnbUV4Y2lxb2lwL09zeXBaCmxxSlBCK2ZhazYrYUQ0c0tkbllhUlBpTGJhUDB4L0EyaFdteG9zQ0Q5M0Qwb0kyRHkzKzdGQ3A2Zzh4THdSdFkKY04yNXdab3ppckxYV08zaUZuaFJPb0tXWEFhKzNrSzZYelpuQkYzRSt4WFE2UU5mWHM4YzBUUFF3NVVPVXpYUwp3cDFodGJJcTdvZS9DaGJEcGI5RjBldlcwTkFUc2xWQ2Rpc2FmdEpUUnFiTm1zQ3BJbHBpR2lCNGk2VnN6NXFHCjkwOThVQzYvNlR1RURyazYvNUFkNmk1OFBWQzUzZjNRYUN0VUdpTEdKQzNmTHNTUjJoR3UvTG1yUUNmOTA1QlkKblJKY1h3S0NBUUVBbjJkQUV5SUtEY3B0akI4S0JGdEhmUjg0OXljeldnYWh4ak5oS1I0ZmNMMUtaR3hiWFdxcgpZS2dpM0tvOGVGdzRlaGpVUnJMeGtPRjlnckhzNG5KczUrNUVlQmVxOEVidGN3VFBBYlkzLzQxeVRnNUVjbUlyCnA5Z2Jlbk8xY3F6YWhzdEtzcHJmWTFIdkNURmlkU0pPZlZBZmEyYnNHZkthRzdTcXVVTjlIYXFwZHpieUpjMksKVXFwYUNOckRUWmhlb1FCTkhKYzAyY21zZDNubytZLzJYVjRtMlRpTVNobHE1R3c0eEpUa3FRbUIxY25YZ05MWApENlFSWWZWZ2ZQQStYUEp3czJOMm9pMDJpdVFlb016T2pwbE45a1JOREsxT2k4MUpZRitlKzdTYm9nbkJZMXZHCktoU2FlQ0dqWkFkMG1BbElaYmVtZlVmbk1PeHNaSStvTVFLQ0FRQmdETzBkTEt2Z3k0OFFwNzdzU3FkeGRRdTEKb2pqYm9rMGY4VVo5ZDJZWWl1WHMwb0k2WFQ4cmpESmJYUGZSUmFVUU1JYWRrL1VZOWxRdHZRRThHbW9aR2ozbgpXYTVXWGVkcUR3YUR4aHpmVnZQUzFMVm1VdkhsbllPWVBVT0JPc1ZUaU4yWXk1L0Y5WEpxMWRlVW0xVnVOZCs1ClVuK3d0YWVHVGR5K1pyQjF2RUFRT3M3R1REVFI2MjgwV1BPZ1JsenVRejhkYllYR29iajJrd3N1empCa0EvSjAKc2dkeEF0dExBWmIzQlVSQ2NmenkrdHJCd0Y3S1ZYek5EQnhmcit3MklRR0hINXR5NmNvcExTVDNXb2Y4WVRuTQpMdHBCVDNZTmgwTm5hS25HTlRGc3pZRldIRlJqSjRZU1BrcW85TkdWa0tiblZyOTllMDFjLys1VjBYY00KLS0tLS1FTkQgUlNBIFBSSVZBVEUgS0VZLS0tLS0K")
-		smtc.pushRef = fakeRef{
-			key: keyName,
+		smtc.pushData = testingfake.PushSecretData{
+			SecretKey: secretKey,
+			RemoteKey: keyName,
 		}
 		smtc.keyOutput = keyvault.KeyBundle{
 			Tags: map[string]*string{
@@ -511,8 +514,9 @@ func TestAzureKeyVaultPushSecret(t *testing.T) {
 	}
 	ECKeySuccess := func(smtc *secretManagerTestCase) {
 		smtc.setValue, _ = base64.StdEncoding.DecodeString("LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1JR2tBZ0VCQkRBWTk0L0NYOGo4UDNBakZXUkZYR0pWMFNWT1ErU1ZpV01nd0VFdy9rV2ZXcHF1OGtidllVTnAKVTQyN1Fubk5NV3VnQndZRks0RUVBQ0toWkFOaUFBU1FyOXAvcytDWHpFY2RUZ2t0aVFhTkxuVzJnNmQ1QkF4cQpBQXNaQms2UW11WngrZTZMUUdra080Uit0SVVaZCtWTGJlV3pLeEl3dk9xSVA3bkp0QldtTjZ4N3JsMjJibnhNCm5QWVQyNy9wSXM1RTk1L2dPV2RhOGMyUStHQTd5RTQ9Ci0tLS0tRU5EIEVDIFBSSVZBVEUgS0VZLS0tLS0K")
-		smtc.pushRef = fakeRef{
-			key: keyName,
+		smtc.pushData = testingfake.PushSecretData{
+			SecretKey: secretKey,
+			RemoteKey: keyName,
 		}
 		smtc.keyOutput = keyvault.KeyBundle{
 			Tags: map[string]*string{
@@ -523,8 +527,9 @@ func TestAzureKeyVaultPushSecret(t *testing.T) {
 	}
 	invalidKey := func(smtc *secretManagerTestCase) {
 		smtc.setValue, _ = base64.StdEncoding.DecodeString("LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZhekNDQTFPZ0F3SUJBZ0lVUHZKZ21wcTBKUWVRNkJuL0hmVTcvUDhRTFlFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1JURUxNQWtHQTFVRUJoTUNRVlV4RXpBUkJnTlZCQWdNQ2xOdmJXVXRVM1JoZEdVeElUQWZCZ05WQkFvTQpHRWx1ZEdWeWJtVjBJRmRwWkdkcGRITWdVSFI1SUV4MFpEQWVGdzB5TWpBMk1UY3lNREEwTWpSYUZ3MHlNekEyCk1UY3lNREEwTWpSYU1FVXhDekFKQmdOVkJBWVRBa0ZWTVJNd0VRWURWUVFJREFwVGIyMWxMVk4wWVhSbE1TRXcKSHdZRFZRUUtEQmhKYm5SbGNtNWxkQ0JYYVdSbmFYUnpJRkIwZVNCTWRHUXdnZ0lpTUEwR0NTcUdTSWIzRFFFQgpBUVVBQTRJQ0R3QXdnZ0lLQW9JQ0FRRGlEditEVENBL0xaZjZiNnlVYnliQUxlSUViOHh0aHd1dnRFZk5aZ1dOClN3ZWNMZXY0QXF1N3lSUWRidlQ1cnRKOGs3TnJ0TUE0RDNVN1BQamkwOXVpdjFnSGRockY0VlloTjhiRFllc1UKaEpxZXZSVFBVQ0hRek9xMmNhT3ViRnBUN3JxN3lsMVFTQTFlbkptMUQxNnc0UnlJcEtTLzhvVDNQaGtXM1YydwpkWmFjblZSV1RXZE5MTy9iVWdseDd1YzJMS0wwd2pIMzNSbkZiWUUrTTdiZFVDUXlsSXFwcDM2ZWNvL0Y1Ym1xCjdRdzJ2VkRENENGY0g5aUp4N1FDYjc4Skp5WWlMNzRycjJNVXVzMzR5RlhpMUk5RDR0ajdtQTM2VmNHRk9OZUsKdEtLMnlOYWNrWm1VeTlLQUdGWnIxU2c0ODZTcWw2Y2VpTlAvVGpsb3dQaDNMOTFHOEUxaGJSM3dDS2J6MUR1bQpmaEZOSUdNZmNERkNRcXpEUlU4OEpuUlcyYnF2bGpGanFla0NkcncyeHcrOWp1K1NieXkxeVlrN3ZSM015ZHovCmJ1YUY1S29YUlVzUzhxOHIwSEg1TVAzR3ZYVVY3eXU4bE5kUUtzMXhnVVpmL2JYM0ZjS2xjazhNU3ZZbjNMQWoKbDNRNHMwMXZQY1JnaUMyTUZmajlzV0pueW16YVhYUk1qNFpaY0RuVHlFUmhOcHpXSmNMelh3bFcydTVKdkpVTQpRVEdxUlpXYkErMHF5Y0dBOENBTHRRTXc2ZU5sLzI0Mlo5ZnZ0U0JPc3VkWTdEWTFXckFTWTNhbVV1WWU4RjFBCjhNMlg2N0xBc1lGNkY5YW9JNk00S2dVSXdHYm81OGFVTU1qdzJibGkzdHZIaVNSSjduejFXU1VGOHZnZThIYkEKcFFJREFRQUJvMU13VVRBZEJnTlZIUTRFRmdRVWd0Y0xTUXpaUkRmQkFsSWh5b2pJTHNLYXBwc3dId1lEVlIwagpCQmd3Rm9BVWd0Y0xTUXpaUkRmQkFsSWh5b2pJTHNLYXBwc3dEd1lEVlIwVEFRSC9CQVV3QXdFQi96QU5CZ2txCmhraUc5dzBCQVFzRkFBT0NBZ0VBcy96OWNOT1ZSUzZFMmJVZm9GZS9lQW5OZlJjTmNaaW05VkdCWUFtRjc0MDgKSVEvVjhDK3g3cEloR1NGZ2VFNncxS1BRVXF0Z3dldUxFK0psOVhEYlAvMUdhcmgvN0xDWTVBUXk5eEdTVTNkcAp5VWs3SWE2a0wxRENkS3M0dXdGZ24wVjE1SytSM01Ud2FsemhVb1NVS2tDYVVSeU4vNTZXYk9OanhzRUhUbFhnClBBTEVYKzZVNDMzdktkYnNZdTJXZ2hXSmNwMytSZkI2MU90VmdvYTJYaThhL2pSbFpKVUJ1ZURESGEwVTE0L2EKaFRKcVdQWElROFlTY1BCbndsTzFyRjJkaEtMU0hiczZBd3d6VEVHUE5SUVpGRXF4YTJlb3VvV0NWUmxHTGVueQpMcWxnb1FSQ1pGRTdNNnBJazE5b0ZwV2tTSmNXYjFRMjJRWE03SFdKNjNtM2VBRjBUNThXcE45UzBsYXFNbnZCClZxNVpueUs1YVNDNjV3MGp1YzJteWM2K1RyUmNQSmM0UHJCY3VSZ0gvS1M1bkQvVFlKSStOSVBjU0NVZ2VKWFgKR003THNZanVuY1pCQmJkbFByRXJJN3pkYVNGdVJJbWYrSmh3T2p4OThSZjg3WkQ3d05pRmtzd1ZQYWZFQzFXQQoxc3ZMZDI0Nk0vR3I0RFVDK2Y2MUx4eFNKUkRWMDNySmdsZnY2cWlrL3hjaVlKU2lDdkZzR0hqYzBJaEtyTXBNCnFKRW03dWQxK3VTM3NHWTR6SkVUMUhleEJudjJ4RVlESjZhbGErV3FsNDdZTllSNm4yNlAvUWpNYjdSSGE1ZWMKUEhPMW5HaTY5L1U1dmVMRVlmZmtIV01qSTlKa1dhQzFiREcrMDl0clpSdXNUQWJCZHhqbWxzZ3o0UUFDeFd3PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==")
-		smtc.pushRef = fakeRef{
-			key: keyName,
+		smtc.pushData = testingfake.PushSecretData{
+			SecretKey: secretKey,
+			RemoteKey: keyName,
 		}
 		smtc.keyOutput = keyvault.KeyBundle{
 			Tags: map[string]*string{
@@ -537,8 +542,9 @@ func TestAzureKeyVaultPushSecret(t *testing.T) {
 
 	noTags := func(smtc *secretManagerTestCase) {
 		smtc.setValue = goodKey
-		smtc.pushRef = fakeRef{
-			key: keyName,
+		smtc.pushData = testingfake.PushSecretData{
+			SecretKey: secretKey,
+			RemoteKey: keyName,
 		}
 		smtc.keyOutput = keyvault.KeyBundle{
 			Tags: map[string]*string{},
@@ -548,8 +554,9 @@ func TestAzureKeyVaultPushSecret(t *testing.T) {
 	}
 	wrongTags := func(smtc *secretManagerTestCase) {
 		smtc.setValue = goodKey
-		smtc.pushRef = fakeRef{
-			key: keyName,
+		smtc.pushData = testingfake.PushSecretData{
+			SecretKey: secretKey,
+			RemoteKey: keyName,
 		}
 		smtc.keyOutput = keyvault.KeyBundle{
 			Tags: map[string]*string{
@@ -561,24 +568,27 @@ func TestAzureKeyVaultPushSecret(t *testing.T) {
 	}
 	errorGetKey := func(smtc *secretManagerTestCase) {
 		smtc.setValue = goodKey
-		smtc.pushRef = fakeRef{
-			key: keyName,
+		smtc.pushData = testingfake.PushSecretData{
+			SecretKey: secretKey,
+			RemoteKey: keyName,
 		}
 		smtc.apiErr = autorest.DetailedError{StatusCode: 403, Method: "GET", Message: "Forbidden"}
 		smtc.expectError = errAPI
 	}
 	keyNotFound := func(smtc *secretManagerTestCase) {
 		smtc.setValue = goodKey
-		smtc.pushRef = fakeRef{
-			key: keyName,
+		smtc.pushData = testingfake.PushSecretData{
+			SecretKey: secretKey,
+			RemoteKey: keyName,
 		}
 		smtc.apiErr = autorest.DetailedError{StatusCode: 404, Method: "GET", Message: "Not Found"}
 		smtc.expectError = ""
 	}
 	importKeyFailed := func(smtc *secretManagerTestCase) {
 		smtc.setValue = goodKey
-		smtc.pushRef = fakeRef{
-			key: keyName,
+		smtc.pushData = testingfake.PushSecretData{
+			SecretKey: secretKey,
+			RemoteKey: keyName,
 		}
 		smtc.apiErr = autorest.DetailedError{StatusCode: 404, Method: "GET", Message: "Not Found"}
 		smtc.setErr = autorest.DetailedError{StatusCode: 403, Method: "POST", Message: "Forbidden"}
@@ -586,8 +596,9 @@ func TestAzureKeyVaultPushSecret(t *testing.T) {
 	}
 	certP12Success := func(smtc *secretManagerTestCase) {
 		smtc.setValue = p12Cert
-		smtc.pushRef = fakeRef{
-			key: certName,
+		smtc.pushData = testingfake.PushSecretData{
+			SecretKey: secretKey,
+			RemoteKey: certName,
 		}
 		smtc.certOutput = keyvault.CertificateBundle{
 			X509Thumbprint: pointer.To("123"),
@@ -599,8 +610,9 @@ func TestAzureKeyVaultPushSecret(t *testing.T) {
 	certPEMSuccess := func(smtc *secretManagerTestCase) {
 		pemCert, _ := base64.StdEncoding.DecodeString("LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZwekNDQTQrZ0F3SUJBZ0lVTUhhVDZtZG8vd2Urbit0NFB2R0JZaUdDSXE0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1l6RUxNQWtHQTFVRUJoTUNRVlV4RXpBUkJnTlZCQWdNQ2xOdmJXVXRVM1JoZEdVeElUQWZCZ05WQkFvTQpHRWx1ZEdWeWJtVjBJRmRwWkdkcGRITWdVSFI1SUV4MFpERWNNQm9HQTFVRUF3d1RZVzV2ZEdobGNpMW1iMjh0ClltRnlMbU52YlRBZUZ3MHlNakEyTURreE56UTFNelphRncweU16QTJNRGt4TnpRMU16WmFNR014Q3pBSkJnTlYKQkFZVEFrRlZNUk13RVFZRFZRUUlEQXBUYjIxbExWTjBZWFJsTVNFd0h3WURWUVFLREJoSmJuUmxjbTVsZENCWAphV1JuYVhSeklGQjBlU0JNZEdReEhEQWFCZ05WQkFNTUUyRnViM1JvWlhJdFptOXZMV0poY2k1amIyMHdnZ0lpCk1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQ0R3QXdnZ0lLQW9JQ0FRQ1pITzRvNkpteU9aZGZBdDdEV2pHa0d3N0QKNVVIU1BHZXQyTjg2cnBGWXcrZThnL3dSeDBnZDBzRk9pelBBREdjcnpmdWE5Z3ZFcDRWc1dvYUduY3dReGp2cworZ1orWmQ2UkVPNHRLNzRURmYxaWZibmowUHE2OENlQlFpaG8xbDNwM2UwQy8yemVJMjNidlZEdmUybXdVcTloCjY4UTFFUmdWMU1LaWJHU1Naak5DQzdkRGFQWmpKazViMFlWVFdxREViemREVnh2ZVVMNVJxRmcvREpBMzNWcTYKVFQzQ2U5RjBIcEorb3graSs4cUxmWU5qZExSUDZlbEtLTU5naVhhNTFvdnQ5MjF4UkVGdlhFdi9NS2pZOWE2SgppNndIRSs0NmdvbFY4V2puK2xMRkRKVHh6WEFEN2p2NzVzaHY0WEczdFlaQ2J4cTMzZ2Jtb3pzRVBneVNEa0IyCm5zc0tIUEFhSVNPaWpjNDhiSXhwbDVocFJPWUZFblJDWnhablhQNjdLZVF1VWZXQkpoVWdhaW1zQlErenpwUHoKZjVUbjRnVExkWll2NU41V1V2djJJdUF5Qktha0ZhR1ZYTzFpZ2FDeVQvUTNBcEE2ZGx4SjVVbjhLNjh1L0pIYQpmWWZ5engwVnVoZk5zbmtiWkxWSEZsR2Rxd3JrU0tCWSs1eS9WWlpkeC9hSHNWWndVN3ZEY2VobGVaUU00ZXZyCm5tMUY3dk5xSHBUK3BHSnpNVWVUNGZMVFpabTBra1Y3ZXl5RGRMMDFEWXRXQk1TM2NEb1F1Tm9YSUEwK0N4Vk8KOHcxcC9wbXF2UFQ3cmpad2pwYkVMUkp3MWs4R3ozU2FKb2VqaFBzWC9xNzNGWWdBc09PRHBNcm4rdmlTZTRmcgpmR0VmZlEvYXJUVE5qK1BUb3dJREFRQUJvMU13VVRBZEJnTlZIUTRFRmdRVWJPQk14azJ5UkNkR1N4eEZGMzBUCkZORFhHS3N3SHdZRFZSMGpCQmd3Rm9BVWJPQk14azJ5UkNkR1N4eEZGMzBURk5EWEdLc3dEd1lEVlIwVEFRSC8KQkFVd0F3RUIvekFOQmdrcWhraUc5dzBCQVFzRkFBT0NBZ0VBQXdudUtxOThOQ2hUMlUzU2RSNEFVem1MTjFCVwowNHIwMTA3TjlKdW9LbzJycjhoZ21mRmd0MDgrdFNDYzR5ajZSNStyY1hudXpqeEZLaWJVYnFncFpvd0pSSGEyCjF0NUJicEwxeWcybGZyZnhIb3YvRjh0VnNTbUE4d3loNlVpV1J3RTlrdlBXUm5LblR1a3Y1enpzcVNsTlNpbG0KNDl6UTdTV05sK0lBRnkvc3dacnRKUTEwVlQ5czRuUGVHM29XUU1vdE9QUCtsbFNpeW5LTFpxUTRnU0tSaTNmZQpQTGlXcHQ5WGZYb0dVQ0VqN3E1cGhibExQZ2RLVUNyaEdQMW4yalltWHNjV0xNeWtBbmEyMGNobHJxVlluQ2E4CkpVcDRMZnRGRHA4OVlUb1hPRkhuRm1uTkN2Y0lyRGZGeURmaGw0VU1GcEswT1VLcVRUeFdhSzl1cU9JcGFySXMKS1l3c3ArZkxlV0xiUTZrR2Ztbk81aURSZCtvT2hyTllvb1RaVks5ZlFSNXJEMmU0QitlYTByelFGWEFBVWpKNQpPWGFieGJEclErT01landjNEhxcXN4enRKZ0QyYVAyZUsyL0w1UFdQdWcwRSsxZzhBQlpmVmJvaC9NM01IZ2J6ClBnYVRxZ3V6R0Zka0czRVh1K09oR2JVMC8rNzdWTW5aaTJJUVpuL2F3R1VhN1grTVAwQkR2alZZNWtWcE1aMWgKYzJDbERqZ3hOc0xHdGlrTzRjV2I1c1FSUjJHWU0zZE1rNTBWUWN0SjVScXNSczZwT0NYRFhFM1JlVlFqNGhOQgplV3ZhRFdRMktteU9haTU1ZGJEcmxKK251ODNPbUNwNTlSelA1azU4WmFEWG5sQzM4VXdUdDBxMUQ3K3pGMHRzCjFHOTMydUVCSFdZSHVPQT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=")
 		smtc.setValue = pemCert
-		smtc.pushRef = fakeRef{
-			key: certName,
+		smtc.pushData = testingfake.PushSecretData{
+			SecretKey: secretKey,
+			RemoteKey: certName,
 		}
 		smtc.certOutput = keyvault.CertificateBundle{
 			X509Thumbprint: pointer.To("123"),
@@ -613,8 +625,9 @@ func TestAzureKeyVaultPushSecret(t *testing.T) {
 	certPEMWithGarbageSuccess := func(smtc *secretManagerTestCase) {
 		pemCert, _ := base64.StdEncoding.DecodeString("LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb3dJQkFBS0NBUUVBNWNXTTdWYnd2dGtxWXVLd1lrVUhlSXRMQnd2eUd2ekhzODQwbDZpT00rZXZneEVXCmcydFAvb3NYeG1Rb1ZOdDJLUXRScEwweTh4K3JhWHhRRm5VTlJEc3pHSEkyWTdmWnVVRWd0M2FQQVhmUUlMNm0KazdJaWQ0VmZUdlpLTFhNbnB6dEduNVlaTVBxak0yU3k3ZWY5ZjJMNkxuamNwRkRNZFBqN25vd0pxcTdMb3kxcAo2aU1xeHNyRGY1RXloRHdGUVhiZHRQM0pPNmpjSDY4UUVsVkE0eVR5RHR4WXpxSS9mb0pIM2tGZStHSmJwS0FNCnlNQXRwVkphS2F6VGVnTCtWZnc1MFV2czFLT3A3L1ZxZXVCd2FpZDhtWkhYWDFRUE44RE9VUmJRbkhoVUp1Y3UKZlIyNVdlbHhqWUtOMGdGWFE1bHo5MXY1TmVlTnhQWkhRbkZ2NVFJREFRQUJBb0lCQUNQR2FuYlp2b280amR6dgpwcjdtT0krUVFKSk1UZG5kMmNvcEpROG44MXdwaXE1Qmp0dlBiWmtZVnc5UXNPYmxkTFJYU3RMM2ttTkFYeFFCCmd3YThHdUN3eHZmYmNKUitINncwYzcrYytnOGtkSWRrcDlML1BWYVdzWXc5MUxiVzR5bXFsUWhyK21naDNoODIKWXBXZ05Wd01NUi9qT1pkcjdTbVpTclFZNGJodFN6eFlDOE5Vc0hwL1JaR3FqejdILzRyR1B5dEpTMjFVYVMzegpabXBLdHcrRm81ZVF5UW5lUVUyL2dmNkxTV3JUZjI5Y3NXSEVlMUpRWHZzYlA1enAxbGEzRjBXczEvOUNyT0VNCnFsbUNWNFRXWXR1Nno1a2k2Y1c1enkybEVLSnpCYTVqT0ZqRGtqREFzRm1IZmNydXlMbVVqZUU2MWlPZjAycXQKV1Z5MkZZRUNnWUVBNmRRdFgxTDNmaVpKdFUzd0lkVytxVkZSeEFwMUd6RG5TaEJBQmg0SDA5eHFhMzc2RXovSgpYUmdrV0xLZTU0VUdnZi9ZTzJDTkRkSzVGZmw1MHNrN1hDeGJPRzZITTNSRytxZjQ0MXUzQWd6L0ppa3QyOFBMCmZ2dUJYRG91a1hQUUVvWHR1cHNHaFJLRUxleWhZTHNJSzZNWndJQnFBQThGV200cWc1b2RPazBDZ1lFQSs0N2sKaXNHMWRxaFdnUk1Fc1ZBVG9SeW9ITDBXYVFpbkhXUWQ4ZFBDZ1BDNzJqbmZQdmZ2THZnUEVEeEMxTk41VEJNUQpwOHliS2EvOEZOVzV0VkpQdXdsSGlveURKdHZVVFQ1UVZtVmtOa21LZllZR1h0dVlqQUVtaVJWL0JSRVZQSG0yCnYvTjBLRHA2YVRTQXAxdm10czZoQ0I0ZGNSeXkyNnNTdG5XcUova0NnWUEwRHlBMjYrTGNQQ3dHNko1QStqU2oKdjg0amhteUNMRVlpVURIZzZzaTFXNHA1K21BMDd1dW5CVnY2UDNKdmUwZHlwQUtCWGNLcHhET2U5OWN1bmN6UQpmYk9sZ2I0cUw0WXFBa0hBWk1mKzllUE1uRGh3aUV3RExuMmppZlNhUDUyZ3NoNjJnQk5ZaDBIVWM2Mk9PclhiCitVa2ZlYmVmNGJoQVpPeWtOaWl4dFFLQmdFNm1MRm9kbWlpUkZRcWg4Wk9tWDV5OW91bnBUSHBtVkNsaVJlSjMKdkpZbnJmUGFxQ3U5eExCQXFpVC9VajNNS0Y1YWo1aUc1ZlF3cTNXd0pMSEdIRnR6MlVRK0RqczErN2h5eFJkZAo5K2pwTVQxeGk4aFlpK2NwN094ckpoMWxhK2hPZlk2aUJTMFdxM0w5RVVSQi9XNG1TRDZMZTlVRGpnQVVDbk8xCmNnK3hBb0dCQU9YVktjTzFpS3UrZWNCZUxFMVV0M2JUcUFCL2tCcFRkdVZZbTh3Mld0b1BUQ2tqUTZNc2o5ZWcKRjJ0R0pwbUV0djZ6NnMzbmo1TmhSWlYyWDh0WjMxWHViVkdVQUt4aGprSnlPQnBuczk3bTlxZUMxRHlFcDlMaQp6RnFpQ1VMWVp1c1JObzVTWVRCcHBCbmFPN1ArODhFMnFmV3Fob0h6b1dYNWk1a2dpK0tXCi0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCi0tLS0tQkVHSU4gQ0VSVElGSUNBVEUtLS0tLQpNSUlGcHpDQ0E0K2dBd0lCQWdJVU1IYVQ2bWRvL3dlK24rdDRQdkdCWWlHQ0lxNHdEUVlKS29aSWh2Y05BUUVMCkJRQXdZekVMTUFrR0ExVUVCaE1DUVZVeEV6QVJCZ05WQkFnTUNsTnZiV1V0VTNSaGRHVXhJVEFmQmdOVkJBb00KR0VsdWRHVnlibVYwSUZkcFpHZHBkSE1nVUhSNUlFeDBaREVjTUJvR0ExVUVBd3dUWVc1dmRHaGxjaTFtYjI4dApZbUZ5TG1OdmJUQWVGdzB5TWpBMk1Ea3hOelExTXpaYUZ3MHlNekEyTURreE56UTFNelphTUdNeEN6QUpCZ05WCkJBWVRBa0ZWTVJNd0VRWURWUVFJREFwVGIyMWxMVk4wWVhSbE1TRXdId1lEVlFRS0RCaEpiblJsY201bGRDQlgKYVdSbmFYUnpJRkIwZVNCTWRHUXhIREFhQmdOVkJBTU1FMkZ1YjNSb1pYSXRabTl2TFdKaGNpNWpiMjB3Z2dJaQpNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUNEd0F3Z2dJS0FvSUNBUUNaSE80bzZKbXlPWmRmQXQ3RFdqR2tHdzdECjVVSFNQR2V0Mk44NnJwRll3K2U4Zy93UngwZ2Qwc0ZPaXpQQURHY3J6ZnVhOWd2RXA0VnNXb2FHbmN3UXhqdnMKK2daK1pkNlJFTzR0Szc0VEZmMWlmYm5qMFBxNjhDZUJRaWhvMWwzcDNlMEMvMnplSTIzYnZWRHZlMm13VXE5aAo2OFExRVJnVjFNS2liR1NTWmpOQ0M3ZERhUFpqSms1YjBZVlRXcURFYnpkRFZ4dmVVTDVScUZnL0RKQTMzVnE2ClRUM0NlOUYwSHBKK294K2krOHFMZllOamRMUlA2ZWxLS01OZ2lYYTUxb3Z0OTIxeFJFRnZYRXYvTUtqWTlhNkoKaTZ3SEUrNDZnb2xWOFdqbitsTEZESlR4elhBRDdqdjc1c2h2NFhHM3RZWkNieHEzM2dibW96c0VQZ3lTRGtCMgpuc3NLSFBBYUlTT2lqYzQ4Ykl4cGw1aHBST1lGRW5SQ1p4Wm5YUDY3S2VRdVVmV0JKaFVnYWltc0JRK3p6cFB6CmY1VG40Z1RMZFpZdjVONVdVdnYySXVBeUJLYWtGYUdWWE8xaWdhQ3lUL1EzQXBBNmRseEo1VW44SzY4dS9KSGEKZllmeXp4MFZ1aGZOc25rYlpMVkhGbEdkcXdya1NLQlkrNXkvVlpaZHgvYUhzVlp3VTd2RGNlaGxlWlFNNGV2cgpubTFGN3ZOcUhwVCtwR0p6TVVlVDRmTFRaWm0wa2tWN2V5eURkTDAxRFl0V0JNUzNjRG9RdU5vWElBMCtDeFZPCjh3MXAvcG1xdlBUN3JqWndqcGJFTFJKdzFrOEd6M1NhSm9lamhQc1gvcTczRllnQXNPT0RwTXJuK3ZpU2U0ZnIKZkdFZmZRL2FyVFROaitQVG93SURBUUFCbzFNd1VUQWRCZ05WSFE0RUZnUVViT0JNeGsyeVJDZEdTeHhGRjMwVApGTkRYR0tzd0h3WURWUjBqQkJnd0ZvQVViT0JNeGsyeVJDZEdTeHhGRjMwVEZORFhHS3N3RHdZRFZSMFRBUUgvCkJBVXdBd0VCL3pBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQWdFQUF3bnVLcTk4TkNoVDJVM1NkUjRBVXptTE4xQlcKMDRyMDEwN045SnVvS28ycnI4aGdtZkZndDA4K3RTQ2M0eWo2UjUrcmNYbnV6anhGS2liVWJxZ3Bab3dKUkhhMgoxdDVCYnBMMXlnMmxmcmZ4SG92L0Y4dFZzU21BOHd5aDZVaVdSd0U5a3ZQV1JuS25UdWt2NXp6c3FTbE5TaWxtCjQ5elE3U1dObCtJQUZ5L3N3WnJ0SlExMFZUOXM0blBlRzNvV1FNb3RPUFArbGxTaXluS0xacVE0Z1NLUmkzZmUKUExpV3B0OVhmWG9HVUNFajdxNXBoYmxMUGdkS1VDcmhHUDFuMmpZbVhzY1dMTXlrQW5hMjBjaGxycVZZbkNhOApKVXA0TGZ0RkRwODlZVG9YT0ZIbkZtbk5DdmNJckRmRnlEZmhsNFVNRnBLME9VS3FUVHhXYUs5dXFPSXBhcklzCktZd3NwK2ZMZVdMYlE2a0dmbW5PNWlEUmQrb09ock5Zb29UWlZLOWZRUjVyRDJlNEIrZWEwcnpRRlhBQVVqSjUKT1hhYnhiRHJRK09NZWp3YzRIcXFzeHp0SmdEMmFQMmVLMi9MNVBXUHVnMEUrMWc4QUJaZlZib2gvTTNNSGdiegpQZ2FUcWd1ekdGZGtHM0VYdStPaEdiVTAvKzc3Vk1uWmkySVFabi9hd0dVYTdYK01QMEJEdmpWWTVrVnBNWjFoCmMyQ2xEamd4TnNMR3Rpa080Y1diNXNRUlIyR1lNM2RNazUwVlFjdEo1UnFzUnM2cE9DWERYRTNSZVZRajRoTkIKZVd2YURXUTJLbXlPYWk1NWRiRHJsSitudTgzT21DcDU5UnpQNWs1OFphRFhubEMzOFV3VHQwcTFENyt6RjB0cwoxRzkzMnVFQkhXWUh1T0E9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K")
 		smtc.setValue = pemCert
-		smtc.pushRef = fakeRef{
-			key: certName,
+		smtc.pushData = testingfake.PushSecretData{
+			SecretKey: secretKey,
+			RemoteKey: certName,
 		}
 		smtc.certOutput = keyvault.CertificateBundle{
 			X509Thumbprint: pointer.To("123"),
@@ -627,8 +640,9 @@ func TestAzureKeyVaultPushSecret(t *testing.T) {
 	certDERSuccess := func(smtc *secretManagerTestCase) {
 		derCert, _ := base64.StdEncoding.DecodeString("MIIFpzCCA4+gAwIBAgIUMHaT6mdo/we+n+t4PvGBYiGCIq4wDQYJKoZIhvcNAQELBQAwYzELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDEcMBoGA1UEAwwTYW5vdGhlci1mb28tYmFyLmNvbTAeFw0yMjA2MDkxNzQ1MzZaFw0yMzA2MDkxNzQ1MzZaMGMxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQxHDAaBgNVBAMME2Fub3RoZXItZm9vLWJhci5jb20wggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQCZHO4o6JmyOZdfAt7DWjGkGw7D5UHSPGet2N86rpFYw+e8g/wRx0gd0sFOizPADGcrzfua9gvEp4VsWoaGncwQxjvs+gZ+Zd6REO4tK74TFf1ifbnj0Pq68CeBQiho1l3p3e0C/2zeI23bvVDve2mwUq9h68Q1ERgV1MKibGSSZjNCC7dDaPZjJk5b0YVTWqDEbzdDVxveUL5RqFg/DJA33Vq6TT3Ce9F0HpJ+ox+i+8qLfYNjdLRP6elKKMNgiXa51ovt921xREFvXEv/MKjY9a6Ji6wHE+46golV8Wjn+lLFDJTxzXAD7jv75shv4XG3tYZCbxq33gbmozsEPgySDkB2nssKHPAaISOijc48bIxpl5hpROYFEnRCZxZnXP67KeQuUfWBJhUgaimsBQ+zzpPzf5Tn4gTLdZYv5N5WUvv2IuAyBKakFaGVXO1igaCyT/Q3ApA6dlxJ5Un8K68u/JHafYfyzx0VuhfNsnkbZLVHFlGdqwrkSKBY+5y/VZZdx/aHsVZwU7vDcehleZQM4evrnm1F7vNqHpT+pGJzMUeT4fLTZZm0kkV7eyyDdL01DYtWBMS3cDoQuNoXIA0+CxVO8w1p/pmqvPT7rjZwjpbELRJw1k8Gz3SaJoejhPsX/q73FYgAsOODpMrn+viSe4frfGEffQ/arTTNj+PTowIDAQABo1MwUTAdBgNVHQ4EFgQUbOBMxk2yRCdGSxxFF30TFNDXGKswHwYDVR0jBBgwFoAUbOBMxk2yRCdGSxxFF30TFNDXGKswDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAgEAAwnuKq98NChT2U3SdR4AUzmLN1BW04r0107N9JuoKo2rr8hgmfFgt08+tSCc4yj6R5+rcXnuzjxFKibUbqgpZowJRHa21t5BbpL1yg2lfrfxHov/F8tVsSmA8wyh6UiWRwE9kvPWRnKnTukv5zzsqSlNSilm49zQ7SWNl+IAFy/swZrtJQ10VT9s4nPeG3oWQMotOPP+llSiynKLZqQ4gSKRi3fePLiWpt9XfXoGUCEj7q5phblLPgdKUCrhGP1n2jYmXscWLMykAna20chlrqVYnCa8JUp4LftFDp89YToXOFHnFmnNCvcIrDfFyDfhl4UMFpK0OUKqTTxWaK9uqOIparIsKYwsp+fLeWLbQ6kGfmnO5iDRd+oOhrNYooTZVK9fQR5rD2e4B+ea0rzQFXAAUjJ5OXabxbDrQ+OMejwc4HqqsxztJgD2aP2eK2/L5PWPug0E+1g8ABZfVboh/M3MHgbzPgaTqguzGFdkG3EXu+OhGbU0/+77VMnZi2IQZn/awGUa7X+MP0BDvjVY5kVpMZ1hc2ClDjgxNsLGtikO4cWb5sQRR2GYM3dMk50VQctJ5RqsRs6pOCXDXE3ReVQj4hNBeWvaDWQ2KmyOai55dbDrlJ+nu83OmCp59RzP5k58ZaDXnlC38UwTt0q1D7+zF0ts1G932uEBHWYHuOA=")
 		smtc.setValue = derCert
-		smtc.pushRef = fakeRef{
-			key: certName,
+		smtc.pushData = testingfake.PushSecretData{
+			SecretKey: secretKey,
+			RemoteKey: certName,
 		}
 		smtc.certOutput = keyvault.CertificateBundle{
 			X509Thumbprint: pointer.To("123"),
@@ -641,8 +655,9 @@ func TestAzureKeyVaultPushSecret(t *testing.T) {
 	certImportCertificateError := func(smtc *secretManagerTestCase) {
 		smtc.setErr = errors.New("error")
 		smtc.setValue = p12Cert
-		smtc.pushRef = fakeRef{
-			key: certName,
+		smtc.pushData = testingfake.PushSecretData{
+			SecretKey: secretKey,
+			RemoteKey: certName,
 		}
 		smtc.certOutput = keyvault.CertificateBundle{
 			X509Thumbprint: pointer.To("123"),
@@ -657,8 +672,9 @@ func TestAzureKeyVaultPushSecret(t *testing.T) {
 		smtc.setErr = errors.New("error")
 		cert, _ := base64.StdEncoding.DecodeString("MIIFpzCCA4+gAwIBAgIUMHaT6mdo/we+n+t4PvGBYiGCIq4wDQYJKoZIhvcNAQELBQAwYzELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDEcMBoGA1UEAwwTYW5vdGhlci1mb28tYmFyLmNvbTAeFw0yMjA2MDkxNzQ1MzZaFw0yMzA2MDkxNzQ1MzZaMGMxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQxHDAaBgNVBAMME2Fub3RoZXItZm9vLWJhci5jb20wggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQCZHO4o6JmyOZdfAt7DWjGkGw7D5UHSPGet2N86rpFYw+e8g/wRx0gd0sFOizPADGcrzfua9gvEp4VsWoaGncwQxjvs+gZ+Zd6REO4tK74TFf1ifbnj0Pq68CeBQiho1l3p3e0C/2zeI23bvVDve2mwUq9h68Q1ERgV1MKibGSSZjNCC7dDaPZjJk5b0YVTWqDEbzdDVxveUL5RqFg/DJA33Vq6TT3Ce9F0HpJ+ox+i+8qLfYNjdLRP6elKKMNgiXa51ovt921xREFvXEv/MKjY9a6Ji6wHE+46golV8Wjn+lLFDJTxzXAD7jv75shv4XG3tYZCbxq33gbmozsEPgySDkB2nssKHPAaISOijc48bIxpl5hpROYFEnRCZxZnXP67KeQuUfWBJhUgaimsBQ+zzpPzf5Tn4gTLdZYv5N5WUvv2IuAyBKakFaGVXO1igaCyT/Q3ApA6dlxJ5Un8K68u/JHafYfyzx0VuhfNsnkbZLVHFlGdqwrkSKBY+5y/VZZdx/aHsVZwU7vDcehleZQM4evrnm1F7vNqHpT+pGJzMUeT4fLTZZm0kkV7eyyDdL01DYtWBMS3cDoQuNoXIA0+CxVO8w1p/pmqvPT7rjZwjpbELRJw1k8Gz3SaJoejhPsX/q73FYgAsOODpMrn+viSe4frfGEffQ/arTTNj+PTowIDAQABo1MwUTAdBgNVHQ4EFgQUbOBMxk2yRCdGSxxFF30TFNDXGKswHwYDVR0jBBgwFoAUbOBMxk2yRCdGSxxFF30TFNDXGKswDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAgEAAwnuKq98NChT2U3SdR4AUzmLN1BW04r0107N9JuoKo2rr8hgmfFgt08+tSCc4yj6R5+rcXnuzjxFKibUbqgpZowJRHa21t5BbpL1yg2lfrfxHov/F8tVsSmA8wyh6UiWRwE9kvPWRnKnTukv5zzsqSlNSilm49zQ7SWNl+IAFy/swZrtJQ10VT9s4nPeG3oWQMotOPP+llSiynKLZqQ4gSKRi3fePLiWpt9XfXoGUCEj7q5phblLPgdKUCrhGP1n2jYmXscWLMykAna20chlrqVYnCa8JUp4LftFDp89YToXOFHnFmnNCvcIrDfFyDfhl4UMFpK0OUKqTTxWaK9uqOIparIsKYwsp+fLeWLbQ6kGfmnO5iDRd+oOhrNYooTZVK9fQR5rD2e4B+ea0rzQFXAAUjJ5OXabxbDrQ+OMejwc4HqqsxztJgD2aP2eK2/L5PWPug0E+1g8ABZfVboh/M3MHgbzPgaTqguzGFdkG3EXu+OhGbU0/+77VMnZi2IQZn/awGUa7X+MP0BDvjVY5kVpMZ1hc2ClDjgxNsLGtikO4cWb5sQRR2GYM3dMk50VQctJ5RqsRs6pOCXDXE3ReVQj4hNBeWvaDWQ2KmyOai55dbDrlJ+nu83OmCp59RzP5k58ZaDXnlC38UwTt0q1D7+zF0ts1G932uEBHWYHuOA=")
 		smtc.setValue = p12Cert
-		smtc.pushRef = fakeRef{
-			key: certName,
+		smtc.pushData = testingfake.PushSecretData{
+			SecretKey: secretKey,
+			RemoteKey: certName,
 		}
 		smtc.certOutput = keyvault.CertificateBundle{
 			Cer: &cert,
@@ -670,8 +686,9 @@ func TestAzureKeyVaultPushSecret(t *testing.T) {
 
 	certNotManagedByES := func(smtc *secretManagerTestCase) {
 		smtc.setValue = p12Cert
-		smtc.pushRef = fakeRef{
-			key: certName,
+		smtc.pushData = testingfake.PushSecretData{
+			SecretKey: secretKey,
+			RemoteKey: certName,
 		}
 		smtc.certOutput = keyvault.CertificateBundle{
 			X509Thumbprint: pointer.To("123"),
@@ -684,8 +701,9 @@ func TestAzureKeyVaultPushSecret(t *testing.T) {
 
 	certNoManagerTags := func(smtc *secretManagerTestCase) {
 		smtc.setValue = p12Cert
-		smtc.pushRef = fakeRef{
-			key: certName,
+		smtc.pushData = testingfake.PushSecretData{
+			SecretKey: secretKey,
+			RemoteKey: certName,
 		}
 		smtc.certOutput = keyvault.CertificateBundle{
 			X509Thumbprint: pointer.To("123"),
@@ -695,8 +713,9 @@ func TestAzureKeyVaultPushSecret(t *testing.T) {
 
 	certNotACertificate := func(smtc *secretManagerTestCase) {
 		smtc.setValue = []byte("foobar")
-		smtc.pushRef = fakeRef{
-			key: certName,
+		smtc.pushData = testingfake.PushSecretData{
+			SecretKey: secretKey,
+			RemoteKey: certName,
 		}
 		smtc.certOutput = keyvault.CertificateBundle{
 			X509Thumbprint: pointer.To("123"),
@@ -711,8 +730,9 @@ func TestAzureKeyVaultPushSecret(t *testing.T) {
 			Message:    "Insufficient Permissions",
 		}
 		smtc.setValue = p12Cert
-		smtc.pushRef = fakeRef{
-			key: certName,
+		smtc.pushData = testingfake.PushSecretData{
+			SecretKey: secretKey,
+			RemoteKey: certName,
 		}
 		smtc.certOutput = keyvault.CertificateBundle{
 			X509Thumbprint: pointer.To("123"),
@@ -757,7 +777,12 @@ func TestAzureKeyVaultPushSecret(t *testing.T) {
 	}
 	for k, v := range successCases {
 		sm.baseClient = v.mockClient
-		err := sm.PushSecret(context.Background(), v.setValue, "", nil, v.pushRef)
+		secret := &corev1.Secret{
+			Data: map[string][]byte{
+				secretKey: v.setValue,
+			},
+		}
+		err := sm.PushSecret(context.Background(), secret, v.pushData)
 		if !utils.ErrorContains(err, v.expectError) {
 			if err == nil {
 				t.Errorf("[%d] unexpected error: <nil>, expected: '%s'", k, v.expectError)

--- a/pkg/provider/conjur/provider.go
+++ b/pkg/provider/conjur/provider.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cyberark/conjur-api-go/conjurapi"
 	"github.com/cyberark/conjur-api-go/conjurapi/authn"
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/client-go/kubernetes"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -172,12 +171,12 @@ func (p *Client) GetSecret(ctx context.Context, ref esv1beta1.ExternalSecretData
 }
 
 // PushSecret will write a single secret into the provider.
-func (p *Client) PushSecret(_ context.Context, _ []byte, _ corev1.SecretType, _ *apiextensionsv1.JSON, _ esv1beta1.PushRemoteRef) error {
+func (p *Client) PushSecret(_ context.Context, _ *corev1.Secret, _ esv1beta1.PushSecretData) error {
 	// NOT IMPLEMENTED
 	return nil
 }
 
-func (p *Client) DeleteSecret(_ context.Context, _ esv1beta1.PushRemoteRef) error {
+func (p *Client) DeleteSecret(_ context.Context, _ esv1beta1.PushSecretRemoteRef) error {
 	// NOT IMPLEMENTED
 	return nil
 }

--- a/pkg/provider/delinea/client.go
+++ b/pkg/provider/delinea/client.go
@@ -25,7 +25,6 @@ import (
 	"github.com/DelineaXPM/dsv-sdk-go/v2/vault"
 	"github.com/tidwall/gjson"
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 )
@@ -72,11 +71,11 @@ func (c *client) GetSecret(ctx context.Context, ref esv1beta1.ExternalSecretData
 	return []byte(val.String()), nil
 }
 
-func (c *client) PushSecret(_ context.Context, _ []byte, _ corev1.SecretType, _ *apiextensionsv1.JSON, _ esv1beta1.PushRemoteRef) error {
+func (c *client) PushSecret(_ context.Context, _ *corev1.Secret, _ esv1beta1.PushSecretData) error {
 	return errors.New("pushing secrets is not supported by Delinea DevOps Secrets Vault")
 }
 
-func (c *client) DeleteSecret(_ context.Context, _ esv1beta1.PushRemoteRef) error {
+func (c *client) DeleteSecret(_ context.Context, _ esv1beta1.PushSecretRemoteRef) error {
 	return errors.New("deleting secrets is not supported by Delinea DevOps Secrets Vault")
 }
 

--- a/pkg/provider/doppler/client.go
+++ b/pkg/provider/doppler/client.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/types"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -116,11 +115,11 @@ func (c *Client) Validate() (esv1beta1.ValidationResult, error) {
 	return esv1beta1.ValidationResultReady, nil
 }
 
-func (c *Client) DeleteSecret(_ context.Context, _ esv1beta1.PushRemoteRef) error {
+func (c *Client) DeleteSecret(_ context.Context, _ esv1beta1.PushSecretRemoteRef) error {
 	return fmt.Errorf("not implemented")
 }
 
-func (c *Client) PushSecret(_ context.Context, _ []byte, _ corev1.SecretType, _ *apiextensionsv1.JSON, _ esv1beta1.PushRemoteRef) error {
+func (c *Client) PushSecret(_ context.Context, _ *corev1.Secret, _ esv1beta1.PushSecretData) error {
 	return fmt.Errorf("not implemented")
 }
 

--- a/pkg/provider/fake/fake.go
+++ b/pkg/provider/fake/fake.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/tidwall/gjson"
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
@@ -104,14 +103,15 @@ func getProvider(store esv1beta1.GenericStore) (*esv1beta1.FakeProvider, error) 
 	return spc.Provider.Fake, nil
 }
 
-func (p *Provider) DeleteSecret(_ context.Context, _ esv1beta1.PushRemoteRef) error {
+func (p *Provider) DeleteSecret(_ context.Context, _ esv1beta1.PushSecretRemoteRef) error {
 	return nil
 }
 
-func (p *Provider) PushSecret(_ context.Context, value []byte, _ corev1.SecretType, _ *apiextensionsv1.JSON, remoteRef esv1beta1.PushRemoteRef) error {
-	currentData, ok := p.config[remoteRef.GetRemoteKey()]
+func (p *Provider) PushSecret(_ context.Context, secret *corev1.Secret, data esv1beta1.PushSecretData) error {
+	value := secret.Data[data.GetSecretKey()]
+	currentData, ok := p.config[data.GetRemoteKey()]
 	if !ok {
-		p.config[remoteRef.GetRemoteKey()] = &Data{
+		p.config[data.GetRemoteKey()] = &Data{
 			Value:  string(value),
 			Origin: FakeSetSecret,
 		}

--- a/pkg/provider/fake/fake_test.go
+++ b/pkg/provider/fake/fake_test.go
@@ -20,10 +20,11 @@ import (
 	"testing"
 
 	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	esv1alpha1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
+	testingfake "github.com/external-secrets/external-secrets/pkg/provider/testing/fake"
 )
 
 func TestNewClient(t *testing.T) {
@@ -181,6 +182,7 @@ type setSecretTestCase struct {
 func TestSetSecret(t *testing.T) {
 	gomega.RegisterTestingT(t)
 	p := &Provider{}
+	secretKey := "secret-key"
 	tbl := []setSecretTestCase{
 		{
 			name:       "return nil if no existing secret",
@@ -216,7 +218,13 @@ func TestSetSecret(t *testing.T) {
 				},
 			}, nil, "")
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			err = cl.PushSecret(context.TODO(), []byte(row.expValue), "", nil, esv1alpha1.PushSecretRemoteRef{
+			secret := &corev1.Secret{
+				Data: map[string][]byte{
+					secretKey: []byte(row.expValue),
+				},
+			}
+			err = cl.PushSecret(context.TODO(), secret, testingfake.PushSecretData{
+				SecretKey: secretKey,
 				RemoteKey: row.requestKey,
 			})
 			if row.expErr != "" {

--- a/pkg/provider/gcp/secretmanager/client.go
+++ b/pkg/provider/gcp/secretmanager/client.go
@@ -31,7 +31,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -62,7 +61,7 @@ const (
 	errInvalidStoreSpec       = "invalid store spec"
 	errInvalidStoreProv       = "invalid store provider"
 	errInvalidGCPProv         = "invalid gcp secrets manager provider"
-	errInvalidAuthSecretRef   = "invalid auth secret ref: %w"
+	errInvalidAuthSecretRef   = "invalid auth secret data: %w"
 	errInvalidWISARef         = "invalid workload identity service account reference: %w"
 	errUnexpectedFindOperator = "unexpected find operator"
 
@@ -96,7 +95,7 @@ type GoogleSecretManagerClient interface {
 
 var log = ctrl.Log.WithName("provider").WithName("gcp").WithName("secretsmanager")
 
-func (c *Client) DeleteSecret(ctx context.Context, remoteRef esv1beta1.PushRemoteRef) error {
+func (c *Client) DeleteSecret(ctx context.Context, remoteRef esv1beta1.PushSecretRemoteRef) error {
 	gcpSecret, err := c.smClient.GetSecret(ctx, &secretmanagerpb.GetSecretRequest{
 		Name: fmt.Sprintf("projects/%s/secrets/%s", c.store.ProjectID, remoteRef.GetRemoteKey()),
 	})
@@ -131,8 +130,9 @@ func parseError(err error) error {
 }
 
 // PushSecret pushes a kubernetes secret key into gcp provider Secret.
-func (c *Client) PushSecret(ctx context.Context, payload []byte, _ corev1.SecretType, metadata *apiextensionsv1.JSON, remoteRef esv1beta1.PushRemoteRef) error {
-	secretName := fmt.Sprintf("projects/%s/secrets/%s", c.store.ProjectID, remoteRef.GetRemoteKey())
+func (c *Client) PushSecret(ctx context.Context, secret *corev1.Secret, pushSecretData esv1beta1.PushSecretData) error {
+	payload := secret.Data[pushSecretData.GetSecretKey()]
+	secretName := fmt.Sprintf("projects/%s/secrets/%s", c.store.ProjectID, pushSecretData.GetRemoteKey())
 	gcpSecret, err := c.smClient.GetSecret(ctx, &secretmanagerpb.GetSecretRequest{
 		Name: secretName,
 	})
@@ -145,7 +145,7 @@ func (c *Client) PushSecret(ctx context.Context, payload []byte, _ corev1.Secret
 
 		gcpSecret, err = c.smClient.CreateSecret(ctx, &secretmanagerpb.CreateSecretRequest{
 			Parent:   fmt.Sprintf("projects/%s", c.store.ProjectID),
-			SecretId: remoteRef.GetRemoteKey(),
+			SecretId: pushSecretData.GetRemoteKey(),
 			Secret: &secretmanagerpb.Secret{
 				Labels: map[string]string{
 					managedByKey: managedByValue,
@@ -163,7 +163,7 @@ func (c *Client) PushSecret(ctx context.Context, payload []byte, _ corev1.Secret
 		}
 	}
 
-	builder, err := newPushSecretBuilder(payload, metadata, remoteRef)
+	builder, err := newPushSecretBuilder(payload, pushSecretData)
 	if err != nil {
 		return err
 	}
@@ -221,7 +221,7 @@ func (c *Client) PushSecret(ctx context.Context, payload []byte, _ corev1.Secret
 	}
 
 	addSecretVersionReq := &secretmanagerpb.AddSecretVersionRequest{
-		Parent: fmt.Sprintf("projects/%s/secrets/%s", c.store.ProjectID, remoteRef.GetRemoteKey()),
+		Parent: fmt.Sprintf("projects/%s/secrets/%s", c.store.ProjectID, pushSecretData.GetRemoteKey()),
 		Payload: &secretmanagerpb.SecretPayload{
 			Data: data,
 		},

--- a/pkg/provider/gcp/secretmanager/client_test.go
+++ b/pkg/provider/gcp/secretmanager/client_test.go
@@ -26,13 +26,14 @@ import (
 	"github.com/googleapis/gax-go/v2/apierror"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	pointer "k8s.io/utils/ptr"
 
-	esv1alpha1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 	v1 "github.com/external-secrets/external-secrets/apis/meta/v1"
 	fakesm "github.com/external-secrets/external-secrets/pkg/provider/gcp/secretmanager/fake"
+	testingfake "github.com/external-secrets/external-secrets/pkg/provider/testing/fake"
 )
 
 type secretManagerTestCase struct {
@@ -143,7 +144,7 @@ func TestSecretManagerGetSecret(t *testing.T) {
 		smtc.expectedSecret = "Tom"
 	}
 
-	// good case: ref with
+	// good case: data with
 	setCustomRef := func(smtc *secretManagerTestCase) {
 		smtc.ref = &esv1beta1.ExternalSecretDataRemoteRef{
 			Key:      "/baz",
@@ -397,18 +398,6 @@ func TestGetSecret_MetadataPolicyFetch(t *testing.T) {
 	}
 }
 
-type fakeRef struct {
-	key string
-}
-
-func (f fakeRef) GetRemoteKey() string {
-	return f.key
-}
-
-func (f fakeRef) GetProperty() string {
-	return ""
-}
-
 func TestDeleteSecret(t *testing.T) {
 	fErr := status.Error(codes.NotFound, "failed")
 	notFoundError, _ := apierror.FromError(fErr)
@@ -493,7 +482,7 @@ func TestDeleteSecret(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			ref := fakeRef{key: "fake-key"}
+			ref := testingfake.PushSecretData{RemoteKey: "fake-key"}
 			client := Client{
 				smClient: &tc.args.client,
 				store: &esv1beta1.GCPSMProvider{
@@ -519,8 +508,8 @@ func TestDeleteSecret(t *testing.T) {
 }
 
 func TestPushSecret(t *testing.T) {
-	ref := fakeRef{key: "/baz"}
-
+	secretKey := "secret-key"
+	remoteKey := "/baz"
 	notFoundError := status.Error(codes.NotFound, "failed")
 	notFoundError, _ = apierror.FromError(notFoundError)
 
@@ -528,7 +517,7 @@ func TestPushSecret(t *testing.T) {
 	canceledError, _ = apierror.FromError(canceledError)
 
 	APIerror := fmt.Errorf("API Error")
-	labelError := fmt.Errorf("secret %v is not managed by external secrets", ref.GetRemoteKey())
+	labelError := fmt.Errorf("secret %v is not managed by external secrets", remoteKey)
 
 	secret := secretmanagerpb.Secret{
 		Name: "projects/default/secrets/baz",
@@ -759,7 +748,14 @@ func TestPushSecret(t *testing.T) {
 					ProjectID: smtc.projectID,
 				},
 			}
-			err := c.PushSecret(context.Background(), []byte("fake-value"), "", tc.args.Metadata, ref)
+			s := &corev1.Secret{Data: map[string][]byte{secretKey: []byte("fake-value")}}
+			data := testingfake.PushSecretData{
+				SecretKey: secretKey,
+				Metadata:  tc.args.Metadata,
+				RemoteKey: "/baz",
+			}
+
+			err := c.PushSecret(context.Background(), s, data)
 			if err != nil {
 				if tc.want.err == nil {
 					t.Errorf("received an unexpected error: %v", err)
@@ -779,6 +775,7 @@ func TestPushSecret(t *testing.T) {
 }
 
 func TestPushSecret_Property(t *testing.T) {
+	secretKey := "secret-key"
 	defaultAddSecretVersionMockReturn := func(gotPayload, expectedPayload string) (*secretmanagerpb.SecretVersion, error) {
 		if gotPayload != expectedPayload {
 			t.Fatalf("payload does not match: got %s, expected: %s", gotPayload, expectedPayload)
@@ -790,7 +787,7 @@ func TestPushSecret_Property(t *testing.T) {
 	tests := []struct {
 		desc                          string
 		payload                       string
-		ref                           esv1beta1.PushRemoteRef
+		data                          testingfake.PushSecretData
 		getSecretMockReturn           fakesm.SecretMockReturn
 		createSecretMockReturn        fakesm.SecretMockReturn
 		updateSecretMockReturn        fakesm.SecretMockReturn
@@ -802,8 +799,9 @@ func TestPushSecret_Property(t *testing.T) {
 		{
 			desc:    "Add new key value paris",
 			payload: "testValue2",
-			ref: esv1alpha1.PushSecretRemoteRef{
-				Property: "testKey2",
+			data: testingfake.PushSecretData{
+				SecretKey: secretKey,
+				Property:  "testKey2",
 			},
 			getSecretMockReturn: fakesm.SecretMockReturn{
 				Secret: &secretmanagerpb.Secret{
@@ -825,8 +823,9 @@ func TestPushSecret_Property(t *testing.T) {
 		{
 			desc:    "Update existing value",
 			payload: "testValue2",
-			ref: esv1alpha1.PushSecretRemoteRef{
-				Property: "testKey1.testKey2",
+			data: testingfake.PushSecretData{
+				SecretKey: secretKey,
+				Property:  "testKey1.testKey2",
 			},
 			getSecretMockReturn: fakesm.SecretMockReturn{
 				Secret: &secretmanagerpb.Secret{
@@ -848,8 +847,9 @@ func TestPushSecret_Property(t *testing.T) {
 		{
 			desc:    "Secret not found",
 			payload: "testValue2",
-			ref: esv1alpha1.PushSecretRemoteRef{
-				Property: "testKey1.testKey3",
+			data: testingfake.PushSecretData{
+				SecretKey: secretKey,
+				Property:  "testKey1.testKey3",
 			},
 			getSecretMockReturn: fakesm.SecretMockReturn{
 				Secret: &secretmanagerpb.Secret{},
@@ -873,8 +873,9 @@ func TestPushSecret_Property(t *testing.T) {
 		{
 			desc:    "Secret version is not found",
 			payload: "testValue1",
-			ref: esv1alpha1.PushSecretRemoteRef{
-				Property: "testKey1",
+			data: testingfake.PushSecretData{
+				SecretKey: secretKey,
+				Property:  "testKey1",
 			},
 			getSecretMockReturn: fakesm.SecretMockReturn{
 				Secret: &secretmanagerpb.Secret{
@@ -890,8 +891,9 @@ func TestPushSecret_Property(t *testing.T) {
 		{
 			desc:    "Secret is not managed by the controller",
 			payload: "testValue1",
-			ref: esv1alpha1.PushSecretRemoteRef{
-				Property: "testKey1.testKey2",
+			data: testingfake.PushSecretData{
+				SecretKey: secretKey,
+				Property:  "testKey1.testKey2",
 			},
 			getSecretMockReturn: fakesm.SecretMockReturn{
 				Secret: &secretmanagerpb.Secret{},
@@ -914,8 +916,9 @@ func TestPushSecret_Property(t *testing.T) {
 		{
 			desc:    "Payload is the same with the existing one",
 			payload: "testValue1",
-			ref: esv1alpha1.PushSecretRemoteRef{
-				Property: "testKey1.testKey2",
+			data: testingfake.PushSecretData{
+				SecretKey: secretKey,
+				Property:  "testKey1.testKey2",
 			},
 			getSecretMockReturn: fakesm.SecretMockReturn{
 				Secret: &secretmanagerpb.Secret{
@@ -953,8 +956,8 @@ func TestPushSecret_Property(t *testing.T) {
 				smClient: smClient,
 				store:    &esv1beta1.GCPSMProvider{},
 			}
-
-			err := client.PushSecret(context.Background(), []byte(tc.payload), "", nil, tc.ref)
+			s := &corev1.Secret{Data: map[string][]byte{secretKey: []byte(tc.payload)}}
+			err := client.PushSecret(context.Background(), s, tc.data)
 			if err != nil {
 				if tc.expectedErr == "" {
 					t.Fatalf("PushSecret returns unexpected error: %v", err)
@@ -1011,7 +1014,7 @@ func TestGetSecretMap(t *testing.T) {
 			t.Errorf("[%d] unexpected error: %s, expected: '%s'", k, err.Error(), v.expectError)
 		}
 		if err == nil && !reflect.DeepEqual(out, v.expectedData) {
-			t.Errorf("[%d] unexpected secret data: expected %#v, got %#v", k, v.expectedData, out)
+			t.Errorf("[%d] unexpected secret pushSecretData: expected %#v, got %#v", k, v.expectedData, out)
 		}
 	}
 }
@@ -1041,7 +1044,7 @@ func TestValidateStore(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:    "invalid secret ref",
+			name:    "invalid secret data",
 			wantErr: true,
 			args: args{
 				auth: esv1beta1.GCPSMAuth{
@@ -1055,7 +1058,7 @@ func TestValidateStore(t *testing.T) {
 			},
 		},
 		{
-			name:    "invalid wi sa ref",
+			name:    "invalid wi sa data",
 			wantErr: true,
 			args: args{
 				auth: esv1beta1.GCPSMAuth{

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -25,7 +25,6 @@ import (
 	"github.com/tidwall/gjson"
 	"github.com/xanzy/go-gitlab"
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -109,11 +108,11 @@ func (g *gitlabBase) getAuth(ctx context.Context) ([]byte, error) {
 	return credentials, nil
 }
 
-func (g *gitlabBase) DeleteSecret(_ context.Context, _ esv1beta1.PushRemoteRef) error {
+func (g *gitlabBase) DeleteSecret(_ context.Context, _ esv1beta1.PushSecretRemoteRef) error {
 	return fmt.Errorf("not implemented")
 }
 
-func (g *gitlabBase) PushSecret(_ context.Context, _ []byte, _ corev1.SecretType, _ *apiextensionsv1.JSON, _ esv1beta1.PushRemoteRef) error {
+func (g *gitlabBase) PushSecret(_ context.Context, _ *corev1.Secret, _ esv1beta1.PushSecretData) error {
 	return fmt.Errorf("not implemented")
 }
 

--- a/pkg/provider/ibm/provider.go
+++ b/pkg/provider/ibm/provider.go
@@ -27,7 +27,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/tidwall/gjson"
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/types"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -124,12 +123,12 @@ func (c *client) setAuth(ctx context.Context) error {
 	return nil
 }
 
-func (ibm *providerIBM) DeleteSecret(_ context.Context, _ esv1beta1.PushRemoteRef) error {
+func (ibm *providerIBM) DeleteSecret(_ context.Context, _ esv1beta1.PushSecretRemoteRef) error {
 	return fmt.Errorf("not implemented")
 }
 
 // Not Implemented PushSecret.
-func (ibm *providerIBM) PushSecret(_ context.Context, _ []byte, _ corev1.SecretType, _ *apiextensionsv1.JSON, _ esv1beta1.PushRemoteRef) error {
+func (ibm *providerIBM) PushSecret(_ context.Context, _ *corev1.Secret, _ esv1beta1.PushSecretData) error {
 	return fmt.Errorf("not implemented")
 }
 

--- a/pkg/provider/keepersecurity/client.go
+++ b/pkg/provider/keepersecurity/client.go
@@ -24,7 +24,6 @@ import (
 	ksm "github.com/keeper-security/secrets-manager-go/core"
 	"golang.org/x/exp/maps"
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 )
@@ -162,23 +161,24 @@ func (c *Client) Close(_ context.Context) error {
 	return nil
 }
 
-func (c *Client) PushSecret(_ context.Context, value []byte, _ corev1.SecretType, _ *apiextensionsv1.JSON, remoteRef esv1beta1.PushRemoteRef) error {
-	parts, err := c.buildSecretNameAndKey(remoteRef)
+func (c *Client) PushSecret(_ context.Context, secret *corev1.Secret, data esv1beta1.PushSecretData) error {
+	value := secret.Data[data.GetSecretKey()]
+	parts, err := c.buildSecretNameAndKey(data)
 	if err != nil {
 		return err
 	}
-	secret, err := c.findSecretByName(parts[0])
+	record, err := c.findSecretByName(parts[0])
 	if err != nil {
 		_, err = c.createSecret(parts[0], parts[1], value)
 		if err != nil {
 			return err
 		}
 	}
-	if secret != nil {
-		if secret.Type() != externalSecretType {
-			return fmt.Errorf(errInvalidSecretType, externalSecretType, secret.Title(), secret.Type())
+	if record != nil {
+		if record.Type() != externalSecretType {
+			return fmt.Errorf(errInvalidSecretType, externalSecretType, record.Title(), record.Type())
 		}
-		err = c.updateSecret(secret, parts[1], value)
+		err = c.updateSecret(record, parts[1], value)
 		if err != nil {
 			return err
 		}
@@ -187,7 +187,7 @@ func (c *Client) PushSecret(_ context.Context, value []byte, _ corev1.SecretType
 	return nil
 }
 
-func (c *Client) DeleteSecret(_ context.Context, remoteRef esv1beta1.PushRemoteRef) error {
+func (c *Client) DeleteSecret(_ context.Context, remoteRef esv1beta1.PushSecretRemoteRef) error {
 	parts, err := c.buildSecretNameAndKey(remoteRef)
 	if err != nil {
 		return err
@@ -207,7 +207,7 @@ func (c *Client) DeleteSecret(_ context.Context, remoteRef esv1beta1.PushRemoteR
 	return nil
 }
 
-func (c *Client) buildSecretNameAndKey(remoteRef esv1beta1.PushRemoteRef) ([]string, error) {
+func (c *Client) buildSecretNameAndKey(remoteRef esv1beta1.PushSecretRemoteRef) ([]string, error) {
 	parts := strings.Split(remoteRef.GetRemoteKey(), "/")
 	if len(parts) != 2 {
 		return nil, fmt.Errorf(errInvalidRemoteRefKey, remoteRef.GetRemoteKey())

--- a/pkg/provider/keepersecurity/client_test.go
+++ b/pkg/provider/keepersecurity/client_test.go
@@ -21,10 +21,12 @@ import (
 	"testing"
 
 	ksm "github.com/keeper-security/secrets-manager-go/core"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
 	"github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 	"github.com/external-secrets/external-secrets/pkg/provider/keepersecurity/fake"
+	testingfake "github.com/external-secrets/external-secrets/pkg/provider/testing/fake"
 )
 
 const (
@@ -49,7 +51,7 @@ func TestClientDeleteSecret(t *testing.T) {
 	}
 	type args struct {
 		ctx       context.Context
-		remoteRef v1beta1.PushRemoteRef
+		remoteRef v1beta1.PushSecretRemoteRef
 	}
 	tests := []struct {
 		name    string
@@ -472,14 +474,14 @@ func TestClientGetSecretMap(t *testing.T) {
 }
 
 func TestClientPushSecret(t *testing.T) {
+	secretKey := "secret-key"
 	type fields struct {
 		ksmClient SecurityClient
 		folderID  string
 	}
 	type args struct {
-		ctx       context.Context
-		value     []byte
-		remoteRef v1beta1.PushRemoteRef
+		value []byte
+		data  testingfake.PushSecretData
 	}
 	tests := []struct {
 		name    string
@@ -494,8 +496,8 @@ func TestClientPushSecret(t *testing.T) {
 				folderID:  folderID,
 			},
 			args: args{
-				ctx: context.Background(),
-				remoteRef: v1alpha1.PushSecretRemoteRef{
+				data: testingfake.PushSecretData{
+					SecretKey: secretKey,
 					RemoteKey: record0,
 				},
 				value: []byte("foo"),
@@ -516,8 +518,8 @@ func TestClientPushSecret(t *testing.T) {
 				folderID: folderID,
 			},
 			args: args{
-				ctx: context.Background(),
-				remoteRef: v1alpha1.PushSecretRemoteRef{
+				data: testingfake.PushSecretData{
+					SecretKey: secretKey,
 					RemoteKey: invalidRecord,
 				},
 				value: []byte("foo"),
@@ -538,8 +540,8 @@ func TestClientPushSecret(t *testing.T) {
 				folderID: folderID,
 			},
 			args: args{
-				ctx: context.Background(),
-				remoteRef: v1alpha1.PushSecretRemoteRef{
+				data: testingfake.PushSecretData{
+					SecretKey: secretKey,
 					RemoteKey: validExistingRecord,
 				},
 				value: []byte("foo2"),
@@ -560,8 +562,8 @@ func TestClientPushSecret(t *testing.T) {
 				folderID: folderID,
 			},
 			args: args{
-				ctx: context.Background(),
-				remoteRef: v1alpha1.PushSecretRemoteRef{
+				data: testingfake.PushSecretData{
+					SecretKey: secretKey,
 					RemoteKey: validExistingRecord,
 				},
 				value: []byte("foo2"),
@@ -582,8 +584,8 @@ func TestClientPushSecret(t *testing.T) {
 				folderID: folderID,
 			},
 			args: args{
-				ctx: context.Background(),
-				remoteRef: v1alpha1.PushSecretRemoteRef{
+				data: testingfake.PushSecretData{
+					SecretKey: secretKey,
 					RemoteKey: invalidRecord,
 				},
 				value: []byte("foo"),
@@ -604,8 +606,8 @@ func TestClientPushSecret(t *testing.T) {
 				folderID: folderID,
 			},
 			args: args{
-				ctx: context.Background(),
-				remoteRef: v1alpha1.PushSecretRemoteRef{
+				data: testingfake.PushSecretData{
+					SecretKey: secretKey,
 					RemoteKey: validExistingRecord,
 				},
 				value: []byte("foo2"),
@@ -619,7 +621,8 @@ func TestClientPushSecret(t *testing.T) {
 				ksmClient: tt.fields.ksmClient,
 				folderID:  tt.fields.folderID,
 			}
-			if err := c.PushSecret(tt.args.ctx, tt.args.value, "", nil, tt.args.remoteRef); (err != nil) != tt.wantErr {
+			s := &corev1.Secret{Data: map[string][]byte{secretKey: tt.args.value}}
+			if err := c.PushSecret(context.Background(), s, tt.args.data); (err != nil) != tt.wantErr {
 				t.Errorf("PushSecret() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pkg/provider/onepassword/onepassword.go
+++ b/pkg/provider/onepassword/onepassword.go
@@ -22,7 +22,6 @@ import (
 	"github.com/1Password/connect-sdk-go/connect"
 	"github.com/1Password/connect-sdk-go/onepassword"
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/types"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -153,12 +152,12 @@ func validateStore(store esv1beta1.GenericStore) error {
 	return nil
 }
 
-func (provider *ProviderOnePassword) DeleteSecret(_ context.Context, _ esv1beta1.PushRemoteRef) error {
+func (provider *ProviderOnePassword) DeleteSecret(_ context.Context, _ esv1beta1.PushSecretRemoteRef) error {
 	return fmt.Errorf("not implemented")
 }
 
 // Not Implemented PushSecret.
-func (provider *ProviderOnePassword) PushSecret(_ context.Context, _ []byte, _ corev1.SecretType, _ *apiextensionsv1.JSON, _ esv1beta1.PushRemoteRef) error {
+func (provider *ProviderOnePassword) PushSecret(_ context.Context, _ *corev1.Secret, _ esv1beta1.PushSecretData) error {
 	return fmt.Errorf("not implemented")
 }
 

--- a/pkg/provider/oracle/oracle.go
+++ b/pkg/provider/oracle/oracle.go
@@ -32,7 +32,6 @@ import (
 	"github.com/oracle/oci-go-sdk/v65/vault"
 	"github.com/tidwall/gjson"
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -95,8 +94,9 @@ const (
 	SecretAPIError
 )
 
-func (vms *VaultManagementService) PushSecret(ctx context.Context, value []byte, _ corev1.SecretType, _ *apiextensionsv1.JSON, remoteRef esv1beta1.PushRemoteRef) error {
-	secretName := remoteRef.GetRemoteKey()
+func (vms *VaultManagementService) PushSecret(ctx context.Context, secret *corev1.Secret, data esv1beta1.PushSecretData) error {
+	value := secret.Data[data.GetSecretKey()]
+	secretName := data.GetRemoteKey()
 	encodedValue := base64.StdEncoding.EncodeToString(value)
 	sec, action, err := vms.getSecretBundleWithCode(ctx, secretName)
 	switch action {
@@ -135,7 +135,7 @@ func (vms *VaultManagementService) PushSecret(ctx context.Context, value []byte,
 	}
 }
 
-func (vms *VaultManagementService) DeleteSecret(ctx context.Context, remoteRef esv1beta1.PushRemoteRef) error {
+func (vms *VaultManagementService) DeleteSecret(ctx context.Context, remoteRef esv1beta1.PushSecretRemoteRef) error {
 	secretName := remoteRef.GetRemoteKey()
 	resp, action, err := vms.getSecretBundleWithCode(ctx, secretName)
 	switch action {

--- a/pkg/provider/scaleway/client.go
+++ b/pkg/provider/scaleway/client.go
@@ -27,7 +27,6 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/scw"
 	"github.com/tidwall/gjson"
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 	"github.com/external-secrets/external-secrets/pkg/find"
@@ -102,8 +101,9 @@ func (c *client) GetSecret(ctx context.Context, ref esv1beta1.ExternalSecretData
 	return value, nil
 }
 
-func (c *client) PushSecret(ctx context.Context, value []byte, _ corev1.SecretType, _ *apiextensionsv1.JSON, remoteRef esv1beta1.PushRemoteRef) error {
-	scwRef, err := decodeScwSecretRef(remoteRef.GetRemoteKey())
+func (c *client) PushSecret(ctx context.Context, secret *corev1.Secret, data esv1beta1.PushSecretData) error {
+	value := secret.Data[data.GetSecretKey()]
+	scwRef, err := decodeScwSecretRef(data.GetRemoteKey())
 	if err != nil {
 		return err
 	}
@@ -211,7 +211,7 @@ func (c *client) PushSecret(ctx context.Context, value []byte, _ corev1.SecretTy
 	return nil
 }
 
-func (c *client) DeleteSecret(ctx context.Context, remoteRef esv1beta1.PushRemoteRef) error {
+func (c *client) DeleteSecret(ctx context.Context, remoteRef esv1beta1.PushSecretRemoteRef) error {
 	scwRef, err := decodeScwSecretRef(remoteRef.GetRemoteKey())
 	if err != nil {
 		return err

--- a/pkg/provider/scaleway/client_test.go
+++ b/pkg/provider/scaleway/client_test.go
@@ -15,11 +15,14 @@ package scaleway
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
+	testingfake "github.com/external-secrets/external-secrets/pkg/provider/testing/fake"
 	"github.com/external-secrets/external-secrets/pkg/utils"
 )
 
@@ -205,24 +208,26 @@ func TestGetSecret(t *testing.T) {
 	}
 }
 
-type pushRemoteRef string
-
-func (ref pushRemoteRef) GetRemoteKey() string {
-	return string(ref)
-}
-
-func (ref pushRemoteRef) GetProperty() string {
-	return ""
-}
-
 func TestPushSecret(t *testing.T) {
+	secretKey := "secret-key"
+	pushSecretData := func(remoteKey string) testingfake.PushSecretData {
+		return testingfake.PushSecretData{
+			SecretKey: secretKey,
+			RemoteKey: remoteKey,
+		}
+	}
+	secret := func(value []byte) *corev1.Secret {
+		return &corev1.Secret{
+			Data: map[string][]byte{secretKey: value},
+		}
+	}
 	t.Run("to new secret", func(t *testing.T) {
 		ctx := context.Background()
 		c := newTestClient()
 		data := []byte("some secret data 6a8ff33b-c69a-4e42-b162-b7b595ee7f5f")
 		secretName := "secret-creation-test"
 
-		pushErr := c.PushSecret(ctx, data, "", nil, pushRemoteRef("name:"+secretName))
+		pushErr := c.PushSecret(ctx, secret(data), pushSecretData(fmt.Sprintf("name:%s", secretName)))
 
 		assert.NoError(t, pushErr)
 		assert.Len(t, db.secret(secretName).versions, 1)
@@ -234,9 +239,9 @@ func TestPushSecret(t *testing.T) {
 		c := newTestClient()
 		data := []byte("some secret data a11d416b-9169-4f4a-8c27-d2959b22e189")
 		secretName := "secret-update-test"
-		assert.NoError(t, c.PushSecret(ctx, []byte("original data"), "", nil, pushRemoteRef("name:"+secretName)))
+		assert.NoError(t, c.PushSecret(ctx, secret([]byte("original data")), pushSecretData(fmt.Sprintf("name:%s", secretName))))
 
-		pushErr := c.PushSecret(ctx, data, "", nil, pushRemoteRef("name:"+secretName))
+		pushErr := c.PushSecret(ctx, secret(data), pushSecretData(fmt.Sprintf("name:%s", secretName)))
 
 		assert.NoError(t, pushErr)
 		assert.Len(t, db.secret(secretName).versions, 2)
@@ -249,7 +254,7 @@ func TestPushSecret(t *testing.T) {
 		data := []byte("some secret data a11d416b-9169-4f4a-8c27-d2959b22e189")
 		secretName := "push-me"
 
-		pushErr := c.PushSecret(ctx, data, "", nil, pushRemoteRef("name:"+secretName))
+		pushErr := c.PushSecret(ctx, secret(data), pushSecretData(fmt.Sprintf("name:%s", secretName)))
 
 		assert.NoError(t, pushErr)
 		assert.Len(t, db.secret(secretName).versions, 1)
@@ -263,7 +268,7 @@ func TestPushSecret(t *testing.T) {
 		secretPath := "/folder"
 		secretName := "secret-in-path"
 
-		pushErr := c.PushSecret(ctx, data, "", nil, pushRemoteRef("path:"+secretPath+"/"+secretName))
+		pushErr := c.PushSecret(ctx, secret(data), pushSecretData(fmt.Sprintf("path:%s/%s", secretPath, secretName)))
 		assert.NoError(t, pushErr)
 		assert.Len(t, db.secret(secretName).versions, 1)
 		assert.Equal(t, data, db.secret(secretName).versions[0].data)
@@ -274,7 +279,7 @@ func TestPushSecret(t *testing.T) {
 		ctx := context.Background()
 		c := newTestClient()
 
-		pushErr := c.PushSecret(ctx, []byte("some data"), "", nil, pushRemoteRef("invalid:abcd"))
+		pushErr := c.PushSecret(ctx, secret([]byte("some data")), pushSecretData("invalid:abcd"))
 
 		assert.Error(t, pushErr)
 	})
@@ -283,7 +288,7 @@ func TestPushSecret(t *testing.T) {
 		ctx := context.Background()
 		c := newTestClient()
 
-		pushErr := c.PushSecret(ctx, []byte("some data"), "", nil, pushRemoteRef("id:"+db.secret("cant-push").id))
+		pushErr := c.PushSecret(ctx, secret([]byte("some data")), pushSecretData(fmt.Sprintf("id:%s", db.secret("cant-push").id)))
 
 		assert.Error(t, pushErr)
 	})
@@ -291,24 +296,24 @@ func TestPushSecret(t *testing.T) {
 	t.Run("without change does not create a version", func(t *testing.T) {
 		ctx := context.Background()
 		c := newTestClient()
-		secret := db.secret("not-changed")
+		fs := db.secret("not-changed")
 
-		pushErr := c.PushSecret(ctx, secret.versions[0].data, "", nil, pushRemoteRef("name:"+secret.name))
+		pushErr := c.PushSecret(ctx, secret(fs.versions[0].data), pushSecretData(fmt.Sprintf("name:%s", fs.name)))
 
 		assert.NoError(t, pushErr)
-		assert.Equal(t, 1, len(secret.versions))
+		assert.Equal(t, 1, len(fs.versions))
 	})
 
 	t.Run("previous version is disabled", func(t *testing.T) {
 		ctx := context.Background()
 		c := newTestClient()
-		secret := db.secret("disabling-old-versions")
+		fs := db.secret("disabling-old-versions")
 
-		pushErr := c.PushSecret(ctx, []byte("some new data"), "", nil, pushRemoteRef("name:"+secret.name))
+		pushErr := c.PushSecret(ctx, secret([]byte("some new data")), pushSecretData(fmt.Sprintf("name:%s", fs.name)))
 
 		assert.NoError(t, pushErr)
-		assert.Equal(t, 2, len(secret.versions))
-		assert.Equal(t, "disabled", secret.versions[0].status)
+		assert.Equal(t, 2, len(fs.versions))
+		assert.Equal(t, "disabled", fs.versions[0].status)
 	})
 }
 
@@ -404,19 +409,19 @@ func TestDeleteSecret(t *testing.T) {
 	byPath := db.secret("nested-secret")
 
 	testCases := map[string]struct {
-		ref esv1beta1.PushRemoteRef
+		ref testingfake.PushSecretData
 		err error
 	}{
 		"Delete Successfully": {
-			ref: pushRemoteRef("name:" + secret.name),
+			ref: testingfake.PushSecretData{RemoteKey: "name:" + secret.name},
 			err: nil,
 		},
 		"Delete by path": {
-			ref: pushRemoteRef("path:" + byPath.path + "/" + byPath.name),
+			ref: testingfake.PushSecretData{RemoteKey: "path:" + byPath.path + "/" + byPath.name},
 			err: nil,
 		},
 		"Secret Not Found": {
-			ref: pushRemoteRef("name:not-a-secret"),
+			ref: testingfake.PushSecretData{RemoteKey: "name:not-a-secret"},
 			err: nil,
 		},
 	}

--- a/pkg/provider/senhasegura/dsm/dsm.go
+++ b/pkg/provider/senhasegura/dsm/dsm.go
@@ -25,7 +25,6 @@ import (
 	"net/url"
 
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 	senhaseguraAuth "github.com/external-secrets/external-secrets/pkg/provider/senhasegura/auth"
@@ -93,12 +92,12 @@ func New(isoSession *senhaseguraAuth.SenhaseguraIsoSession) (*DSM, error) {
 	}, nil
 }
 
-func (dsm *DSM) DeleteSecret(_ context.Context, _ esv1beta1.PushRemoteRef) error {
+func (dsm *DSM) DeleteSecret(_ context.Context, _ esv1beta1.PushSecretRemoteRef) error {
 	return fmt.Errorf("not implemented")
 }
 
 // Not Implemented PushSecret.
-func (dsm *DSM) PushSecret(_ context.Context, _ []byte, _ corev1.SecretType, _ *apiextensionsv1.JSON, _ esv1beta1.PushRemoteRef) error {
+func (dsm *DSM) PushSecret(_ context.Context, _ *corev1.Secret, _ esv1beta1.PushSecretData) error {
 	return fmt.Errorf("not implemented")
 }
 

--- a/pkg/provider/testing/fake/fake.go
+++ b/pkg/provider/testing/fake/fake.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
@@ -28,7 +27,7 @@ var _ esv1beta1.Provider = &Client{}
 
 type SetSecretCallArgs struct {
 	Value     []byte
-	RemoteRef esv1beta1.PushRemoteRef
+	RemoteRef esv1beta1.PushSecretRemoteRef
 }
 
 // Client is a fake client for testing.
@@ -81,15 +80,15 @@ func (v *Client) GetAllSecrets(ctx context.Context, ref esv1beta1.ExternalSecret
 }
 
 // Not Implemented PushSecret.
-func (v *Client) PushSecret(_ context.Context, value []byte, _ corev1.SecretType, _ *apiextensionsv1.JSON, remoteRef esv1beta1.PushRemoteRef) error {
-	v.SetSecretArgs[remoteRef.GetRemoteKey()] = SetSecretCallArgs{
-		Value:     value,
-		RemoteRef: remoteRef,
+func (v *Client) PushSecret(_ context.Context, secret *corev1.Secret, data esv1beta1.PushSecretData) error {
+	v.SetSecretArgs[data.GetRemoteKey()] = SetSecretCallArgs{
+		Value:     secret.Data[data.GetSecretKey()],
+		RemoteRef: data,
 	}
 	return v.SetSecretFn()
 }
 
-func (v *Client) DeleteSecret(_ context.Context, _ esv1beta1.PushRemoteRef) error {
+func (v *Client) DeleteSecret(_ context.Context, _ esv1beta1.PushSecretRemoteRef) error {
 	return v.DeleteSecretFn()
 }
 

--- a/pkg/provider/testing/fake/push_secret_data.go
+++ b/pkg/provider/testing/fake/push_secret_data.go
@@ -1,0 +1,40 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+type PushSecretData struct {
+	Metadata  *apiextensionsv1.JSON
+	SecretKey string
+	RemoteKey string
+	Property  string
+}
+
+func (f PushSecretData) GetMetadata() *apiextensionsv1.JSON {
+	return f.Metadata
+}
+
+func (f PushSecretData) GetSecretKey() string {
+	return f.SecretKey
+}
+
+func (f PushSecretData) GetRemoteKey() string {
+	return f.RemoteKey
+}
+
+func (f PushSecretData) GetProperty() string {
+	return f.Property
+}

--- a/pkg/provider/vault/vault.go
+++ b/pkg/provider/vault/vault.go
@@ -44,7 +44,6 @@ import (
 	"github.com/tidwall/gjson"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -435,7 +434,7 @@ func (c *Connector) ValidateStore(store esv1beta1.GenericStore) error {
 	return nil
 }
 
-func (v *client) DeleteSecret(ctx context.Context, remoteRef esv1beta1.PushRemoteRef) error {
+func (v *client) DeleteSecret(ctx context.Context, remoteRef esv1beta1.PushSecretRemoteRef) error {
 	path := v.buildPath(remoteRef.GetRemoteKey())
 	metaPath, err := v.buildMetadataPath(remoteRef.GetRemoteKey())
 	if err != nil {
@@ -483,15 +482,16 @@ func (v *client) DeleteSecret(ctx context.Context, remoteRef esv1beta1.PushRemot
 	return nil
 }
 
-func (v *client) PushSecret(ctx context.Context, value []byte, _ corev1.SecretType, _ *apiextensionsv1.JSON, remoteRef esv1beta1.PushRemoteRef) error {
+func (v *client) PushSecret(ctx context.Context, secret *corev1.Secret, data esv1beta1.PushSecretData) error {
+	value := secret.Data[data.GetSecretKey()]
 	label := map[string]interface{}{
 		"custom_metadata": map[string]string{
 			"managed-by": "external-secrets",
 		},
 	}
 	secretVal := make(map[string]interface{})
-	path := v.buildPath(remoteRef.GetRemoteKey())
-	metaPath, err := v.buildMetadataPath(remoteRef.GetRemoteKey())
+	path := v.buildPath(data.GetRemoteKey())
+	metaPath, err := v.buildMetadataPath(data.GetRemoteKey())
 	if err != nil {
 		return err
 	}
@@ -504,7 +504,7 @@ func (v *client) PushSecret(ctx context.Context, value []byte, _ corev1.SecretTy
 	}
 	// If the secret exists (err == nil), we should check if it is managed by external-secrets
 	if err == nil {
-		metadata, err := v.readSecretMetadata(ctx, remoteRef.GetRemoteKey())
+		metadata, err := v.readSecretMetadata(ctx, data.GetRemoteKey())
 		if err != nil {
 			return err
 		}
@@ -528,9 +528,9 @@ func (v *client) PushSecret(ctx context.Context, value []byte, _ corev1.SecretTy
 		return nil
 	}
 	// If a Push of a property only, we should merge and add/update the property
-	if remoteRef.GetProperty() != "" {
-		if _, ok := vaultSecret[remoteRef.GetProperty()]; ok {
-			d := vaultSecret[remoteRef.GetProperty()].(string)
+	if data.GetProperty() != "" {
+		if _, ok := vaultSecret[data.GetProperty()]; ok {
+			d := vaultSecret[data.GetProperty()].(string)
 			if err != nil {
 				return fmt.Errorf("error marshaling vault secret: %w", err)
 			}
@@ -543,7 +543,7 @@ func (v *client) PushSecret(ctx context.Context, value []byte, _ corev1.SecretTy
 			secretVal[k] = v
 		}
 		// Secret got from vault is already on map[string]string format
-		secretVal[remoteRef.GetProperty()] = string(value)
+		secretVal[data.GetProperty()] = string(value)
 	} else {
 		err = json.Unmarshal(value, &secretVal)
 		if err != nil {

--- a/pkg/provider/vault/vault_test.go
+++ b/pkg/provider/vault/vault_test.go
@@ -34,6 +34,7 @@ import (
 
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 	esmeta "github.com/external-secrets/external-secrets/apis/meta/v1"
+	testingfake "github.com/external-secrets/external-secrets/pkg/provider/testing/fake"
 	utilfake "github.com/external-secrets/external-secrets/pkg/provider/util/fake"
 	"github.com/external-secrets/external-secrets/pkg/provider/vault/fake"
 	"github.com/external-secrets/external-secrets/pkg/provider/vault/util"
@@ -1668,19 +1669,6 @@ func TestValidateStore(t *testing.T) {
 	}
 }
 
-type fakeRef struct {
-	key      string
-	property string
-}
-
-func (f fakeRef) GetRemoteKey() string {
-	return f.key
-}
-
-func (f fakeRef) GetProperty() string {
-	return f.property
-}
-
 func TestDeleteSecret(t *testing.T) {
 	type args struct {
 		store    *esv1beta1.VaultProvider
@@ -1693,7 +1681,7 @@ func TestDeleteSecret(t *testing.T) {
 	tests := map[string]struct {
 		reason string
 		args   args
-		ref    *fakeRef
+		ref    *testingfake.PushSecretData
 		want   want
 		value  []byte
 	}{
@@ -1790,7 +1778,7 @@ func TestDeleteSecret(t *testing.T) {
 		},
 		"DeleteSecretUpdateProperty": {
 			reason: "Secret should only be updated if Property is set",
-			ref:    &fakeRef{key: "secret", property: "fake-key"},
+			ref:    &testingfake.PushSecretData{RemoteKey: "secret", Property: "fake-key"},
 			args: args{
 				store: makeValidSecretStoreWithVersion(esv1beta1.VaultKVStoreV2).Spec.Provider.Vault,
 				vLogical: &fake.Logical{
@@ -1813,7 +1801,7 @@ func TestDeleteSecret(t *testing.T) {
 		},
 		"DeleteSecretIfNoOtherProperties": {
 			reason: "Secret should only be deleted if no other properties are set",
-			ref:    &fakeRef{key: "secret", property: "foo"},
+			ref:    &testingfake.PushSecretData{RemoteKey: "secret", Property: "foo"},
 			args: args{
 				store: makeValidSecretStoreWithVersion(esv1beta1.VaultKVStoreV2).Spec.Provider.Vault,
 				vLogical: &fake.Logical{
@@ -1836,7 +1824,7 @@ func TestDeleteSecret(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			ref := fakeRef{key: "secret", property: ""}
+			ref := testingfake.PushSecretData{RemoteKey: "secret", Property: ""}
 			if tc.ref != nil {
 				ref = *tc.ref
 			}
@@ -1860,7 +1848,8 @@ func TestDeleteSecret(t *testing.T) {
 		})
 	}
 }
-func TestSetSecret(t *testing.T) {
+func TestPushSecret(t *testing.T) {
+	secretKey := "secret-key"
 	noPermission := errors.New("no permission")
 
 	type args struct {
@@ -1875,7 +1864,7 @@ func TestSetSecret(t *testing.T) {
 		reason string
 		args   args
 		want   want
-		ref    *fakeRef
+		data   *testingfake.PushSecretData
 		value  []byte
 	}{
 		"SetSecret": {
@@ -1928,7 +1917,7 @@ func TestSetSecret(t *testing.T) {
 		"PushSecretProperty": {
 			reason: "push secret with property adds the property",
 			value:  []byte("fake-value"),
-			ref:    &fakeRef{key: "secret", property: "foo"},
+			data:   &testingfake.PushSecretData{SecretKey: secretKey, RemoteKey: "secret", Property: "foo"},
 			args: args{
 				store: makeValidSecretStoreWithVersion(esv1beta1.VaultKVStoreV2).Spec.Provider.Vault,
 				vLogical: &fake.Logical{
@@ -1950,7 +1939,7 @@ func TestSetSecret(t *testing.T) {
 		"PushSecretUpdateProperty": {
 			reason: "push secret with property only updates the property",
 			value:  []byte("new-value"),
-			ref:    &fakeRef{key: "secret", property: "foo"},
+			data:   &testingfake.PushSecretData{SecretKey: secretKey, RemoteKey: "secret", Property: "foo"},
 			args: args{
 				store: makeValidSecretStoreWithVersion(esv1beta1.VaultKVStoreV2).Spec.Provider.Vault,
 				vLogical: &fake.Logical{
@@ -1972,7 +1961,7 @@ func TestSetSecret(t *testing.T) {
 		"PushSecretPropertyNoUpdate": {
 			reason: "push secret with property only updates the property",
 			value:  []byte("fake-value"),
-			ref:    &fakeRef{key: "secret", property: "foo"},
+			data:   &testingfake.PushSecretData{SecretKey: secretKey, RemoteKey: "secret", Property: "foo"},
 			args: args{
 				store: makeValidSecretStoreWithVersion(esv1beta1.VaultKVStoreV2).Spec.Provider.Vault,
 				vLogical: &fake.Logical{
@@ -2028,9 +2017,9 @@ func TestSetSecret(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			ref := fakeRef{key: "secret", property: ""}
-			if tc.ref != nil {
-				ref = *tc.ref
+			data := testingfake.PushSecretData{SecretKey: secretKey, RemoteKey: "secret", Property: ""}
+			if tc.data != nil {
+				data = *tc.data
 			}
 			client := &client{
 				logical: tc.args.vLogical,
@@ -2040,7 +2029,8 @@ func TestSetSecret(t *testing.T) {
 			if val == nil {
 				val = []byte(`{"fake-key":"fake-value"}`)
 			}
-			err := client.PushSecret(context.Background(), val, "", nil, ref)
+			s := &corev1.Secret{Data: map[string][]byte{secretKey: val}}
+			err := client.PushSecret(context.Background(), s, data)
 
 			// Error nil XOR tc.want.err nil
 			if ((err == nil) || (tc.want.err == nil)) && !((err == nil) && (tc.want.err == nil)) {

--- a/pkg/provider/webhook/webhook.go
+++ b/pkg/provider/webhook/webhook.go
@@ -30,7 +30,6 @@ import (
 	"github.com/PaesslerAG/jsonpath"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
@@ -118,12 +117,12 @@ func (w *WebHook) getStoreSecret(ctx context.Context, ref esmeta.SecretKeySelect
 	return secret, nil
 }
 
-func (w *WebHook) DeleteSecret(_ context.Context, _ esv1beta1.PushRemoteRef) error {
+func (w *WebHook) DeleteSecret(_ context.Context, _ esv1beta1.PushSecretRemoteRef) error {
 	return fmt.Errorf("not implemented")
 }
 
 // Not Implemented PushSecret.
-func (w *WebHook) PushSecret(_ context.Context, _ []byte, _ corev1.SecretType, _ *apiextensionsv1.JSON, _ esv1beta1.PushRemoteRef) error {
+func (w *WebHook) PushSecret(_ context.Context, _ *corev1.Secret, _ esv1beta1.PushSecretData) error {
 	return fmt.Errorf("not implemented")
 }
 

--- a/pkg/provider/yandex/common/secretsclient.go
+++ b/pkg/provider/yandex/common/secretsclient.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 )
@@ -37,11 +36,11 @@ func (c *yandexCloudSecretsClient) GetSecret(ctx context.Context, ref esv1beta1.
 	return c.secretGetter.GetSecret(ctx, c.iamToken, ref.Key, ref.Version, ref.Property)
 }
 
-func (c *yandexCloudSecretsClient) DeleteSecret(_ context.Context, _ esv1beta1.PushRemoteRef) error {
+func (c *yandexCloudSecretsClient) DeleteSecret(_ context.Context, _ esv1beta1.PushSecretRemoteRef) error {
 	return fmt.Errorf("not implemented")
 }
 
-func (c *yandexCloudSecretsClient) PushSecret(_ context.Context, _ []byte, _ corev1.SecretType, _ *apiextensionsv1.JSON, _ esv1beta1.PushRemoteRef) error {
+func (c *yandexCloudSecretsClient) PushSecret(_ context.Context, _ *corev1.Secret, _ esv1beta1.PushSecretData) error {
 	return fmt.Errorf("not implemented")
 }
 


### PR DESCRIPTION
## Problem Statement

https://github.com/external-secrets/external-secrets/pull/2792 added `typed corev1.SecretType` argument to the PushSecret interface, but this does not make much sense since the argument can be used only from the Kubernetes providers. If an interface contains information for a specific member, that indicates something is likely to be wrong with the design. So I've decided to refactor the interface. 

## Related Issue

N/A

## Proposed Changes

Change the interface to `PushSecret(ctx context.Context, secret *corev1.Secret, data PushSecretData) error` to accept a wider range of information.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
