### PR TITLE
Add githubaccesstoken CRD to kustomization.yaml

### DIFF
--- a/config/crds/bases/kustomization.yaml
+++ b/config/crds/bases/kustomization.yaml
@@ -13,3 +13,5 @@ resources:
   - generators.external-secrets.io_gcraccesstokens.yaml
   - generators.external-secrets.io_githubaccesstokens.yaml
   - generators.external-secrets.io_passwords.yaml
+  - generators.external-secrets.io_vaultdynamicsecrets.yaml
+  - generators.external-secrets.io_webhooks.yaml

--- a/config/crds/bases/kustomization.yaml
+++ b/config/crds/bases/kustomization.yaml
@@ -11,4 +11,5 @@ resources:
   - generators.external-secrets.io_ecrauthorizationtokens.yaml
   - generators.external-secrets.io_fakes.yaml
   - generators.external-secrets.io_gcraccesstokens.yaml
+  - generators.external-secrets.io_githubaccesstokens.yaml
   - generators.external-secrets.io_passwords.yaml

--- a/hack/crd.generate.sh
+++ b/hack/crd.generate.sh
@@ -15,6 +15,11 @@ go run sigs.k8s.io/controller-tools/cmd/controller-gen crd \
   paths="./apis/..." \
   output:crd:artifacts:config="${CRD_DIR}/bases"
 
+## Update resources list from kustomization.yaml
+ls "${CRD_DIR}"/bases | grep -v "kustomization.yaml" | jq -R -s -c 'split("\n")[:-1]' | yq -p=json - > kustomize-files.yaml
+yq -i '.resources = (load("kustomize-files.yaml"))' "${CRD_DIR}"/bases/kustomization.yaml
+rm kustomize-files.yaml
+
 # Remove extra header lines in generated CRDs
 # This is needed for building the helm chart
 for f in "${CRD_DIR}"/bases/*.yaml; do


### PR DESCRIPTION
## Problem Statement

The file `generators.external-secrets.io_githubaccesstokens.yaml` is not included in the `kustomization.yaml` file, so the CRD `GithubAppToken` is not installed through Kustomize.

## Related Issue

Fixes https://github.com/external-secrets/external-secrets/issues/3448

## Proposed Changes

- Adding `generators.external-secrets.io_githubaccesstokens.yaml` to `kustomization.yaml` file

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
