### PR TITLE
feat(fake): deprecate ValueMap to use Value instead

### DIFF
--- a/apis/externalsecrets/v1beta1/secretstore_fake_types.go
+++ b/apis/externalsecrets/v1beta1/secretstore_fake_types.go
@@ -20,8 +20,9 @@ type FakeProvider struct {
 }
 
 type FakeProviderData struct {
-	Key      string            `json:"key"`
-	Value    string            `json:"value,omitempty"`
+	Key   string `json:"key"`
+	Value string `json:"value,omitempty"`
+	// Deprecated: ValueMap is deprecated and is intended to be removed in the future, use the `value` field instead.
 	ValueMap map[string]string `json:"valueMap,omitempty"`
 	Version  string            `json:"version,omitempty"`
 }

--- a/config/crds/bases/external-secrets.io_clustersecretstores.yaml
+++ b/config/crds/bases/external-secrets.io_clustersecretstores.yaml
@@ -2546,6 +2546,9 @@ spec:
                             valueMap:
                               additionalProperties:
                                 type: string
+                              description: 'Deprecated: ValueMap is deprecated and
+                                is intended to be removed in the future, use the `value`
+                                field instead.'
                               type: object
                             version:
                               type: string

--- a/config/crds/bases/external-secrets.io_secretstores.yaml
+++ b/config/crds/bases/external-secrets.io_secretstores.yaml
@@ -2546,6 +2546,9 @@ spec:
                             valueMap:
                               additionalProperties:
                                 type: string
+                              description: 'Deprecated: ValueMap is deprecated and
+                                is intended to be removed in the future, use the `value`
+                                field instead.'
                               type: object
                             version:
                               type: string

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -2386,6 +2386,7 @@ spec:
                               valueMap:
                                 additionalProperties:
                                   type: string
+                                description: 'Deprecated: ValueMap is deprecated and is intended to be removed in the future, use the `value` field instead.'
                                 type: object
                               version:
                                 type: string
@@ -6309,6 +6310,7 @@ spec:
                               valueMap:
                                 additionalProperties:
                                   type: string
+                                description: 'Deprecated: ValueMap is deprecated and is intended to be removed in the future, use the `value` field instead.'
                                 type: object
                               version:
                                 type: string

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -204,7 +204,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Role is a Role ARN which the SecretManager provider will assume</p>
+<p>Role is a Role ARN which the provider will assume</p>
 </td>
 </tr>
 <tr>
@@ -227,7 +227,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>AdditionalRoles is a chained list of Role ARNs which the SecretManager provider will sequentially assume before assuming Role</p>
+<p>AdditionalRoles is a chained list of Role ARNs which the provider will sequentially assume before assuming the Role</p>
 </td>
 </tr>
 <tr>
@@ -257,6 +257,20 @@ string
 </tr>
 <tr>
 <td>
+<code>secretsManager</code></br>
+<em>
+<a href="#external-secrets.io/v1beta1.SecretsManager">
+SecretsManager
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SecretsManager defines how the provider behaves when interacting with AWS SecretsManager</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>transitiveTagKeys</code></br>
 <em>
 []*string
@@ -264,7 +278,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>AWS STS assume role transitive session tags. Required when multiple rules are used with SecretStore</p>
+<p>AWS STS assume role transitive session tags. Required when multiple rules are used with the provider</p>
 </td>
 </tr>
 </tbody>
@@ -286,11 +300,11 @@ string
 </tr>
 </thead>
 <tbody><tr><td><p>&#34;ParameterStore&#34;</p></td>
-<td><p>AWSServiceParameterStore is the AWS SystemsManager ParameterStore.
+<td><p>AWSServiceParameterStore is the AWS SystemsManager ParameterStore service.
 see: <a href="https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html">https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html</a></p>
 </td>
 </tr><tr><td><p>&#34;SecretsManager&#34;</p></td>
-<td><p>AWSServiceSecretsManager is the AWS SecretsManager.
+<td><p>AWSServiceSecretsManager is the AWS SecretsManager service.
 see: <a href="https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html">https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html</a></p>
 </td>
 </tr></tbody>
@@ -3482,6 +3496,7 @@ map[string]string
 </em>
 </td>
 <td>
+<p>Deprecated: ValueMap is deprecated and is intended to be removed in the future, use the <code>value</code> field instead.</p>
 </td>
 </tr>
 <tr>
@@ -5573,6 +5588,60 @@ Kubernetes meta/v1.Time
 <p>
 <p>SecretsClient provides access to secrets.</p>
 </p>
