### PR TITLE
Update Scaleway provider to use v1beta1 API version

### DIFF
--- a/pkg/provider/scaleway/client.go
+++ b/pkg/provider/scaleway/client.go
@@ -336,7 +336,7 @@ func (c *client) GetAllSecrets(ctx context.Context, ref esv1beta1.ExternalSecret
 		}
 
 		totalFetched := uint64(*request.Page-1)*uint64(*request.PageSize) + uint64(len(response.Secrets))
-		done = totalFetched == uint64(response.TotalCount)
+		done = totalFetched == response.TotalCount
 
 		*request.Page++
 

--- a/pkg/provider/scaleway/client.go
+++ b/pkg/provider/scaleway/client.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	smapi "github.com/scaleway/scaleway-sdk-go/api/secret/v1alpha1"
+	smapi "github.com/scaleway/scaleway-sdk-go/api/secret/v1beta1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 	"github.com/tidwall/gjson"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/provider/scaleway/fake_secret_api_test.go
+++ b/pkg/provider/scaleway/fake_secret_api_test.go
@@ -20,7 +20,7 @@ import (
 	"strconv"
 
 	"github.com/google/uuid"
-	smapi "github.com/scaleway/scaleway-sdk-go/api/secret/v1alpha1"
+	smapi "github.com/scaleway/scaleway-sdk-go/api/secret/v1beta1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 )
 
@@ -316,7 +316,7 @@ func (f *fakeSecretAPI) ListSecrets(request *smapi.ListSecretsRequest, _ ...scw.
 	// pagination
 
 	response := smapi.ListSecretsResponse{
-		TotalCount: uint32(len(matches)),
+		TotalCount: uint64(len(matches)),
 	}
 
 	if request.Page == nil || request.PageSize == nil {

--- a/pkg/provider/scaleway/provider.go
+++ b/pkg/provider/scaleway/provider.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"fmt"
 
-	smapi "github.com/scaleway/scaleway-sdk-go/api/secret/v1alpha1"
+	smapi "github.com/scaleway/scaleway-sdk-go/api/secret/v1beta1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 	"github.com/scaleway/scaleway-sdk-go/validation"
 	ctrl "sigs.k8s.io/controller-runtime"

--- a/pkg/provider/scaleway/secret_api.go
+++ b/pkg/provider/scaleway/secret_api.go
@@ -15,7 +15,7 @@ limitations under the License.
 package scaleway
 
 import (
-	smapi "github.com/scaleway/scaleway-sdk-go/api/secret/v1alpha1"
+	smapi "github.com/scaleway/scaleway-sdk-go/api/secret/v1beta1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 )
 


### PR DESCRIPTION
## Problem Statement

Scaleway has published a new version of the Secret Manager API.

## Related Issue

No related issue.

## Proposed Changes

Update to the new Secret Manager API version

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
