### PR TITLE
bug fix: merge secret metadata instead of overriding

### DIFF
--- a/pkg/controllers/commontest/common.go
+++ b/pkg/controllers/commontest/common.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -62,14 +61,11 @@ func HasOwnerRef(meta metav1.ObjectMeta, kind, name string) bool {
 	return false
 }
 
-func HasFieldOwnership(meta metav1.ObjectMeta, mgr, expected string) string {
+func HasFieldOwnership(meta metav1.ObjectMeta, mgr, rawFields string) bool {
 	for _, ref := range meta.ManagedFields {
-		if ref.Manager == mgr {
-			if diff := cmp.Diff(string(ref.FieldsV1.Raw), expected); diff != "" {
-				return fmt.Sprintf("(-got, +want)\n%s", diff)
-			}
-			return ""
+		if ref.Manager == mgr && string(ref.FieldsV1.Raw) == rawFields {
+			return true
 		}
 	}
-	return fmt.Sprintf("No managed fields managed by %s", mgr)
+	return false
 }

--- a/pkg/controllers/externalsecret/externalsecret_controller_test.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller_test.go
@@ -359,24 +359,12 @@ var _ = Describe("ExternalSecret controller", Serial, func() {
 	mergeWithSecret := func(tc *testCase) {
 		const secretVal = "someValue"
 		tc.externalSecret.Spec.Target.CreationPolicy = esv1beta1.CreatePolicyMerge
-		tc.externalSecret.Labels = map[string]string{
-			"es-label-key": "es-label-value",
-		}
-		tc.externalSecret.Annotations = map[string]string{
-			"es-annotation-key": "es-annotation-value",
-		}
 
 		// create secret beforehand
 		Expect(k8sClient.Create(context.Background(), &v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      ExternalSecretTargetSecretName,
 				Namespace: ExternalSecretNamespace,
-				Labels: map[string]string{
-					"existing-label-key": "existing-label-value",
-				},
-				Annotations: map[string]string{
-					"existing-annotation-key": "existing-annotation-value",
-				},
 			},
 			Data: map[string][]byte{
 				existingKey: []byte(existingVal),
@@ -389,23 +377,21 @@ var _ = Describe("ExternalSecret controller", Serial, func() {
 			Expect(string(secret.Data[existingKey])).To(Equal(existingVal))
 			Expect(string(secret.Data[targetProp])).To(Equal(secretVal))
 
-			Expect(secret.ObjectMeta.Labels).To(HaveLen(2))
-			Expect(secret.ObjectMeta.Labels).To(HaveKeyWithValue("existing-label-key", "existing-label-value"))
-			Expect(secret.ObjectMeta.Labels).To(HaveKeyWithValue("es-label-key", "es-label-value"))
-
-			Expect(secret.ObjectMeta.Annotations).To(HaveLen(3))
-			Expect(secret.ObjectMeta.Annotations).To(HaveKeyWithValue("existing-annotation-key", "existing-annotation-value"))
-			Expect(secret.ObjectMeta.Annotations).To(HaveKeyWithValue("es-annotation-key", "es-annotation-value"))
-			Expect(secret.ObjectMeta.Annotations).To(HaveKey(esv1beta1.AnnotationDataHash))
-
+			// check labels & annotations
+			for k, v := range es.ObjectMeta.Labels {
+				Expect(secret.ObjectMeta.Labels).To(HaveKeyWithValue(k, v))
+			}
+			for k, v := range es.ObjectMeta.Annotations {
+				Expect(secret.ObjectMeta.Annotations).To(HaveKeyWithValue(k, v))
+			}
 			Expect(ctest.HasOwnerRef(secret.ObjectMeta, "ExternalSecret", ExternalSecretFQDN)).To(BeFalse())
 			Expect(secret.ObjectMeta.ManagedFields).To(HaveLen(2))
 			Expect(ctest.HasFieldOwnership(
 				secret.ObjectMeta,
 				ExternalSecretFQDN,
-				fmt.Sprintf(`{"f:data":{"f:targetProperty":{}},"f:immutable":{},"f:metadata":{"f:annotations":{"f:es-annotation-key":{},"f:%s":{}},"f:labels":{"f:es-label-key":{}}}}`, esv1beta1.AnnotationDataHash)),
-			).To(BeEmpty())
-			Expect(ctest.HasFieldOwnership(secret.ObjectMeta, FakeManager, `{"f:data":{".":{},"f:pre-existing-key":{}},"f:metadata":{"f:annotations":{".":{},"f:existing-annotation-key":{}},"f:labels":{".":{},"f:existing-label-key":{}}},"f:type":{}}`)).To(BeEmpty())
+				fmt.Sprintf("{\"f:data\":{\"f:targetProperty\":{}},\"f:immutable\":{},\"f:metadata\":{\"f:annotations\":{\"f:%s\":{}}}}", esv1beta1.AnnotationDataHash)),
+			).To(BeTrue())
+			Expect(ctest.HasFieldOwnership(secret.ObjectMeta, FakeManager, "{\"f:data\":{\".\":{},\"f:pre-existing-key\":{}},\"f:type\":{}}")).To(BeTrue())
 		}
 	}
 
@@ -502,7 +488,7 @@ var _ = Describe("ExternalSecret controller", Serial, func() {
 				secret.ObjectMeta,
 				ExternalSecretFQDN,
 				fmt.Sprintf("{\"f:data\":{\"f:targetProperty\":{}},\"f:immutable\":{},\"f:metadata\":{\"f:annotations\":{\"f:%s\":{}}}}", esv1beta1.AnnotationDataHash)),
-			).To(BeEmpty())
+			).To(BeTrue())
 		}
 	}
 


### PR DESCRIPTION
## Problem Statement

The secret metadata is being overridden instead of being merged. This is breaking our secret automation.

## Related Issue

Fixes https://github.com/external-secrets/external-secrets/issues/2864

## Proposed Changes
Reverting the changes made in https://github.com/external-secrets/external-secrets/pull/2705, as per the discussion [here](https://github.com/external-secrets/external-secrets/issues/2864#issuecomment-1804828252)


## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
