### PR TITLE
Make UBI safer from OS vulnerabilities

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -1,11 +1,35 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:5f1cd3422d5d46aea35dac80825dbcbd58213eef49c317f42a394345fb4e8ff1
+FROM registry.access.redhat.com/ubi8/ubi as minimal-ubi
+
+ARG TARGETOS
+ARG TARGETARCH
+RUN dnf update -y && dnf install -y binutils
+# prep target rootfs for scratch container
+WORKDIR /
+RUN mkdir /image && \
+    ln -s usr/bin /image/bin && \
+	ln -s usr/sbin /image/sbin && \
+	ln -s usr/lib64 /image/lib64 && \
+	ln -s usr/lib /image/lib && \
+	mkdir -p /image/{usr/bin,usr/lib64,usr/lib,root,home,proc,etc,sys,var,dev}
+
+COPY ubi-build-files-${TARGETARCH}.txt /tmp
+# Copy all the required files from the base UBI image into the image directory
+# As the go binary is not statically compiled this includes everything needed for CGO to work, cacerts, tzdata and RH release files
+RUN tar cf /tmp/files.tar -T /tmp/ubi-build-files-${TARGETARCH}.txt && tar xf /tmp/files.tar -C /image/ \
+  && strip --strip-unneeded /image/usr/lib64/*[0-9].so
+
+# Generate a rpm database which contains all the packages that you said were needed in ubi-build-files-*.txt
+RUN rpm --root /image --initdb \
+  && PACKAGES=$(rpm -qf $(cat /tmp/ubi-build-files-${TARGETARCH}.txt) | grep -v "is not owned by any package" | sort -u) \
+  && echo dnf install -y 'dnf-command(download)' \
+  && dnf download --destdir / ${PACKAGES} \
+  && rpm --root /image -ivh --justdb --nodeps `for i in ${PACKAGES}; do echo $i.rpm; done`
+
+FROM scratch
+# Copy all required files + rpm database so the image is scannable
+COPY --from=minimal-ubi /image/ /
+USER 65534
 ARG TARGETOS
 ARG TARGETARCH
 COPY bin/external-secrets-${TARGETOS}-${TARGETARCH} /bin/external-secrets
-
-RUN microdnf update
-
-# Run as UID for nobody
-USER 65534
-
 ENTRYPOINT ["/bin/external-secrets"]


### PR DESCRIPTION
## Problem Statement

Currently the UBI based image is based off ubi-minimal which is has >100 packages most of which are not needed. This creates vulnerability churn so this commit swaps it out for something the equivalent of Distroless but using UBI packages

## Related Issue

https://github.com/external-secrets/external-secrets/issues/3606

## Proposed Changes

I have created an image directory in the first stage of the build that contains the minimum set of files to run a non-statically compiled Go app and be scannable by image vulnerability scanners. An RPM database is then created just for the packages in the image dir both this and the libs are then copied to the final base image. 

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage - Build changes only tested by CI
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
