### PR TITLE
Feat/add validations to external secret data from remote ref

### DIFF
--- a/apis/externalsecrets/v1beta1/externalsecret_validator.go
+++ b/apis/externalsecrets/v1beta1/externalsecret_validator.go
@@ -61,6 +61,14 @@ func validateExternalSecret(obj runtime.Object) (admission.Warnings, error) {
 		if findOrExtract && ref.SourceRef != nil && ref.SourceRef.GeneratorRef != nil {
 			errs = errors.Join(errs, fmt.Errorf("generator can not be used with find or extract"))
 		}
+
+		if ref.SourceRef != nil &&  ref.SourceRef.GeneratorRef == nil {
+			errs = errors.Join(errs, fmt.Errorf("generator must be set if SourceRef is used"))
+		}
+
+		if !findOrExtract && (ref.SourceRef != nil ||  ref.SourceRef.GeneratorRef != nil) {
+			errs = errors.Join(errs, fmt.Errorf("either find, extract or source and generator must be set"))
+		}
 	}
 
 	return nil, errs

--- a/apis/externalsecrets/v1beta1/externalsecret_validator_test.go
+++ b/apis/externalsecrets/v1beta1/externalsecret_validator_test.go
@@ -100,6 +100,30 @@ func TestValidateExternalSecret(t *testing.T) {
 			expectedErr: "generator can not be used with find or extract",
 		},
 		{
+			name: "source without generator",
+			obj: &ExternalSecret{
+				Spec: ExternalSecretSpec{
+					DataFrom: []ExternalSecretDataFromRemoteRef{
+						{
+							SourceRef: &StoreGeneratorSourceRef{}
+						},
+					},
+				},
+			},
+			expectedErr: "generator must be set if SourceRef is used",
+		},
+		{
+			name: "source without generator",
+			obj: &ExternalSecret{
+				Spec: ExternalSecretSpec{
+					DataFrom: []ExternalSecretDataFromRemoteRef{
+						{}
+					},
+				},
+			},
+			expectedErr: "either find, extract or source and generator must be set",
+		},
+		{
 			name: "multiple errors",
 			obj: &ExternalSecret{
 				Spec: ExternalSecretSpec{
@@ -117,7 +141,11 @@ either data or dataFrom should be specified`,
 			obj: &ExternalSecret{
 				Spec: ExternalSecretSpec{
 					DataFrom: []ExternalSecretDataFromRemoteRef{
-						{},
+						{
+							SourceRef: &StoreGeneratorSourceRef{
+								GeneratorRef: &GeneratorRef{},
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
## Problem Statement

Currently, there are no validations on the ExternalSecretDataFromRemoteRef, but it should
- set either Find, Exact, or SourceRef & SourceRef.GeneratorRef.
- set SourceRef.GeneratorRef if we want to use SourceRef.

## Related Issue

Relates to #2916 

## Proposed Changes

I added the validations on the validateExternalSecret function

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
