### PR TITLE
issue/3153 - added missing snapshots for Pulumi and Chef crd tests

### DIFF
--- a/deploy/charts/external-secrets/tests/__snapshot__/crds_test.yaml.snap
+++ b/deploy/charts/external-secrets/tests/__snapshot__/crds_test.yaml.snap
@@ -2075,6 +2075,49 @@ should match snapshot of default values:
                           required:
                             - vaultUrl
                           type: object
+                        chef:
+                          description: Chef configures this store to sync secrets with chef server
+                          properties:
+                            auth:
+                              description: Auth defines the information necessary to authenticate against chef Server
+                              properties:
+                                secretRef:
+                                  description: ChefAuthSecretRef holds secret references for chef server login credentials.
+                                  properties:
+                                    privateKeySecretRef:
+                                      description: SecretKey is the Signing Key in PEM format, used for authentication.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
+                                            defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
+                                            to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                  required:
+                                    - privateKeySecretRef
+                                  type: object
+                              required:
+                                - secretRef
+                              type: object
+                            serverUrl:
+                              description: ServerURL is the chef server URL used to connect to. If using orgs you should include your org in the url and terminate the url with a "/"
+                              type: string
+                            username:
+                              description: UserName should be the user ID on the chef server
+                              type: string
+                          required:
+                            - auth
+                            - serverUrl
+                            - username
+                          type: object
                         conjur:
                           description: Conjur configures this store to sync secrets using conjur provider
                           properties:
@@ -2864,6 +2907,51 @@ should match snapshot of default values:
                           required:
                             - region
                             - vault
+                          type: object
+                        pulumi:
+                          description: Pulumi configures this store to sync secrets using the Pulumi provider
+                          properties:
+                            accessToken:
+                              description: AccessToken is the access tokens to sign in to the Pulumi Cloud Console.
+                              properties:
+                                secretRef:
+                                  description: SecretRef is a reference to a secret containing the Pulumi API token.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
+                                        defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
+                                        to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                            apiUrl:
+                              default: https://api.pulumi.com
+                              description: APIURL is the URL of the Pulumi API.
+                              type: string
+                            environment:
+                              description: |-
+                                Environment are YAML documents composed of static key-value pairs, programmatic expressions,
+                                dynamically retrieved values from supported providers including all major clouds,
+                                and other Pulumi ESC environments.
+                                To create a new environment, visit https://www.pulumi.com/docs/esc/environments/ for more information.
+                              type: string
+                            organization:
+                              description: |-
+                                Organization are a space to collaborate on shared projects and stacks.
+                                To create a new organization, visit https://app.pulumi.com/ and click "New Organization".
+                              type: string
+                          required:
+                            - accessToken
+                            - environment
+                            - organization
                           type: object
                         scaleway:
                           description: Scaleway


### PR DESCRIPTION
## Problem Statement

Fixing failing Helm tests for crds due to missing snaps for Chef and Pulumi.

## Related Issue

Fixes #3153 

## Proposed Changes

Adding missing snaps for both crds.

```yaml
➜  external-secrets git:(issue/3153) make helm.test            
./hack/helm.generate.sh deploy/crds deploy/charts/external-secrets
21:34:22 [ OK ] Finished generating helm chart files

### Chart [ external-secrets ] deploy/charts/external-secrets/

 PASS  test cert controller deployment  deploy/charts/external-secrets/tests/cert_controller_test.yaml
 PASS  test controller deployment       deploy/charts/external-secrets/tests/controller_test.yaml
 PASS  test crds        deploy/charts/external-secrets/tests/crds_test.yaml
 PASS  test service monitor     deploy/charts/external-secrets/tests/service_monitor_test.yaml
 PASS  test webhook deployment  deploy/charts/external-secrets/tests/webhook_test.yaml

Charts:      1 passed, 1 total
Test Suites: 5 passed, 5 total
Tests:       39 passed, 39 total
Snapshot:    5 passed, 5 total
Time:        437.509589ms

```

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
