### PR TITLE
chore: replace deprecated command with environment file

### DIFF
--- a/.github/actions/e2e-managed/action.yml
+++ b/.github/actions/e2e-managed/action.yml
@@ -46,8 +46,8 @@ runs:
       id: go
       shell: bash
       run: |
-        echo "::set-output name=build-cache::$(go env GOCACHE)"
-        echo "::set-output name=mod-cache::$(go env GOMODCACHE)"
+        echo "build-cache=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+        echo "mod-cache=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
 
     - name: Cache the Go Build Cache
       uses: actions/cache@v3
@@ -135,7 +135,7 @@ runs:
       if: env.CLOUD_PROVIDER == 'aws'
       run: |-
         aws --region $AWS_REGION eks update-kubeconfig --name $AWS_CLUSTER_NAME
-    
+
     - name: Get AKS credentials
       if: env.CLOUD_PROVIDER == 'azure'
       shell: bash

--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -20,8 +20,8 @@ runs:
       id: go
       shell: bash
       run: |
-        echo "::set-output name=build-cache::$(go env GOCACHE)"
-        echo "::set-output name=mod-cache::$(go env GOMODCACHE)"
+        echo "build-cache=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+        echo "mod-cache=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
 
     - name: Cache the Go Build Cache
       uses: actions/cache@v3

--- a/.github/actions/sign/action.yml
+++ b/.github/actions/sign/action.yml
@@ -57,7 +57,7 @@ runs:
     - name: Get docker image tag
       id: container_info
       shell: bash
-      run: echo "::set-output name=digest::$(crane digest ${{ inputs.image-name }}:${{ inputs.image-tag }})"
+      run: echo "digest=$(crane digest ${{ inputs.image-name }}:${{ inputs.image-tag }})" >> $GITHUB_OUTPUT
 
     - name: Sign image
       shell: bash

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           changed=$(ct list-changed --config=.github/ci/ct.yaml)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> $GITHUB_OUTPUT
           fi
       - name: Install chart unittest
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -103,7 +103,7 @@ jobs:
           else
             TAG=$(make docker.tag)
           fi
-          echo "::set-output name=image-tag::${TAG}"
+          echo "image-tag=${TAG}" >> $GITHUB_OUTPUT
 
       - name: Build & Publish Artifacts
         if: env.IS_FORK == 'false'


### PR DESCRIPTION
## Problem Statement

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

## Related Issue

Fixes #2969 

## Proposed Changes

**AS-IS**

```yaml
echo "::set-output name=changed::true"
```

**TO-BE**

```yaml
echo "changed=true" >> $GITHUB_OUTPUT
```

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
