### PR TITLE
Configure codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,12 @@ jobs:
         run: |
           make test
 
+      - name: Publish Unit Test Coverage
+        uses: codecov/codecov-action@v3
+        with:
+          flags: unittests
+          file: ./cover.out
+
   publish-artifacts:
     needs: detect-noop
     if: needs.detect-noop.outputs.noop != 'true'

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+# When modifying this file, please validate using
+# curl -X POST --data-binary @codecov.yml https://codecov.io/validate

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,16 @@
+# When modifying this file, please validate using
+# curl -X POST --data-binary @codecov.yml https://codecov.io/validate
+ignore:
+  - "**/zz_generated.deepcopy.go"
+  - "assets"
+  - "config"
+  - "deploy"
+  - "design"
+  - "docs"
+  - "e2e"
+  - "hacks"
+  - "overrides"
+  - "terraform"
 github_checks:
   annotations: false
 coverage:
@@ -8,6 +21,3 @@ coverage:
     patch:
       default:
         informational: true
-
-# When modifying this file, please validate using
-# curl -X POST --data-binary @codecov.yml https://codecov.io/validate

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,5 @@
+github_checks:
+  annotations: false
 coverage:
   status:
     project:


### PR DESCRIPTION
## Problem Statement

I'd like to try configuring Codecov again so that we can visualize and track test coverage over time.
See [the related Slack thread](https://kubernetes.slack.com/archives/C047LA9MUPJ/p1703655390563569) for the discussion.

## Related Issue

N/A

## Proposed Changes

Configure Codecov integration without blocking any PRs.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
