### PR TITLE
Add CONTRIBUTING.md file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,6 @@
+# Contributing
+
+See the [Developer guide](docs/contributing/devguide.md) for information
+about setting up your development environment, and the
+[Contributing Process](docs/contributing/process.md) document
+for details about the workflow.


### PR DESCRIPTION
## Problem Statement

After cloning the repository and attempting to figure out how to build and run the tests locally, I couldn't immediately find what I was looking for. I normally look in the CONTRIBUTING.md file in the root of a repository, which is a standard place for such documentation.

## Related Issue

N/A

## Proposed Changes

In the case of ESO, there are robust dev docs already, but they're not in that standard location. Therefore, I propose we add a link to them in the standard CONTRIBUTING.md file.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
