### PR TITLE
Fix flaky ES controller test

### DIFF
--- a/pkg/controllers/externalsecret/externalsecret_controller_test.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller_test.go
@@ -50,7 +50,7 @@ var (
 	fakeProvider   *fake.Client
 	metric         dto.Metric
 	metricDuration dto.Metric
-	timeout        = time.Second * 20
+	timeout        = time.Second * 10
 	interval       = time.Millisecond * 250
 )
 

--- a/pkg/controllers/externalsecret/suite_test.go
+++ b/pkg/controllers/externalsecret/suite_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"go.uber.org/zap/zapcore"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -79,6 +80,11 @@ var _ = BeforeSuite(func() {
 		Scheme: scheme.Scheme,
 		Metrics: server.Options{
 			BindAddress: "0", // avoid port collision when testing
+		},
+		Client: client.Options{
+			Cache: &client.CacheOptions{
+				DisableFor: []client.Object{&v1.Secret{}, &v1.ConfigMap{}},
+			},
 		},
 	})
 	Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
## Problem Statement

Since we merged https://github.com/external-secrets/external-secrets/pull/3459, [the checkDeletion test case](https://github.com/external-secrets/external-secrets/blob/faac2b95618bf750bd40d7e56320cf2553df3b1a/pkg/controllers/externalsecret/externalsecret_controller_test.go#L1854) has become flaky. ([ref](https://github.com/external-secrets/external-secrets/actions/runs/9047984481/job/24860568776)) I dug into it and realized since we started using the cache client from the controller,  the controller received a deleted secret [here](https://github.com/external-secrets/external-secrets/blob/30f2f902cd76dbc3e74d8fadd688dfbd971a1962/pkg/controllers/externalsecret/externalsecret_controller.go#L172) after reconciliation starts due to the secret deletion. To tackle the problem, I've disabled the cache client for secrets and config maps [as we do in the actual environment](https://github.com/external-secrets/external-secrets/blob/43a7a16baf033c526c221cbf71cb3e52eb84bf7e/cmd/root.go#L115-L121). One good new is since we use the non-cache client for those resources, we can shorten the timeout from 20 seconds to 10 seconds.

## Related Issue

N/A

## Proposed Changes

The description above says it all.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
