### PR TITLE
Use grpc.NewClient instead of grpc.Dial

### DIFF
--- a/pkg/provider/yandex/common/sdk.go
+++ b/pkg/provider/yandex/common/sdk.go
@@ -57,7 +57,7 @@ func NewGrpcConnection(
 		return nil, err
 	}
 
-	return grpc.Dial(serviceAPIEndpoint.Address,
+	return grpc.NewClient(serviceAPIEndpoint.Address,
 		grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
 			Time:                time.Second * 30,


### PR DESCRIPTION
## Problem Statement

`grpc.Dial` is deprecated, so we should use `grpc.NewClient` instead, or the linter keeps failing...

- https://github.com/grpc/grpc-go/blob/a4afd4d995b0e60b9beb7b54923fa74ef97a5098/clientconn.go#L199-L204

## Related Issue

N/A

## Proposed Changes

Use `grpc.NewClient` instead

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
