### PR TITLE
Methods for managing securityContext and OpenShift support

### DIFF
--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -58,7 +58,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | certController.podAnnotations | object | `{}` | Annotations to add to Pod |
 | certController.podDisruptionBudget | object | `{"enabled":false,"minAvailable":1}` | Pod disruption budget - for more details see https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
 | certController.podLabels | object | `{}` |  |
-| certController.podSecurityContext | object | `{}` |  |
+| certController.podSecurityContext.enabled | bool | `true` |  |
 | certController.priorityClassName | string | `""` | Pod priority class name. |
 | certController.rbac.create | bool | `true` | Specifies whether role and rolebinding resources should be created. |
 | certController.readinessProbe.address | string | `""` | Address for readiness probe |
@@ -69,6 +69,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | certController.revisionHistoryLimit | int | `10` | Specifies the amount of historic ReplicaSets k8s should keep (see https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy) |
 | certController.securityContext.allowPrivilegeEscalation | bool | `false` |  |
 | certController.securityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| certController.securityContext.enabled | bool | `true` |  |
 | certController.securityContext.readOnlyRootFilesystem | bool | `true` |  |
 | certController.securityContext.runAsNonRoot | bool | `true` |  |
 | certController.securityContext.runAsUser | int | `1000` |  |
@@ -95,11 +96,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | extraArgs | object | `{}` |  |
 | extraContainers | list | `[]` |  |
 | extraEnv | list | `[]` |  |
-| extraObjects | list | `[]` | Extra Kubernetes manifests to deploy with the chart |
+| extraObjects | list | `[]` |  |
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | global.affinity | object | `{}` |  |
+| global.compatibility.openshift.adaptSecurityContext | string | `"auto"` | Manages the securityContext properties to make them compatible with OpenShift. Possible values: auto - Apply configurations if it is detected that OpenShift is the target platform. force - Always apply configurations. disabled - No modification applied. |
 | global.nodeSelector | object | `{}` |  |
 | global.tolerations | list | `[]` |  |
 | global.topologySpreadConstraints | list | `[]` |  |
@@ -121,7 +123,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | podAnnotations | object | `{}` | Annotations to add to Pod |
 | podDisruptionBudget | object | `{"enabled":false,"minAvailable":1}` | Pod disruption budget - for more details see https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
 | podLabels | object | `{}` |  |
-| podSecurityContext | object | `{}` |  |
+| podSecurityContext.enabled | bool | `true` |  |
 | podSpecExtra | object | `{}` | Any extra pod spec on the deployment |
 | priorityClassName | string | `""` | Pod priority class name. |
 | processClusterExternalSecret | bool | `true` | if true, the operator will process cluster external secret. Else, it will ignore them. |
@@ -136,6 +138,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | scopedRBAC | bool | `false` | Must be used with scopedNamespace. If true, create scoped RBAC roles under the scoped namespace and implicitly disable cluster stores and cluster external secrets |
 | securityContext.allowPrivilegeEscalation | bool | `false` |  |
 | securityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| securityContext.enabled | bool | `true` |  |
 | securityContext.readOnlyRootFilesystem | bool | `true` |  |
 | securityContext.runAsNonRoot | bool | `true` |  |
 | securityContext.runAsUser | int | `1000` |  |
@@ -191,7 +194,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | webhook.podAnnotations | object | `{}` | Annotations to add to Pod |
 | webhook.podDisruptionBudget | object | `{"enabled":false,"minAvailable":1}` | Pod disruption budget - for more details see https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
 | webhook.podLabels | object | `{}` |  |
-| webhook.podSecurityContext | object | `{}` |  |
+| webhook.podSecurityContext.enabled | bool | `true` |  |
 | webhook.port | int | `10250` | The port the webhook will listen to |
 | webhook.priorityClassName | string | `""` | Pod priority class name. |
 | webhook.rbac.create | bool | `true` | Specifies whether role and rolebinding resources should be created. |
