### PR TITLE
Add 'namespaceOverride' value for helm chart

### DIFF
--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -111,6 +111,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | metrics.service.enabled | bool | `false` | Enable if you use another monitoring tool than Prometheus to scrape the metrics |
 | metrics.service.port | int | `8080` | Metrics service port to scrape |
 | nameOverride | string | `""` |  |
+| namespaceOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` | Annotations to add to Pod |
 | podDisruptionBudget | object | `{"enabled":false,"minAvailable":1}` | Pod disruption budget - for more details see https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |

--- a/deploy/charts/external-secrets/templates/NOTES.txt
+++ b/deploy/charts/external-secrets/templates/NOTES.txt
@@ -1,8 +1,7 @@
-external-secrets has been deployed successfully!
+external-secrets has been deployed successfully in namespace {{ template "external-secrets.namespace" . }}!
 
 In order to begin using ExternalSecrets, you will need to set up a SecretStore
 or ClusterSecretStore resource (for example, by creating a 'vault' SecretStore).
 
 More information on the different types of SecretStores and how to configure them
 can be found in our Github: {{ .Chart.Home }}
-

--- a/deploy/charts/external-secrets/templates/_helpers.tpl
+++ b/deploy/charts/external-secrets/templates/_helpers.tpl
@@ -24,6 +24,17 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+Define namespace of chart, useful for multi-namespace deployments
+*/}}
+{{- define "external-secrets.namespace" -}}
+{{- if .Values.namespaceOverride }}
+{{- .Values.namespaceOverride }}
+{{- else }}
+{{- .Release.Namespace }}
+{{- end }}
+{{- end }}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "external-secrets.chart" -}}

--- a/deploy/charts/external-secrets/templates/cert-controller-deployment.yaml
+++ b/deploy/charts/external-secrets/templates/cert-controller-deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "external-secrets.fullname" . }}-cert-controller
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ template "external-secrets.namespace" . }}
   labels:
     {{- include "external-secrets-cert-controller.labels" . | nindent 4 }}
   {{- with .Values.certController.deploymentAnnotations }}
@@ -51,9 +51,9 @@ spec:
           - certcontroller
           - --crd-requeue-interval={{ .Values.certController.requeueInterval }}
           - --service-name={{ include "external-secrets.fullname" . }}-webhook
-          - --service-namespace={{ .Release.Namespace }}
+          - --service-namespace={{ template "external-secrets.namespace" . }}
           - --secret-name={{ include "external-secrets.fullname" . }}-webhook
-          - --secret-namespace={{ .Release.Namespace }}
+          - --secret-namespace={{ template "external-secrets.namespace" . }}
           - --metrics-addr=:{{ .Values.certController.metrics.listen.port }}
           - --healthz-addr={{ .Values.certController.readinessProbe.address }}:{{ .Values.certController.readinessProbe.port }}
           {{ if not .Values.crds.createClusterSecretStore -}}

--- a/deploy/charts/external-secrets/templates/cert-controller-poddisruptionbudget.yaml
+++ b/deploy/charts/external-secrets/templates/cert-controller-poddisruptionbudget.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "external-secrets.fullname" . }}-cert-controller-pdb
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ template "external-secrets.namespace" . }}
   labels:
     {{- include "external-secrets-cert-controller.labels" . | nindent 4 }}
 spec:

--- a/deploy/charts/external-secrets/templates/cert-controller-rbac.yaml
+++ b/deploy/charts/external-secrets/templates/cert-controller-rbac.yaml
@@ -73,6 +73,6 @@ roleRef:
   name: {{ include "external-secrets.fullname" . }}-cert-controller
 subjects:
   - name: {{ include "external-secrets-cert-controller.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace | quote }}
+    namespace: {{ template "external-secrets.namespace" . }}
     kind: ServiceAccount
 {{- end }}

--- a/deploy/charts/external-secrets/templates/cert-controller-service.yaml
+++ b/deploy/charts/external-secrets/templates/cert-controller-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "external-secrets.fullname" . }}-cert-controller-metrics
+  namespace: {{ template "external-secrets.namespace" . }}
   labels:
     {{- include "external-secrets.labels" . | nindent 4 }}
   {{- with .Values.metrics.service.annotations }}

--- a/deploy/charts/external-secrets/templates/cert-controller-serviceaccount.yaml
+++ b/deploy/charts/external-secrets/templates/cert-controller-serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "external-secrets-cert-controller.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ template "external-secrets.namespace" . }}
   labels:
     {{- include "external-secrets-cert-controller.labels" . | nindent 4 }}
     {{- with .Values.certController.serviceAccount.extraLabels }}

--- a/deploy/charts/external-secrets/templates/deployment.yaml
+++ b/deploy/charts/external-secrets/templates/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "external-secrets.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ template "external-secrets.namespace" . }}
   labels:
     {{- include "external-secrets.labels" . | nindent 4 }}
   {{- with .Values.deploymentAnnotations }}

--- a/deploy/charts/external-secrets/templates/poddisruptionbudget.yaml
+++ b/deploy/charts/external-secrets/templates/poddisruptionbudget.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "external-secrets.fullname" . }}-pdb
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ template "external-secrets.namespace" . }}
   labels:
     {{- include "external-secrets.labels" . | nindent 4 }}
 spec:

--- a/deploy/charts/external-secrets/templates/rbac.yaml
+++ b/deploy/charts/external-secrets/templates/rbac.yaml
@@ -220,14 +220,14 @@ roleRef:
   name: {{ include "external-secrets.fullname" . }}-controller
 subjects:
   - name: {{ include "external-secrets.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace | quote }}
+    namespace: {{ template "external-secrets.namespace" . }}
     kind: ServiceAccount
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "external-secrets.fullname" . }}-leaderelection
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ template "external-secrets.namespace" . }}
   labels:
     {{- include "external-secrets.labels" . | nindent 4 }}
 rules:
@@ -261,7 +261,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "external-secrets.fullname" . }}-leaderelection
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ template "external-secrets.namespace" . }}
   labels:
     {{- include "external-secrets.labels" . | nindent 4 }}
 roleRef:
@@ -271,7 +271,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "external-secrets.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace | quote }}
+    namespace: {{ template "external-secrets.namespace" . }}
 {{- if .Values.rbac.servicebindings.create }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/charts/external-secrets/templates/service.yaml
+++ b/deploy/charts/external-secrets/templates/service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "external-secrets.fullname" . }}-metrics
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ template "external-secrets.namespace" . }}
   labels:
     {{- include "external-secrets.labels" . | nindent 4 }}
   {{- with .Values.metrics.service.annotations }}

--- a/deploy/charts/external-secrets/templates/serviceaccount.yaml
+++ b/deploy/charts/external-secrets/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "external-secrets.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ template "external-secrets.namespace" . }}
   labels:
     {{- include "external-secrets.labels" . | nindent 4 }}
     {{- with .Values.serviceAccount.extraLabels }}

--- a/deploy/charts/external-secrets/templates/servicemonitor.yaml
+++ b/deploy/charts/external-secrets/templates/servicemonitor.yaml
@@ -24,7 +24,7 @@ metadata:
 {{ toYaml .Values.serviceMonitor.additionalLabels | indent 4 }}
 {{- end }}
   name: {{ include "external-secrets.fullname" . }}-metrics
-  namespace: {{ .Values.serviceMonitor.namespace | default template "external-secrets.namespace" . | quote }}
+  namespace: {{ .Values.serviceMonitor.namespace | default (include "external-secrets.namespace" .) | quote }}
 spec:
   selector:
     matchLabels:
@@ -72,7 +72,7 @@ metadata:
 {{ toYaml .Values.serviceMonitor.additionalLabels | indent 4 }}
 {{- end }}
   name: {{ include "external-secrets.fullname" . }}-webhook-metrics
-  namespace: {{ .Values.serviceMonitor.namespace | default template "external-secrets.namespace" . | quote }}
+  namespace: {{ .Values.serviceMonitor.namespace | default (include "external-secrets.namespace" .) | quote }}
 spec:
   selector:
     matchLabels:
@@ -121,7 +121,7 @@ metadata:
 {{ toYaml .Values.serviceMonitor.additionalLabels | indent 4 }}
 {{- end }}
   name: {{ include "external-secrets.fullname" . }}-cert-controller-metrics
-  namespace: {{ .Values.serviceMonitor.namespace | default template "external-secrets.namespace" . | quote }}
+  namespace: {{ .Values.serviceMonitor.namespace | default (include "external-secrets.namespace" .) | quote }}
 spec:
   selector:
     matchLabels:

--- a/deploy/charts/external-secrets/templates/servicemonitor.yaml
+++ b/deploy/charts/external-secrets/templates/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "external-secrets.fullname" . }}-metrics
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ template "external-secrets.namespace" . }}
   labels:
     {{- include "external-secrets.labels" . | nindent 4 }}
 spec:
@@ -24,14 +24,14 @@ metadata:
 {{ toYaml .Values.serviceMonitor.additionalLabels | indent 4 }}
 {{- end }}
   name: {{ include "external-secrets.fullname" . }}-metrics
-  namespace: {{ .Values.serviceMonitor.namespace | default .Release.Namespace | quote }}
+  namespace: {{ .Values.serviceMonitor.namespace | default template "external-secrets.namespace" . | quote }}
 spec:
   selector:
     matchLabels:
       {{- include "external-secrets.selectorLabels" . | nindent 6 }}
   namespaceSelector:
     matchNames:
-    - {{ .Release.Namespace | quote }}
+    - {{ template "external-secrets.namespace" . }}
   endpoints:
   - port: metrics
     interval: {{ .Values.serviceMonitor.interval }}
@@ -51,7 +51,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "external-secrets.fullname" . }}-webhook-metrics
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ template "external-secrets.namespace" . }}
   labels:
     {{- include "external-secrets-webhook-metrics.labels" . | nindent 4 }}
 spec:
@@ -72,14 +72,14 @@ metadata:
 {{ toYaml .Values.serviceMonitor.additionalLabels | indent 4 }}
 {{- end }}
   name: {{ include "external-secrets.fullname" . }}-webhook-metrics
-  namespace: {{ .Values.serviceMonitor.namespace | default .Release.Namespace | quote }}
+  namespace: {{ .Values.serviceMonitor.namespace | default template "external-secrets.namespace" . | quote }}
 spec:
   selector:
     matchLabels:
       {{- include "external-secrets-webhook-metrics.labels" . | nindent 6 }}
   namespaceSelector:
     matchNames:
-    - {{ .Release.Namespace | quote }}
+    - {{ template "external-secrets.namespace" . }}
   endpoints:
   - port: metrics
     interval: {{ .Values.serviceMonitor.interval }}
@@ -100,7 +100,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "external-secrets.fullname" . }}-cert-controller-metrics
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ template "external-secrets.namespace" . }}
   labels:
     {{- include "external-secrets-cert-controller-metrics.labels" . | nindent 4 }}
 spec:
@@ -121,14 +121,14 @@ metadata:
 {{ toYaml .Values.serviceMonitor.additionalLabels | indent 4 }}
 {{- end }}
   name: {{ include "external-secrets.fullname" . }}-cert-controller-metrics
-  namespace: {{ .Values.serviceMonitor.namespace | default .Release.Namespace | quote }}
+  namespace: {{ .Values.serviceMonitor.namespace | default template "external-secrets.namespace" . | quote }}
 spec:
   selector:
     matchLabels:
       {{- include "external-secrets-cert-controller-metrics.labels" . | nindent 6 }}
   namespaceSelector:
     matchNames:
-    - {{ .Release.Namespace | quote }}
+    - {{ template "external-secrets.namespace" . }}
   endpoints:
   - port: metrics
     interval: {{ .Values.serviceMonitor.interval }}

--- a/deploy/charts/external-secrets/templates/validatingwebhook.yaml
+++ b/deploy/charts/external-secrets/templates/validatingwebhook.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- end }}
   {{- if and .Values.webhook.certManager.enabled .Values.webhook.certManager.addInjectorAnnotations }}
   annotations:
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "external-secrets.fullname" . }}-webhook
+    cert-manager.io/inject-ca-from: {{ template "external-secrets.namespace" . }}/{{ include "external-secrets.fullname" . }}-webhook
   {{- end }}
 webhooks:
 - name: "validate.secretstore.external-secrets.io"
@@ -22,7 +22,7 @@ webhooks:
     scope:       "Namespaced"
   clientConfig:
     service:
-      namespace: {{ .Release.Namespace | quote }}
+      namespace: {{ template "external-secrets.namespace" . }}
       name: {{ include "external-secrets.fullname" . }}-webhook
       path: /validate-external-secrets-io-v1beta1-secretstore
   admissionReviewVersions: ["v1", "v1beta1"]
@@ -38,7 +38,7 @@ webhooks:
     scope:       "Cluster"
   clientConfig:
     service:
-      namespace: {{ .Release.Namespace | quote }}
+      namespace: {{ template "external-secrets.namespace" . }}
       name: {{ include "external-secrets.fullname" . }}-webhook
       path: /validate-external-secrets-io-v1beta1-clustersecretstore
   admissionReviewVersions: ["v1", "v1beta1"]
@@ -56,7 +56,7 @@ metadata:
     {{- end }}
   {{- if and .Values.webhook.certManager.enabled .Values.webhook.certManager.addInjectorAnnotations }}
   annotations:
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "external-secrets.fullname" . }}-webhook
+    cert-manager.io/inject-ca-from: {{ template "external-secrets.namespace" . }}/{{ include "external-secrets.fullname" . }}-webhook
   {{- end }}
 webhooks:
 - name: "validate.externalsecret.external-secrets.io"
@@ -68,7 +68,7 @@ webhooks:
     scope:       "Namespaced"
   clientConfig:
     service:
-      namespace: {{ .Release.Namespace | quote }}
+      namespace: {{ template "external-secrets.namespace" . }}
       name: {{ include "external-secrets.fullname" . }}-webhook
       path: /validate-external-secrets-io-v1beta1-externalsecret
   admissionReviewVersions: ["v1", "v1beta1"]

--- a/deploy/charts/external-secrets/templates/webhook-certificate.yaml
+++ b/deploy/charts/external-secrets/templates/webhook-certificate.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "external-secrets.fullname" . }}-webhook
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ template "external-secrets.namespace" . }}
   labels:
     {{- include "external-secrets-webhook.labels" . | nindent 4 }}
     external-secrets.io/component: webhook
@@ -16,8 +16,8 @@ spec:
   commonName: {{ include "external-secrets.fullname" . }}-webhook
   dnsNames:
     - {{ include "external-secrets.fullname" . }}-webhook
-    - {{ include "external-secrets.fullname" . }}-webhook.{{ .Release.Namespace }}
-    - {{ include "external-secrets.fullname" . }}-webhook.{{ .Release.Namespace }}.svc
+    - {{ include "external-secrets.fullname" . }}-webhook.{{ template "external-secrets.namespace" . }}
+    - {{ include "external-secrets.fullname" . }}-webhook.{{ template "external-secrets.namespace" . }}.svc
   issuerRef:
     {{- toYaml .Values.webhook.certManager.cert.issuerRef | nindent 4 }}
   {{- with .Values.webhook.certManager.cert.duration }}

--- a/deploy/charts/external-secrets/templates/webhook-deployment.yaml
+++ b/deploy/charts/external-secrets/templates/webhook-deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "external-secrets.fullname" . }}-webhook
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ template "external-secrets.namespace" . }}
   labels:
     {{- include "external-secrets-webhook.labels" . | nindent 4 }}
   {{- with .Values.webhook.deploymentAnnotations }}
@@ -50,7 +50,7 @@ spec:
           args:
           - webhook
           - --port={{ .Values.webhook.port }}
-          - --dns-name={{ include "external-secrets.fullname" . }}-webhook.{{ .Release.Namespace }}.svc
+          - --dns-name={{ include "external-secrets.fullname" . }}-webhook.{{ template "external-secrets.namespace" . }}.svc
           - --cert-dir={{ .Values.webhook.certDir }}
           - --check-interval={{ .Values.webhook.certCheckInterval }}
           - --metrics-addr=:{{ .Values.webhook.metrics.listen.port }}

--- a/deploy/charts/external-secrets/templates/webhook-poddisruptionbudget.yaml
+++ b/deploy/charts/external-secrets/templates/webhook-poddisruptionbudget.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "external-secrets.fullname" . }}-webhook-pdb
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ template "external-secrets.namespace" . }}
   labels:
     {{- include "external-secrets-webhook.labels" . | nindent 4 }}
     external-secrets.io/component: webhook

--- a/deploy/charts/external-secrets/templates/webhook-secret.yaml
+++ b/deploy/charts/external-secrets/templates/webhook-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "external-secrets.fullname" . }}-webhook
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ template "external-secrets.namespace" . }}
   labels:
     {{- include "external-secrets-webhook.labels" . | nindent 4 }}
     external-secrets.io/component: webhook

--- a/deploy/charts/external-secrets/templates/webhook-service.yaml
+++ b/deploy/charts/external-secrets/templates/webhook-service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "external-secrets.fullname" . }}-webhook
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ template "external-secrets.namespace" . }}
   labels:
     {{- include "external-secrets-webhook.labels" . | nindent 4 }}
     external-secrets.io/component: webhook

--- a/deploy/charts/external-secrets/templates/webhook-serviceaccount.yaml
+++ b/deploy/charts/external-secrets/templates/webhook-serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "external-secrets-webhook.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ template "external-secrets.namespace" . }}
   labels:
     {{- include "external-secrets-webhook.labels" . | nindent 4 }}
     {{- with .Values.webhook.serviceAccount.extraLabels }}

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -31,6 +31,7 @@ crds:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+namespaceOverride: ""
 
 # -- Additional labels added to all helm chart resources.
 commonLabels: {}


### PR DESCRIPTION
## Problem Statement

Adding helm value `namespaceOverride` to allow multi-namespace deployments (for umbrella charts)

## Proposed Changes

Add `namespaceOverride` value to `deploy/charts/external-secrets/values.yaml` and corresponding helper value to allow use self-provided namespace or default 

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
