### PR TITLE
feat: add custom user agent to scaleway provider

### DIFF
--- a/pkg/provider/scaleway/provider.go
+++ b/pkg/provider/scaleway/provider.go
@@ -67,6 +67,7 @@ func (p *Provider) NewClient(ctx context.Context, store esv1beta1.GenericStore, 
 		scw.WithDefaultRegion(scw.Region(cfg.Region)),
 		scw.WithDefaultProjectID(cfg.ProjectID),
 		scw.WithAuth(accessKey, secretKey),
+		scw.WithUserAgent("external-secrets"),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Problem Statement

Being able to segregate queries from the Scaleway go SDK and external-secrets operator.

## Related Issue

No related issues.

## Proposed Changes

Initialize the Scaleway SDK client with a custom user agent.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
