### PR TITLE
fix: Small typo in the 'templateFrom' guide

### DIFF
--- a/docs/snippets/template-v2-from-secret.yaml
+++ b/docs/snippets/template-v2-from-secret.yaml
@@ -47,7 +47,7 @@ spec:
           items:
           - key: config.yaml
             templateAs: Values
-          - key: generated
+          - key: templated
             templateAs: KeysAndValues
       - target: Annotations
         configMap:


### PR DESCRIPTION
## Problem Statement

I believe there's a typo in the `templateFrom` guide.

## Related Issue

Fixes #...

## Proposed Changes

This PR should address the issue.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
