### PR TITLE
Remove the use of "golang.org/x/crypto/pkcs12"

### DIFF
--- a/pkg/provider/azure/keyvault/keyvault.go
+++ b/pkg/provider/azure/keyvault/keyvault.go
@@ -35,7 +35,6 @@ import (
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/confidential"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/tidwall/gjson"
-	"golang.org/x/crypto/pkcs12"
 	"golang.org/x/crypto/sha3"
 	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -47,6 +46,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlcfg "sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	gopkcs12 "software.sslmate.com/src/go-pkcs12"
 
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 	"github.com/external-secrets/external-secrets/pkg/constants"
@@ -345,7 +345,7 @@ func (a *Azure) SecretExists(ctx context.Context, remoteRef esv1beta1.PushSecret
 
 func getCertificateFromValue(value []byte) (*x509.Certificate, error) {
 	// 1st: try decode pkcs12
-	_, localCert, err := pkcs12.Decode(value, "")
+	_, localCert, err := gopkcs12.Decode(value, "")
 	if err == nil {
 		return localCert, nil
 	}

--- a/pkg/template/v1/template.go
+++ b/pkg/template/v1/template.go
@@ -26,8 +26,8 @@ import (
 
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/youmark/pkcs8"
-	"golang.org/x/crypto/pkcs12"
 	corev1 "k8s.io/api/core/v1"
+	"software.sslmate.com/src/go-pkcs12"
 
 	esapi "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 )

--- a/pkg/template/v2/template.go
+++ b/pkg/template/v2/template.go
@@ -59,6 +59,7 @@ const (
 	errParsePrivKey         = "unable to parse private key type"
 
 	pemTypeCertificate = "CERTIFICATE"
+	pemTypeKey         = "PRIVATE KEY"
 )
 
 func init() {


### PR DESCRIPTION
## Problem Statement

Remove the use of "golang.org/x/crypto/pkcs12" and switch to software.sslmate.com/src/go-pkcs12 instead.

## Related Issue

Fixes https://github.com/external-secrets/external-secrets/issues/3585

## Proposed Changes

Remove the use of "golang.org/x/crypto/pkcs12" and switch to software.sslmate.com/src/go-pkcs12 instead.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
