### PR TITLE
Set CODECOV_TOKEN to upload results from the upstream branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,8 @@ jobs:
 
       - name: Publish Unit Test Coverage
         uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044 # v4.0.1
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: unittests
           file: ./cover.out


### PR DESCRIPTION
## Problem Statement

See [the Slack message](https://kubernetes.slack.com/archives/C047LA9MUPJ/p1708300085013439) for the details. I'll merge this PR after setting the CODECOV_TOKEN secret.

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