+<h3 id="external-secrets.io/v1beta1.SecretsManager">SecretsManager
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#external-secrets.io/v1beta1.AWSProvider">AWSProvider</a>)
+</p>
+<p>
+<p>SecretsManager defines how the provider behaves when interacting with AWS
+SecretsManager. Some of these settings are only applicable to controlling how
+secrets are deleted, and hence only apply to PushSecret (and only when
+deletionPolicy is set to Delete).</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>forceDeleteWithoutRecovery</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Specifies whether to delete the secret without any recovery window. You
+can&rsquo;t use both this parameter and RecoveryWindowInDays in the same call.
+If you don&rsquo;t use either, then by default Secrets Manager uses a 30 day
+recovery window.
+see: <a href="https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_DeleteSecret.html#SecretsManager-DeleteSecret-request-ForceDeleteWithoutRecovery">https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_DeleteSecret.html#SecretsManager-DeleteSecret-request-ForceDeleteWithoutRecovery</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>recoveryWindowInDays</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The number of days from 7 to 30 that Secrets Manager waits before
+permanently deleting the secret. You can&rsquo;t use both this parameter and
+ForceDeleteWithoutRecovery in the same call. If you don&rsquo;t use either,
+then by default Secrets Manager uses a 30 day recovery window.
+see: <a href="https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_DeleteSecret.html#SecretsManager-DeleteSecret-request-RecoveryWindowInDays">https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_DeleteSecret.html#SecretsManager-DeleteSecret-request-RecoveryWindowInDays</a></p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="external-secrets.io/v1beta1.SenhaseguraAuth">SenhaseguraAuth
 </h3>
 <p>

--- a/docs/provider/fake.md
+++ b/docs/provider/fake.md
@@ -2,13 +2,14 @@ We provide a `fake` implementation to help with testing. This provider returns s
 To use the `fake` provider simply create a `SecretStore` or `ClusterSecretStore` and configure it like in the following example:
 
 !!! note inline end
-    The provider returns static data configured in `value` or `valueMap`. You can define a `version`, too. If set the `remoteRef` from an ExternalSecret must match otherwise no value is returned.
+    The provider returns static data configured in `value`. You can define a `version`, too. If set the `remoteRef` from an ExternalSecret must match otherwise no value is returned.
 
 ```yaml
 {% include 'fake-provider-store.yaml' %}
 ```
 
-Please note that `value` is intended for exclusive use with `data` and `valueMap` for `dataFrom`.
+Please note that `value` is intended for exclusive use with `data` for `dataFrom`. You can use the `data` to set a `JSON` compliant value to be used as `dataFrom`.
+
 Here is an example `ExternalSecret` that displays this behavior:
 
 !!! warning inline end

--- a/docs/snippets/fake-provider-es.yaml
+++ b/docs/snippets/fake-provider-es.yaml
@@ -17,3 +17,4 @@ spec:
   dataFrom:
   - extract:
       key: /foo/baz
+      version: v1

--- a/docs/snippets/fake-provider-secret.yaml
+++ b/docs/snippets/fake-provider-secret.yaml
@@ -5,5 +5,4 @@ metadata:
   namespace: default
 data:
   foo_bar: SEVMTE8x # HELLO1  (via data)
-  foo: ZXhhbXBsZQ== # example (via dataFrom)
-  other: dGhpbmc=   # thing   (via dataFrom)
+  john: ZG9l #doe (via dataFrom)

--- a/docs/snippets/fake-provider-store.yaml
+++ b/docs/snippets/fake-provider-store.yaml
@@ -13,8 +13,5 @@ spec:
         value: "HELLO2"
         version: "v2"
       - key: "/foo/baz"
-        valueMap:
-          foo: example
-          other: thing
-
-
+        value: '{"john": "doe"}'
+        version: "v1"

--- a/pkg/provider/fake/fake.go
+++ b/pkg/provider/fake/fake.go
@@ -16,6 +16,7 @@ package fake
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -33,6 +34,7 @@ var (
 	errMissingFakeProvider = fmt.Errorf("missing store provider fake")
 	errMissingKeyField     = "key must be set in data %v"
 	errMissingValueField   = "at least one of value or valueMap must be set in data %v"
+	errJSONSecretUnmarshal = "unable to unmarshal secret"
 )
 
 type SourceOrigin string
@@ -182,12 +184,39 @@ func (p *Provider) GetSecret(_ context.Context, ref esv1beta1.ExternalSecretData
 }
 
 // GetSecretMap returns multiple k/v pairs from the provider.
