### PR TITLE
Start the helm workflow when files in deploy/crds change

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -7,11 +7,11 @@ on:
       - release-*
     paths:
       - 'deploy/charts/**'
-      - 'deploy/crds'
+      - 'deploy/crds/**'
   pull_request:
     paths:
       - 'deploy/charts/**'
-      - 'deploy/crds'
+      - 'deploy/crds/**'
   workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
## Problem Statement

It seems the helm GitHub Actions workflow does not start when deploy/crd/bundle.yaml changes.
For example, it didn't run in https://github.com/external-secrets/external-secrets/pull/2884.

## Related Issue

Closes https://github.com/external-secrets/external-secrets/issues/3059

## Proposed Changes

Fix the paths.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
