### PR TITLE
Improve bitwarden example

### DIFF
--- a/docs/snippets/bitwarden-secret-store.yaml
+++ b/docs/snippets/bitwarden-secret-store.yaml
@@ -34,4 +34,14 @@ spec:
       url: "http://bitwarden-cli:8087/object/item/{{ .remoteRef.key }}"
       result:
         jsonPath: "$.data.notes"
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: bitwarden-attachments
+spec:
+  provider:
+    webhook:
+      url: "http://bitwarden-cli:8087/object/attachment/{{ .remoteRef.property }}?itemid={{ .remoteRef.key }}"
+      result: {}
 {% endraw %}

--- a/docs/snippets/bitwarden-secret.yaml
+++ b/docs/snippets/bitwarden-secret.yaml
@@ -2,11 +2,11 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: my-db-secrets
+  name: my-secrets
   namespace: default
 spec:
   target:
-    name: my-db-secrets
+    name: my-secrets
     deletionPolicy: Delete
     template:
       type: Opaque
@@ -23,6 +23,8 @@ spec:
           postgresql://{{ .username }}:{{ .password }}@my-postgresql:5432/mydb
         service_account_key: |-
           {{ .service_account_key }}
+        ssh_pub_key: |-
+          {{ .ssh_pub_key }}
   data:
     - secretKey: username
       sourceRef:
@@ -63,4 +65,12 @@ spec:
           kind: ClusterSecretStore  # or SecretStore
       remoteRef:
         key: service_account_key
+    - secretKey: ssh_pub_key
+      sourceRef:
+        storeRef:
+          name: bitwarden-attachments
+          kind: ClusterSecretStore  # or SecretStore
+      remoteRef:
+        key: aaaabbbb-cccc-dddd-eeee-000011112222
+        property: id_rsa.pub
 {% endraw %}

--- a/hack/api-docs/mkdocs.yml
+++ b/hack/api-docs/mkdocs.yml
@@ -73,8 +73,8 @@ nav:
       - Find Secrets by Name or Metadata: guides/getallsecrets.md
       - Rewriting Keys: guides/datafrom-rewrite.md
       - Advanced Templating:
-          v2: guides/templating.md
-          v1: guides/templating-v1.md
+        - v2: guides/templating.md
+        - v1: guides/templating-v1.md
       - Kubernetes Secret Types: guides/common-k8s-secret-types.md
       - "Lifecycle: ownership & deletion": guides/ownership-deletion-policy.md
       - Decoding Strategies: guides/decoding-strategy.md


### PR DESCRIPTION
## Problem Statement

No specific problem

## Related Issue

No related isssue

## Proposed Changes

This PR improves the bitwarden example documentation by introducing a new (Cluster)SecretStore that is able to fetch attachments from Bitwarden. This is useful for fetching files like SSH keys for example. I also improved the grammar and spelling in the docs.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`

# Additional information

I could not run `make docs.serve` until I modified the `mkdocs.yaml` file. It had invalid keys that I also fixed in this PR. 
Furthermore, I could not run `make test` or `make reviewable` as yq gives me the following error:
```
usage: yq [-h] [--yaml-output] [--yaml-roundtrip]
          [--yaml-output-grammar-version {1.1,1.2}] [--width WIDTH]
          [--indentless-lists] [--explicit-start] [--explicit-end]
          [--in-place] [--version]
          [jq_filter] [files ...]
yq: error: argument files: can't open '.spec.conversion.strategy = "Webhook" | .spec.conversion.webhook.conversionReviewVersions = ["v1"] | .spec.conversion.webhook.clientConfig.service.name = "kubernetes" | .spec.conversion.webhook.clientConfig.service.namespace = "default" |       .spec.conversion.webhook.clientConfig.service.path = "/convert"': [Errno 36] File name too long: '.spec.conversion.strategy = "Webhook" | .spec.conversion.webhook.conversionReviewVersions = ["v1"] | .spec.conversion.webhook.clientConfig.service.name = "kubernetes" | .spec.conversion.webhook.clientConfig.service.namespace = "default" |\t.spec.conversion.webhook.clientConfig.service.path = "/convert"'
make: *** [Makefile:136: generate] Error 2
```
