### PR TITLE
Akeyless Provider - Add support for Certificate items

### DIFF
--- a/pkg/provider/akeyless/akeyless.go
+++ b/pkg/provider/akeyless/akeyless.go
@@ -69,6 +69,12 @@ type Akeyless struct {
 	url    string
 }
 
+type Item struct {
+	ItemName    string `json:"item_name"`
+	ItemType    string `json:"item_type"`
+	LastVersion int32  `json:"last_version"`
+}
+
 type akeylessVaultInterface interface {
 	GetSecretByType(ctx context.Context, secretName, token string, version int32) (string, error)
 	TokenFromSecretRef(ctx context.Context) (string, error)


### PR DESCRIPTION
## Problem Statement

Akeyless Vaultless Platform supports Certificate items which are not yet supported by ESO

## Related Issue

## Proposed Changes

Adding support for Certificate items to be pulled from the Akeyless Vaultless Platform - https://docs.akeyless.io/docs/certificate-storage

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] My changes have reasonable test coverage
- [X] All tests pass with `make test`
- [X] I ensured my PR is ready for review with `make reviewable`