@@ -203,6 +206,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | webhook.secretAnnotations | object | `{}` | Annotations to add to Secret |
 | webhook.securityContext.allowPrivilegeEscalation | bool | `false` |  |
 | webhook.securityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| webhook.securityContext.enabled | bool | `true` |  |
 | webhook.securityContext.readOnlyRootFilesystem | bool | `true` |  |
 | webhook.securityContext.runAsNonRoot | bool | `true` |  |
 | webhook.securityContext.runAsUser | int | `1000` |  |

--- a/deploy/charts/external-secrets/templates/_helpers.tpl
+++ b/deploy/charts/external-secrets/templates/_helpers.tpl
@@ -155,6 +155,7 @@ Determine the image to use, including if using a flavour.
 {{- end }}
 {{- end }}
 
+<<<<<<< HEAD
 
 {{/*
 Renders a complete tree, even values that contains template.
@@ -166,3 +167,35 @@ Renders a complete tree, even values that contains template.
     {{- tpl (.value | toYaml) .context }}
   {{- end }}
 {{- end -}}
+=======
+{{/* 
+Return true if the OpenShift is the detected platform
+Usage:
+{{- include "external-secrets.isOpenShift" . -}}
+*/}}
+{{- define "external-secrets.isOpenShift" -}}
+{{- if .Capabilities.APIVersions.Has "security.openshift.io/v1" -}}
+{{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Render the securityContext based on the provided securityContext
+  {{- include "external-secrets.renderSecurityContext" (dict "securityContext" .Values.securityContext "context" $) -}}
+*/}}
+{{- define "external-secrets.renderSecurityContext" -}}
+{{- $adaptedContext := .securityContext -}}
+{{- if .context.Values.global.compatibility -}}
+  {{- if .context.Values.global.compatibility.openshift -}}
+    {{- if or (eq .context.Values.global.compatibility.openshift.adaptSecurityContext "force") (and (eq .context.Values.global.compatibility.openshift.adaptSecurityContext "auto") (include "external-secrets.isOpenShift" .context)) -}}
+      {{/* Remove OpenShift managed fields */}}
+      {{- $adaptedContext = omit $adaptedContext "fsGroup" "runAsUser" "runAsGroup" -}}
+      {{- if not .securityContext.seLinuxOptions -}}
+        {{- $adaptedContext = omit $adaptedContext "seLinuxOptions" -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- omit $adaptedContext "enabled" | toYaml -}}
+{{- end -}}
+>>>>>>> 2218c78b (Methods for managing securityContext and OpenShift support)

