### PR TITLE
docs: add command to install CRDs using kustomize

### DIFF
--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -9,7 +9,12 @@ and manages Kubernetes secret resources with ExternalSecret resources.
 
 ## Installing with Helm
 
-The default install options will automatically install and manage the CRDs as part of your helm release. If you do not want the CRDs to be automatically upgraded and managed, you must set the `installCRDs` option to `false`. (e.g. `--set installCRDS=false`)
+The default install options will automatically install and manage the CRDs as part of your helm release. If you do not want the CRDs to be automatically upgraded and managed, you must set the `installCRDs` option to `false`. (e.g. `--set installCRDs=false`)
+
+You can install those CRDs outside of `helm` using:
+```bash
+kubectl apply -k "https://github.com/external-secrets/external-secrets//config/crds/bases?ref=v0.9.11"
+```
 
 Uncomment the relevant line in the next steps to disable the automatic install of CRDs.
 


### PR DESCRIPTION
## Problem Statement
Helm installation order is not fixed, so it may happen that the installation fails because CRDs are referenced before they are installed. The installation page docs did not mention a way to install them outside of helm.

## Related Issue

Fixes #3020

## Proposed Changes

I added the command to install the CRDs with kustomize

## Checklist

- [ x ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ x ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
