### PR TITLE
fix(helm): cert-manager webhook certificate

### DIFF
--- a/deploy/charts/external-secrets/templates/webhook-certificate.yaml
+++ b/deploy/charts/external-secrets/templates/webhook-certificate.yaml
@@ -1,6 +1,16 @@
 {{- if and .Values.webhook.create .Values.webhook.certManager.enabled .Values.webhook.certManager.cert.create }}
 ---
 apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "external-secrets.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "external-secrets-webhook.labels" . | nindent 4 }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "external-secrets.fullname" . }}-webhook
@@ -13,13 +23,15 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  commonName: {{ include "external-secrets.fullname" . }}-webhook
+  commonName: "{{ include "external-secrets.fullname" . }}-webhook.{{ .Release.Namespace }}.svc"
   dnsNames:
-    - {{ include "external-secrets.fullname" . }}-webhook
-    - {{ include "external-secrets.fullname" . }}-webhook.{{ .Release.Namespace }}
-    - {{ include "external-secrets.fullname" . }}-webhook.{{ .Release.Namespace }}.svc
+    - "{{ include "external-secrets.fullname" . }}-webhook.{{ .Release.Namespace }}.svc"
+  {{- with .Values.webhook.certManager.cert.issuerRef }}
   issuerRef:
-    {{- toYaml .Values.webhook.certManager.cert.issuerRef | nindent 4 }}
+    group: {{ .group }}
+    kind: {{ .kind }}
+    name: {{ .name | default include "external-secrets.fullname" . }}
+  {{- end }}
   {{- with .Values.webhook.certManager.cert.duration }}
   duration: {{ . | quote }}
   {{- end }}

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -270,8 +270,8 @@ webhook:
       # https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.IssuerSpec
       issuerRef:
         group: cert-manager.io
-        kind: "Issuer"
-        name: "my-issuer"
+        kind: Issuer
+        name: ""
       # -- Set the requested duration (i.e. lifetime) of the Certificate. See
       # https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificateSpec
       duration: ""


### PR DESCRIPTION
## Problem Statement

We prefer to use cert-manager to manage certificates , and try to avoid various custom solutions to obtain webhook certificates in operators. While ESO supports cert-manager in the Helm chart, it needs "support wheels" - which makes it harder to use. A cert-manager issuer is not included, and currently have to be provided by the user.

Also the certificate attributes should be simplified and better aligned with PKI standards and Kubernetes service DNS names.

## Related Issue

Fixes #...

## Proposed Changes

Adding a cert-manager self-signed issuer next to the cert-manager certificate in the Helm chart, and defaulting to use that issuer if no custom issuer is specified by values. To do this, I am technically proposing a minor breaking change - but only potentially for users that currently use cert-manager with the default issuer name: `my-issuer`. I would not expect this. It would be a very unusual use of cert-manager.

Adjusting the CN and SAN DNSName certificate attributes.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
