### PR TITLE
issue/3262 - updated helm.tests with latest crds changes for passworddepot

### DIFF
--- a/deploy/charts/external-secrets/tests/__snapshot__/crds_test.yaml.snap
+++ b/deploy/charts/external-secrets/tests/__snapshot__/crds_test.yaml.snap
@@ -910,6 +910,46 @@ should match snapshot of default values:
                             - region
                             - vault
                           type: object
+                        passworddepot:
+                          description: Configures a store to sync secrets with a Password Depot instance.
+                          properties:
+                            auth:
+                              description: Auth configures how secret-manager authenticates with a Password Depot instance.
+                              properties:
+                                secretRef:
+                                  properties:
+                                    credentials:
+                                      description: Username / Password is used for authentication.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
+                                            defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
+                                            to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                  type: object
+                              required:
+                                - secretRef
+                              type: object
+                            database:
+                              description: Database to use as source
+                              type: string
+                            host:
+                              description: URL configures the Password Depot instance URL.
+                              type: string
+                          required:
+                            - auth
+                            - database
+                            - host
+                          type: object
                         vault:
                           description: Vault configures this store to sync secrets using Hashi provider
                           properties:
@@ -3004,6 +3044,46 @@ should match snapshot of default values:
                           required:
                             - region
                             - vault
+                          type: object
+                        passworddepot:
+                          description: Configures a store to sync secrets with a Password Depot instance.
+                          properties:
+                            auth:
+                              description: Auth configures how secret-manager authenticates with a Password Depot instance.
+                              properties:
+                                secretRef:
+                                  properties:
+                                    credentials:
+                                      description: Username / Password is used for authentication.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
+                                            defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
+                                            to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                  type: object
+                              required:
+                                - secretRef
+                              type: object
+                            database:
+                              description: Database to use as source
+                              type: string
+                            host:
+                              description: URL configures the Password Depot instance URL.
+                              type: string
+                          required:
+                            - auth
+                            - database
+                            - host
                           type: object
                         pulumi:
                           description: Pulumi configures this store to sync secrets using the Pulumi provider


### PR DESCRIPTION
## Problem Statement

Adding missing snapshots for passworddepot.

## Related Issue

Fixes #3262   

## Proposed Changes

Running `make helm.test.update` to update `crds_test.yaml.snap` to include latest changes for providers `passworddepot`.

```yaml
➜  external-secrets git:(issue/3262) make helm.test.update 
./hack/helm.generate.sh deploy/crds deploy/charts/external-secrets
21:33:56 [ OK ] Finished generating helm chart files

### Chart [ external-secrets ] deploy/charts/external-secrets/

 PASS  test cert controller deployment  deploy/charts/external-secrets/tests/cert_controller_test.yaml
 PASS  test controller deployment       deploy/charts/external-secrets/tests/controller_test.yaml
 PASS  test crds        deploy/charts/external-secrets/tests/crds_test.yaml
 PASS  test service monitor     deploy/charts/external-secrets/tests/service_monitor_test.yaml
 PASS  test webhook deployment  deploy/charts/external-secrets/tests/webhook_test.yaml

Charts:      1 passed, 1 total
Test Suites: 5 passed, 5 total
Tests:       39 passed, 39 total
Snapshot:    5 passed, 5 total
Time:        464.157082ms
```

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] Building the operator binary and docker image with `make build`
- [x] All tests pass with `make lint`
- [x] All tests pass with `make test`
- [x] All tests pass with `make check-diff`
- [x] All tests pass with `make docs`
- [x] All tests pass with `make helm.docs`
- [x] All tests pass with `make helm.test.update`
- [x] All tests pass with `make helm.test`
- [x] I ensured my PR is ready for review with `make reviewable`