### PR TITLE
chore: remove unnecessary role grant from GKE terraform example

### DIFF
--- a/terraform/gcp/eso_gcp_modules/gke/main.tf
+++ b/terraform/gcp/eso_gcp_modules/gke/main.tf
@@ -9,12 +9,6 @@ resource "google_project_iam_member" "secretadmin" {
   member  = "serviceAccount:${google_service_account.default.email}"
 }
 
-resource "google_project_iam_member" "service_account_token_creator" {
-  project = var.project_id
-  role    = "roles/iam.serviceAccountTokenCreator"
-  member  = "serviceAccount:${google_service_account.default.email}"
-}
-
 resource "google_service_account_iam_member" "pod_identity" {
   role               = "roles/iam.workloadIdentityUser"
   member             = "serviceAccount:${var.project_id}.svc.id.goog[default/${var.GCP_KSA_NAME}]"


### PR DESCRIPTION
## Problem Statement

`roles/iam.workloadIdentityUser` already grants access to Kubernetes Service Account. Thus makes `serviceAccountTokenCreator` redundant? Unless I'm missing something, this role doesn't do anything.

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
