### PR TITLE
fix: bump ubi image

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:288239021a429a311233d73a7d91b0a1dd889ab7bbc247d913e1b5726e25354a
+FROM registry.redhat.io/ubi8/ubi-minimal@sha256:70fe679f2a24b76d5e90fee30c1616afc4f96eed13d77a2ad04af0261c928fb1
 ARG TARGETOS
 ARG TARGETARCH
 COPY bin/external-secrets-${TARGETOS}-${TARGETARCH} /bin/external-secrets


### PR DESCRIPTION
bump UBI image.

See: https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8?architecture=amd64&image=65a6d261fd305b13e7e4c87c