### PR TITLE
docs: remove additional space in dockercreds example that causes the last curly brace to be removed

### DIFF
--- a/docs/guides/common-k8s-secret-types.md
+++ b/docs/guides/common-k8s-secret-types.md
@@ -52,7 +52,7 @@ spec:
     template:
       type: kubernetes.io/dockerconfigjson
       data:
-        .dockerconfigjson: '{"auths":{"{{ .registryName | lower }}.{{ .registryHost }}":{"username":"{{ .registryName }}","password":"{{ .password }}", "auth":"{{ printf "%s:%s" .registryName .password | b64enc }}"}}}'
+        .dockerconfigjson: '{"auths":{"{{ .registryName | lower }}.{{ .registryHost }}":{"username":"{{ .registryName }}","password":"{{ .password }}","auth":"{{ printf "%s:%s" .registryName .password | b64enc }}"}}}'
   data:
   - secretKey: registryName
     remoteRef:


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?
I used the original example to try to create a dockerconfigjson type secret in k8s and found that there was an extra space in the templating between the `,` and `auth`.

```
        .dockerconfigjson: '{"auths":{"{{ .registryName | lower }}.{{ .registryHost }}":{"username":"{{ .registryName }}","password":"{{ .password }}", "auth":"{{ printf "%s:%s" .registryName .password | b64enc }}"}}}'
```

When the secret was finally rendered in K8s, the extra space caused the last curly brace to be removed so the secret looked something like:

```
{"auths":{"registry.gitlab.com":{"username":"<redacted>","password":"<redacted>", "auth":"<redacted>"}}%
```
instead of:
```
{"auths":{"registry.gitlab.com":{"username":"<redacted>","password":"<redacted>", "auth":"<redacted>"}}}% # this one has all 3 curly braces
```

Removing the extra space fixed the issue.

## Related Issue

No related issue.

## Proposed Changes

How do you like to solve the issue and why?

Fixed the typo and testing locally with:
```
make doc.publish && make docs.serve
```


## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] My changes have reasonable test coverage
- [X] All tests pass with `make test`
- [X] I ensured my PR is ready for review with `make reviewable`
