### PR TITLE
[typo] Changing date from `2023` to `2024` in mkdocs site

### DIFF
--- a/hack/api-docs/mkdocs.yml
+++ b/hack/api-docs/mkdocs.yml
@@ -25,8 +25,8 @@ plugins:
   - macros:
       include_dir: docs/snippets
 copyright: |
-  &copy; 2023 The external-secrets Authors.<br/>
-  &copy; 2023 The Linux Foundation. All rights reserved.<br/><br/>
+  &copy; 2024 The external-secrets Authors.<br/>
+  &copy; 2024 The Linux Foundation. All rights reserved.<br/><br/>
   The Linux Foundation has registered trademarks and uses trademarks.<br/>
   For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage/">Trademark Usage page</a>.
 extra:


### PR DESCRIPTION
## Problem Statement

Site's copyright was set as `2023`

This PR updates it to be `2024`

## Related Issue

Fixes #...

## Proposed Changes

Changing `2023` to `2024` in copyright footer 



## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
