### PR TITLE
Raise error when unknown key specified in template

### DIFF
--- a/docs/guides/templating-v1.md
+++ b/docs/guides/templating-v1.md
@@ -5,7 +5,9 @@
     Templating Engine v1 is **deprecated** and will be removed in the future. Please migrate to engine v2 and take a look at our [upgrade guide](templating.md#migrating-from-v1) for changes.
 
 
-With External Secrets Operator you can transform the data from the external secret provider before it is stored as `Kind=Secret`. You can do this with the `Spec.Target.Template`. Each data value is interpreted as a [golang template](https://golang.org/pkg/text/template/).
+With External Secrets Operator you can transform the data from the external secret provider before it is stored as `Kind=Secret`. You can do this with the `Spec.Target.Template`.
+
+Each data value is interpreted as a [Go template](https://golang.org/pkg/text/template/). Please note that referencing a non-existing key in the template will raise an error, instead of being suppressed.
 
 ## Examples
 

--- a/docs/guides/templating.md
+++ b/docs/guides/templating.md
@@ -1,6 +1,8 @@
 # Advanced Templating v2
 
-With External Secrets Operator you can transform the data from the external secret provider before it is stored as `Kind=Secret`. You can do this with the `Spec.Target.Template`. Each data value is interpreted as a [golang template](https://golang.org/pkg/text/template/).
+With External Secrets Operator you can transform the data from the external secret provider before it is stored as `Kind=Secret`. You can do this with the `Spec.Target.Template`.
+
+Each data value is interpreted as a [Go template](https://golang.org/pkg/text/template/). Please note that referencing a non-existing key in the template will raise an error, instead of being suppressed.
 
 !!! note
 

--- a/pkg/template/v1/template.go
+++ b/pkg/template/v1/template.go
@@ -89,6 +89,7 @@ func Execute(tpl, data map[string][]byte, _ esapi.TemplateScope, _ esapi.Templat
 
 func execute(k, val string, data map[string][]byte) ([]byte, error) {
 	t, err := tpl.New(k).
+		Option("missingkey=error").
 		Funcs(tplFuncs).
 		Parse(val)
 	if err != nil {

--- a/pkg/template/v1/template_test.go
+++ b/pkg/template/v1/template_test.go
@@ -294,6 +294,14 @@ func TestExecute(t *testing.T) {
 			expErr: "unable to parse template",
 		},
 		{
+			name: "unknown key error",
+			tpl: map[string][]byte{
+				"key": []byte(`{{ .unknown }}`),
+			},
+			data:   map[string][]byte{},
+			expErr: "unable to execute template at key key",
+		},
+		{
 			name: "jwk rsa pub pem",
 			tpl: map[string][]byte{
 				"fn": []byte(`{{ .secret | jwkPublicKeyPem }}`),

--- a/pkg/template/v2/template.go
+++ b/pkg/template/v2/template.go
@@ -139,6 +139,7 @@ func execute(k, val string, data map[string][]byte) ([]byte, error) {
 	}
 
 	t, err := tpl.New(k).
+		Option("missingkey=error").
 		Funcs(tplFuncs).
 		Parse(val)
 	if err != nil {

--- a/pkg/template/v2/template_test.go
+++ b/pkg/template/v2/template_test.go
@@ -370,6 +370,14 @@ func TestExecute(t *testing.T) {
 			expErr: "unable to parse template",
 		},
 		{
+			name: "unknown key error",
+			tpl: map[string][]byte{
+				"key": []byte(`{{ .unknown }}`),
+			},
+			data:   map[string][]byte{},
+			expErr: "unable to execute template at key key",
+		},
+		{
 			name: "jwk rsa pub pem",
 			tpl: map[string][]byte{
 				"fn": []byte(`{{ .secret | jwkPublicKeyPem }}`),


### PR DESCRIPTION
## Problem Statement

While working on the template, I noticed if I specify a non-existent key in the template, the reconciliation succeeds and inserts value `<no value>`. This behavior seems quite error-prone since users could accidentally insert base64 encoded `<no value>` to their secret value.

## Related Issue

N/A

## Proposed Changes

Use the `missingkey=error` option for the go template to raise the error.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
