### PR TITLE
fix: add dnsPolicy to Deployment

### DIFF
--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -92,6 +92,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | createOperator | bool | `true` | Specifies whether an external secret operator deployment be created. |
 | deploymentAnnotations | object | `{}` | Annotations to add to Deployment |
 | dnsConfig | object | `{}` | Specifies `dnsOptions` to deployment |
+| dnsPolicy | string | `"ClusterFirst"` | Specifies `dnsPolicy` to deployment |
 | extendedMetricLabels | bool | `false` | If true external secrets will use recommended kubernetes annotations as prometheus metric labels. |
 | extraArgs | object | `{}` |  |
 | extraContainers | list | `[]` |  |

--- a/deploy/charts/external-secrets/templates/deployment.yaml
+++ b/deploy/charts/external-secrets/templates/deployment.yaml
@@ -110,6 +110,7 @@ spec:
         {{- if .Values.extraContainers }}
           {{ toYaml .Values.extraContainers | nindent 8}}
         {{- end }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
       {{- if .Values.dnsConfig }}
       dnsConfig:
           {{- toYaml .Values.dnsConfig | nindent 8 }}

--- a/deploy/charts/external-secrets/tests/__snapshot__/controller_test.yaml.snap
+++ b/deploy/charts/external-secrets/tests/__snapshot__/controller_test.yaml.snap
@@ -49,5 +49,6 @@ should match snapshot of default values:
                 runAsUser: 1000
                 seccompProfile:
                   type: RuntimeDefault
+          dnsPolicy: ClusterFirst
           hostNetwork: false
           serviceAccountName: RELEASE-NAME-external-secrets

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -510,6 +510,9 @@ certController:
       #   cpu: 10m
       #   memory: 32Mi
 
+# -- Specifies `dnsPolicy` to deployment
+dnsPolicy: ClusterFirst
+
 # -- Specifies `dnsOptions` to deployment
 dnsConfig: {}
 


### PR DESCRIPTION
## Problem Statement

For now, `dnsPolicy` is not optional for Deployment. This is needed when we want to deploy external-secrets on Fargate.

## Related Issue

Fixes #...

## Proposed Changes

This MR makes `dnsPolicy` parameter optional for the Deployment resource.

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] My changes have reasonable test coverage
- [X] All tests pass with `make test`
- [X] I ensured my PR is ready for review with `make reviewable`
