### PR TITLE
feat: Also publish helm chart to OCI registry (ghcr.io)

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
         with:
-          version: v3.4.2
+          version: v3.14.2 # remember to also update for the second job (release)
 
       - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
@@ -70,6 +70,7 @@ jobs:
   release:
     permissions:
       contents: write  # for helm/chart-releaser-action to push chart release and create a release
+      packages: write  # to push OCI chart package to GitHub Registry
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -111,3 +112,25 @@ jobs:
           charts_dir: deploy/charts
           skip_existing: true
           charts_repo_url: https://charts.external-secrets.io
+
+      - name: Set up Helm
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
+        with:
+          version: v3.14.2 # remember to also update for the first job (lint-and-test)
+
+      - name: Login to GHCR
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push chart to GHCR
+        run: |
+          shopt -s nullglob
+          for pkg in .cr-release-packages/*.tgz; do
+            if [ -z "${pkg:-}" ]; then
+              break
+            fi
+            helm push "${pkg}" "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/charts"
+          done


### PR DESCRIPTION
## Problem Statement

Also publish the helm chart to OCI registry. See already created issue for full background info:
- #3208

## Related Issue

Resolves #3208

## Proposed Changes

While here I also updated the very old helm binary (3.4.x) inside the release action (was released on Dec 9, 2020). Time to also update this, as it doesn't support OCI pushing.

Tested it on my fork (already merged on main branch of the fork):
https://github.com/mkilchhofer/external-secrets/actions/runs/8085801631
![grafik](https://github.com/external-secrets/external-secrets/assets/7290987/cb924ccc-2dec-4bb1-ba4f-7bfd02d2eccf)

Also like to mention that this piece of code is already in place on various helm chart publishing pipelines:
- [renovatebot/helm-charts](https://github.com/renovatebot/helm-charts/blob/5457a71d97e5318f3b5c152c332429ddf6a694a7/.github/workflows/release.yaml#L37-L44)
- [nextcloud/helm](https://github.com/nextcloud/helm/blob/9d560de6668ed393f8a8dfa84f5692352cf62ff3/.github/workflows/release.yaml#L39-L43)
- [cloudnative-pg/charts](https://github.com/cloudnative-pg/charts/blob/001d78758b864f8ffd42799f6f44760c0ca5a671/.github/workflows/release-publish.yml#L49)
- [argoproj/argo-helm](https://github.com/argoproj/argo-helm/blob/2f82fb5992fe1e390d1ebdbc4be6d5d6c6549a37/.github/configs/cr.yaml#L12)
- many more ;)

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
