### PR TITLE
Update all-keys-one-secret.md

### DIFF
--- a/docs/guides/all-keys-one-secret.md
+++ b/docs/guides/all-keys-one-secret.md
@@ -20,7 +20,7 @@ Now, when creating our ExternalSecret resource, instead of using the data field,
 ```
 Here, "example" is the name of the external secret that will be created in our cluster.    
 Whereas, "secret-to-be-created" is the name of Kubernetes secrets that will be created.    
-Note: Since these secrets are namespace-based resources, so you can also explicitly specify the "namespace" under the "metadata" block of the above external secret file.    
+Note: Since these secrets are namespace-based resources, you can also explicitly specify the "namespace" under the "metadata" block of the above external secret file.    
 when we use, 
 
 ```
@@ -50,7 +50,7 @@ We can pass a few secrets as env variables as below:
 Here,    
 \<key1\> and \<key2> are the names of keys that will be created and passed as env variables.    
 \<secret-to-be-created\>: is the name of your Kubernetes secret created by you.    
-\<username\> and \<password>: is the particular key in the secrets manager whose value you want to pass.    
+\<username\> and \<surname>: is the particular key in the secrets manager whose value you want to pass.    
 To check both values we can run:
 ```
 kubectl get secret secret-to-be-created -n <namespace> -o jsonpath='{.data.username}' | base64 -d

--- a/docs/guides/all-keys-one-secret.md
+++ b/docs/guides/all-keys-one-secret.md
@@ -9,7 +9,7 @@ Then create a secret in Google Cloud Secret Manager that contains a JSON string 
 ![secret-value](../pictures/screenshot_json_string_gcp_secret_value.png)
 
 Let's call this secret all-keys-example-secret on Google Cloud.
-
+ 
 
 ### Creating dataFrom external secret
 
@@ -18,10 +18,53 @@ Now, when creating our ExternalSecret resource, instead of using the data field,
 ```yaml
 {% include 'gcpsm-data-from-external-secret.yaml' %}
 ```
+Here, "example" is the name of the external secret that will be created in our cluster.    
+Whereas, "secret-to-be-created" is the name of Kubernetes secrets that will be created.    
+Note: Since these secrets are namespace-based resources, so you can also explicitly specify the "namespace" under the "metadata" block of the above external secret file.    
+when we use, 
 
+```
+  dataFrom:
+  - extract:
+      key: all-keys-example-secret
+```
+We get all the key-value pairs present over the remote secret store (GCP or AWS or Azure) and can pass either all or a few key-values as environment variables.    
+Please note that, "all-keys-example-secret" is the name of your secret present on GCP/AWS secrets manager/Azure    
+    
+We can pass a few secrets as env variables as below:
+```
+        env:
+          - name: key1
+            valueFrom:
+              secretKeyRef:
+                name: secret-to-be-created
+                key: username
+
+          - name: key2
+            valueFrom:
+              secretKeyRef:
+                name: secret-to-be-created
+                key: surname
+```
+ 
+Here,    
+\<key1\> and \<key2> are the names of keys that will be created and passed as env variables.    
+\<secret-to-be-created\>: is the name of your Kubernetes secret created by you.    
+\<username\> and \<password>: is the particular key in the secrets manager whose value you want to pass.    
 To check both values we can run:
-
 ```
 kubectl get secret secret-to-be-created -n <namespace> -o jsonpath='{.data.username}' | base64 -d
 kubectl get secret secret-to-be-created -n <namespace> -o jsonpath='{.data.surname}' | base64 -d
+```
+
+Also, if you have a large number of secrets and you want to pass all of them as enviromnent variables, then either you can replicate the above steps in your deployment file for all the keys or you can use the envFrom block as below:    
+
+```
+    spec:
+      containers:
+      - command:
+        - mkdir abc.sh
+        envFrom:
+        - secretRef:
+            name: secret-to-be-created
 ```


### PR DESCRIPTION
Signed-off-by: Mohit Bishesh mohitbishesh7@gmail.com

## Problem Statement

How a user using an external secrets operator can pass all the secrets or only a few as a key-value pair in the environment variables of his pod despite of that the key-values are stored either in the form of key-value or in the form of plain text over the remote secret like (GCP or AWS secrets manager or of Azure).

## Related Issue

Fixes #...
https://stackoverflow.com/questions/72487297/how-to-add-vault-secrets-to-kubernetes-env-vars 
## Proposed Changes
I had updated the readme.md file and explained

dataFrom:
  extract:
    key:
in more details

To pass a particular/all key-value secrets from the secrets manager as environment variables by adding an envFrom block in the spec of our container in the deployment file as below:

```yaml
spec:
  containers:
  - command:
    - mkdir ABC
  envFrom:
    - secretRef:
        name: 
```
How do you like to solve the issue and why?
I really want to solve this problem as recently I was working on a same use case of external secrets operator but I didn't find any proper explanation over the internet. I read different blogs, websites and even did some hit and trial and got the proper solution. I do not want someone else to face the same issues as it may stuck them and and kill their time
I feels, that after this update it will be very much useful for one using external secrets operator and understand it more easily as I have provided a detailed explanation for the same in a same page, so they will not even worry to look into multiple different pages.
## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
