### PR TITLE
feat: allow provider to return admission warnings

### DIFF
--- a/apis/externalsecrets/v1beta1/provider.go
+++ b/apis/externalsecrets/v1beta1/provider.go
@@ -19,6 +19,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 const (
@@ -51,7 +52,11 @@ type Provider interface {
 	NewClient(ctx context.Context, store GenericStore, kube client.Client, namespace string) (SecretsClient, error)
 
 	// ValidateStore checks if the provided store is valid
-	ValidateStore(store GenericStore) error
+	// The provider may return a warning and an error.
+	// The intended use of the warning to indicate a deprecation of behavior
+	// or other type of message that is NOT a validation failure but should be noticed by the user.
+	ValidateStore(store GenericStore) (admission.Warnings, error)
+
 	// Capabilities returns the provider Capabilities (Read, Write, ReadWrite)
 	Capabilities() SecretStoreCapabilities
 }

--- a/apis/externalsecrets/v1beta1/provider_schema_test.go
+++ b/apis/externalsecrets/v1beta1/provider_schema_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 type PP struct{}
@@ -69,8 +70,8 @@ func (p *PP) Validate() (ValidationResult, error) {
 	return ValidationResultReady, nil
 }
 
-func (p *PP) ValidateStore(_ GenericStore) error {
-	return nil
+func (p *PP) ValidateStore(_ GenericStore) (admission.Warnings, error) {
+	return nil, nil
 }
 
 // TestRegister tests if the Register function

--- a/apis/externalsecrets/v1beta1/secretstore_validator.go
+++ b/apis/externalsecrets/v1beta1/secretstore_validator.go
@@ -58,5 +58,5 @@ func validateStore(store GenericStore) (admission.Warnings, error) {
 	if err != nil {
 		return nil, err
 	}
-	return nil, provider.ValidateStore(store)
+	return provider.ValidateStore(store)
 }

--- a/pkg/controllers/secretstore/client_manager_test.go
+++ b/pkg/controllers/secretstore/client_manager_test.go
@@ -28,6 +28,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 )
@@ -331,8 +332,8 @@ func (f *WrapProvider) Capabilities() esv1beta1.SecretStoreCapabilities {
 }
 
 // ValidateStore checks if the provided store is valid.
-func (f *WrapProvider) ValidateStore(_ esv1beta1.GenericStore) error {
-	return nil
+func (f *WrapProvider) ValidateStore(_ esv1beta1.GenericStore) (admission.Warnings, error) {
+	return nil, nil
 }
 
 type MockFakeClient struct {

--- a/pkg/provider/akeyless/akeyless.go
+++ b/pkg/provider/akeyless/akeyless.go
@@ -34,6 +34,7 @@ import (
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlcfg "sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 	esmeta "github.com/external-secrets/external-secrets/apis/meta/v1"
@@ -110,7 +111,7 @@ func (p *Provider) NewClient(ctx context.Context, store esv1beta1.GenericStore, 
 	return newClient(ctx, store, kube, clientset.CoreV1(), namespace)
 }
 
-func (p *Provider) ValidateStore(store esv1beta1.GenericStore) error {
+func (p *Provider) ValidateStore(store esv1beta1.GenericStore) (admission.Warnings, error) {
 	storeSpec := store.GetSpec()
 	akeylessSpec := storeSpec.Provider.Akeyless
 
@@ -119,63 +120,63 @@ func (p *Provider) ValidateStore(store esv1beta1.GenericStore) error {
 	if akeylessGWApiURL != nil && *akeylessGWApiURL != "" {
 		url, err := url.Parse(*akeylessGWApiURL)
 		if err != nil {
-			return fmt.Errorf(errInvalidAkeylessURL)
+			return nil, fmt.Errorf(errInvalidAkeylessURL)
 		}
 
 		if url.Host == "" {
-			return fmt.Errorf(errInvalidAkeylessURL)
+			return nil, fmt.Errorf(errInvalidAkeylessURL)
 		}
 	}
 	if akeylessSpec.Auth.KubernetesAuth != nil {
 		if akeylessSpec.Auth.KubernetesAuth.ServiceAccountRef != nil {
 			if err := utils.ValidateReferentServiceAccountSelector(store, *akeylessSpec.Auth.KubernetesAuth.ServiceAccountRef); err != nil {
-				return fmt.Errorf(errInvalidKubeSA, err)
+				return nil, fmt.Errorf(errInvalidKubeSA, err)
 			}
 		}
 		if akeylessSpec.Auth.KubernetesAuth.SecretRef != nil {
 			err := utils.ValidateSecretSelector(store, *akeylessSpec.Auth.KubernetesAuth.SecretRef)
 			if err != nil {
-				return err
+				return nil, err
 			}
 		}
 
 		if akeylessSpec.Auth.KubernetesAuth.AccessID == "" {
-			return fmt.Errorf("missing kubernetes auth-method access-id")
+			return nil, fmt.Errorf("missing kubernetes auth-method access-id")
 		}
 
 		if akeylessSpec.Auth.KubernetesAuth.K8sConfName == "" {
-			return fmt.Errorf("missing kubernetes config name")
+			return nil, fmt.Errorf("missing kubernetes config name")
 		}
-		return nil
+		return nil, nil
 	}
 
 	accessID := akeylessSpec.Auth.SecretRef.AccessID
 	err := utils.ValidateSecretSelector(store, accessID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if accessID.Name == "" {
-		return fmt.Errorf(errInvalidAkeylessAccessIDName)
+		return nil, fmt.Errorf(errInvalidAkeylessAccessIDName)
 	}
 
 	if accessID.Key == "" {
-		return fmt.Errorf(errInvalidAkeylessAccessIDKey)
+		return nil, fmt.Errorf(errInvalidAkeylessAccessIDKey)
 	}
 
 	accessType := akeylessSpec.Auth.SecretRef.AccessType
 	err = utils.ValidateSecretSelector(store, accessType)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	accessTypeParam := akeylessSpec.Auth.SecretRef.AccessTypeParam
 	err = utils.ValidateSecretSelector(store, accessTypeParam)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return nil, nil
 }
 
 func newClient(_ context.Context, store esv1beta1.GenericStore, kube client.Client, corev1 typedcorev1.CoreV1Interface, namespace string) (esv1beta1.SecretsClient, error) {

--- a/pkg/provider/akeyless/akeyless_test.go
+++ b/pkg/provider/akeyless/akeyless_test.go
@@ -157,7 +157,7 @@ func TestValidateStore(t *testing.T) {
 			},
 		}
 
-		err := provider.ValidateStore(store)
+		_, err := provider.ValidateStore(store)
 		if err != nil {
 			t.Errorf(err.Error())
 		}
@@ -183,7 +183,7 @@ func TestValidateStore(t *testing.T) {
 			},
 		}
 
-		err := provider.ValidateStore(store)
+		_, err := provider.ValidateStore(store)
 		if err != nil {
 			t.Errorf(err.Error())
 		}
@@ -201,7 +201,7 @@ func TestValidateStore(t *testing.T) {
 			},
 		}
 
-		err := provider.ValidateStore(store)
+		_, err := provider.ValidateStore(store)
 		if err == nil {
 			t.Errorf("expected an error")
 		}
@@ -226,7 +226,7 @@ func TestValidateStore(t *testing.T) {
 			},
 		}
 
-		err := provider.ValidateStore(store)
+		_, err := provider.ValidateStore(store)
 		if err == nil {
 			t.Errorf("expected an error")
 		}

--- a/pkg/provider/alibaba/kms.go
+++ b/pkg/provider/alibaba/kms.go
@@ -27,6 +27,7 @@ import (
 	"github.com/tidwall/gjson"
 	corev1 "k8s.io/api/core/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 	"github.com/external-secrets/external-secrets/pkg/utils"
@@ -260,17 +261,17 @@ func (kms *KeyManagementService) Validate() (esv1beta1.ValidationResult, error) 
 	return esv1beta1.ValidationResultReady, nil
 }
 
-func (kms *KeyManagementService) ValidateStore(store esv1beta1.GenericStore) error {
+func (kms *KeyManagementService) ValidateStore(store esv1beta1.GenericStore) (admission.Warnings, error) {
 	storeSpec := store.GetSpec()
 	alibabaSpec := storeSpec.Provider.Alibaba
 
 	regionID := alibabaSpec.RegionID
 
 	if regionID == "" {
-		return fmt.Errorf("missing alibaba region")
+		return nil, fmt.Errorf("missing alibaba region")
 	}
 
-	return kms.validateStoreAuth(store)
+	return nil, kms.validateStoreAuth(store)
 }
 
 func (kms *KeyManagementService) validateStoreAuth(store esv1beta1.GenericStore) error {

--- a/pkg/provider/alibaba/kms_test.go
+++ b/pkg/provider/alibaba/kms_test.go
@@ -201,7 +201,7 @@ func TestValidateAccessKeyStore(t *testing.T) {
 		},
 	}
 
-	err := kms.ValidateStore(store)
+	_, err := kms.ValidateStore(store)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -228,7 +228,7 @@ func TestValidateRRSAStore(t *testing.T) {
 		},
 	}
 
-	err := kms.ValidateStore(store)
+	_, err := kms.ValidateStore(store)
 	if err != nil {
 		t.Errorf(err.Error())
 	}

--- a/pkg/provider/aws/provider_test.go
+++ b/pkg/provider/aws/provider_test.go
@@ -474,7 +474,7 @@ func TestValidateStore(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &Provider{}
-			if err := p.ValidateStore(tt.args.store); (err != nil) != tt.wantErr {
+			if _, err := p.ValidateStore(tt.args.store); (err != nil) != tt.wantErr {
 				t.Errorf("Provider.ValidateStore() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pkg/provider/azure/keyvault/keyvault_test.go
+++ b/pkg/provider/azure/keyvault/keyvault_test.go
@@ -1611,10 +1611,10 @@ func TestValidateStore(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			a := &Azure{}
 			if tt.name == "storeIsNil" {
-				if err := a.ValidateStore(nil); (err != nil) != tt.wantErr {
+				if _, err := a.ValidateStore(nil); (err != nil) != tt.wantErr {
 					t.Errorf(errStore, err, tt.wantErr)
 				}
-			} else if err := a.ValidateStore(tt.args.store); (err != nil) != tt.wantErr {
+			} else if _, err := a.ValidateStore(tt.args.store); (err != nil) != tt.wantErr {
 				t.Errorf(errStore, err, tt.wantErr)
 			}
 		})

--- a/pkg/provider/conjur/provider_test.go
+++ b/pkg/provider/conjur/provider_test.go
@@ -112,7 +112,7 @@ func TestValidateStore(t *testing.T) {
 	}
 	c := Provider{}
 	for _, tc := range testCases {
-		err := c.ValidateStore(tc.store)
+		_, err := c.ValidateStore(tc.store)
 		if tc.err != nil && err != nil && err.Error() != tc.err.Error() {
 			t.Errorf("test failed! want %v, got %v", tc.err, err)
 		} else if tc.err == nil && err != nil {

--- a/pkg/provider/delinea/provider.go
+++ b/pkg/provider/delinea/provider.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/DelineaXPM/dsv-sdk-go/v2/vault"
 	kubeClient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 	"github.com/external-secrets/external-secrets/pkg/utils"
@@ -178,9 +179,9 @@ func getConfig(store esv1beta1.GenericStore) (*esv1beta1.DelineaProvider, error)
 	return cfg, nil
 }
 
-func (p *Provider) ValidateStore(store esv1beta1.GenericStore) error {
+func (p *Provider) ValidateStore(store esv1beta1.GenericStore) (admission.Warnings, error) {
 	_, err := getConfig(store)
-	return err
+	return nil, err
 }
 
 func init() {

--- a/pkg/provider/delinea/provider_test.go
+++ b/pkg/provider/delinea/provider_test.go
@@ -153,7 +153,7 @@ func TestValidateStore(t *testing.T) {
 				},
 			}
 			p := &Provider{}
-			got := p.ValidateStore(&s)
+			_, got := p.ValidateStore(&s)
 			assert.Equal(t, tc.want, got)
 		})
 	}
@@ -178,7 +178,7 @@ func TestValidateStoreBailsOnUnexpectedStore(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			p := &Provider{}
-			got := p.ValidateStore(tc.store)
+			_, got := p.ValidateStore(tc.store)
 			assert.Equal(t, tc.want, got)
 		})
 	}

--- a/pkg/provider/doppler/doppler_test.go
+++ b/pkg/provider/doppler/doppler_test.go
@@ -268,7 +268,7 @@ func TestValidateStore(t *testing.T) {
 	p := Provider{}
 	for _, tc := range testCases {
 		t.Run(tc.label, func(t *testing.T) {
-			err := p.ValidateStore(tc.store)
+			_, err := p.ValidateStore(tc.store)
 			if tc.err != nil && err != nil && err.Error() != tc.err.Error() {
 				t.Errorf("test failed! want %v, got %v", tc.err, err)
 			} else if tc.err == nil && err != nil {

--- a/pkg/provider/doppler/provider.go
+++ b/pkg/provider/doppler/provider.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 	dClient "github.com/external-secrets/external-secrets/pkg/provider/doppler/client"
@@ -102,17 +103,17 @@ func (p *Provider) NewClient(ctx context.Context, store esv1beta1.GenericStore, 
 	return client, nil
 }
 
-func (p *Provider) ValidateStore(store esv1beta1.GenericStore) error {
+func (p *Provider) ValidateStore(store esv1beta1.GenericStore) (admission.Warnings, error) {
 	storeSpec := store.GetSpec()
 	dopplerStoreSpec := storeSpec.Provider.Doppler
 	dopplerTokenSecretRef := dopplerStoreSpec.Auth.SecretRef.DopplerToken
 	if err := utils.ValidateSecretSelector(store, dopplerTokenSecretRef); err != nil {
-		return fmt.Errorf(errInvalidStore, err)
+		return nil, fmt.Errorf(errInvalidStore, err)
 	}
 
 	if dopplerTokenSecretRef.Name == "" {
-		return fmt.Errorf(errInvalidStore, "dopplerToken.name cannot be empty")
+		return nil, fmt.Errorf(errInvalidStore, "dopplerToken.name cannot be empty")
 	}
 
-	return nil
+	return nil, nil
 }

--- a/pkg/provider/fake/fake.go
+++ b/pkg/provider/fake/fake.go
@@ -23,6 +23,7 @@ import (
 	"github.com/tidwall/gjson"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 	"github.com/external-secrets/external-secrets/pkg/find"
@@ -235,20 +236,20 @@ func (p *Provider) Validate() (esv1beta1.ValidationResult, error) {
 	return esv1beta1.ValidationResultReady, nil
 }
 
-func (p *Provider) ValidateStore(store esv1beta1.GenericStore) error {
+func (p *Provider) ValidateStore(store esv1beta1.GenericStore) (admission.Warnings, error) {
 	prov := store.GetSpec().Provider.Fake
 	if prov == nil {
-		return nil
+		return nil, nil
 	}
 	for pos, data := range prov.Data {
 		if data.Key == "" {
-			return fmt.Errorf(errMissingKeyField, pos)
+			return nil, fmt.Errorf(errMissingKeyField, pos)
 		}
 		if data.Value == "" && data.ValueMap == nil {
-			return fmt.Errorf(errMissingValueField, pos)
+			return nil, fmt.Errorf(errMissingValueField, pos)
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 func mapKey(key, version string) string {

--- a/pkg/provider/fake/fake_test.go
+++ b/pkg/provider/fake/fake_test.go
@@ -56,24 +56,24 @@ func TestValidateStore(t *testing.T) {
 		},
 	}
 	// empty data must not error
-	err := p.ValidateStore(store)
+	_, err := p.ValidateStore(store)
 	gomega.Expect(err).To(gomega.BeNil())
 	// missing key in data
 	data := esv1beta1.FakeProviderData{}
 	data.Version = "v1"
 	store.Spec.Provider.Fake.Data = []esv1beta1.FakeProviderData{data}
-	err = p.ValidateStore(store)
+	_, err = p.ValidateStore(store)
 	gomega.Expect(err).To(gomega.BeEquivalentTo(fmt.Errorf(errMissingKeyField, 0)))
 	// missing values in data
 	data.Key = "/foo"
 	store.Spec.Provider.Fake.Data = []esv1beta1.FakeProviderData{data}
-	err = p.ValidateStore(store)
+	_, err = p.ValidateStore(store)
 	gomega.Expect(err).To(gomega.BeEquivalentTo(fmt.Errorf(errMissingValueField, 0)))
 	// spec ok
 	data.Value = "bar"
 	data.ValueMap = map[string]string{"foo": "bar"}
 	store.Spec.Provider.Fake.Data = []esv1beta1.FakeProviderData{data}
-	err = p.ValidateStore(store)
+	_, err = p.ValidateStore(store)
 	gomega.Expect(err).To(gomega.BeNil())
 }
 func TestClose(t *testing.T) {

--- a/pkg/provider/gcp/secretmanager/client_test.go
+++ b/pkg/provider/gcp/secretmanager/client_test.go
@@ -1084,7 +1084,7 @@ func TestValidateStore(t *testing.T) {
 					},
 				},
 			}
-			if err := sm.ValidateStore(store); (err != nil) != tt.wantErr {
+			if _, err := sm.ValidateStore(store); (err != nil) != tt.wantErr {
 				t.Errorf("ProviderGCP.ValidateStore() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pkg/provider/gitlab/gitlab_test.go
+++ b/pkg/provider/gitlab/gitlab_test.go
@@ -873,7 +873,7 @@ func TestValidateStore(t *testing.T) {
 	}
 	p := Provider{}
 	for _, tc := range testCases {
-		err := p.ValidateStore(tc.store)
+		_, err := p.ValidateStore(tc.store)
 		if tc.err != nil && err != nil && err.Error() != tc.err.Error() {
 			t.Errorf("test failed! want %v, got %v", tc.err, err)
 		} else if tc.err == nil && err != nil {

--- a/pkg/provider/ibm/provider_test.go
+++ b/pkg/provider/ibm/provider_test.go
@@ -185,7 +185,7 @@ func TestValidateStore(t *testing.T) {
 			},
 		},
 	}
-	err := p.ValidateStore(store)
+	_, err := p.ValidateStore(store)
 	if err == nil {
 		t.Errorf(errExpectedErr)
 	} else if err.Error() != "serviceURL is required" {
@@ -193,7 +193,7 @@ func TestValidateStore(t *testing.T) {
 	}
 	url := "my-url"
 	store.Spec.Provider.IBM.ServiceURL = &url
-	err = p.ValidateStore(store)
+	_, err = p.ValidateStore(store)
 	if err == nil {
 		t.Errorf(errExpectedErr)
 	} else if err.Error() != "missing auth method" {
@@ -207,7 +207,7 @@ func TestValidateStore(t *testing.T) {
 			Namespace: &ns,
 		},
 	}
-	err = p.ValidateStore(store)
+	_, err = p.ValidateStore(store)
 	if err == nil {
 		t.Errorf(errExpectedErr)
 	} else if err.Error() != "namespace not allowed with namespaced SecretStore" {
@@ -230,7 +230,7 @@ func TestValidateStore(t *testing.T) {
 			},
 		},
 	}
-	err = p.ValidateStore(store)
+	_, err = p.ValidateStore(store)
 	expected := "cannot read container auth token"
 	if !ErrorContains(err, expected) {
 		t.Errorf("ProfileSelector test failed: %s, expected: '%s'", err.Error(), expected)

--- a/pkg/provider/kubernetes/validate_test.go
+++ b/pkg/provider/kubernetes/validate_test.go
@@ -245,7 +245,7 @@ func TestValidateStore(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			k := &Provider{}
-			if err := k.ValidateStore(tt.store); (err != nil) != tt.wantErr {
+			if _, err := k.ValidateStore(tt.store); (err != nil) != tt.wantErr {
 				t.Errorf("ProviderKubernetes.ValidateStore() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pkg/provider/onepassword/onepassword.go
+++ b/pkg/provider/onepassword/onepassword.go
@@ -24,6 +24,7 @@ import (
 	"github.com/1Password/connect-sdk-go/onepassword"
 	corev1 "k8s.io/api/core/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 	"github.com/external-secrets/external-secrets/pkg/find"
@@ -111,8 +112,8 @@ func (provider *ProviderOnePassword) NewClient(ctx context.Context, store esv1be
 }
 
 // ValidateStore checks if the provided store is valid.
-func (provider *ProviderOnePassword) ValidateStore(store esv1beta1.GenericStore) error {
-	return validateStore(store)
+func (provider *ProviderOnePassword) ValidateStore(store esv1beta1.GenericStore) (admission.Warnings, error) {
+	return nil, validateStore(store)
 }
 
 func validateStore(store esv1beta1.GenericStore) error {

--- a/pkg/provider/oracle/oracle_test.go
+++ b/pkg/provider/oracle/oracle_test.go
@@ -308,7 +308,7 @@ func TestValidateStore(t *testing.T) {
 	}
 	p := VaultManagementService{}
 	for _, tc := range testCases {
-		err := p.ValidateStore(tc.store)
+		_, err := p.ValidateStore(tc.store)
 		if tc.err != nil && err != nil && err.Error() != tc.err.Error() {
 			t.Errorf("test failed! want %v, got %v", tc.err, err)
 		} else if tc.err == nil && err != nil {

--- a/pkg/provider/scaleway/provider.go
+++ b/pkg/provider/scaleway/provider.go
@@ -23,6 +23,7 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/validation"
 	ctrl "sigs.k8s.io/controller-runtime"
 	kubeClient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 	"github.com/external-secrets/external-secrets/pkg/utils"
@@ -159,9 +160,9 @@ func getConfig(store esv1beta1.GenericStore) (*esv1beta1.ScalewayProvider, error
 	return cfg, nil
 }
 
-func (p *Provider) ValidateStore(store esv1beta1.GenericStore) error {
+func (p *Provider) ValidateStore(store esv1beta1.GenericStore) (admission.Warnings, error) {
 	_, err := getConfig(store)
-	return err
+	return nil, err
 }
 
 func init() {

--- a/pkg/provider/senhasegura/provider.go
+++ b/pkg/provider/senhasegura/provider.go
@@ -20,6 +20,7 @@ import (
 	"net/url"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 	senhaseguraAuth "github.com/external-secrets/external-secrets/pkg/provider/senhasegura/auth"
@@ -70,8 +71,8 @@ func (p *Provider) NewClient(ctx context.Context, store esv1beta1.GenericStore, 
 // Validate store using Validating webhook during secret store creating
 // Checks here are usually the best experience for the user, as the SecretStore will not be created until it is a 'valid' one.
 // https://github.com/external-secrets/external-secrets/pull/830#discussion_r833278518
-func (p *Provider) ValidateStore(store esv1beta1.GenericStore) error {
-	return validateStore(store)
+func (p *Provider) ValidateStore(store esv1beta1.GenericStore) (admission.Warnings, error) {
+	return nil, validateStore(store)
 }
 
 func validateStore(store esv1beta1.GenericStore) error {

--- a/pkg/provider/testing/fake/fake.go
+++ b/pkg/provider/testing/fake/fake.go
@@ -19,6 +19,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 )
@@ -118,8 +119,8 @@ func (v *Client) Validate() (esv1beta1.ValidationResult, error) {
 	return esv1beta1.ValidationResultReady, nil
 }
 
-func (v *Client) ValidateStore(_ esv1beta1.GenericStore) error {
-	return nil
+func (v *Client) ValidateStore(_ esv1beta1.GenericStore) (admission.Warnings, error) {
+	return nil, nil
 }
 
 // WithGetSecretMap wraps the secret data map returned by this fake provider.

--- a/pkg/provider/vault/vault.go
+++ b/pkg/provider/vault/vault.go
@@ -49,6 +49,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlcfg "sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 	esmeta "github.com/external-secrets/external-secrets/apis/meta/v1"
@@ -330,120 +331,120 @@ func (c *Connector) initClient(ctx context.Context, vStore *client, client util.
 	return vStore, nil
 }
 
-func (c *Connector) ValidateStore(store esv1beta1.GenericStore) error {
+func (c *Connector) ValidateStore(store esv1beta1.GenericStore) (admission.Warnings, error) {
 	if store == nil {
-		return fmt.Errorf(errInvalidStore)
+		return nil, fmt.Errorf(errInvalidStore)
 	}
 	spc := store.GetSpec()
 	if spc == nil {
-		return fmt.Errorf(errInvalidStoreSpec)
+		return nil, fmt.Errorf(errInvalidStoreSpec)
 	}
 	if spc.Provider == nil {
-		return fmt.Errorf(errInvalidStoreProv)
+		return nil, fmt.Errorf(errInvalidStoreProv)
 	}
 	p := spc.Provider.Vault
 	if p == nil {
-		return fmt.Errorf(errInvalidVaultProv)
+		return nil, fmt.Errorf(errInvalidVaultProv)
 	}
 	if p.Auth.AppRole != nil {
 		// check SecretRef for valid configuration
 		if err := utils.ValidateReferentSecretSelector(store, p.Auth.AppRole.SecretRef); err != nil {
-			return fmt.Errorf(errInvalidAppRoleSec, err)
+			return nil, fmt.Errorf(errInvalidAppRoleSec, err)
 		}
 
 		// prefer .auth.appRole.roleId, fallback to .auth.appRole.roleRef, give up after that.
 		if p.Auth.AppRole.RoleID == "" { // prevents further RoleID tests if .auth.appRole.roleId is given
 			if p.Auth.AppRole.RoleRef != nil { // check RoleRef for valid configuration
 				if err := utils.ValidateReferentSecretSelector(store, *p.Auth.AppRole.RoleRef); err != nil {
-					return fmt.Errorf(errInvalidAppRoleRef, err)
+					return nil, fmt.Errorf(errInvalidAppRoleRef, err)
 				}
 			} else { // we ran out of ways to get RoleID. return an appropriate error
-				return fmt.Errorf(errInvalidAppRoleID)
+				return nil, fmt.Errorf(errInvalidAppRoleID)
 			}
 		}
 	}
 	if p.Auth.Cert != nil {
 		if err := utils.ValidateReferentSecretSelector(store, p.Auth.Cert.ClientCert); err != nil {
-			return fmt.Errorf(errInvalidClientCert, err)
+			return nil, fmt.Errorf(errInvalidClientCert, err)
 		}
 		if err := utils.ValidateReferentSecretSelector(store, p.Auth.Cert.SecretRef); err != nil {
-			return fmt.Errorf(errInvalidCertSec, err)
+			return nil, fmt.Errorf(errInvalidCertSec, err)
 		}
 	}
 	if p.Auth.Jwt != nil {
 		if p.Auth.Jwt.SecretRef != nil {
 			if err := utils.ValidateReferentSecretSelector(store, *p.Auth.Jwt.SecretRef); err != nil {
-				return fmt.Errorf(errInvalidJwtSec, err)
+				return nil, fmt.Errorf(errInvalidJwtSec, err)
 			}
 		} else if p.Auth.Jwt.KubernetesServiceAccountToken != nil {
 			if err := utils.ValidateReferentServiceAccountSelector(store, p.Auth.Jwt.KubernetesServiceAccountToken.ServiceAccountRef); err != nil {
-				return fmt.Errorf(errInvalidJwtK8sSA, err)
+				return nil, fmt.Errorf(errInvalidJwtK8sSA, err)
 			}
 		} else {
-			return fmt.Errorf(errJwtNoTokenSource)
+			return nil, fmt.Errorf(errJwtNoTokenSource)
 		}
 	}
 	if p.Auth.Kubernetes != nil {
 		if p.Auth.Kubernetes.ServiceAccountRef != nil {
 			if err := utils.ValidateReferentServiceAccountSelector(store, *p.Auth.Kubernetes.ServiceAccountRef); err != nil {
-				return fmt.Errorf(errInvalidKubeSA, err)
+				return nil, fmt.Errorf(errInvalidKubeSA, err)
 			}
 		}
 		if p.Auth.Kubernetes.SecretRef != nil {
 			if err := utils.ValidateReferentSecretSelector(store, *p.Auth.Kubernetes.SecretRef); err != nil {
-				return fmt.Errorf(errInvalidKubeSec, err)
+				return nil, fmt.Errorf(errInvalidKubeSec, err)
 			}
 		}
 	}
 	if p.Auth.Ldap != nil {
 		if err := utils.ValidateReferentSecretSelector(store, p.Auth.Ldap.SecretRef); err != nil {
-			return fmt.Errorf(errInvalidLdapSec, err)
+			return nil, fmt.Errorf(errInvalidLdapSec, err)
 		}
 	}
 	if p.Auth.UserPass != nil {
 		if err := utils.ValidateReferentSecretSelector(store, p.Auth.UserPass.SecretRef); err != nil {
-			return fmt.Errorf(errInvalidUserPassSec, err)
+			return nil, fmt.Errorf(errInvalidUserPassSec, err)
 		}
 	}
 	if p.Auth.TokenSecretRef != nil {
 		if err := utils.ValidateReferentSecretSelector(store, *p.Auth.TokenSecretRef); err != nil {
-			return fmt.Errorf(errInvalidTokenRef, err)
+			return nil, fmt.Errorf(errInvalidTokenRef, err)
 		}
 	}
 	if p.Auth.Iam != nil {
 		if p.Auth.Iam.JWTAuth != nil {
 			if p.Auth.Iam.JWTAuth.ServiceAccountRef != nil {
 				if err := utils.ValidateReferentServiceAccountSelector(store, *p.Auth.Iam.JWTAuth.ServiceAccountRef); err != nil {
-					return fmt.Errorf(errInvalidTokenRef, err)
+					return nil, fmt.Errorf(errInvalidTokenRef, err)
 				}
 			}
 		}
 
 		if p.Auth.Iam.SecretRef != nil {
 			if err := utils.ValidateReferentSecretSelector(store, p.Auth.Iam.SecretRef.AccessKeyID); err != nil {
-				return fmt.Errorf(errInvalidTokenRef, err)
+				return nil, fmt.Errorf(errInvalidTokenRef, err)
 			}
 			if err := utils.ValidateReferentSecretSelector(store, p.Auth.Iam.SecretRef.SecretAccessKey); err != nil {
-				return fmt.Errorf(errInvalidTokenRef, err)
+				return nil, fmt.Errorf(errInvalidTokenRef, err)
 			}
 			if p.Auth.Iam.SecretRef.SessionToken != nil {
 				if err := utils.ValidateReferentSecretSelector(store, *p.Auth.Iam.SecretRef.SessionToken); err != nil {
-					return fmt.Errorf(errInvalidTokenRef, err)
+					return nil, fmt.Errorf(errInvalidTokenRef, err)
 				}
 			}
 		}
 	}
 	if p.ClientTLS.CertSecretRef != nil && p.ClientTLS.KeySecretRef != nil {
 		if err := utils.ValidateReferentSecretSelector(store, *p.ClientTLS.CertSecretRef); err != nil {
-			return fmt.Errorf(errInvalidClientTLSCert, err)
+			return nil, fmt.Errorf(errInvalidClientTLSCert, err)
 		}
 		if err := utils.ValidateReferentSecretSelector(store, *p.ClientTLS.KeySecretRef); err != nil {
-			return fmt.Errorf(errInvalidClientTLSSecret, err)
+			return nil, fmt.Errorf(errInvalidClientTLSSecret, err)
 		}
 	} else if p.ClientTLS.CertSecretRef != nil || p.ClientTLS.KeySecretRef != nil {
-		return errors.New(errInvalidClientTLS)
+		return nil, errors.New(errInvalidClientTLS)
 	}
-	return nil
+	return nil, nil
 }
 
 func (v *client) DeleteSecret(ctx context.Context, remoteRef esv1beta1.PushSecretRemoteRef) error {

--- a/pkg/provider/vault/vault_test.go
+++ b/pkg/provider/vault/vault_test.go
@@ -1785,7 +1785,7 @@ func TestValidateStore(t *testing.T) {
 					},
 				},
 			}
-			if err := c.ValidateStore(store); (err != nil) != tt.wantErr {
+			if _, err := c.ValidateStore(store); (err != nil) != tt.wantErr {
 				t.Errorf("connector.ValidateStore() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pkg/provider/webhook/webhook.go
+++ b/pkg/provider/webhook/webhook.go
@@ -31,6 +31,7 @@ import (
 	"github.com/PaesslerAG/jsonpath"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 	esmeta "github.com/external-secrets/external-secrets/apis/meta/v1"
@@ -88,8 +89,8 @@ func (p *Provider) NewClient(_ context.Context, store esv1beta1.GenericStore, ku
 	return whClient, nil
 }
 
-func (p *Provider) ValidateStore(_ esv1beta1.GenericStore) error {
-	return nil
+func (p *Provider) ValidateStore(_ esv1beta1.GenericStore) (admission.Warnings, error) {
+	return nil, nil
 }
 
 func getProvider(store esv1beta1.GenericStore) (*esv1beta1.WebhookProvider, error) {

--- a/pkg/provider/yandex/common/provider.go
+++ b/pkg/provider/yandex/common/provider.go
@@ -25,6 +25,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/yandex-cloud/go-sdk/iamkey"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 	esmeta "github.com/external-secrets/external-secrets/apis/meta/v1"
@@ -230,10 +231,10 @@ func (p *YandexCloudProvider) CleanUpIamTokenMap() {
 	}
 }
 
-func (p *YandexCloudProvider) ValidateStore(store esv1beta1.GenericStore) error {
+func (p *YandexCloudProvider) ValidateStore(store esv1beta1.GenericStore) (admission.Warnings, error) {
 	_, err := p.adaptInputFunc(store) // adaptInputFunc validates the input store
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+	return nil, nil
 }


### PR DESCRIPTION
Towards #3030

This PR allows providers to return a `admission.Warnings  / []string` value when the `func ValidateStore()` is called.

Its intended use is that providers return a message to the user indicating a deprecation of behaviour or other type of message that is NOT a validation failure but should be noticed by the user.

