### PR TITLE
Feat/Adding support for PushSecret using HashiCorp Vault KV v1

### DIFF
--- a/docs/provider/hashicorp-vault.md
+++ b/docs/provider/hashicorp-vault.md
@@ -78,13 +78,13 @@ spec:
   # metadataPolicy to fetch all the labels in JSON format
   - secretKey: tags
     remoteRef:
-      metadataPolicy: Fetch 
+      metadataPolicy: Fetch
       key: foo
 
   # metadataPolicy to fetch a specific label (dev) from the source secret
   - secretKey: developer
     remoteRef:
-      metadataPolicy: Fetch 
+      metadataPolicy: Fetch
       key: foo
       property: dev
 
@@ -401,6 +401,8 @@ This approach assumes that appropriate IRSA setup is done controller's pod (i.e.
 
 Vault supports PushSecret features which allow you to sync a given Kubernetes secret key into a Hashicorp vault secret. To do so, it is expected that the secret key is a valid JSON object or that the `property` attribute has been specified under the `remoteRef`.
 To use PushSecret, you need to give `create`, `read` and `update` permissions to the path where you want to push secrets for both `data` and `metadata` of the secret. Use it with care!
+
+Important note: Enabling PushSecret with Vault provider using the KV v1 backend might expose your infrastructure to a potential risks, as the operator is unable to verify the metadata of the secrets. It is highly recommended to add additional layer of security using [Vault Policies](https://developer.hashicorp.com/vault/docs/concepts/policies) for your secrets.
 
 Here is an example of how to set up `PushSecret`:
 

--- a/docs/provider/hashicorp-vault.md
+++ b/docs/provider/hashicorp-vault.md
@@ -402,7 +402,9 @@ This approach assumes that appropriate IRSA setup is done controller's pod (i.e.
 Vault supports PushSecret features which allow you to sync a given Kubernetes secret key into a Hashicorp vault secret. To do so, it is expected that the secret key is a valid JSON object or that the `property` attribute has been specified under the `remoteRef`.
 To use PushSecret, you need to give `create`, `read` and `update` permissions to the path where you want to push secrets for both `data` and `metadata` of the secret. Use it with care!
 
-Important note: Since Vault KV v1 API is not supported with storing secrets metadata, PushSecret will add a custom metadata map to each secret in Vault that he will manage.
+!!! note
+     Since Vault KV v1 API is not supported with storing secrets metadata, PushSecret will add a `custom_metadata` map to each secret in Vault that he will manage. It means pushing secret keys named `custom_metadata` is not supported with Vault KV v1.
+
 
 Here is an example of how to set up `PushSecret`:
 

--- a/docs/provider/hashicorp-vault.md
+++ b/docs/provider/hashicorp-vault.md
@@ -402,7 +402,7 @@ This approach assumes that appropriate IRSA setup is done controller's pod (i.e.
 Vault supports PushSecret features which allow you to sync a given Kubernetes secret key into a Hashicorp vault secret. To do so, it is expected that the secret key is a valid JSON object or that the `property` attribute has been specified under the `remoteRef`.
 To use PushSecret, you need to give `create`, `read` and `update` permissions to the path where you want to push secrets for both `data` and `metadata` of the secret. Use it with care!
 
-Important note: Enabling PushSecret with Vault provider using the KV v1 backend might expose your infrastructure to a potential risks, as the operator is unable to verify the metadata of the secrets. It is highly recommended to add additional layer of security using [Vault Policies](https://developer.hashicorp.com/vault/docs/concepts/policies) for your secrets.
+Important note: Since Vault KV v1 API is not supported with storing secrets metadata, PushSecret will add a custom metadata map to each secret in Vault that he will manage.
 
 Here is an example of how to set up `PushSecret`:
 

--- a/pkg/provider/vault/vault.go
+++ b/pkg/provider/vault/vault.go
@@ -913,7 +913,6 @@ func (v *client) buildMetadataPath(path string) (string, error) {
 			url = fmt.Sprintf("%s/metadata/%s", *v.store.Path, path)
 		}
 	}
-
 	return url, nil
 }
 

