### PR TITLE
feat: add push secret to e2e tests

### DIFF
--- a/apis/externalsecrets/v1beta1/externalsecret_validator.go
+++ b/apis/externalsecrets/v1beta1/externalsecret_validator.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1beta1
 
 import (

--- a/apis/externalsecrets/v1beta1/externalsecret_validator_test.go
+++ b/apis/externalsecrets/v1beta1/externalsecret_validator_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1beta1
 
 import (

--- a/apis/externalsecrets/v1beta1/provider_schema_test.go
+++ b/apis/externalsecrets/v1beta1/provider_schema_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1beta1
 
 import (

--- a/cmd/certcontroller.go
+++ b/cmd/certcontroller.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cmd
 
 import (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cmd
 
 import (

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cmd
 
 import (

--- a/e2e/framework/addon/addon.go
+++ b/e2e/framework/addon/addon.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package addon
 
 import (

--- a/e2e/framework/addon/chart.go
+++ b/e2e/framework/addon/chart.go
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package addon
 
 import (

--- a/e2e/framework/addon/eso.go
+++ b/e2e/framework/addon/eso.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package addon
 
 import (

--- a/e2e/framework/addon/eso_argocd_application.go
+++ b/e2e/framework/addon/eso_argocd_application.go
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package addon
 
 import (

--- a/e2e/framework/addon/eso_flux_helm.go
+++ b/e2e/framework/addon/eso_flux_helm.go
@@ -10,6 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package addon
 
 import (

--- a/e2e/framework/addon/helmserver.go
+++ b/e2e/framework/addon/helmserver.go
@@ -10,6 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package addon
 
 import (

--- a/e2e/framework/addon/uninstall_eso_crds.go
+++ b/e2e/framework/addon/uninstall_eso_crds.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package addon
 
 import (

--- a/e2e/framework/addon/vault.go
+++ b/e2e/framework/addon/vault.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package addon
 
 import (
@@ -33,7 +34,7 @@ import (
 	vault "github.com/hashicorp/vault/api"
 
 	// nolint
-	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/e2e/framework/framework.go
+++ b/e2e/framework/framework.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package framework
 
 import (

--- a/e2e/framework/log/log.go
+++ b/e2e/framework/log/log.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package log
 
 import (

--- a/e2e/framework/testcase.go
+++ b/e2e/framework/testcase.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package framework
 
 import (
@@ -31,13 +32,16 @@ var TargetSecretName = "target-secret"
 
 // TestCase contains the test infra to run a table driven test.
 type TestCase struct {
-	Framework              *Framework
-	ExternalSecret         *esv1beta1.ExternalSecret
-	ExternalSecretV1Alpha1 *esv1alpha1.ExternalSecret
-	AdditionalObjects      []client.Object
-	Secrets                map[string]SecretEntry
-	ExpectedSecret         *v1.Secret
-	AfterSync              func(SecretStoreProvider, *v1.Secret)
+	Framework               *Framework
+	ExternalSecret          *esv1beta1.ExternalSecret
+	ExternalSecretV1Alpha1  *esv1alpha1.ExternalSecret
+	PushSecret              *esv1alpha1.PushSecret
+	PushSecretSource        *v1.Secret
+	AdditionalObjects       []client.Object
+	Secrets                 map[string]SecretEntry
+	ExpectedSecret          *v1.Secret
+	AfterSync               func(SecretStoreProvider, *v1.Secret)
+	VerifyPushSecretOutcome func(ps *esv1alpha1.PushSecret, pushClient esv1beta1.SecretsClient)
 }
 
 type SecretEntry struct {
@@ -52,64 +56,114 @@ type SecretStoreProvider interface {
 	DeleteSecret(key string)
 }
 
-// TableFunc returns the main func that runs a TestCase in a table driven test.
-func TableFunc(f *Framework, prov SecretStoreProvider) func(...func(*TestCase)) {
+// TableFuncWithExternalSecret returns the main func that runs a TestCase in a table driven test.
+func TableFuncWithExternalSecret(f *Framework, prov SecretStoreProvider) func(...func(*TestCase)) {
 	return func(tweaks ...func(*TestCase)) {
-		var err error
-
 		// make default test case
 		// and apply customization to it
-		tc := makeDefaultTestCase(f)
+		tc := makeDefaultExternalSecretTestCase(f)
 		for _, tweak := range tweaks {
 			tweak(tc)
 		}
 
 		// create secrets & defer delete
+		var deferRemoveKeys []string
 		for k, v := range tc.Secrets {
 			key := k
 			prov.CreateSecret(key, v)
-			defer func() {
-				prov.DeleteSecret(key)
-			}()
+			deferRemoveKeys = append(deferRemoveKeys, key)
 		}
 
-		// create v1alpha1 external secret, if provided
-		if tc.ExternalSecretV1Alpha1 != nil {
-			err = tc.Framework.CRClient.Create(context.Background(), tc.ExternalSecretV1Alpha1)
-			Expect(err).ToNot(HaveOccurred())
-		} else if tc.ExternalSecret != nil {
-			// create v1beta1 external secret otherwise
-			err = tc.Framework.CRClient.Create(context.Background(), tc.ExternalSecret)
-			Expect(err).ToNot(HaveOccurred())
-		}
-		if tc.AdditionalObjects != nil {
-			for _, obj := range tc.AdditionalObjects {
-				err = tc.Framework.CRClient.Create(context.Background(), obj)
-				Expect(err).ToNot(HaveOccurred())
+		defer func() {
+			for _, k := range deferRemoveKeys {
+				prov.DeleteSecret(k)
 			}
-		}
+		}()
+
+		// create v1alpha1 external secret, if provided
+		createProvidedExternalSecret(tc)
+
+		// create additional objects
+		generateAdditionalObjects(tc)
+
 		// in case target name is empty
 		if tc.ExternalSecret != nil && tc.ExternalSecret.Spec.Target.Name == "" {
 			TargetSecretName = tc.ExternalSecret.ObjectMeta.Name
 		}
 
 		// wait for Kind=Secret to have the expected data
-		if tc.ExpectedSecret != nil {
-			secret, err := tc.Framework.WaitForSecretValue(tc.Framework.Namespace.Name, TargetSecretName, tc.ExpectedSecret)
-			if err != nil {
-				f.printESDebugLogs(tc.ExternalSecret.Name, tc.ExternalSecret.Namespace)
-				log.Logf("Did not match. Expected: %+v, Got: %+v", tc.ExpectedSecret, secret)
-			}
+		executeAfterSync(tc, f, prov)
+	}
+}
 
+func executeAfterSync(tc *TestCase, f *Framework, prov SecretStoreProvider) {
+	if tc.ExpectedSecret != nil {
+		secret, err := tc.Framework.WaitForSecretValue(tc.Framework.Namespace.Name, TargetSecretName, tc.ExpectedSecret)
+		if err != nil {
+			f.printESDebugLogs(tc.ExternalSecret.Name, tc.ExternalSecret.Namespace)
+			log.Logf("Did not match. Expected: %+v, Got: %+v", tc.ExpectedSecret, secret)
+		}
+
+		Expect(err).ToNot(HaveOccurred())
+		tc.AfterSync(prov, secret)
+	} else {
+		tc.AfterSync(prov, nil)
+	}
+}
+
+func generateAdditionalObjects(tc *TestCase) {
+	if tc.AdditionalObjects != nil {
+		for _, obj := range tc.AdditionalObjects {
+			err := tc.Framework.CRClient.Create(context.Background(), obj)
 			Expect(err).ToNot(HaveOccurred())
-			tc.AfterSync(prov, secret)
-		} else {
-			tc.AfterSync(prov, nil)
 		}
 	}
 }
 
-func makeDefaultTestCase(f *Framework) *TestCase {
+func createProvidedExternalSecret(tc *TestCase) {
+	if tc.ExternalSecretV1Alpha1 != nil {
+		err := tc.Framework.CRClient.Create(context.Background(), tc.ExternalSecretV1Alpha1)
+		Expect(err).ToNot(HaveOccurred())
+	} else if tc.ExternalSecret != nil {
+		// create v1beta1 external secret otherwise
+		err := tc.Framework.CRClient.Create(context.Background(), tc.ExternalSecret)
+		Expect(err).ToNot(HaveOccurred())
+	}
+}
+
+// TableFuncWithPushSecret returns the main func that runs a TestCase in a table driven test for push secrets.
+func TableFuncWithPushSecret(f *Framework, prov SecretStoreProvider, pushClient esv1beta1.SecretsClient) func(...func(*TestCase)) {
+	return func(tweaks ...func(*TestCase)) {
+		var err error
+
+		// make default test case
+		// and apply customization to it
+		tc := makeDefaultPushSecretTestCase(f)
+		for _, tweak := range tweaks {
+			tweak(tc)
+		}
+
+		if tc.PushSecretSource != nil {
+			err := tc.Framework.CRClient.Create(context.Background(), tc.PushSecretSource)
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		// create v1alpha1 push secret, if provided
+		if tc.PushSecret != nil {
+			// create v1beta1 external secret otherwise
+			err = tc.Framework.CRClient.Create(context.Background(), tc.PushSecret)
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		// additional objects
+		generateAdditionalObjects(tc)
+
+		// Run verification on the secret that push secret created or not.
+		tc.VerifyPushSecretOutcome(tc.PushSecret, pushClient)
+	}
+}
+
+func makeDefaultExternalSecretTestCase(f *Framework) *TestCase {
 	return &TestCase{
 		AfterSync: func(ssp SecretStoreProvider, s *v1.Secret) {},
 		Framework: f,
@@ -125,6 +179,26 @@ func makeDefaultTestCase(f *Framework) *TestCase {
 				},
 				Target: esv1beta1.ExternalSecretTarget{
 					Name: TargetSecretName,
+				},
+			},
+		},
+	}
+}
+
+func makeDefaultPushSecretTestCase(f *Framework) *TestCase {
+	return &TestCase{
+		Framework: f,
+		PushSecret: &esv1alpha1.PushSecret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "e2e-ps",
+				Namespace: f.Namespace.Name,
+			},
+			Spec: esv1alpha1.PushSecretSpec{
+				RefreshInterval: &metav1.Duration{Duration: time.Second * 5},
+				SecretStoreRefs: []esv1alpha1.PushSecretStoreRef{
+					{
+						Name: f.Namespace.Name,
+					},
 				},
 			},
 		},

--- a/e2e/framework/util/util.go
+++ b/e2e/framework/util/util.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package util
 
 import (

--- a/e2e/suites/argocd/argocd.go
+++ b/e2e/suites/argocd/argocd.go
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package argocd
 
 import (
@@ -28,7 +29,7 @@ var _ = Describe("argocd", Label("argocd"), func() {
 	f := framework.New("argocd")
 	prov := fake.NewProvider(f)
 
-	DescribeTable("sync secrets", framework.TableFunc(f, prov),
+	DescribeTable("sync secrets", framework.TableFuncWithExternalSecret(f, prov),
 		Entry(common.SimpleDataSync(f)),
 		Entry(common.JSONDataFromSync(f)),
 		Entry(common.SSHKeySync(f)),

--- a/e2e/suites/argocd/install.go
+++ b/e2e/suites/argocd/install.go
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package argocd
 
 import (

--- a/e2e/suites/argocd/suite_test.go
+++ b/e2e/suites/argocd/suite_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package argocd
 
 import (

--- a/e2e/suites/flux/flux.go
+++ b/e2e/suites/flux/flux.go
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package flux
 
 import (
@@ -28,7 +29,7 @@ var _ = Describe("flux", Label("flux"), func() {
 	f := framework.New("flux")
 	prov := fake.NewProvider(f)
 
-	DescribeTable("sync secrets", framework.TableFunc(f, prov),
+	DescribeTable("sync secrets", framework.TableFuncWithExternalSecret(f, prov),
 		Entry(common.SimpleDataSync(f)),
 		Entry(common.JSONDataFromSync(f)),
 		Entry(common.SSHKeySync(f)),

--- a/e2e/suites/flux/install.go
+++ b/e2e/suites/flux/install.go
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package flux
 
 import (

--- a/e2e/suites/flux/suite_test.go
+++ b/e2e/suites/flux/suite_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package flux
 
 import (

--- a/e2e/suites/generator/ecr.go
+++ b/e2e/suites/generator/ecr.go
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package generator
 
 import (

--- a/e2e/suites/generator/fake.go
+++ b/e2e/suites/generator/fake.go
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package generator
 
 import (

--- a/e2e/suites/generator/password.go
+++ b/e2e/suites/generator/password.go
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package generator
 
 import (

--- a/e2e/suites/generator/suite_test.go
+++ b/e2e/suites/generator/suite_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package generator
 
 import (

--- a/e2e/suites/generator/testcase.go
+++ b/e2e/suites/generator/testcase.go
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package generator
 
 import (

--- a/e2e/suites/provider/cases/akeyless/akeyless.go
+++ b/e2e/suites/provider/cases/akeyless/akeyless.go
@@ -27,7 +27,7 @@ var _ = Describe("[akeyless]", Label("akeyless"), func() {
 	f := framework.New("eso-akeyless")
 	prov := newFromEnv(f)
 
-	DescribeTable("sync secrets", framework.TableFunc(f, prov),
+	DescribeTable("sync secrets", framework.TableFuncWithExternalSecret(f, prov),
 		Entry(common.SimpleDataSync(f)),
 		Entry(common.NestedJSONWithGJSON(f)),
 		Entry(common.JSONDataFromSync(f)),

--- a/e2e/suites/provider/cases/alibaba/alibaba.go
+++ b/e2e/suites/provider/cases/alibaba/alibaba.go
@@ -27,7 +27,7 @@ var _ = Describe("[alibaba]", Label("alibaba"), func() {
 	f := framework.New("eso-alibaba")
 	prov := newFromEnv(f)
 
-	DescribeTable("sync secrets", framework.TableFunc(f, prov),
+	DescribeTable("sync secrets", framework.TableFuncWithExternalSecret(f, prov),
 		Entry(common.SimpleDataSync(f)),
 		Entry(common.NestedJSONWithGJSON(f)),
 		Entry(common.JSONDataFromSync(f)),

--- a/e2e/suites/provider/cases/aws/common.go
+++ b/e2e/suites/provider/cases/aws/common.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package common
 
 import (

--- a/e2e/suites/provider/cases/aws/parameterstore/parameterstore.go
+++ b/e2e/suites/provider/cases/aws/parameterstore/parameterstore.go
@@ -35,7 +35,7 @@ var _ = Describe("[aws] ", Label("aws", "parameterstore"), func() {
 	prov := NewFromEnv(f)
 
 	DescribeTable("sync secrets",
-		framework.TableFunc(f,
+		framework.TableFuncWithExternalSecret(f,
 			prov),
 		framework.Compose(withStaticAuth, f, common.SimpleDataSync, useStaticAuth),
 		framework.Compose(withStaticAuth, f, common.NestedJSONWithGJSON, useStaticAuth),

--- a/e2e/suites/provider/cases/aws/parameterstore/parameterstore_managed.go
+++ b/e2e/suites/provider/cases/aws/parameterstore/parameterstore_managed.go
@@ -34,7 +34,7 @@ var _ = Describe("[awsmanaged] IRSA via referenced service account", Label("aws"
 
 	// nolint
 	DescribeTable("sync secrets",
-		framework.TableFunc(f,
+		framework.TableFuncWithExternalSecret(f,
 			prov),
 		framework.Compose(awscommon.WithReferencedIRSA, f, common.SimpleDataSync, awscommon.UseClusterSecretStore),
 		framework.Compose(awscommon.WithReferencedIRSA, f, common.NestedJSONWithGJSON, awscommon.UseClusterSecretStore),
@@ -74,7 +74,7 @@ var _ = Describe("[awsmanaged] with mounted IRSA", Label("aws", "parameterstore"
 
 	// nolint
 	DescribeTable("sync secrets",
-		framework.TableFunc(f,
+		framework.TableFuncWithExternalSecret(f,
 			prov),
 		framework.Compose(awscommon.WithMountedIRSA, f, common.SimpleDataSync, awscommon.UseMountedIRSAStore),
 		framework.Compose(awscommon.WithMountedIRSA, f, common.NestedJSONWithGJSON, awscommon.UseMountedIRSAStore),

--- a/e2e/suites/provider/cases/aws/secretsmanager/secretsmanager.go
+++ b/e2e/suites/provider/cases/aws/secretsmanager/secretsmanager.go
@@ -37,7 +37,7 @@ var _ = Describe("[aws] ", Label("aws", "secretsmanager"), func() {
 	prov := NewFromEnv(f)
 
 	DescribeTable("sync secrets",
-		framework.TableFunc(f,
+		framework.TableFuncWithExternalSecret(f,
 			prov),
 		framework.Compose(withStaticAuth, f, common.SimpleDataSync, useStaticAuth),
 		framework.Compose(withStaticAuth, f, common.NestedJSONWithGJSON, useStaticAuth),

--- a/e2e/suites/provider/cases/aws/secretsmanager/secretsmanager_managed.go
+++ b/e2e/suites/provider/cases/aws/secretsmanager/secretsmanager_managed.go
@@ -34,7 +34,7 @@ var _ = Describe("[awsmanaged] IRSA via referenced service account", Label("aws"
 
 	// nolint
 	DescribeTable("sync secretsmanager secrets",
-		framework.TableFunc(f,
+		framework.TableFuncWithExternalSecret(f,
 			prov),
 		framework.Compose(awscommon.WithReferencedIRSA, f, common.SimpleDataSync, awscommon.UseClusterSecretStore),
 		framework.Compose(awscommon.WithReferencedIRSA, f, common.NestedJSONWithGJSON, awscommon.UseClusterSecretStore),
@@ -74,7 +74,7 @@ var _ = Describe("[awsmanaged] with mounted IRSA", Label("aws", "secretsmanager"
 
 	// nolint
 	DescribeTable("sync secretsmanager secrets",
-		framework.TableFunc(f,
+		framework.TableFuncWithExternalSecret(f,
 			prov),
 		framework.Compose(awscommon.WithMountedIRSA, f, common.SimpleDataSync, awscommon.UseMountedIRSAStore),
 		framework.Compose(awscommon.WithMountedIRSA, f, common.NestedJSONWithGJSON, awscommon.UseMountedIRSAStore),

--- a/e2e/suites/provider/cases/azure/azure_cert.go
+++ b/e2e/suites/provider/cases/azure/azure_cert.go
@@ -41,7 +41,7 @@ var _ = Describe("[azure]", Label("azure", "keyvault", "cert"), func() {
 		prov.DeleteCertificate(certName)
 	})
 
-	ff := framework.TableFunc(f, prov)
+	ff := framework.TableFuncWithExternalSecret(f, prov)
 	It("should sync keyvault objects with type=cert", func() {
 		ff(func(tc *framework.TestCase) {
 			secretKey := "azkv-cert"

--- a/e2e/suites/provider/cases/azure/azure_key.go
+++ b/e2e/suites/provider/cases/azure/azure_key.go
@@ -42,7 +42,7 @@ var _ = Describe("[azure]", Label("azure", "keyvault", "key"), func() {
 		prov.DeleteKey(keyName)
 	})
 
-	ff := framework.TableFunc(f, prov)
+	ff := framework.TableFuncWithExternalSecret(f, prov)
 
 	It("should sync keyvault objects with type=key", func() {
 		ff(func(tc *framework.TestCase) {

--- a/e2e/suites/provider/cases/azure/azure_managed.go
+++ b/e2e/suites/provider/cases/azure/azure_managed.go
@@ -49,7 +49,7 @@ var _ = Describe("[azuremanaged] with pod identity", Label("azure", "keyvault", 
 	})
 
 	DescribeTable("sync secrets",
-		framework.TableFunc(f,
+		framework.TableFuncWithExternalSecret(f,
 			prov),
 		// uses pod id
 		framework.Compose(withPodID, f, common.SimpleDataSync, usePodIDESReference),

--- a/e2e/suites/provider/cases/azure/azure_secret.go
+++ b/e2e/suites/provider/cases/azure/azure_secret.go
@@ -32,7 +32,7 @@ var _ = Describe("[azure]", Label("azure", "keyvault", "secret"), func() {
 	f := framework.New("eso-azure")
 	prov := newFromEnv(f)
 
-	DescribeTable("sync secrets", framework.TableFunc(f, prov),
+	DescribeTable("sync secrets", framework.TableFuncWithExternalSecret(f, prov),
 		framework.Compose(withStaticCredentials, f, common.SimpleDataSync, useStaticCredentials),
 		framework.Compose(withStaticCredentials, f, common.NestedJSONWithGJSON, useStaticCredentials),
 		framework.Compose(withStaticCredentials, f, common.JSONDataFromSync, useStaticCredentials),

--- a/e2e/suites/provider/cases/delinea/delinea.go
+++ b/e2e/suites/provider/cases/delinea/delinea.go
@@ -30,7 +30,7 @@ var _ = ginkgo.Describe("[delinea]", ginkgo.Label("delinea"), func() {
 		createResources(context.Background(), f, cfg)
 	})
 
-	ginkgo.DescribeTable("sync secrets", framework.TableFunc(f, provider),
+	ginkgo.DescribeTable("sync secrets", framework.TableFuncWithExternalSecret(f, provider),
 
 		ginkgo.Entry(common.JSONDataWithProperty(f)),
 		ginkgo.Entry(common.JSONDataWithoutTargetName(f)),

--- a/e2e/suites/provider/cases/fake/provider.go
+++ b/e2e/suites/provider/cases/fake/provider.go
@@ -11,12 +11,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package fake
 
 import (
 	"context"
 	"encoding/json"
-
 	// nolint
 	. "github.com/onsi/ginkgo/v2"
 

--- a/e2e/suites/provider/cases/gcp/gcp.go
+++ b/e2e/suites/provider/cases/gcp/gcp.go
@@ -39,7 +39,7 @@ var _ = Describe("[gcp]", Label("gcp", "secretsmanager"), func() {
 	f := framework.New("eso-gcp")
 	prov := NewFromEnv(f, "")
 
-	DescribeTable("sync secrets", framework.TableFunc(f, prov),
+	DescribeTable("sync secrets", framework.TableFuncWithExternalSecret(f, prov),
 		framework.Compose(withStaticAuth, f, common.SimpleDataSync, useStaticAuth),
 		framework.Compose(withStaticAuth, f, common.JSONDataWithProperty, useStaticAuth),
 		framework.Compose(withStaticAuth, f, common.JSONDataFromSync, useStaticAuth),

--- a/e2e/suites/provider/cases/gcp/gcp_managed.go
+++ b/e2e/suites/provider/cases/gcp/gcp_managed.go
@@ -50,7 +50,7 @@ var _ = Describe("[gcpmanaged] with pod identity", Label("gcp", "secretsmanager"
 	})
 
 	DescribeTable("sync secrets",
-		framework.TableFunc(f,
+		framework.TableFuncWithExternalSecret(f,
 			prov),
 		// uses pod id
 		framework.Compose(withPodID, f, common.SimpleDataSync, usePodIDESReference),
@@ -86,7 +86,7 @@ var _ = Describe("[gcpmanaged] with service account", Label("gcp", "secretsmanag
 	})
 
 	DescribeTable("sync secrets",
-		framework.TableFunc(f,
+		framework.TableFuncWithExternalSecret(f,
 			prov),
 		// uses specific sa
 		framework.Compose(withSpecifcSA, f, common.JSONDataFromSync, useSpecifcSAESReference(prov)),

--- a/e2e/suites/provider/cases/gitlab/gitlab.go
+++ b/e2e/suites/provider/cases/gitlab/gitlab.go
@@ -30,7 +30,7 @@ var _ = Describe("[gitlab]", Label("gitlab"), func() {
 	f := framework.New("eso-gitlab")
 	prov := newFromEnv(f)
 
-	DescribeTable("sync secrets", framework.TableFunc(f, prov),
+	DescribeTable("sync secrets", framework.TableFuncWithExternalSecret(f, prov),
 		Entry(common.SimpleDataSync(f)),
 		Entry(common.JSONDataWithProperty(f)),
 		Entry(common.JSONDataFromSync(f)),

--- a/e2e/suites/provider/cases/gitlab/provider.go
+++ b/e2e/suites/provider/cases/gitlab/provider.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package gitlab
 
 import (
@@ -23,7 +24,7 @@ import (
 
 	// nolint
 	. "github.com/onsi/gomega"
-	gitlab "github.com/xanzy/go-gitlab"
+	"github.com/xanzy/go-gitlab"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/e2e/suites/provider/cases/import.go
+++ b/e2e/suites/provider/cases/import.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package suite
 
 import (

--- a/e2e/suites/provider/cases/kubernetes/kubernetes.go
+++ b/e2e/suites/provider/cases/kubernetes/kubernetes.go
@@ -33,7 +33,7 @@ var _ = Describe("[kubernetes] ", Label("kubernetes"), func() {
 	prov := NewProvider(f)
 
 	DescribeTable("sync secrets",
-		framework.TableFunc(f,
+		framework.TableFuncWithExternalSecret(f,
 			prov),
 		Entry(common.JSONDataWithProperty(f)),
 		Entry(common.JSONDataWithoutTargetName(f)),

--- a/e2e/suites/provider/cases/kubernetes/provider.go
+++ b/e2e/suites/provider/cases/kubernetes/provider.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package kubernetes
 
 import (

--- a/e2e/suites/provider/cases/oracle/oracle.go
+++ b/e2e/suites/provider/cases/oracle/oracle.go
@@ -25,7 +25,7 @@ var _ = Describe("[oracle]", Label("oracle"), func() {
 	f := framework.New("eso-oracle")
 	prov := newFromEnv(f)
 
-	DescribeTable("sync secrets", framework.TableFunc(f, prov),
+	DescribeTable("sync secrets", framework.TableFuncWithExternalSecret(f, prov),
 		Entry(common.SimpleDataSync(f)),
 		Entry(common.NestedJSONWithGJSON(f)),
 		Entry(common.JSONDataFromSync(f)),

--- a/e2e/suites/provider/cases/scaleway/scaleway.go
+++ b/e2e/suites/provider/cases/scaleway/scaleway.go
@@ -2,6 +2,8 @@ package scaleway
 
 import (
 	"context"
+	"sync"
+
 	"github.com/external-secrets/external-secrets-e2e/framework"
 	"github.com/external-secrets/external-secrets-e2e/suites/provider/cases/common"
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
@@ -10,7 +12,6 @@ import (
 	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sync"
 )
 
 var cleanupOnce sync.Once
@@ -37,7 +38,7 @@ var _ = ginkgo.Describe("[scaleway]", ginkgo.Label("scaleway"), func() {
 		createResources(context.Background(), f, cfg)
 	})
 
-	ginkgo.DescribeTable("sync secrets", framework.TableFunc(f, provider),
+	ginkgo.DescribeTable("sync secrets", framework.TableFuncWithExternalSecret(f, provider),
 
 		//ginkgo.Entry(common.SyncV1Alpha1(f)), // not supported
 		ginkgo.Entry(common.SimpleDataSync(f)),

--- a/e2e/suites/provider/cases/template/provider.go
+++ b/e2e/suites/provider/cases/template/provider.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package template
 
 import (

--- a/e2e/suites/provider/cases/template/template.go
+++ b/e2e/suites/provider/cases/template/template.go
@@ -10,25 +10,39 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 limitations under the License.
 */
+
 package template
 
 import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/external-secrets/external-secrets-e2e/framework"
+	esv1alpha1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
+	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
+	"github.com/external-secrets/external-secrets/pkg/provider/testing/fake"
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	// nolint
 	. "github.com/onsi/ginkgo/v2"
-	v1 "k8s.io/api/core/v1"
-
-	"github.com/external-secrets/external-secrets-e2e/framework"
-	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 )
 
 var _ = Describe("[template]", Label("template"), func() {
-	f := framework.New("eso-template")
+	f := framework.New("templating")
 	prov := newProvider(f)
+	fakeSecretClient := fake.New()
 
-	DescribeTable("sync secrets", framework.TableFunc(f, prov),
-		framework.Compose("template v1", f, genericTemplate, useTemplateV1),
-		framework.Compose("template v2", f, genericTemplate, useTemplateV2),
+	DescribeTable("sync secrets", framework.TableFuncWithExternalSecret(f, prov),
+		framework.Compose("template v1", f, genericExternalSecretTemplate, useTemplateV1),
+		framework.Compose("template v2", f, genericExternalSecretTemplate, useTemplateV2),
+	)
+
+	DescribeTable("push secret", framework.TableFuncWithPushSecret(f, prov, fakeSecretClient),
+		framework.Compose("template", f, genericPushSecretTemplate, useTemplateWithPushSecret),
 	)
 })
 
@@ -67,7 +81,7 @@ func useTemplateV2(tc *framework.TestCase) {
 }
 
 // This case uses template engine v1.
-func genericTemplate(f *framework.Framework) (string, func(*framework.TestCase)) {
+func genericExternalSecretTemplate(f *framework.Framework) (string, func(*framework.TestCase)) {
 	return "[template] should execute template v1", func(tc *framework.TestCase) {
 		tc.ExpectedSecret = &v1.Secret{
 			Type: v1.SecretTypeOpaque,
@@ -99,5 +113,63 @@ func genericTemplate(f *framework.Framework) (string, func(*framework.TestCase))
 				},
 			},
 		}
+	}
+}
+
+// This case uses template engine v1.
+func genericPushSecretTemplate(f *framework.Framework) (string, func(*framework.TestCase)) {
+	return "[template] should execute template v1", func(tc *framework.TestCase) {
+		secretKey1 := fmt.Sprintf("%s-%s", f.Namespace.Name, "one")
+		tc.PushSecretSource = &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretKey1,
+				Namespace: f.Namespace.Name,
+			},
+			Data: map[string][]byte{
+				"singlefoo": []byte("bar"),
+			},
+			Type: v1.SecretTypeOpaque,
+		}
+		tc.PushSecret.Spec.Selector = esv1alpha1.PushSecretSelector{
+			Secret: esv1alpha1.PushSecretSecret{
+				Name: secretKey1,
+			},
+		}
+		tc.PushSecret.Spec.Data = []esv1alpha1.PushSecretData{
+			{
+				Match: esv1alpha1.PushSecretMatch{
+					SecretKey: "singlefoo",
+					RemoteRef: esv1alpha1.PushSecretRemoteRef{
+						RemoteKey: "key",
+						Property:  "singlefoo",
+					},
+				},
+			},
+		}
+		tc.VerifyPushSecretOutcome = func(sourcePs *esv1alpha1.PushSecret, pushClient esv1beta1.SecretsClient) {
+			gomega.Eventually(func() bool {
+				s := &esv1alpha1.PushSecret{}
+				err := tc.Framework.CRClient.Get(context.Background(), types.NamespacedName{Name: tc.PushSecret.Name, Namespace: tc.PushSecret.Namespace}, s)
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+				for i := range s.Status.Conditions {
+					c := s.Status.Conditions[i]
+					if c.Type == esv1alpha1.PushSecretReady && c.Status == v1.ConditionTrue {
+						return true
+					}
+				}
+
+				return false
+			}, time.Minute*1, time.Second*5).Should(gomega.BeTrue())
+		}
+	}
+}
+
+// useTemplateWithPushSecret specifies a test case which uses the template engine v1.
+func useTemplateWithPushSecret(tc *framework.TestCase) {
+	tc.PushSecret.Spec.Template = &esv1beta1.ExternalSecretTemplate{
+		EngineVersion: esv1beta1.TemplateEngineV2,
+		Data: map[string]string{
+			"singlefoo": "executed: {{ .singlefoo | upper }}",
+		},
 	}
 }

--- a/e2e/suites/provider/cases/template/template.go
+++ b/e2e/suites/provider/cases/template/template.go
@@ -165,6 +165,7 @@ func genericPushSecretTemplate(f *framework.Framework) (string, func(*framework.
 
 			// create an external secret that fetches the created remote secret
 			// and check the value
+			exampleOutput := "example-output"
 			es := &esv1beta1.ExternalSecret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "e2e-es",
@@ -176,11 +177,11 @@ func genericPushSecretTemplate(f *framework.Framework) (string, func(*framework.
 						Name: f.Namespace.Name,
 					},
 					Target: esv1beta1.ExternalSecretTarget{
-						Name: "example-output",
+						Name: exampleOutput,
 					},
 					Data: []esv1beta1.ExternalSecretData{
 						{
-							SecretKey: "example-output",
+							SecretKey: exampleOutput,
 							RemoteRef: esv1beta1.ExternalSecretDataRemoteRef{
 								Key: "key",
 							},
@@ -196,7 +197,7 @@ func genericPushSecretTemplate(f *framework.Framework) (string, func(*framework.
 			err = wait.PollImmediate(time.Second*5, time.Second*15, func() (bool, error) {
 				err := f.CRClient.Get(context.Background(), types.NamespacedName{
 					Namespace: f.Namespace.Name,
-					Name:      "example-output",
+					Name:      exampleOutput,
 				}, outputSecret)
 				if apierrors.IsNotFound(err) {
 					return false, nil
@@ -205,7 +206,7 @@ func genericPushSecretTemplate(f *framework.Framework) (string, func(*framework.
 			})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-			v, ok := outputSecret.Data["example-output"]
+			v, ok := outputSecret.Data[exampleOutput]
 			gomega.Expect(ok).To(gomega.BeTrue())
 			gomega.Expect(string(v)).To(gomega.Equal("executed: BAR"))
 		}

--- a/e2e/suites/provider/cases/vault/provider.go
+++ b/e2e/suites/provider/cases/vault/provider.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package vault
 
 import (

--- a/e2e/suites/provider/cases/vault/vault.go
+++ b/e2e/suites/provider/cases/vault/vault.go
@@ -15,10 +15,11 @@ package vault
 import (
 	"context"
 	"fmt"
+	"time"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"time"
 
 	// nolint
 	. "github.com/onsi/ginkgo/v2"
@@ -48,7 +49,7 @@ var _ = Describe("[vault]", Label("vault"), func() {
 	prov := newVaultProvider(f)
 
 	DescribeTable("sync secrets",
-		framework.TableFunc(f, prov),
+		framework.TableFuncWithExternalSecret(f, prov),
 		// uses token auth
 		framework.Compose(withTokenAuth, f, common.FindByName, useTokenAuth),
 		framework.Compose(withTokenAuth, f, common.FindByNameAndRewrite, useTokenAuth),
@@ -127,7 +128,7 @@ var _ = Describe("[vault] with mTLS", Label("vault", "vault-mtls"), func() {
 	prov := newVaultProvider(f)
 
 	DescribeTable("sync secrets",
-		framework.TableFunc(f, prov),
+		framework.TableFuncWithExternalSecret(f, prov),
 		// uses token auth
 		framework.Compose(withTokenAuthAndMTLS, f, common.FindByName, useMTLSAndTokenAuth),
 		// use referent auth

--- a/e2e/suites/provider/suite_test.go
+++ b/e2e/suites/provider/suite_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package e2e
 
 import (

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package main
 
 import "github.com/external-secrets/external-secrets/cmd"

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cache
 
 import (

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package constants
 
 const (

--- a/pkg/controllers/crds/common_test.go
+++ b/pkg/controllers/crds/common_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package crds
 
 import (

--- a/pkg/controllers/externalsecret/externalsecret_controller.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller.go
@@ -58,12 +58,7 @@ const (
 	errInvalidKeys          = "secret keys from spec.dataFrom.%v[%d] can only have alphanumeric,'-', '_' or '.' characters. Convert them using rewrite (https://external-secrets.io/latest/guides-datafrom-rewrite)"
 	errUpdateSecret         = "could not update Secret"
 	errPatchStatus          = "unable to patch status"
-	errStoreRef             = "could not get store reference"
-	errStoreUsability       = "could not use store reference"
-	errStoreProvider        = "could not get store provider"
-	errStoreClient          = "could not get provider client"
 	errGetExistingSecret    = "could not get existing secret: %w"
-	errCloseStoreClient     = "could not close provider client"
 	errSetCtrlReference     = "could not set ExternalSecret controller reference: %w"
 	errFetchTplFrom         = "error fetching templateFrom data: %w"
 	errGetSecretData        = "could not get secret data from provider"
@@ -75,8 +70,6 @@ const (
 	errPolicyMergeGetSecret = "unable to get secret %s: %w"
 	errPolicyMergeMutate    = "unable to mutate secret %s: %w"
 	errPolicyMergePatch     = "unable to patch secret %s: %w"
-	errTplCMMissingKey      = "error in configmap %s: missing key %s"
-	errTplSecMissingKey     = "error in secret %s: missing key %s"
 )
 
 // Reconciler reconciles a ExternalSecret object.

--- a/pkg/controllers/externalsecret/externalsecret_controller_test.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package externalsecret
 
 import (

--- a/pkg/controllers/externalsecret/util.go
+++ b/pkg/controllers/externalsecret/util.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package externalsecret
 
 import (
@@ -18,7 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
-	esmetrics "github.com/external-secrets/external-secrets/pkg/controllers/externalsecret/esmetrics"
+	"github.com/external-secrets/external-secrets/pkg/controllers/externalsecret/esmetrics"
 )
 
 // NewExternalSecretCondition a set of default options for creating an External Secret Condition.

--- a/pkg/controllers/externalsecret/util_test.go
+++ b/pkg/controllers/externalsecret/util_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package externalsecret
 
 import (

--- a/pkg/controllers/secretstore/common.go
+++ b/pkg/controllers/secretstore/common.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package secretstore
 
 import (

--- a/pkg/controllers/secretstore/common_test.go
+++ b/pkg/controllers/secretstore/common_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package secretstore
 
 import (

--- a/pkg/controllers/webhookconfig/webhookconfig_test.go
+++ b/pkg/controllers/webhookconfig/webhookconfig_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package webhookconfig
 
 import (

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package feature
 
 import (

--- a/pkg/provider/akeyless/akeyless_test.go
+++ b/pkg/provider/akeyless/akeyless_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package akeyless
 
 import (

--- a/pkg/provider/akeyless/fake/fake.go
+++ b/pkg/provider/akeyless/fake/fake.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package fake
 
 import (

--- a/pkg/provider/akeyless/utils.go
+++ b/pkg/provider/akeyless/utils.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package akeyless
 
 import (

--- a/pkg/provider/aws/auth/fake/assumeroler.go
+++ b/pkg/provider/aws/auth/fake/assumeroler.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package fake
 
 import (

--- a/pkg/provider/aws/auth/resolver.go
+++ b/pkg/provider/aws/auth/resolver.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package auth
 
 import (

--- a/pkg/provider/aws/auth/resolver_test.go
+++ b/pkg/provider/aws/auth/resolver_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package auth
 
 import (

--- a/pkg/provider/aws/auth/token_fetcher.go
+++ b/pkg/provider/aws/auth/token_fetcher.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package auth
 
 import (

--- a/pkg/provider/aws/auth/token_fetcher_test.go
+++ b/pkg/provider/aws/auth/token_fetcher_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package auth
 
 import (

--- a/pkg/provider/aws/parameterstore/fake/fake.go
+++ b/pkg/provider/aws/parameterstore/fake/fake.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package fake
 
 import (

--- a/pkg/provider/aws/parameterstore/parameterstore.go
+++ b/pkg/provider/aws/parameterstore/parameterstore.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package parameterstore
 
 import (

--- a/pkg/provider/aws/parameterstore/parameterstore_test.go
+++ b/pkg/provider/aws/parameterstore/parameterstore_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package parameterstore
 
 import (

--- a/pkg/provider/aws/util/errors_test.go
+++ b/pkg/provider/aws/util/errors_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package util
 
 import (

--- a/pkg/provider/aws/util/provider.go
+++ b/pkg/provider/aws/util/provider.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package util
 
 import (

--- a/pkg/provider/aws/util/validation.go
+++ b/pkg/provider/aws/util/validation.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package util
 
 import (

--- a/pkg/provider/azure/keyvault/fake/fake.go
+++ b/pkg/provider/azure/keyvault/fake/fake.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package fake
 
 import (

--- a/pkg/provider/conjur/auth_jwt.go
+++ b/pkg/provider/conjur/auth_jwt.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package conjur
 
 import (

--- a/pkg/provider/conjur/conjur_api.go
+++ b/pkg/provider/conjur/conjur_api.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package conjur
 
 import (

--- a/pkg/provider/conjur/provider.go
+++ b/pkg/provider/conjur/provider.go
@@ -1,4 +1,3 @@
-// Package conjur provides a Conjur provider for External Secrets.
 /*
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -12,6 +11,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// Package conjur provides a Conjur provider for External Secrets.
 package conjur
 
 import (

--- a/pkg/provider/conjur/util/provider.go
+++ b/pkg/provider/conjur/util/provider.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package util
 
 import (

--- a/pkg/provider/delinea/client.go
+++ b/pkg/provider/delinea/client.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package delinea
 
 import (

--- a/pkg/provider/delinea/client_test.go
+++ b/pkg/provider/delinea/client_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package delinea
 
 import (

--- a/pkg/provider/delinea/provider_test.go
+++ b/pkg/provider/delinea/provider_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package delinea
 
 import (

--- a/pkg/provider/delinea/secret_api.go
+++ b/pkg/provider/delinea/secret_api.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package delinea
 
 import (

--- a/pkg/provider/doppler/fake/fake.go
+++ b/pkg/provider/doppler/fake/fake.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package fake
 
 import (

--- a/pkg/provider/fake/fake.go
+++ b/pkg/provider/fake/fake.go
@@ -122,10 +122,12 @@ func (p *Provider) PushSecret(_ context.Context, secret *corev1.Secret, data esv
 		}
 		return nil
 	}
+
 	if currentData.Origin != FakeSetSecret {
 		return fmt.Errorf("key already exists")
 	}
 	currentData.Value = string(value)
+
 	return nil
 }
 

--- a/pkg/provider/fake/fake_test.go
+++ b/pkg/provider/fake/fake_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package fake
 
 import (

--- a/pkg/provider/gcp/secretmanager/auth.go
+++ b/pkg/provider/gcp/secretmanager/auth.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package secretmanager
 
 import (

--- a/pkg/provider/gcp/secretmanager/client.go
+++ b/pkg/provider/gcp/secretmanager/client.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package secretmanager
 
 import (

--- a/pkg/provider/gcp/secretmanager/client_test.go
+++ b/pkg/provider/gcp/secretmanager/client_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package secretmanager
 
 import (

--- a/pkg/provider/gcp/secretmanager/fake/fake.go
+++ b/pkg/provider/gcp/secretmanager/fake/fake.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package fake
 
 import (

--- a/pkg/provider/gcp/secretmanager/provider.go
+++ b/pkg/provider/gcp/secretmanager/provider.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package secretmanager
 
 import (

--- a/pkg/provider/gcp/secretmanager/push_secret.go
+++ b/pkg/provider/gcp/secretmanager/push_secret.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package secretmanager
 
 import (

--- a/pkg/provider/gcp/secretmanager/workload_identity.go
+++ b/pkg/provider/gcp/secretmanager/workload_identity.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package secretmanager
 
 import (

--- a/pkg/provider/gcp/secretmanager/workload_identity_test.go
+++ b/pkg/provider/gcp/secretmanager/workload_identity_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package secretmanager
 
 import (

--- a/pkg/provider/gitlab/fake/fake.go
+++ b/pkg/provider/gitlab/fake/fake.go
@@ -11,12 +11,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package fake
 
 import (
 	"net/http"
 
-	gitlab "github.com/xanzy/go-gitlab"
+	"github.com/xanzy/go-gitlab"
 )
 
 type APIResponse[O any] struct {

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package gitlab
 
 import (

--- a/pkg/provider/gitlab/gitlab_test.go
+++ b/pkg/provider/gitlab/gitlab_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package gitlab
 
 import (

--- a/pkg/provider/gitlab/provider.go
+++ b/pkg/provider/gitlab/provider.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package gitlab
 
 import (

--- a/pkg/provider/ibm/fake/fake.go
+++ b/pkg/provider/ibm/fake/fake.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package fake
 
 import (

--- a/pkg/provider/ibm/provider.go
+++ b/pkg/provider/ibm/provider.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ibm
 
 import (

--- a/pkg/provider/ibm/provider_test.go
+++ b/pkg/provider/ibm/provider_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ibm
 
 import (

--- a/pkg/provider/keepersecurity/client.go
+++ b/pkg/provider/keepersecurity/client.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package keepersecurity
 
 import (

--- a/pkg/provider/keepersecurity/client_test.go
+++ b/pkg/provider/keepersecurity/client_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package keepersecurity
 
 import (

--- a/pkg/provider/keepersecurity/fake/fake.go
+++ b/pkg/provider/keepersecurity/fake/fake.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package fake
 
 import ksm "github.com/keeper-security/secrets-manager-go/core"

--- a/pkg/provider/keepersecurity/provider.go
+++ b/pkg/provider/keepersecurity/provider.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package keepersecurity
 
 import (

--- a/pkg/provider/kubernetes/auth_test.go
+++ b/pkg/provider/kubernetes/auth_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package kubernetes
 
 import (

--- a/pkg/provider/kubernetes/client_test.go
+++ b/pkg/provider/kubernetes/client_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package kubernetes
 
 import (

--- a/pkg/provider/kubernetes/provider_test.go
+++ b/pkg/provider/kubernetes/provider_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package kubernetes
 
 import (

--- a/pkg/provider/kubernetes/validate.go
+++ b/pkg/provider/kubernetes/validate.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package kubernetes
 
 import (

--- a/pkg/provider/kubernetes/validate_test.go
+++ b/pkg/provider/kubernetes/validate_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package kubernetes
 
 import (

--- a/pkg/provider/onepassword/fake/fake.go
+++ b/pkg/provider/onepassword/fake/fake.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package fake
 
 import (

--- a/pkg/provider/onepassword/onepassword.go
+++ b/pkg/provider/onepassword/onepassword.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package onepassword
 
 import (

--- a/pkg/provider/onepassword/onepassword_test.go
+++ b/pkg/provider/onepassword/onepassword_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package onepassword
 
 import (
@@ -28,7 +29,7 @@ import (
 
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 	esmeta "github.com/external-secrets/external-secrets/apis/meta/v1"
-	fake "github.com/external-secrets/external-secrets/pkg/provider/onepassword/fake"
+	"github.com/external-secrets/external-secrets/pkg/provider/onepassword/fake"
 )
 
 const (

--- a/pkg/provider/oracle/fake/fake.go
+++ b/pkg/provider/oracle/fake/fake.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package fake
 
 import (

--- a/pkg/provider/oracle/oracle.go
+++ b/pkg/provider/oracle/oracle.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package oracle
 
 import (

--- a/pkg/provider/oracle/oracle_test.go
+++ b/pkg/provider/oracle/oracle_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package oracle
 
 import (

--- a/pkg/provider/oracle/serviceaccount.go
+++ b/pkg/provider/oracle/serviceaccount.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package oracle
 
 import (

--- a/pkg/provider/scaleway/cache.go
+++ b/pkg/provider/scaleway/cache.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package scaleway
 
 import (

--- a/pkg/provider/scaleway/cache_test.go
+++ b/pkg/provider/scaleway/cache_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package scaleway
 
 import (

--- a/pkg/provider/scaleway/client.go
+++ b/pkg/provider/scaleway/client.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package scaleway
 
 import (

--- a/pkg/provider/scaleway/client_test.go
+++ b/pkg/provider/scaleway/client_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package scaleway
 
 import (

--- a/pkg/provider/scaleway/fake_secret_api_test.go
+++ b/pkg/provider/scaleway/fake_secret_api_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package scaleway
 
 import (

--- a/pkg/provider/scaleway/secret_api.go
+++ b/pkg/provider/scaleway/secret_api.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package scaleway
 
 import (

--- a/pkg/provider/testing/fake/fake.go
+++ b/pkg/provider/testing/fake/fake.go
@@ -16,7 +16,6 @@ package fake
 
 import (
 	"context"
-	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -82,7 +81,6 @@ func (v *Client) GetAllSecrets(ctx context.Context, ref esv1beta1.ExternalSecret
 }
 
 func (v *Client) PushSecret(_ context.Context, secret *corev1.Secret, data esv1beta1.PushSecretData) error {
-	fmt.Println("CALLING PUSH SECRET: ", secret.Data, data)
 	v.SetSecretArgs[data.GetRemoteKey()] = SetSecretCallArgs{
 		Value:     secret.Data[data.GetSecretKey()],
 		RemoteRef: data,

--- a/pkg/provider/testing/fake/fake.go
+++ b/pkg/provider/testing/fake/fake.go
@@ -16,6 +16,7 @@ package fake
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -80,8 +81,8 @@ func (v *Client) GetAllSecrets(ctx context.Context, ref esv1beta1.ExternalSecret
 	return v.GetAllSecretsFn(ctx, ref)
 }
 
-// Not Implemented PushSecret.
 func (v *Client) PushSecret(_ context.Context, secret *corev1.Secret, data esv1beta1.PushSecretData) error {
+	fmt.Println("CALLING PUSH SECRET: ", secret.Data, data)
 	v.SetSecretArgs[data.GetRemoteKey()] = SetSecretCallArgs{
 		Value:     secret.Data[data.GetSecretKey()],
 		RemoteRef: data,

--- a/pkg/provider/util/fake/token_fetcher.go
+++ b/pkg/provider/util/fake/token_fetcher.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package fake
 
 import (

--- a/pkg/provider/util/locks/secret_locks.go
+++ b/pkg/provider/util/locks/secret_locks.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package locks
 
 import (

--- a/pkg/provider/util/locks/secret_locks_test.go
+++ b/pkg/provider/util/locks/secret_locks_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package locks
 
 import (

--- a/pkg/provider/vault/iamauth/iamauth_test.go
+++ b/pkg/provider/vault/iamauth/iamauth_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package iamauth
 
 import (

--- a/pkg/provider/webhook/webhook_test.go
+++ b/pkg/provider/webhook/webhook_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package webhook
 
 import (

--- a/pkg/provider/yandex/certificatemanager/certificatemanager.go
+++ b/pkg/provider/yandex/certificatemanager/certificatemanager.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package certificatemanager
 
 import (

--- a/pkg/provider/yandex/certificatemanager/certificatemanager_test.go
+++ b/pkg/provider/yandex/certificatemanager/certificatemanager_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package certificatemanager
 
 import (

--- a/pkg/provider/yandex/certificatemanager/certificatemanagersecretgetter.go
+++ b/pkg/provider/yandex/certificatemanager/certificatemanagersecretgetter.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package certificatemanager
 
 import (

--- a/pkg/provider/yandex/certificatemanager/client/client.go
+++ b/pkg/provider/yandex/certificatemanager/client/client.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package client
 
 import (

--- a/pkg/provider/yandex/certificatemanager/client/fakeclient.go
+++ b/pkg/provider/yandex/certificatemanager/client/fakeclient.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package client
 
 import (

--- a/pkg/provider/yandex/certificatemanager/client/grpcclient.go
+++ b/pkg/provider/yandex/certificatemanager/client/grpcclient.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package client
 
 import (

--- a/pkg/provider/yandex/common/clock/clock.go
+++ b/pkg/provider/yandex/common/clock/clock.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package clock
 
 import (

--- a/pkg/provider/yandex/common/clock/fakeclock.go
+++ b/pkg/provider/yandex/common/clock/fakeclock.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package clock
 
 import "time"

--- a/pkg/provider/yandex/common/clock/realclock.go
+++ b/pkg/provider/yandex/common/clock/realclock.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package clock
 
 import "time"

--- a/pkg/provider/yandex/common/provider.go
+++ b/pkg/provider/yandex/common/provider.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package common
 
 import (

--- a/pkg/provider/yandex/common/sdk.go
+++ b/pkg/provider/yandex/common/sdk.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package common
 
 import (

--- a/pkg/provider/yandex/common/secretgetter.go
+++ b/pkg/provider/yandex/common/secretgetter.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package common
 
 import (

--- a/pkg/provider/yandex/common/secretsclient.go
+++ b/pkg/provider/yandex/common/secretsclient.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package common
 
 import (

--- a/pkg/provider/yandex/common/secretsetter.go
+++ b/pkg/provider/yandex/common/secretsetter.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package common
 
 type SecretSetter interface {

--- a/pkg/provider/yandex/lockbox/client/client.go
+++ b/pkg/provider/yandex/lockbox/client/client.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package client
 
 import (

--- a/pkg/provider/yandex/lockbox/client/fakeclient.go
+++ b/pkg/provider/yandex/lockbox/client/fakeclient.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package client
 
 import (

--- a/pkg/provider/yandex/lockbox/client/grpcclient.go
+++ b/pkg/provider/yandex/lockbox/client/grpcclient.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package client
 
 import (

--- a/pkg/provider/yandex/lockbox/lockbox.go
+++ b/pkg/provider/yandex/lockbox/lockbox.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package lockbox
 
 import (

--- a/pkg/provider/yandex/lockbox/lockbox_test.go
+++ b/pkg/provider/yandex/lockbox/lockbox_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package lockbox
 
 import (

--- a/pkg/provider/yandex/lockbox/lockboxsecretgetter.go
+++ b/pkg/provider/yandex/lockbox/lockboxsecretgetter.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package lockbox
 
 import (

--- a/pkg/template/engine.go
+++ b/pkg/template/engine.go
@@ -10,6 +10,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 limitations under the License.
 */
+
 package template
 
 import (

--- a/pkg/template/v1/template.go
+++ b/pkg/template/v1/template.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package template
 
 import (

--- a/pkg/template/v1/template_test.go
+++ b/pkg/template/v1/template_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package template
 
 import (

--- a/pkg/template/v2/jwk.go
+++ b/pkg/template/v2/jwk.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package template
 
 import (

--- a/pkg/template/v2/pem.go
+++ b/pkg/template/v2/pem.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package template
 
 import (

--- a/pkg/template/v2/pem_chain.go
+++ b/pkg/template/v2/pem_chain.go
@@ -24,6 +24,7 @@ SOFTWARE
 Original Author: Anish Ramasekar https://github.com/aramase
 In: https://github.com/Azure/secrets-store-csi-driver-provider-azure/pull/332
 */
+
 package template
 
 import (

--- a/pkg/template/v2/pem_test.go
+++ b/pkg/template/v2/pem_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package template
 
 import "testing"

--- a/pkg/template/v2/pkcs12.go
+++ b/pkg/template/v2/pkcs12.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package template
 
 import (

--- a/pkg/template/v2/template.go
+++ b/pkg/template/v2/template.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package template
 
 import (

--- a/pkg/template/v2/template_test.go
+++ b/pkg/template/v2/template_test.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package template
 
 import (

--- a/pkg/template/v2/yaml.go
+++ b/pkg/template/v2/yaml.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package template
 
 import (


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?

## Related Issue

Details about the edit. The refactor now includes a different setup for tests using PushSecret. The reason why it's separate from the ExternalSecret things is because it requires different things as a source. For example, it requires a source secret to exist in Kubernetes.

The proof, however, is a bit difficult. I included a sample test case under `e2e/suites/provider/cases/template/template.go`. The only way to prove that PushSecret succeeded in what it wanted to push is by either checking if the Status of the push secret is a success, as in condition `Ready` is `true`, or by using ANOTHER `ExternalSecret` to fetch the value that the push secret created.

I'm debating baking that into the default test case, but you might not want to do that based on your scenario.

That said, if the need arises, we can always refactor it and include the ExternalSecret part into the default test case setup to make the actual test case leaner.

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
