### PR TITLE
Pulumi: Remove unwanted chars when extract secret

### DIFF
--- a/pkg/provider/pulumi/pulumi.go
+++ b/pkg/provider/pulumi/pulumi.go
@@ -79,7 +79,7 @@ func (c *client) GetSecretMap(ctx context.Context, ref esv1beta1.ExternalSecretD
 		return nil, fmt.Errorf(errGettingSecrets, ref.Key, err)
 	}
 
-	kv := make(map[string]json.RawMessage)
+	kv := make(map[string]interface{})
 	err = json.Unmarshal(data, &kv)
 	if err != nil {
 		return nil, fmt.Errorf(errUnmarshalSecret, err)

--- a/pkg/provider/pulumi/pulumi_test.go
+++ b/pkg/provider/pulumi/pulumi_test.go
@@ -86,19 +86,17 @@ func TestGetSecretMap(t *testing.T) {
 	tests := []struct {
 		name  string
 		ref   esv1beta1.ExternalSecretDataRemoteRef
-		input func() (esc2.Value, error)
+		input string
 
 		want    map[string][]byte
 		wantErr bool
 	}{
 		{
 			name: "successful case",
-			input: func() (esc2.Value, error) {
-				return esc2.FromJSON(`{"foo": "bar", "foobar": 42, "bar": {"foo": "bar"}}`, false)
-			},
 			ref: esv1beta1.ExternalSecretDataRemoteRef{
 				Key: "mysec",
 			},
+			input: `{"foo": "bar", "foobar": 42, "bar": {"foo": "bar"}}`,
 			want: map[string][]byte{
 				"foo":    []byte("bar"),
 				"foobar": []byte("42"),
@@ -110,9 +108,9 @@ func TestGetSecretMap(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := newTestClient(t, "", "", func(w http.ResponseWriter, r *http.Request) {
-				expected, err1 := tt.input()
+				esc2Input, err1 := esc2.FromJSON(tt.input, false)
 				require.NoError(t, err1)
-				err2 := json.NewEncoder(w).Encode(expected)
+				err2 := json.NewEncoder(w).Encode(esc2Input)
 				require.NoError(t, err2)
 			})
 			got, err := p.GetSecretMap(context.Background(), tt.ref)


### PR DESCRIPTION
Add TestGetSecretMap
Fixes #3332

## Problem Statement

When extracting secret with the pulumi provider, the extracted elements who are strings contains unwanted double quotes at the begining and at the end of the extracted secret. 

## Related Issue

Fixes #3332 

## Proposed Changes

This is due to `json.RawMessage` : With `interface{}`, the `GetByteValue` method correctly handle it and return the value without quotes.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
