### PR TITLE
Helm pod spec extra

### DIFF
--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -114,6 +114,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | podDisruptionBudget | object | `{"enabled":false,"minAvailable":1}` | Pod disruption budget - for more details see https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
 | podLabels | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
+| podSpecExtra | object | `{}` | Any extra pod spec on the deployment |
 | priorityClassName | string | `""` | Pod priority class name. |
 | processClusterExternalSecret | bool | `true` | if true, the operator will process cluster external secret. Else, it will ignore them. |
 | processClusterStore | bool | `true` | if true, the operator will process cluster store. Else, it will ignore them. |

--- a/deploy/charts/external-secrets/templates/deployment.yaml
+++ b/deploy/charts/external-secrets/templates/deployment.yaml
@@ -133,4 +133,7 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
+      {{- if .Values.podSpecExtra }}
+      {{- toYaml .Values.podSpecExtra | nindent 6 }}
+      {{- end }}
 {{- end }}

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -476,3 +476,6 @@ certController:
 
 # -- Specifies `dnsOptions` to deployment
 dnsConfig: {}
+
+# -- Any extra pod spec on the deployment
+podSpecExtra: {}


### PR DESCRIPTION
## Problem Statement

My problem is that I am not able to set the `spec.hostAliases` field on the Pod through Helm values.

## Related Issue

None.

## Proposed Changes

I want to provide a flexible way to add extra fields to helm deployment's pod spec through Helm values. 

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