--- a/pkg/provider/vault/vault.go
+++ b/pkg/provider/vault/vault.go
@@ -522,7 +522,7 @@ func (v *client) PushSecret(ctx context.Context, secret *corev1.Secret, data esv
 			return fmt.Errorf("secret not managed by external-secrets")
 		}
 	}
-	// Remove the metadata map to check the reconcile differance
+	// Remove the metadata map to check the reconcile difference
 	if v.store.Version == esv1beta1.VaultKVStoreV1 {
 		delete(vaultSecret, "custom_metadata")
 	}

--- a/pkg/provider/vault/vault.go
+++ b/pkg/provider/vault/vault.go
@@ -479,13 +479,11 @@ func (v *client) DeleteSecret(ctx context.Context, remoteRef esv1beta1.PushSecre
 			return fmt.Errorf("could not delete secret metadata %v: %w", remoteRef.GetRemoteKey(), err)
 		}
 	}
-
 	_, err = v.logical.DeleteWithContext(ctx, path)
 	metrics.ObserveAPICall(constants.ProviderHCVault, constants.CallHCVaultDeleteSecret, err)
 	if err != nil {
 		return fmt.Errorf("could not delete secret %v: %w", remoteRef.GetRemoteKey(), err)
 	}
-
 	return nil
 }
 

