### PR TITLE
Run unit tests on the main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     needs: detect-noop
-    if: needs.detect-noop.outputs.noop != 'true' && github.ref != 'refs/heads/main'
+    if: needs.detect-noop.outputs.noop != 'true'
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Problem Statement

Currently, we don't run the unit tests on the main branch, but this is a little problematic for Codecov since it implicitly relies on the main (default) branch to track the coverage over time. I'd like to run the unit tests and report the coverage to Codecov.

- https://app.codecov.io/gh/external-secrets/external-secrets
## Related Issue

N/A

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
