### PR TITLE
feat(chart): Enable partial cache for certcontroller when installCRDs=true

### DIFF
--- a/.github/ci/ct.yaml
+++ b/.github/ci/ct.yaml
@@ -1,5 +1,6 @@
 chart-dirs:
   - deploy/charts
 helm-extra-args: "--timeout=5m"
+helm-extra-set-args: "--set image.tag=main --set webhook.image.tag=main --set certController.image.tag=main"
 check-version-increment: false
 target-branch: main

--- a/.github/ci/ct.yaml
+++ b/.github/ci/ct.yaml
@@ -1,6 +1,5 @@
 chart-dirs:
   - deploy/charts
 helm-extra-args: "--timeout=5m"
-helm-extra-set-args: "--set image.tag=main --set webhook.image.tag=main --set certController.image.tag=main"
 check-version-increment: false
 target-branch: main

--- a/deploy/charts/external-secrets/ci/main-values.yaml
+++ b/deploy/charts/external-secrets/ci/main-values.yaml
@@ -1,2 +1,10 @@
 image:
   tag: main
+
+webhook:
+  image:
+    tag: main
+
+certController:
+  image:
+    tag: main

--- a/deploy/charts/external-secrets/templates/cert-controller-deployment.yaml
+++ b/deploy/charts/external-secrets/templates/cert-controller-deployment.yaml
@@ -62,10 +62,10 @@ spec:
           - --healthz-addr={{ .Values.certController.readinessProbe.address }}:{{ .Values.certController.readinessProbe.port }}
           - --loglevel={{ .Values.certController.log.level }}
           - --zap-time-encoding={{ .Values.certController.log.timeEncoding }}
-          {{ if not .Values.crds.createClusterSecretStore -}}
+          {{- if not .Values.crds.createClusterSecretStore }}
           - --crd-names=externalsecrets.external-secrets.io
           - --crd-names=secretstores.external-secrets.io
-          {{- end -}}
+          {{- end }}
           {{- range $key, $value := .Values.certController.extraArgs }}
             {{- if $value }}
           - --{{ $key }}={{ $value }}

--- a/deploy/charts/external-secrets/templates/cert-controller-deployment.yaml
+++ b/deploy/charts/external-secrets/templates/cert-controller-deployment.yaml
@@ -66,6 +66,9 @@ spec:
           - --crd-names=externalsecrets.external-secrets.io
           - --crd-names=secretstores.external-secrets.io
           {{- end }}
+          {{- if .Values.installCRDs }}
+          - --enable-partial-cache=true
+          {{- end }}
           {{- range $key, $value := .Values.certController.extraArgs }}
             {{- if $value }}
           - --{{ $key }}={{ $value }}

--- a/deploy/charts/external-secrets/tests/__snapshot__/cert_controller_test.yaml.snap
+++ b/deploy/charts/external-secrets/tests/__snapshot__/cert_controller_test.yaml.snap
@@ -40,6 +40,7 @@ should match snapshot of default values:
                 - --healthz-addr=:8081
                 - --loglevel=info
                 - --zap-time-encoding=epoch
+                - --enable-partial-cache=true
               image: ghcr.io/external-secrets/external-secrets:v0.9.19
               imagePullPolicy: IfNotPresent
               name: cert-controller

--- a/deploy/charts/external-secrets/tests/__snapshot__/crds_test.yaml.snap
+++ b/deploy/charts/external-secrets/tests/__snapshot__/crds_test.yaml.snap
@@ -5,6 +5,8 @@ should match snapshot of default values:
     metadata:
       annotations:
         controller-gen.kubebuilder.io/version: v0.15.0
+      labels:
+        external-secrets.io/component: controller
       name: secretstores.external-secrets.io
     spec:
       conversion:
@@ -1555,6 +1557,11 @@ should match snapshot of default values:
                           ClusterSecretStoreCondition describes a condition by which to choose namespaces to process ExternalSecrets in
                           for a ClusterSecretStore instance.
                         properties:
+                          namespaceRegexes:
+                            description: Choose namespaces by using regex matching
+                            items:
+                              type: string
+                            type: array
                           namespaceSelector:
                             description: Choose namespace using a labelSelector
                             properties:
@@ -2412,6 +2419,42 @@ should match snapshot of default values:
                             - clientSecret
                             - tenant
                           type: object
+                        device42:
+                          description: Device42 configures this store to sync secrets using the Device42 provider
+                          properties:
+                            auth:
+                              description: Auth configures how secret-manager authenticates with a Device42 instance.
+                              properties:
+                                secretRef:
+                                  properties:
+                                    credentials:
+                                      description: Username / Password is used for authentication.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
+                                            defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
+                                            to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                  type: object
+                              required:
+                                - secretRef
+                              type: object
+                            host:
+                              description: URL configures the Device42 instance URL.
+                              type: string
+                          required:
+                            - auth
+                            - host
+                          type: object
                         doppler:
                           description: Doppler configures this store to sync secrets using the Doppler provider
                           properties:
@@ -2692,6 +2735,77 @@ should match snapshot of default values:
                               type: string
                           required:
                             - auth
