### PR TITLE
Allow specifying the same namespace for SecretStores

### DIFF
--- a/pkg/provider/chef/chef_test.go
+++ b/pkg/provider/chef/chef_test.go
@@ -302,7 +302,7 @@ func TestValidateStore(t *testing.T) {
 		},
 		{
 			store: makeSecretStore(name, baseURL, makeAuth(authName, authNamespace, authKey)),
-			err:   fmt.Errorf("received invalid Chef SecretStore resource: namespace not allowed with namespaced SecretStore"),
+			err:   fmt.Errorf("received invalid Chef SecretStore resource: namespace should either be empty or match the namespace of the SecretStore for a namespaced SecretStore"),
 		},
 		{
 			store: &esv1beta1.SecretStore{

--- a/pkg/provider/doppler/doppler_test.go
+++ b/pkg/provider/doppler/doppler_test.go
@@ -423,7 +423,7 @@ func TestValidateStore(t *testing.T) {
 		{
 			label: "invalid store namespace not allowed",
 			store: makeSecretStore(withAuth(secretName, "", &namespace)),
-			err:   fmt.Errorf("invalid store: namespace not allowed with namespaced SecretStore"),
+			err:   fmt.Errorf("invalid store: namespace should either be empty or match the namespace of the SecretStore for a namespaced SecretStore"),
 		},
 		{
 			label: "valid provide optional dopplerToken.key",

--- a/pkg/provider/fortanix/provider_test.go
+++ b/pkg/provider/fortanix/provider_test.go
@@ -199,7 +199,7 @@ func TestValidateStore(t *testing.T) {
 					},
 				},
 			},
-			want: errors.New("namespace not allowed with namespaced SecretStore"),
+			want: errors.New("namespace should either be empty or match the namespace of the SecretStore for a namespaced SecretStore"),
 		},
 	}
 	for name, tc := range tests {

--- a/pkg/provider/gitlab/gitlab_test.go
+++ b/pkg/provider/gitlab/gitlab_test.go
@@ -861,7 +861,7 @@ func TestValidateStore(t *testing.T) {
 		},
 		{
 			store: makeSecretStore(project, environment, withAccessToken("userName", "userKey", &namespace)),
-			err:   fmt.Errorf("namespace not allowed with namespaced SecretStore"),
+			err:   fmt.Errorf("namespace should either be empty or match the namespace of the SecretStore for a namespaced SecretStore"),
 		},
 		{
 			store: makeSecretStore(project, environment, withAccessToken("userName", "userKey", nil)),

--- a/pkg/provider/ibm/provider_test.go
+++ b/pkg/provider/ibm/provider_test.go
@@ -188,7 +188,7 @@ func TestValidateStore(t *testing.T) {
 	_, err = p.ValidateStore(store)
 	if err == nil {
 		t.Errorf(errExpectedErr)
-	} else if err.Error() != "namespace not allowed with namespaced SecretStore" {
+	} else if err.Error() != "namespace should either be empty or match the namespace of the SecretStore for a namespaced SecretStore" {
 		t.Errorf("KeySelector test failed: expected namespace not allowed, got %v", err)
 	}
 

--- a/pkg/provider/onboardbase/onboardbase_test.go
+++ b/pkg/provider/onboardbase/onboardbase_test.go
@@ -329,7 +329,7 @@ func TestValidateStore(t *testing.T) {
 		{
 			label: "invalid store namespace not allowed",
 			store: makeSecretStore(withAuth(secretName, "", &namespace, "passcode")),
-			err:   fmt.Errorf("invalid store: namespace not allowed with namespaced SecretStore"),
+			err:   fmt.Errorf("invalid store: namespace should either be empty or match the namespace of the SecretStore for a namespaced SecretStore"),
 		},
 		{
 			label: "valid provide optional onboardbaseAPIKey.key",

--- a/pkg/provider/onepassword/onepassword_test.go
+++ b/pkg/provider/onepassword/onepassword_test.go
@@ -441,7 +441,7 @@ func TestValidateStore(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: fmt.Errorf(errOnePasswordStore, fmt.Errorf("namespace not allowed with namespaced SecretStore")),
+			expectedErr: fmt.Errorf(errOnePasswordStore, fmt.Errorf("namespace should either be empty or match the namespace of the SecretStore for a namespaced SecretStore")),
 		},
 		{
 			checkNote: "invalid: more than one vault with the same number",

--- a/pkg/provider/oracle/oracle_test.go
+++ b/pkg/provider/oracle/oracle_test.go
@@ -284,7 +284,7 @@ func TestValidateStore(t *testing.T) {
 		},
 		{
 			store: makeSecretStore(vaultOCID, region, withSecretAuth(userOCID, tenant), withPrivateKey(secretName, secretKey, &namespace)),
-			err:   fmt.Errorf("namespace not allowed with namespaced SecretStore"),
+			err:   fmt.Errorf("namespace should either be empty or match the namespace of the SecretStore for a namespaced SecretStore"),
 		},
 		{
 			store: makeSecretStore(vaultOCID, region, withSecretAuth(userOCID, tenant), withPrivateKey(secretName, "", nil)),
@@ -296,7 +296,7 @@ func TestValidateStore(t *testing.T) {
 		},
 		{
 			store: makeSecretStore(vaultOCID, region, withSecretAuth(userOCID, tenant), withPrivateKey(secretName, secretKey, nil), withFingerprint(secretName, secretKey, &namespace)),
-			err:   fmt.Errorf("namespace not allowed with namespaced SecretStore"),
+			err:   fmt.Errorf("namespace should either be empty or match the namespace of the SecretStore for a namespaced SecretStore"),
 		},
 		{
 			store: makeSecretStore(vaultOCID, region, withSecretAuth(userOCID, tenant), withPrivateKey(secretName, secretKey, nil), withFingerprint(secretName, "", nil)),

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -359,7 +359,7 @@ func ErrorContains(out error, want string) bool {
 }
 
 var (
-	errNamespaceNotAllowed = errors.New("namespace not allowed with namespaced SecretStore")
+	errNamespaceNotAllowed = errors.New("namespace should either be empty or match the namespace of the SecretStore for a namespaced SecretStore")
 	errRequireNamespace    = errors.New("cluster scope requires namespace")
 )
 
@@ -371,7 +371,7 @@ func ValidateSecretSelector(store esv1beta1.GenericStore, ref esmeta.SecretKeySe
 	if clusterScope && ref.Namespace == nil {
 		return errRequireNamespace
 	}
-	if !clusterScope && ref.Namespace != nil {
+	if !clusterScope && ref.Namespace != nil && *ref.Namespace != store.GetNamespace() {
 		return errNamespaceNotAllowed
 	}
 	return nil
@@ -383,7 +383,7 @@ func ValidateSecretSelector(store esv1beta1.GenericStore, ref esmeta.SecretKeySe
 // support referent auth.
 func ValidateReferentSecretSelector(store esv1beta1.GenericStore, ref esmeta.SecretKeySelector) error {
 	clusterScope := store.GetObjectKind().GroupVersionKind().Kind == esv1beta1.ClusterSecretStoreKind
-	if !clusterScope && ref.Namespace != nil {
+	if !clusterScope && ref.Namespace != nil && *ref.Namespace != store.GetNamespace() {
 		return errNamespaceNotAllowed
 	}
 	return nil
@@ -397,7 +397,7 @@ func ValidateServiceAccountSelector(store esv1beta1.GenericStore, ref esmeta.Ser
 	if clusterScope && ref.Namespace == nil {
 		return errRequireNamespace
 	}
-	if !clusterScope && ref.Namespace != nil {
+	if !clusterScope && ref.Namespace != nil && *ref.Namespace != store.GetNamespace() {
 		return errNamespaceNotAllowed
 	}
 	return nil
@@ -409,7 +409,7 @@ func ValidateServiceAccountSelector(store esv1beta1.GenericStore, ref esmeta.Ser
 // support referent auth.
 func ValidateReferentServiceAccountSelector(store esv1beta1.GenericStore, ref esmeta.ServiceAccountSelector) error {
 	clusterScope := store.GetObjectKind().GroupVersionKind().Kind == esv1beta1.ClusterSecretStoreKind
-	if !clusterScope && ref.Namespace != nil {
+	if !clusterScope && ref.Namespace != nil && *ref.Namespace != store.GetNamespace() {
 		return errNamespaceNotAllowed
 	}
 	return nil


### PR DESCRIPTION
## Problem Statement

As described in the original issue, currently, we do not allow specifying the namespaces fields at all for namespace SecretStore, but it is more intuitive for users to allow them to specify the same namespace with the SecretStore.

## Related Issue

Relates to https://github.com/external-secrets/external-secrets/issues/3520

## Proposed Changes

Allow users to specify the same namespace with the SecretStore.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
