### PR TITLE
feat: add support to set Type for AWS parameter store

### DIFF
--- a/docs/provider/aws-parameter-store.md
+++ b/docs/provider/aws-parameter-store.md
@@ -101,6 +101,18 @@ The SetSecret method for the Parameter Store allows the user to set the value st
 {% include "full-pushsecret.yaml" %}
 ```
 
+#### Additional Metadata for PushSecret
+
+Optionally, it is possible to configure additional options for the parameter such as `Type` and encryption Key. To control this behaviour you can set the following provider's `metadata`:
+
+```yaml
+{% include 'aws-pm-push-secret-with-metadata.yaml' %}
+```
+
+`parameterStoreType` takes three options. `String`, `StringList`, and `SecureString`, where `String` is the _default_.
+
+`parameterStoreKeyID` takes a KMS Key `$ID` or `$ARN` (in case a key source is created in another account) as a string, where `alias/aws/ssm` is the _default_. This property is only used if `parameterStoreType` is set as `SecureString`.
+
 #### Check successful secret sync
 
 To be able to check that the secret has been succesfully synced you can run the following command:

--- a/docs/snippets/aws-pm-push-secret-with-metadata.yaml
+++ b/docs/snippets/aws-pm-push-secret-with-metadata.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: pushsecret-example # Customisable
+  namespace: default # Same of the SecretStores
+spec:
+  deletionPolicy: Delete # the provider' secret will be deleted if the PushSecret is deleted
+  refreshInterval: 10s # Refresh interval for which push secret will reconcile
+  secretStoreRefs: # A list of secret stores to push secrets to
+    - name: aws-parameterstore
+      kind: SecretStore
+  selector:
+    secret:
+      name: pokedex-credentials # Source Kubernetes secret to be pushed
+  data:
+    - match:
+        remoteRef:
+          remoteKey: my-first-parameter # Remote reference (where the secret is going to be pushed)
+      metadata:
+        parameterStoreType: "SecureString"
+        parameterStoreKeyID: "bb123123-b2b0-4f60-ac3a-44a13f0e6b6c"


### PR DESCRIPTION
## Problem Statement

Currently, we don't have the option to set which parameter type to use for the AWS parameter store, and as a result, all secrets are stored remotely as plain text `String`. This PR adds the possibility to work with the following types `String`, `SecureString`, and `StringList` through `PushSecret`'s metadata.

## Related Issue

Fixes #3422

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] My changes have reasonable test coverage
- [X] All tests pass with `make test`
- [X] I ensured my PR is ready for review with `make reviewable`
