### PR TITLE
fix: do not error if helm chart version already exists

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -94,4 +94,5 @@ jobs:
           CR_RELEASE_NAME_TEMPLATE: "helm-chart-{{ .Version }}"
         with:
           charts_dir: deploy/charts
+          skip_existing: true
           charts_repo_url: https://charts.external-secrets.io


### PR DESCRIPTION
WRT: https://kubernetes.slack.com/archives/C047LA9MUPJ/p1703281915697679

The Helm Release job fails if files in the helm chart are changed and a release already exists.