### PR TITLE
doc: update bitwarden-cli image & version

### DIFF
--- a/docs/examples/bitwarden.md
+++ b/docs/examples/bitwarden.md
@@ -20,13 +20,13 @@ which is synced with the BitWarden server.
 * Bitwarden account (it works also with VaultWarden)
 * A Kubernetes secret which contains your BitWarden Credentials
 * You need a Docker image with BitWarden CLI installed.
-  You could use `registry.gitlab.com/ttblt-oss/docker-bw:2023.1.0` or build your own.
+  You could use `ghcr.io/charlesthomas/bitwarden-cli:2023.12.1` or build your own.
 
 Here an example of Dockerfile use to build this image:
 ```dockerfile
 FROM debian:sid
 
-ENV BW_CLI_VERSION=2023.1.0
+ENV BW_CLI_VERSION=2023.12.1
 
 RUN apt update && \
     apt install -y wget unzip && \


### PR DESCRIPTION
i tried to implement this yesterday using the provided image, and it wouldn't allow me to pull it.

[i created my own here](https://github.com/charlesthomas/bitwarden-cli), using a copy/paste from these docs (with a slight modification for the purposes of CI/CD automation)

the updated image is that image, and then since i updated the version in the image, i updated it in the `Dockerfile` example, too

## Problem Statement

What is the problem you're trying to solve?

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
