### PR TITLE
Fix typo in webhook.md

### DIFF
--- a/docs/provider/webhook.md
+++ b/docs/provider/webhook.md
@@ -117,7 +117,7 @@ spec:
       # Add CAs here for the TLS handshake
       caBundle: <base64 encoded cabundle>
       caProvider:
-        type: Secret or COnfigMap
+        type: Secret or ConfigMap
         name: <name of secret or configmap>
         namespace: <namespace> # Only used in ClusterSecretStores
         key: <key inside secret>


### PR DESCRIPTION
## Problem Statement

There is a typo in webhook docs.

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
