### PR TITLE
doc(BitWarden): extends the liveness timeout

### DIFF
--- a/docs/snippets/bitwarden-cli-deployment.yaml
+++ b/docs/snippets/bitwarden-cli-deployment.yaml
@@ -54,7 +54,7 @@ spec:
                 - --post-data=''
             initialDelaySeconds: 20
             failureThreshold: 3
-            timeoutSeconds: 1
+            timeoutSeconds: 10
             periodSeconds: 120
           readinessProbe:
             tcpSocket:


### PR DESCRIPTION
## Problem Statement

The example for the BitWarden integration in the documentation contains a misconfiguration, leading to confusion as per current behavior (see [this issue](https://github.com/bitwarden/clients/issues/8762))

The liveness command perform a vault re-sync which usually takes a few second to perform. This commit replace the current value which is too low and lead to timeout and pod termination.

## Related Issue

Fixes bitwarden/clients#8762

## Proposed Changes

Update the probe timeout to a higher value, taking into account the actual time taken by the sync operation (usually, somewhere between 2 to 5 seconds) 

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [-] My changes have reasonable test coverage
- [-] All tests pass with `make test`
- [-] I ensured my PR is ready for review with `make reviewable`
