### PR TITLE
Extract support for SDKMS provider

### DIFF
--- a/docs/provider/fortanix.md
+++ b/docs/provider/fortanix.md
@@ -26,6 +26,7 @@ spec:
 ### Referencing Secrets
 
 ```yaml
+# Raw stored value
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -36,15 +37,37 @@ spec:
     kind: SecretStore
     name: secret-store
   data:
-
-  # Raw stored value
   - secretKey: <KEY_IN_KUBE_SECRET>
     remoteRef:
       key: <SDKMS_SECURITY_OBJECT_NAME>
-
-  # From stored key-value JSON
+---
+# From stored key-value JSON
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: secret-from-property
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: SecretStore
+    name: secret-store
+  data:
   - secretKey: <KEY_IN_KUBE_SECRET>
     remoteRef:
       key: <SDKMS_SECURITY_OBJECT_NAME>
       property: <SECURITY_OBJECT_VALUE_INNER_PROPERTY>
+---
+# Extract all keys from stored key-value JSON
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: secret-from-extract
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: SecretStore
+    name: secret-store
+  dataFrom:
+  - extract:
+      key: <SDKMS_SECURITY_OBJECT_NAME>
 ```

--- a/pkg/provider/fortanix/fortanix.go
+++ b/pkg/provider/fortanix/fortanix.go
@@ -35,7 +35,6 @@ const (
 	errDeleteSecretsNotSupported     = "deleting secrets is currently not supported"
 	errUnmarshalSecret               = "unable to unmarshal secret, is it a valid JSON?: %w"
 	errUnableToGetValue              = "unable to get value for key %s"
-	errGettingSecretMapNotSupported  = "getting secret map is currently not supported"
 	errGettingAllSecretsNotSupported = "getting all secrets is currently not supported"
 )
 
@@ -74,6 +73,28 @@ func (c *client) GetSecret(ctx context.Context, ref esv1beta1.ExternalSecretData
 	return utils.GetByteValue(value)
 }
 
+func (c *client) GetSecretMap(ctx context.Context, ref esv1beta1.ExternalSecretDataRemoteRef) (map[string][]byte, error) {
+	data, err := c.GetSecret(ctx, ref)
+
+	if err != nil {
+		return nil, err
+	}
+
+	kv := make(map[string]string)
+	err = json.Unmarshal(data, &kv)
+
+	if err != nil {
+		return nil, fmt.Errorf(errUnmarshalSecret, err)
+	}
+
+	secretData := make(map[string][]byte)
+	for k, v := range kv {
+		secretData[k] = []byte(v)
+	}
+
+	return secretData, nil
+}
+
 func (c *client) PushSecret(_ context.Context, _ *corev1.Secret, _ esv1beta1.PushSecretData) error {
 	return errors.New(errPushSecretsNotSupported)
 }
@@ -84,10 +105,6 @@ func (c *client) DeleteSecret(_ context.Context, _ esv1beta1.PushSecretRemoteRef
 
 func (c *client) Validate() (esv1beta1.ValidationResult, error) {
 	return esv1beta1.ValidationResultReady, nil
-}
-
-func (c *client) GetSecretMap(_ context.Context, _ esv1beta1.ExternalSecretDataRemoteRef) (map[string][]byte, error) {
-	return nil, errors.New(errGettingSecretMapNotSupported)
 }
 
 func (c *client) GetAllSecrets(_ context.Context, _ esv1beta1.ExternalSecretFind) (map[string][]byte, error) {

--- a/pkg/provider/fortanix/fortanix.go
+++ b/pkg/provider/fortanix/fortanix.go
@@ -75,19 +75,17 @@ func (c *client) GetSecret(ctx context.Context, ref esv1beta1.ExternalSecretData
 
 func (c *client) GetSecretMap(ctx context.Context, ref esv1beta1.ExternalSecretDataRemoteRef) (map[string][]byte, error) {
 	data, err := c.GetSecret(ctx, ref)
-
 	if err != nil {
 		return nil, err
 	}
 
 	kv := make(map[string]string)
 	err = json.Unmarshal(data, &kv)
-
 	if err != nil {
 		return nil, fmt.Errorf(errUnmarshalSecret, err)
 	}
 
-	secretData := make(map[string][]byte)
+	secretData := make(map[string][]byte, len(kv))
 	for k, v := range kv {
 		secretData[k] = []byte(v)
 	}


### PR DESCRIPTION
## Problem Statement

Adding support for `dataFrom[*].extract` to SDKMS / Fortanix provider

## Proposed Changes

Implements `GetSecretMap()`

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
