### PR TITLE
fix: location of secruity context when updating deploying using Tilt

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -26,8 +26,8 @@ settings.update(read_yaml(
 objects = decode_yaml_stream(read_file('bin/deploy/manifests/external-secrets.yaml'))
 for o in objects:
     if o.get('kind') == 'Deployment' and o.get('metadata').get('name') in ['external-secrets-cert-controller', 'external-secrets', 'external-secrets-webhook']:
-        o['spec']['template']['spec']['securityContext'] = {'runAsNonRoot': False}
-        o['spec']['template']['spec']['imagePullPolicy'] = 'Always'
+        o['spec']['template']['spec']['containers'][0]['securityContext'] = {'runAsNonRoot': False, 'readOnlyRootFilesystem': False}
+        o['spec']['template']['spec']['containers'][0]['imagePullPolicy'] = 'Always'
         if settings.get('debug').get('enabled') and o.get('metadata').get('name') == 'external-secrets':
             o['spec']['template']['spec']['containers'][0]['ports'] = [{'containerPort': 30000}]
 


### PR DESCRIPTION
## Problem Statement

The wrong location was used when updating `secruityContext` which prevent hot-reloading from working giving the following error:

```
tar: can't remove old file external-secrets: Read-only file system
```

This is now fix by updating the right location, which is the first `container` in the deployment.

It could be something like :

```python
        for container in o['spec']['template']['spec']['containers']:
            if container['name'] in ['external-secrets', 'webhook', 'cert-controller']
```

But honestly, we'll change the container name first, before we ever introduce a second container, I think. :)

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
