### PR TITLE
Helm externalObjects

### DIFF
--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -95,6 +95,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | extraArgs | object | `{}` |  |
 | extraContainers | list | `[]` |  |
 | extraEnv | list | `[]` |  |
+| extraObjects | list | `[]` | Array of extra K8s manifests to deploy |
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `""` |  |

--- a/deploy/charts/external-secrets/templates/extra-objects.yaml
+++ b/deploy/charts/external-secrets/templates/extra-objects.yaml
@@ -1,0 +1,8 @@
+{{ range .Values.extraObjects }}
+￼---
+{{ if typeIs "string" . }}
+    {{- tpl . $ }}
+{{- else }}
+    {{- tpl (toYaml .) $ }}
+{{- end }}
+{{ end }}

--- a/deploy/charts/external-secrets/templates/extra-objects.yaml
+++ b/deploy/charts/external-secrets/templates/extra-objects.yaml
@@ -1,5 +1,5 @@
 {{ range .Values.extraObjects }}
-￼---
+---
 {{ if typeIs "string" . }}
     {{- tpl . $ }}
 {{- else }}

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -498,3 +498,6 @@ dnsConfig: {}
 
 # -- Any extra pod spec on the deployment
 podSpecExtra: {}
+
+# -- Array of extra K8s manifests to deploy
+extraObjects: []


### PR DESCRIPTION
## Proposed Changes

Adding the extraObject field in the Helm chart such that additional resources can be injected in the Helm chart from the values.yaml file.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
