### PR TITLE
docs: update controller reconcile error rule

### DIFF
--- a/docs/api/metrics.md
+++ b/docs/api/metrics.md
@@ -101,6 +101,6 @@ The controller should be able to reconcile resources without errors. When errors
 
 ```
 sum(increase(
-  controller_runtime_reconcile_total{service=~"external-secrets.*",controller=~"$controller"}[1m])
+  controller_runtime_reconcile_total{service=~"external-secrets.*",controller=~"$controller",result="error"}[1m])
 ) by (result)
 ```


### PR DESCRIPTION
## Problem Statement

Missing label in Controller Reconcile Error documentation section.

## Proposed Changes

Add the `result="error"` label

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