-func (p *Provider) GetSecretMap(_ context.Context, ref esv1beta1.ExternalSecretDataRemoteRef) (map[string][]byte, error) {
-	data, ok := p.config[mapKey(ref.Key, ref.Version)]
-	if !ok || data.Version != ref.Version || data.ValueMap == nil {
+func (p *Provider) GetSecretMap(ctx context.Context, ref esv1beta1.ExternalSecretDataRemoteRef) (map[string][]byte, error) {
+	ddata, ok := p.config[mapKey(ref.Key, ref.Version)]
+	if !ok || ddata.Version != ref.Version {
 		return nil, esv1beta1.NoSecretErr
 	}
-	return convertMap(data.ValueMap), nil
+
+	if ddata.ValueMap != nil {
+		return convertMap(ddata.ValueMap), nil
+	}
+
+	data, err := p.GetSecret(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+
+	secretData := make(map[string][]byte)
+	kv := make(map[string]json.RawMessage)
+	err = json.Unmarshal(data, &kv)
+	if err != nil {
+		return nil, fmt.Errorf(errJSONSecretUnmarshal, err)
+	}
+
+	for k, v := range kv {
+		var strVal string
+		err = json.Unmarshal(v, &strVal)
+		if err == nil {
+			secretData[k] = []byte(strVal)
+		} else {
+			secretData[k] = v
+		}
+	}
+
+	return secretData, nil
 }
 
 func convertMap(in map[string]string) map[string][]byte {

--- a/pkg/provider/fake/fake_test.go
+++ b/pkg/provider/fake/fake_test.go
@@ -414,8 +414,84 @@ func TestGetSecretMap(t *testing.T) {
 			expErr: esv1beta1.NoSecretErr.Error(),
 		},
 		{
+			name: "get correct map from multiple versions by using Value only",
+			input: []esv1beta1.FakeProviderData{
+				{
+					Key:     "/bar",
+					Version: "v1",
+					Value:   `{"john":"doe"}`,
+				},
+			},
+			request: esv1beta1.ExternalSecretDataRemoteRef{
+				Key:     "/bar",
+				Version: "v1",
+			},
+			expValue: map[string][]byte{
+				"john": []byte("doe"),
+			},
+		},
+		{
+			name: "get correct maps from multiple versions by using Value only",
+			input: []esv1beta1.FakeProviderData{
+				{
+					Key:     "/bar",
+					Version: "v3",
+					Value:   `{"john":"doe", "foo": "bar"}`,
+				},
+			},
+			request: esv1beta1.ExternalSecretDataRemoteRef{
+				Key:     "/bar",
+				Version: "v3",
+			},
+			expValue: map[string][]byte{
+				"john": []byte("doe"),
+				"foo":  []byte("bar"),
+			},
+		},
+		{
+			name: "invalid marshal",
+			input: []esv1beta1.FakeProviderData{
+				{
+					Key:     "/bar",
+					Version: "v3",
+					Value:   `---------`,
+				},
+			},
+			request: esv1beta1.ExternalSecretDataRemoteRef{
+				Key:     "/bar",
+				Version: "v3",
+			},
+			expErr: "unable to unmarshal secret%!(EXTRA *json.SyntaxError=invalid character '-' in numeric literal)",
+		},
+		{
+			name: "get correct value from ValueMap due to retrocompatibility",
+			input: []esv1beta1.FakeProviderData{
+				{
+					Key:     "/foo/bar",
+					Version: "v3",
+					ValueMap: map[string]string{
+						"john": "doe",
+						"baz":  "bang",
+					},
+				},
+			},
+			request: esv1beta1.ExternalSecretDataRemoteRef{
+				Key:     "/foo/bar",
+				Version: "v3",
+			},
+			expValue: map[string][]byte{
+				"john": []byte("doe"),
+				"baz":  []byte("bang"),
+			},
+		},
+		{
 			name: "get correct value from multiple versions",
 			input: []esv1beta1.FakeProviderData{
+				{
+					Key:     "john",
+					Value:   "doe",
+					Version: "v2",
+				},
 				{
 					Key: "junk",
 					ValueMap: map[string]string{


### PR DESCRIPTION
Deprecates `ValueMap` and adds support for structure data directly in `Value` to be used as `dataFrom`.

Fixes: #2845

## Problem Statement

What is the problem you're trying to solve?

Make Fake's provider consistent by using `Value` instead of `ValueMap`.

## Related Issue

Fixes #2845

## Proposed Changes

How do you like to solve the issue and why?

By implementing the same GCP's Provider logic to handle structure data as `dataFrom` instead of relying on the `valueMap` field.

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] My changes have reasonable test coverage
- [X] All tests pass with `make test`
- [X] I ensured my PR is ready for review with `make reviewable`