--- a/deploy/charts/external-secrets/templates/cert-controller-deployment.yaml
+++ b/deploy/charts/external-secrets/templates/cert-controller-deployment.yaml
@@ -35,15 +35,19 @@ spec:
       serviceAccountName: {{ include "external-secrets-cert-controller.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.certController.serviceAccount.automount }}
       {{- with .Values.certController.podSecurityContext }}
+       {{- if and (.enabled) (gt (keys . | len) 1) }}
       securityContext:
-        {{- toYaml . | nindent 8 }}
+        {{- include "external-secrets.renderSecurityContext" (dict "securityContext" . "context" $) | nindent 8 }}
+      {{- end }}
       {{- end }}
       hostNetwork: {{ .Values.certController.hostNetwork }}
       containers:
         - name: cert-controller
           {{- with .Values.certController.securityContext }}
+          {{- if and (.enabled) (gt (keys . | len) 1) }}
           securityContext:
-            {{- toYaml . | nindent 12 }}
+            {{- include "external-secrets.renderSecurityContext" (dict "securityContext" . "context" $) | nindent 12 }}
+          {{- end }}
           {{- end }}
           image: {{ include "external-secrets.image" (dict "chartAppVersion" .Chart.AppVersion "image" .Values.certController.image) | trim }}
           imagePullPolicy: {{ .Values.certController.image.pullPolicy }}

--- a/deploy/charts/external-secrets/templates/deployment.yaml
+++ b/deploy/charts/external-secrets/templates/deployment.yaml
@@ -35,15 +35,19 @@ spec:
       serviceAccountName: {{ include "external-secrets.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
       {{- with .Values.podSecurityContext }}
+      {{- if and (.enabled) (gt (keys . | len) 1) }}
       securityContext:
-        {{- toYaml . | nindent 8 }}
+        {{- include "external-secrets.renderSecurityContext" (dict "securityContext" . "context" $) | nindent 8 }}
+      {{- end }}
       {{- end }}
       hostNetwork: {{ .Values.hostNetwork }}
       containers:
         - name: {{ .Chart.Name }}
           {{- with .Values.securityContext }}
+           {{- if and (.enabled) (gt (keys . | len) 1) }}
           securityContext:
-            {{- toYaml . | nindent 12 }}
+            {{- include "external-secrets.renderSecurityContext" (dict "securityContext" . "context" $) | nindent 12 }}
+          {{- end }}
           {{- end }}
           image: {{ include "external-secrets.image" (dict "chartAppVersion" .Chart.AppVersion "image" .Values.image) | trim }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/deploy/charts/external-secrets/templates/webhook-deployment.yaml
+++ b/deploy/charts/external-secrets/templates/webhook-deployment.yaml
@@ -36,14 +36,18 @@ spec:
       serviceAccountName: {{ include "external-secrets-webhook.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.webhook.serviceAccount.automount }}
       {{- with .Values.webhook.podSecurityContext }}
+      {{- if and (.enabled) (gt (keys . | len) 1) }}
       securityContext:
-        {{- toYaml . | nindent 8 }}
+        {{- include "external-secrets.renderSecurityContext" (dict "securityContext" . "context" $) | nindent 8 }}
+      {{- end }}
       {{- end }}
       containers:
         - name: webhook
           {{- with .Values.webhook.securityContext }}
+          {{- if and (.enabled) (gt (keys . | len) 1) }}
           securityContext:
-            {{- toYaml . | nindent 12 }}
+            {{- include "external-secrets.renderSecurityContext" (dict "securityContext" . "context" $) | nindent 12 }}
+          {{- end }}
           {{- end }}
           image: {{ include "external-secrets.image" (dict "chartAppVersion" .Chart.AppVersion "image" .Values.webhook.image) | trim }}
           imagePullPolicy: {{ .Values.webhook.image.pullPolicy }}

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -3,6 +3,14 @@ global:
   tolerations: []
   topologySpreadConstraints: []
   affinity: {}
+  compatibility:
+    openshift:
+      # -- Manages the securityContext properties to make them compatible with OpenShift.
+      # Possible values:
+      # auto - Apply configurations if it is detected that OpenShift is the target platform.
+      # force - Always apply configurations.
+      # disabled - No modification applied.
+      adaptSecurityContext: auto
 
 replicaCount: 1
 
@@ -131,7 +139,8 @@ podAnnotations: {}
 
 podLabels: {}
 
-podSecurityContext: {}
+podSecurityContext:
+  enabled: true
   # fsGroup: 2000
 
 securityContext:
@@ -139,6 +148,7 @@ securityContext:
   capabilities:
     drop:
       - ALL
+  enabled: true
   readOnlyRootFilesystem: true
   runAsNonRoot: true
   runAsUser: 1000
@@ -364,7 +374,8 @@ webhook:
 
   podLabels: {}
 
-  podSecurityContext: {}
+  podSecurityContext:
+    enabled: true
       # fsGroup: 2000
 
   securityContext:
@@ -372,6 +383,7 @@ webhook:
     capabilities:
       drop:
         - ALL
+    enabled: true
     readOnlyRootFilesystem: true
     runAsNonRoot: true
     runAsUser: 1000
@@ -477,7 +489,8 @@ certController:
 
   podLabels: {}
 
-  podSecurityContext: {}
+  podSecurityContext:
+    enabled: true
       # fsGroup: 2000
 
   securityContext:
@@ -485,6 +498,7 @@ certController:
     capabilities:
       drop:
         - ALL
+    enabled: true
     readOnlyRootFilesystem: true
     runAsNonRoot: true
     runAsUser: 1000


### PR DESCRIPTION
## Problem Statement

Enhanced `securityContext` customizations with specific considerations for OpenShift

## Proposed Changes

Provided new Helm partial that provides enhancements for managing `securityContext` values. Supports removing fields set automatically by OpenShift

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
