### PR TITLE
Start reconciliation when a secret has changed

### DIFF
--- a/pkg/controllers/externalsecret/externalsecret_controller_test.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller_test.go
@@ -50,7 +50,7 @@ var (
 	fakeProvider   *fake.Client
 	metric         dto.Metric
 	metricDuration dto.Metric
-	timeout        = time.Second * 10
+	timeout        = time.Second * 20
 	interval       = time.Millisecond * 250
 )
 

--- a/pkg/controllers/externalsecret/suite_test.go
+++ b/pkg/controllers/externalsecret/suite_test.go
@@ -90,7 +90,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&Reconciler{
-		Client:                    k8sClient,
+		Client:                    k8sManager.GetClient(),
 		RestConfig:                cfg,
 		Scheme:                    k8sManager.GetScheme(),
 		Log:                       ctrl.Log.WithName("controllers").WithName("ExternalSecrets"),


### PR DESCRIPTION
## Problem Statement

We used to use `Owns(&v1.Secret{}, builder.OnlyMetadata)` in the SetupWithManager method, [but depending on the creation policy, we don't set an owner reference](https://github.com/external-secrets/external-secrets/blob/c73eee267afb8ea707b8b7e11be3adff01282822/pkg/controllers/externalsecret/externalsecret_controller.go#L253). As a result, when users use a creation policy except for Owner, reconciliation does not start even if a secret has changed.

## Related Issue

N/A

## Proposed Changes

Use Watches with a custom field indexer to get the secret effectively.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
