### PR TITLE
fix(vault): Fix crash when caching is enabled and a token expires

### DIFF
--- a/pkg/provider/vault/auth.go
+++ b/pkg/provider/vault/auth.go
@@ -147,6 +147,11 @@ func checkToken(ctx context.Context, token util.Token) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	// LookupSelfWithContext() calls ParseSecret(), which has several places
+	// that return no data and no error, including when a token is expired.
+	if resp == nil {
+		return false, fmt.Errorf("no response nor error for token lookup")
+	}
 	t, ok := resp.Data["type"]
 	if !ok {
 		return false, fmt.Errorf("could not assert token type")


### PR DESCRIPTION
## Problem Statement

In the vault client library, `LookupSelfWithContext` calls `ParseSecret`, which has a few places where it returns `nil, nil` instead of returning a proper error. The most common scenario is when the token expires and the Vault server returns:

```json
{
  "errors": [
    "permission denied"
  ]
}
```

This causes the Vault provider to dereference the `nil` response and crash the process. This only happens when the experimental caching feature is enabled.

## Related Issue

(None reported)

## Proposed Changes

This commit adds an additional check (with corresponding tests) to ensure that a `nil` response won't be dereferenced in `checkToken()`.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
