### PR TITLE
Add flag that turns on/off cert controller certificate renewal 

### DIFF
--- a/cmd/certcontroller.go
+++ b/cmd/certcontroller.go
@@ -145,5 +145,5 @@ func init() {
 	certcontrollerCmd.Flags().StringVar(&loglevel, "loglevel", "info", "loglevel to use, one of: debug, info, warn, error, dpanic, panic, fatal")
 	certcontrollerCmd.Flags().StringVar(&zapTimeEncoding, "zap-time-encoding", "epoch", "Zap time encoding (one of 'epoch', 'millis', 'nano', 'iso8601', 'rfc3339' or 'rfc3339nano')")
 	certcontrollerCmd.Flags().DurationVar(&crdRequeueInterval, "crd-requeue-interval", time.Minute*5, "Time duration between reconciling CRDs for new certs")
-	certcontrollerCmd.Flags().BoolVar(&enableCertRenewal, "enable-cert-renewal", true, "Enable renewal of the webhook certificate by the cert controller.")
+	certcontrollerCmd.Flags().BoolVar(&enableCertRenewal, "enable-cert-renewal", true, "Enable renewal of the webhook certificate by the cert controller. This can be disabled to allow you to manage the certificates on your own and just use the cert-controller to inject the caBundle into CRDs and validating webhook.")
 }

