### PR TITLE
Fix Azure Container Registry Generator invalid YAML

### DIFF
--- a/docs/snippets/generator-acr-example.yaml
+++ b/docs/snippets/generator-acr-example.yaml
@@ -22,7 +22,7 @@ spec:
             "auths": {
               "myregistry.azurecr.io": {
                 "username": "{{ .username }}",
-                "identitytoken": "{{ .password }}",
+                "identitytoken": "{{ .password }}"
               }
             }
           }


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?

The generator-acr-example.yaml contains extra `,` which is causing issue #3365 

## Related Issue

Fixes #3365 

## Proposed Changes

How do you like to solve the issue and why?

Removed `,`

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
