### PR TITLE
Minor: extension of PR #2950 Add support for IBM Cloud Service Credentials secret type

### DIFF
--- a/pkg/provider/ibm/provider.go
+++ b/pkg/provider/ibm/provider.go
@@ -309,10 +309,9 @@ func getServiceCredentialsSecret(ibm *providerIBM, secretName *string, secretGro
 		return nil, err
 	}
 	if val, ok := secMap[credentialsConst]; ok {
-		var mval []byte
-		mval, err = json.Marshal(val)
+		mval, err := json.Marshal(val)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to marshal secret map for service credentials secret: %w", err)
 		}
 		return mval, nil
 	}

--- a/pkg/provider/ibm/provider_test.go
+++ b/pkg/provider/ibm/provider_test.go
@@ -756,7 +756,7 @@ func TestGetSecretMap(t *testing.T) {
 		}
 	}
 
-	//good case: service_credentials
+	// good case: service_credentials
 	setSecretSrvCreds := func(smtc *secretManagerTestCase) {
 		secret := &sm.ServiceCredentialsSecret{
 			Name:        utilpointer.To("testyname"),


### PR DESCRIPTION
## Problem Statement

Minor changes to address the [suggested code changes](https://github.com/external-secrets/external-secrets/pull/2950#discussion_r1430154811) and fix the linting errors.
This is an extension of https://github.com/external-secrets/external-secrets/pull/2950

## Related Issue

https://github.com/external-secrets/external-secrets/issues/2947

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
