### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -13,7 +13,7 @@ The default install options will automatically install and manage the CRDs as pa
 
 You can install those CRDs outside of `helm` using:
 ```bash
-kubectl apply -k "https://github.com/external-secrets/external-secrets//config/crds/bases?ref=v0.9.17"
+kubectl apply -k "https://github.com/external-secrets/external-secrets//config/crds/bases?ref=<replace_with_your_version>"
 ```
 
 Uncomment the relevant line in the next steps to disable the automatic install of CRDs.

--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -13,7 +13,7 @@ The default install options will automatically install and manage the CRDs as pa
 
 You can install those CRDs outside of `helm` using:
 ```bash
-kubectl apply -k "https://github.com/external-secrets/external-secrets//config/crds/bases?ref=v0.9.11"
+kubectl apply -k "https://github.com/external-secrets/external-secrets//config/crds/bases?ref=v0.9.17"
 ```
 
 Uncomment the relevant line in the next steps to disable the automatic install of CRDs.


### PR DESCRIPTION
Bump crds tag from v0.9.11 to v0.9.17

## Problem Statement

The CRDs installed are from a older version than the Helm chart installed in the next step.

Fixes #3462 
