### PR TITLE
feat(parameterstore): add support to set parameter tier for pushsecrets

### DIFF
--- a/docs/provider/aws-parameter-store.md
+++ b/docs/provider/aws-parameter-store.md
@@ -131,9 +131,13 @@ Optionally, it is possible to configure additional options for the parameter suc
 {% include 'aws-pm-push-secret-with-metadata.yaml' %}
 ```
 
-`parameterStoreType` takes three options. `String`, `StringList`, and `SecureString`, where `String` is the _default_.
+`parameterStore.type` takes three options. `String`, `StringList`, and `SecureString`, where `String` is the _default_.
 
-`parameterStoreKeyID` takes a KMS Key `$ID` or `$ARN` (in case a key source is created in another account) as a string, where `alias/aws/ssm` is the _default_. This property is only used if `parameterStoreType` is set as `SecureString`.
+`parameterStore.keyID` takes a KMS Key `$ID` or `$ARN` (in case a key source is created in another account) as a string, where `alias/aws/ssm` is the _default_. This property is only used if `parameterStore.type` is set as `SecureString`.
+
+`parameterStore.tier` takes two options. `Standard` or `Advanced`, where `Standard` is the _default_.
+
+`parameterStore.policies` takes a list of parameter policies. This property is only used if `parameterStore.tier` is set as `Advanced`. To have access to all options regarding policies please use the following official guide: [Assigning parameter policies](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-policies.html)
 
 #### Check successful secret sync
 

--- a/docs/provider/aws-parameter-store.md
+++ b/docs/provider/aws-parameter-store.md
@@ -131,11 +131,11 @@ Optionally, it is possible to configure additional options for the parameter suc
 {% include 'aws-pm-push-secret-with-metadata.yaml' %}
 ```
 
-`parameterStore.type` takes three options. `String`, `StringList`, and `SecureString`, where `String` is the _default_.
+`parameterStore.type` takes one of the following options: `String`, `StringList`, or `SecureString`. The value `String` is the _default_.
 
-`parameterStore.keyID` takes a KMS Key `$ID` or `$ARN` (in case a key source is created in another account) as a string, where `alias/aws/ssm` is the _default_. This property is only used if `parameterStore.type` is set as `SecureString`.
+`parameterStore.keyID` takes a KMS Key `$ID` or `$ARN` (in case a key source is created in another AWS account) as a string. The value `alias/aws/ssm` is the _default_. This property is only used if `parameterStore.type` is set as `SecureString`.
 
-`parameterStore.tier` takes two options. `Standard` or `Advanced`, where `Standard` is the _default_.
+`parameterStore.tier` takes one the following options: `Standard` or `Advanced`. The value `Standard` is the _default_.
 
 `parameterStore.policies` takes a list of parameter policies. This property is only used if `parameterStore.tier` is set as `Advanced`. To have access to all options regarding policies please use the following official guide: [Assigning parameter policies](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-policies.html)
 

--- a/docs/snippets/aws-pm-push-secret-with-metadata.yaml
+++ b/docs/snippets/aws-pm-push-secret-with-metadata.yaml
@@ -17,5 +17,27 @@ spec:
         remoteRef:
           remoteKey: my-first-parameter # Remote reference (where the secret is going to be pushed)
       metadata:
-        parameterStoreType: "SecureString"
-        parameterStoreKeyID: "bb123123-b2b0-4f60-ac3a-44a13f0e6b6c"
+        parameterStore:
+          type: "SecureString"
+          keyID: "bb123123-b2b0-4f60-ac3a-44a13f0e6b6c"
+          tier: "Advanced"
+          policies:
+          - type: "Expiration"
+            version: "1.0"
+            attributes:
+              timestamp: "2024-12-02T21:34:33.000Z"
+          - type: "ExpirationNotification"
+            version: "1.0"
+            attributes:
+              before: "2"
+              unit: "Days"
+          - type: "ExpirationNotification"
+            version: "1.0"
+            attributes:
+              before: "30"
+              unit: "Days"
+          - type: "NoChangeNotification"
+            version: "1.0"
+            attributes:
+              after: "30"
+              unit: "Days"


### PR DESCRIPTION
## Problem Statement

Currently, we don't have the option to set which parameter tier to use for the AWS parameter store, and as a result, all secrets are stored using the default tier `Standard`. This PR adds the possibility to work with parameter tier `Advanced` and all its policies.

## Related Issue

Fixes #3422

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] My changes have reasonable test coverage
- [X] All tests pass with `make test`
- [X] I ensured my PR is ready for review with `make reviewable`