+                          type: object
+                        infisical:
+                          description: Infisical configures this store to sync secrets using the Infisical provider
+                          properties:
+                            auth:
+                              description: Auth configures how the Operator authenticates with the Infisical API
+                              properties:
+                                universalAuthCredentials:
+                                  properties:
+                                    clientId:
+                                      description: |-
+                                        A reference to a specific 'key' within a Secret resource,
+                                        In some instances, `key` is a required field.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
+                                            defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
+                                            to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                    clientSecret:
+                                      description: |-
+                                        A reference to a specific 'key' within a Secret resource,
+                                        In some instances, `key` is a required field.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
+                                            defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
+                                            to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                  required:
+                                    - clientId
+                                    - clientSecret
+                                  type: object
+                              type: object
+                            hostAPI:
+                              default: https://app.infisical.com/api
+                              type: string
+                            secretsScope:
+                              properties:
+                                environmentSlug:
+                                  type: string
+                                projectSlug:
+                                  type: string
+                                secretsPath:
+                                  default: /
+                                  type: string
+                              required:
+                                - environmentSlug
+                                - projectSlug
+                              type: object
+                          required:
+                            - auth
+                            - secretsScope
                           type: object
                         keepersecurity:
                           description: KeeperSecurity configures this store to sync secrets using the KeeperSecurity provider


### PR DESCRIPTION
## Problem Statement

Follow-up PR of #3588. We want to deliver the fix for reducing certcontroller's memory usage to users as much as possible. See https://github.com/external-secrets/external-secrets/pull/3588#pullrequestreview-2121324360 by @moolen.

## Related Issue

Fixes #...

## Proposed Changes

Set `--enable-partial-cache=true` if `installCRDs=true` in the Helm chart.

<details>
<summary><code>helm template external-secrets .  --set installCRDs=true</code></summary>

```yaml
(...)
---
# Source: external-secrets/templates/cert-controller-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: external-secrets-cert-controller
  namespace: default
  labels:
    helm.sh/chart: external-secrets-0.9.19
    app.kubernetes.io/name: external-secrets-cert-controller
    app.kubernetes.io/instance: external-secrets
    app.kubernetes.io/version: "v0.9.19"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app.kubernetes.io/name: external-secrets-cert-controller
      app.kubernetes.io/instance: external-secrets
  template:
    metadata:
      labels:
        helm.sh/chart: external-secrets-0.9.19
        app.kubernetes.io/name: external-secrets-cert-controller
        app.kubernetes.io/instance: external-secrets
        app.kubernetes.io/version: "v0.9.19"
        app.kubernetes.io/managed-by: Helm
    spec:
      serviceAccountName: external-secrets-cert-controller
      automountServiceAccountToken: true
      hostNetwork: false
      containers:
        - name: cert-controller
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: true
            runAsNonRoot: true
            runAsUser: 1000
            seccompProfile:
              type: RuntimeDefault
          image: ghcr.io/external-secrets/external-secrets:v0.9.19
          imagePullPolicy: IfNotPresent
          args:
          - certcontroller
          - --crd-requeue-interval=5m
          - --service-name=external-secrets-webhook
          - --service-namespace=default
          - --secret-name=external-secrets-webhook
          - --secret-namespace=default
          - --metrics-addr=:8080
          - --healthz-addr=:8081
          - --loglevel=info
          - --zap-time-encoding=epoch
          - --enable-partial-cache=true
          ports:
            - containerPort: 8080
              protocol: TCP
              name: metrics
          readinessProbe:
            httpGet:
              port: 8081
              path: /readyz
            initialDelaySeconds: 20
            periodSeconds: 5
---
(...)
```

</details>

<details>
<summary><code>helm template external-secrets .  --set installCRDs=false</code></summary>

```yaml
(...)
---
# Source: external-secrets/templates/cert-controller-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: external-secrets-cert-controller
  namespace: default
  labels:
    helm.sh/chart: external-secrets-0.9.19
    app.kubernetes.io/name: external-secrets-cert-controller
    app.kubernetes.io/instance: external-secrets
    app.kubernetes.io/version: "v0.9.19"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app.kubernetes.io/name: external-secrets-cert-controller
      app.kubernetes.io/instance: external-secrets
  template:
    metadata:
      labels:
        helm.sh/chart: external-secrets-0.9.19
        app.kubernetes.io/name: external-secrets-cert-controller
        app.kubernetes.io/instance: external-secrets
        app.kubernetes.io/version: "v0.9.19"
        app.kubernetes.io/managed-by: Helm
    spec:
      serviceAccountName: external-secrets-cert-controller
      automountServiceAccountToken: true
      hostNetwork: false
      containers:
        - name: cert-controller
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: true
            runAsNonRoot: true
            runAsUser: 1000
            seccompProfile:
              type: RuntimeDefault
          image: ghcr.io/external-secrets/external-secrets:v0.9.19
          imagePullPolicy: IfNotPresent
          args:
          - certcontroller
          - --crd-requeue-interval=5m
          - --service-name=external-secrets-webhook
          - --service-namespace=default
          - --secret-name=external-secrets-webhook
          - --secret-namespace=default
          - --metrics-addr=:8080
          - --healthz-addr=:8081
          - --loglevel=info
          - --zap-time-encoding=epoch
          ports:
            - containerPort: 8080
              protocol: TCP
              name: metrics
          readinessProbe:
            httpGet:
              port: 8081
              path: /readyz
            initialDelaySeconds: 20
            periodSeconds: 5
---
(...)
```

</details>

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`