### PR TITLE
fix(chart): setting processPushSecret 

### DIFF
--- a/deploy/charts/external-secrets/templates/deployment.yaml
+++ b/deploy/charts/external-secrets/templates/deployment.yaml
@@ -65,9 +65,9 @@ spec:
             {{- if not .Values.processClusterExternalSecret }}
           - --enable-cluster-external-secret-reconciler=false
             {{- end }}
-            {{- if not .Values.processPushSecret }}
+          {{- end }}
+          {{- if not .Values.processPushSecret }}
           - --enable-push-secret-reconciler=false
-            {{- end }}
           {{- end }}
           {{- if .Values.controllerClass }}
           - --controller-class={{ .Values.controllerClass }}


### PR DESCRIPTION
Make it possible to set processPushSecret=false when installing namespaced.

## Problem Statement

When setting .Values.scopedNamespace and .Values.scopedRBAC we want to prevent that cluster resources get evaluated.  
In this case it also leads to the else after it not beeing evaluated, where the processPushSecret is also placed.  
So currently you can only set processPushSecret=false when not using namespaced based installation. As pushsecrets are a namespaced resource this should be possible.

## Related Issue

Fixes #...

## Proposed Changes

Remove processPushSecret from the else part as standalone variable

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