--- a/cmd/certcontroller.go
+++ b/cmd/certcontroller.go
@@ -90,7 +90,8 @@ var certcontrollerCmd = &cobra.Command{
 
 		crdctrl := crds.New(mgr.GetClient(), mgr.GetScheme(), mgr.Elected(),
 			ctrl.Log.WithName("controllers").WithName("webhook-certs-updater"),
-			crdRequeueInterval, serviceName, serviceNamespace, secretName, secretNamespace, crdNames)
+			crdRequeueInterval, enableCertRenewal, serviceName, serviceNamespace,
+			secretName, secretNamespace, crdNames)
 		if err := crdctrl.SetupWithManager(mgr, controller.Options{
 			MaxConcurrentReconciles: concurrent,
 		}); err != nil {
@@ -144,4 +145,5 @@ func init() {
 	certcontrollerCmd.Flags().StringVar(&loglevel, "loglevel", "info", "loglevel to use, one of: debug, info, warn, error, dpanic, panic, fatal")
 	certcontrollerCmd.Flags().StringVar(&zapTimeEncoding, "zap-time-encoding", "epoch", "Zap time encoding (one of 'epoch', 'millis', 'nano', 'iso8601', 'rfc3339' or 'rfc3339nano')")
 	certcontrollerCmd.Flags().DurationVar(&crdRequeueInterval, "crd-requeue-interval", time.Minute*5, "Time duration between reconciling CRDs for new certs")
+	certcontrollerCmd.Flags().BoolVar(&enableCertRenewal, "enable-cert-renewal", true, "Enable renewal of the webhook certificate by the cert controller.")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -81,6 +81,7 @@ var (
 	crdRequeueInterval                    time.Duration
 	certCheckInterval                     time.Duration
 	certLookaheadInterval                 time.Duration
+	enableCertRenewal                     bool
 	tlsCiphers                            string
 	tlsMinVersion                         string
 )

--- a/pkg/controllers/crds/crds_controller.go
+++ b/pkg/controllers/crds/crds_controller.go
@@ -58,18 +58,19 @@ const (
 
 type Reconciler struct {
 	client.Client
-	Log             logr.Logger
-	Scheme          *runtime.Scheme
-	recorder        record.EventRecorder
-	SvcName         string
-	SvcNamespace    string
-	SecretName      string
-	SecretNamespace string
-	CrdResources    []string
-	dnsName         string
-	CAName          string
-	CAOrganization  string
-	RequeueInterval time.Duration
+	Log               logr.Logger
+	Scheme            *runtime.Scheme
+	recorder          record.EventRecorder
+	SvcName           string
+	SvcNamespace      string
+	SecretName        string
+	SecretNamespace   string
+	CrdResources      []string
+	dnsName           string
+	CAName            string
+	CAOrganization    string
+	RequeueInterval   time.Duration
+	EnableCertRenewal bool
 
 	// the controller is ready when all crds are injected
 	// and the controller is elected as leader
@@ -80,22 +81,24 @@ type Reconciler struct {
 }
 
 func New(k8sClient client.Client, scheme *runtime.Scheme, leaderChan <-chan struct{}, logger logr.Logger,
-	interval time.Duration, svcName, svcNamespace, secretName, secretNamespace string, resources []string) *Reconciler {
+	interval time.Duration, enableCertRenewal bool, svcName, svcNamespace,
+	secretName, secretNamespace string, resources []string) *Reconciler {
 	return &Reconciler{
-		Client:           k8sClient,
-		Log:              logger,
-		Scheme:           scheme,
-		SvcName:          svcName,
-		SvcNamespace:     svcNamespace,
-		SecretName:       secretName,
-		SecretNamespace:  secretNamespace,
-		RequeueInterval:  interval,
-		CrdResources:     resources,
-		CAName:           "external-secrets",
-		CAOrganization:   "external-secrets",
-		leaderChan:       leaderChan,
-		readyStatusMapMu: &sync.Mutex{},
-		readyStatusMap:   map[string]bool{},
+		Client:            k8sClient,
+		Log:               logger,
+		Scheme:            scheme,
+		SvcName:           svcName,
+		SvcNamespace:      svcNamespace,
+		SecretName:        secretName,
+		SecretNamespace:   secretNamespace,
+		RequeueInterval:   interval,
+		EnableCertRenewal: enableCertRenewal,
+		CrdResources:      resources,
+		CAName:            "external-secrets",
+		CAOrganization:    "external-secrets",
+		leaderChan:        leaderChan,
+		readyStatusMapMu:  &sync.Mutex{},
+		readyStatusMap:    map[string]bool{},
 	}
 }
 
@@ -212,16 +215,21 @@ func (r *Reconciler) updateCRD(ctx context.Context, req ctrl.Request) error {
 		return err
 	}
 	r.dnsName = fmt.Sprintf("%v.%v.svc", r.SvcName, r.SvcNamespace)
-	need, err := r.refreshCertIfNeeded(&secret)
-	if err != nil {
-		return err
+	refreshedCert := false
+	if r.EnableCertRenewal {
+		refreshedCert, err = r.refreshCertIfNeeded(&secret)
+		if err != nil {
+			return err
+		}
 	}
-	if need {
+	// Injects the certificates if they were refreshed or changed
+	if refreshedCert || !r.EnableCertRenewal {
 		artifacts, err := buildArtifactsFromSecret(&secret)
 		if err != nil {
 			return err
 		}
-		if err := injectCert(&updatedResource, artifacts.CertPEM); err != nil {
+		// Only injects if artifacts.CertPEM changed
+		if _, err := injectCert(&updatedResource, artifacts.CertPEM); err != nil {
 			return err
 		}
 	}
@@ -240,14 +248,18 @@ func injectService(crd *apiext.CustomResourceDefinition, svc types.NamespacedNam
 	return nil
 }
 
-func injectCert(crd *apiext.CustomResourceDefinition, certPem []byte) error {
+func injectCert(crd *apiext.CustomResourceDefinition, certPem []byte) (bool, error) {
 	if crd.Spec.Conversion == nil ||
 		crd.Spec.Conversion.Webhook == nil ||
 		crd.Spec.Conversion.Webhook.ClientConfig == nil {
-		return fmt.Errorf("unexpected crd conversion webhook config")
+		return false, fmt.Errorf("unexpected crd conversion webhook config")
+	}
+	if bytes.Equal(crd.Spec.Conversion.Webhook.ClientConfig.CABundle, certPem) {
+		// CABundle unchanged
+		return false, nil
 	}
 	crd.Spec.Conversion.Webhook.ClientConfig.CABundle = certPem
-	return nil
+	return true, nil
 }
 
 type KeyPairArtifacts struct {

--- a/pkg/controllers/crds/suite_test.go
+++ b/pkg/controllers/crds/suite_test.go
@@ -79,8 +79,8 @@ var _ = BeforeSuite(func() {
 
 	leaderChan := make(chan struct{})
 	close(leaderChan)
-	rec := New(k8sClient, k8sManager.GetScheme(), leaderChan, log, time.Second*1,
-		"foo", "default", "foo", "default", []string{
+	rec := New(k8sClient, k8sManager.GetScheme(), leaderChan, log,
+		time.Second*1, true, "foo", "default", "foo", "default", []string{
 			"secretstores.test.io",
 		})
 	rec.SetupWithManager(k8sManager, controller.Options{})


### PR DESCRIPTION
## Problem Statement

The PR #2736 had to be split into two other PRs (as discussed in that same PR), one for the Go changes and another one for the Helm changes. This is the first PR, the second one will be opened after this one is merged.

## Related Issue

Fixes, partially, the issue #2721

## Proposed Changes

Add the following new flag to `cmd/certcontroller.go`:
* **enableCertRenewal**: Whether the certificate controller should renew certificates, or just handle their injection. Default: true

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] My changes have reasonable test coverage
- [X] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
