### PR TITLE
fix: ACR access token generator with Workload Identity

### DIFF
--- a/docs/api/generator/acr.md
+++ b/docs/api/generator/acr.md
@@ -18,7 +18,8 @@ You must choose one out of three authentication mechanisms:
 - managed identity
 - workload identity
 
-The generated token will inherit the permissions from the assigned policy. I.e. when you assign a read-only policy all generated tokens will be read-only.
+The generated token will inherit the permissions from the assigned policy. I.e. when you assign a read-only policy all generated tokens will be read-only. 
+You **must** [assign a Azure RBAC role](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments-steps), such as `AcrPush` or `AcrPull` to the service principal in order to be able to authenticate with the Azure container registry API. 
 
 You can scope tokens to a particular repository using `spec.scope`.
 

--- a/pkg/provider/azure/keyvault/keyvault.go
+++ b/pkg/provider/azure/keyvault/keyvault.go
@@ -967,6 +967,21 @@ func AadEndpointForType(t esv1beta1.AzureEnvironmentType) string {
 	}
 }
 
+func ServiceManagementEndpointForType(t esv1beta1.AzureEnvironmentType) string {
+	switch t {
+	case esv1beta1.AzureEnvironmentPublicCloud:
+		return azure.PublicCloud.ServiceManagementEndpoint
+	case esv1beta1.AzureEnvironmentChinaCloud:
+		return azure.ChinaCloud.ServiceManagementEndpoint
+	case esv1beta1.AzureEnvironmentUSGovernmentCloud:
+		return azure.USGovernmentCloud.ServiceManagementEndpoint
+	case esv1beta1.AzureEnvironmentGermanCloud:
+		return azure.GermanCloud.ServiceManagementEndpoint
+	default:
+		return azure.PublicCloud.ServiceManagementEndpoint
+	}
+}
+
 func kvResourceForProviderConfig(t esv1beta1.AzureEnvironmentType) string {
 	var res string
 	switch t {


### PR DESCRIPTION
The `scope` parameter used to be the ACR url `foobar.azurecr.io`, but this stopped working. Turns out that you need to use the management endpoint as `scope` in order to authenticate with ACR.

Supersedes #2403.

### Proof of work

```yaml
apiVersion: generators.external-secrets.io/v1alpha1
kind: ACRAccessToken
metadata:
  name: acr-gen
spec:
  tenantId: xxxxxx
  registry: mjeso.azurecr.io
  environmentType: "PublicCloud"
  auth:
    workloadIdentity:
      serviceAccountRef:
        name: "workload-identity-sa"
---
apiVersion: external-secrets.io/v1beta1
kind: ExternalSecret
metadata:
  name: azurecr-credentials
spec:
  dataFrom:
    - sourceRef:
        generatorRef:
          apiVersion: generators.external-secrets.io/v1alpha1
          kind: ACRAccessToken
          name: acr-gen
  refreshInterval: 12h
  target:
    name: azurecr-credentials
    template:
      type: kubernetes.io/dockerconfigjson
      data:
        .dockerconfigjson: |
          {
            "auths": {
              "mjeso.azurecr.io": {
                "username": "{{ .username }}",
                "identitytoken": "{{ .password }}"
              }
            }
          }
```


![2023-11-29T23:23:29,505716084+01:00](https://github.com/external-secrets/external-secrets/assets/1709030/d03281ee-9143-4597-894a-19048dd14c35)

![2023-11-29T23:23:45,680655988+01:00](https://github.com/external-secrets/external-secrets/assets/1709030/88272745-e349-41c2-9e81-270202fdba2e)



Approach: I've reverse engineered the CLI call and figured the scope parameter points the the azure mgmt core endpoint. That apparently works :shrug:

```
$ az acr login -n mjeso --debug --verbose
# ...
msal_authentication: UserCredential.get_token: scopes=('https://management.core.windows.net//.default',), claims=None, kwargs={}
msal.application: Cache hit an AT
msal.telemetry: Generate or reuse correlation_id: ...
acr._docker_utils: ... Sending a HTTP Post request to https://mjeso.azurecr.io/oauth2/exchange
Starting new HTTPS connection (1): mjeso.azurecr.io:443
https://mjeso.azurecr.io:443 "POST /oauth2/exchange HTTP/1.1" ...
```