--- a/pkg/provider/vault/vault.go
+++ b/pkg/provider/vault/vault.go
@@ -900,18 +900,14 @@ func (v *client) Validate() (esv1beta1.ValidationResult, error) {
 
 func (v *client) buildMetadataPath(path string) (string, error) {
 	var url string
-	if v.store.Version == esv1beta1.VaultKVStoreV1 {
-		url = fmt.Sprintf("%s/%s", *v.store.Path, path)
+	if v.store.Path == nil && !strings.Contains(path, "data") {
+		return "", fmt.Errorf(errPathInvalid)
+	}
+	if v.store.Path == nil {
+		path = strings.Replace(path, "data", "metadata", 1)
+		url = path
 	} else {
-		if v.store.Path == nil && !strings.Contains(path, "data") {
-			return "", fmt.Errorf(errPathInvalid)
-		}
-		if v.store.Path == nil {
-			path = strings.Replace(path, "data", "metadata", 1)
-			url = path
-		} else {
-			url = fmt.Sprintf("%s/metadata/%s", *v.store.Path, path)
-		}
+		url = fmt.Sprintf("%s/metadata/%s", *v.store.Path, path)
 	}
 	return url, nil
 }

--- a/pkg/provider/vault/vault_test.go
+++ b/pkg/provider/vault/vault_test.go
@@ -1685,7 +1685,21 @@ func TestDeleteSecret(t *testing.T) {
 		want   want
 		value  []byte
 	}{
-		"DeleteSecretNoOp": {
+		"DeleteSecretNoOpKV1": {
+			reason: "No secret is because it does not exist",
+			args: args{
+				store: makeValidSecretStoreWithVersion(esv1beta1.VaultKVStoreV1).Spec.Provider.Vault,
+				vLogical: &fake.Logical{
+					ReadWithDataWithContextFn: fake.NewReadWithContextFn(nil, nil),
+					WriteWithContextFn:        fake.ExpectWriteWithContextNoCall(),
+					DeleteWithContextFn:       fake.ExpectDeleteWithContextNoCall(),
+				},
+			},
+			want: want{
+				err: nil,
+			},
+		},
+		"DeleteSecretNoOpKV2": {
 			reason: "No secret is because it does not exist",
 			args: args{
 				store: makeValidSecretStoreWithVersion(esv1beta1.VaultKVStoreV2).Spec.Provider.Vault,
@@ -1699,7 +1713,21 @@ func TestDeleteSecret(t *testing.T) {
 				err: nil,
 			},
 		},
-		"DeleteSecretFailIfError": {
+		"DeleteSecretFailIfErrorKV1": {
+			reason: "No secret is because it does not exist",
+			args: args{
+				store: makeValidSecretStoreWithVersion(esv1beta1.VaultKVStoreV1).Spec.Provider.Vault,
+				vLogical: &fake.Logical{
+					ReadWithDataWithContextFn: fake.NewReadWithContextFn(nil, fmt.Errorf("failed to read")),
+					WriteWithContextFn:        fake.ExpectWriteWithContextNoCall(),
+					DeleteWithContextFn:       fake.ExpectDeleteWithContextNoCall(),
+				},
+			},
+			want: want{
+				err: fmt.Errorf("failed to read"),
+			},
+		},
+		"DeleteSecretFailIfErrorKV2": {
 			reason: "No secret is because it does not exist",
 			args: args{
 				store: makeValidSecretStoreWithVersion(esv1beta1.VaultKVStoreV2).Spec.Provider.Vault,
@@ -1713,7 +1741,23 @@ func TestDeleteSecret(t *testing.T) {
 				err: fmt.Errorf("failed to read"),
 			},
 		},
-		"DeleteSecretNotManaged": {
+		"DeleteSecretNotManagedKV1": {
+			reason: "No secret is because it does not exist",
+			args: args{
+				store: makeValidSecretStoreWithVersion(esv1beta1.VaultKVStoreV1).Spec.Provider.Vault,
+				vLogical: &fake.Logical{
+					ReadWithDataWithContextFn: fake.NewReadWithContextFn(map[string]interface{}{
+						"fake-key": "fake-value",
+					}, nil),
+					WriteWithContextFn:  fake.ExpectWriteWithContextNoCall(),
+					DeleteWithContextFn: fake.NewDeleteWithContextFn(nil, nil),
+				},
+			},
+			want: want{
+				err: nil,
+			},
+		},
+		"DeleteSecretNotManagedKV2": {
 			reason: "No secret is because it does not exist",
 			args: args{
 				store: makeValidSecretStoreWithVersion(esv1beta1.VaultKVStoreV2).Spec.Provider.Vault,
@@ -1734,7 +1778,23 @@ func TestDeleteSecret(t *testing.T) {
 				err: nil,
 			},
 		},
-		"DeleteSecretSuccess": {
+		"DeleteSecretSuccessKV1": {
+			reason: "No secret is because it does not exist",
+			args: args{
+				store: makeValidSecretStoreWithVersion(esv1beta1.VaultKVStoreV1).Spec.Provider.Vault,
+				vLogical: &fake.Logical{
+					ReadWithDataWithContextFn: fake.NewReadWithContextFn(map[string]interface{}{
+						"fake-key": "fake-value",
+					}, nil),
+					WriteWithContextFn:  fake.ExpectWriteWithContextNoCall(),
+					DeleteWithContextFn: fake.NewDeleteWithContextFn(nil, nil),
+				},
+			},
+			want: want{
+				err: nil,
+			},
+		},
+		"DeleteSecretSuccessKV2": {
 			reason: "No secret is because it does not exist",
 			args: args{
 				store: makeValidSecretStoreWithVersion(esv1beta1.VaultKVStoreV2).Spec.Provider.Vault,
@@ -1755,7 +1815,23 @@ func TestDeleteSecret(t *testing.T) {
 				err: nil,
 			},
 		},
-		"DeleteSecretError": {
+		"DeleteSecretErrorKV1": {
+			reason: "No secret is because it does not exist",
+			args: args{
+				store: makeValidSecretStoreWithVersion(esv1beta1.VaultKVStoreV1).Spec.Provider.Vault,
+				vLogical: &fake.Logical{
+					ReadWithDataWithContextFn: fake.NewReadWithContextFn(map[string]interface{}{
+						"fake-key": "fake-value",
+					}, nil),
+					WriteWithContextFn:  fake.ExpectWriteWithContextNoCall(),
+					DeleteWithContextFn: fake.NewDeleteWithContextFn(nil, fmt.Errorf("failed to delete")),
+				},
+			},
+			want: want{
+				err: fmt.Errorf("failed to delete"),
+			},
+		},
+		"DeleteSecretErrorKV2": {
 			reason: "No secret is because it does not exist",
 			args: args{
 				store: makeValidSecretStoreWithVersion(esv1beta1.VaultKVStoreV2).Spec.Provider.Vault,
@@ -1776,7 +1852,25 @@ func TestDeleteSecret(t *testing.T) {
 				err: fmt.Errorf("failed to delete"),
 			},
 		},
-		"DeleteSecretUpdateProperty": {
+		"DeleteSecretUpdatePropertyKV1": {
+			reason: "Secret should only be updated if Property is set",
+			ref:    &testingfake.PushSecretData{RemoteKey: "secret", Property: "fake-key"},
+			args: args{
+				store: makeValidSecretStoreWithVersion(esv1beta1.VaultKVStoreV1).Spec.Provider.Vault,
+				vLogical: &fake.Logical{
+					ReadWithDataWithContextFn: fake.NewReadWithContextFn(map[string]interface{}{
+						"fake-key": "fake-value",
+						"foo":      "bar",
+					}, nil),
+					WriteWithContextFn:  fake.ExpectWriteWithContextValue(map[string]interface{}{"foo": "bar"}),
+					DeleteWithContextFn: fake.ExpectDeleteWithContextNoCall(),
+				},
+			},
+			want: want{
+				err: nil,
+			},
+		},
+		"DeleteSecretUpdatePropertyKV2": {
 			reason: "Secret should only be updated if Property is set",
 			ref:    &testingfake.PushSecretData{RemoteKey: "secret", Property: "fake-key"},
 			args: args{
@@ -1799,7 +1893,24 @@ func TestDeleteSecret(t *testing.T) {
 				err: nil,
 			},
 		},
-		"DeleteSecretIfNoOtherProperties": {
+		"DeleteSecretIfNoOtherPropertiesKV1": {
+			reason: "Secret should only be deleted if no other properties are set",
+			ref:    &testingfake.PushSecretData{RemoteKey: "secret", Property: "foo"},
+			args: args{
+				store: makeValidSecretStoreWithVersion(esv1beta1.VaultKVStoreV1).Spec.Provider.Vault,
+				vLogical: &fake.Logical{
+					ReadWithDataWithContextFn: fake.NewReadWithContextFn(map[string]interface{}{
+						"foo": "bar",
+					}, nil),
+					WriteWithContextFn:  fake.ExpectWriteWithContextNoCall(),
+					DeleteWithContextFn: fake.NewDeleteWithContextFn(nil, nil),
+				},
+			},
+			want: want{
+				err: nil,
+			},
+		},
+		"DeleteSecretIfNoOtherPropertiesKV2": {
 			reason: "Secret should only be deleted if no other properties are set",
 			ref:    &testingfake.PushSecretData{RemoteKey: "secret", Property: "foo"},
 			args: args{


### PR DESCRIPTION
## Problem Statement

PushSecret is currently supported with HashiCorp Vault provider only when KV v2 backend is used. 
This is because the Vault KV v1 backend is not supporting secrets' metadata. Thus, ESO is not able to verify if secrets were originally pushed by him. 
Using PushSecret with Vault KV v1 might expose your infrastructure to a potential risk while granting the operator permissions to override secrets that were not originally created by him.
This risk is acceptable when using external security layer for managing the access permissions like Vault policies where tokens can be restricted for specific paths. 
But, since ESO should guarantee some assurance and confidence in operation with sensitive assets, supporting Vault KV v1 API without metadata validation is not acceptable.
 
## Related Issue

Fixes #2549 

## Proposed Changes

Enabling the support for PushSecret with Vault KV v1 backend while adding a `custom_metadata` map to each secert that the operator will manage. 
For example, the following Kubernetes secret:

```apiVersion: v1
kind: Secret
metadata:
  name: source-secret
  namespace: default
stringData:
  source-key1: "{\"foo\":\"bar\"}"
```
Will be represented as the following Vault secret:
```
{
  "foo": "bar",
  "custom_metadata": {
    "managed-by": "external-secrets"
  }
}
``` 

 
Adding a note in the documentation about the structure that will be reflected in Vault secrets.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
