### PR TITLE
fix: explicitly fetch status subresource due to inconsistencies

### DIFF
--- a/deploy/charts/external-secrets/templates/rbac.yaml
+++ b/deploy/charts/external-secrets/templates/rbac.yaml
@@ -44,6 +44,7 @@ rules:
     - "pushsecrets/status"
     - "pushsecrets/finalizers"
     verbs:
+    - "get"
     - "update"
     - "patch"
   - apiGroups:

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets-e2e
 
-go 1.22.3
+go 1.22.4
 
 replace (
 	github.com/Masterminds/sprig/v3 => github.com/external-secrets/sprig/v3 v3.3.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets
 
-go 1.22.3
+go 1.22.4
 
 replace github.com/Masterminds/sprig/v3 => github.com/external-secrets/sprig/v3 v3.3.0
 

--- a/pkg/controllers/externalsecret/externalsecret_controller.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller.go
@@ -130,6 +130,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, err
 	}
 
+	// See https://github.com/external-secrets/external-secrets/issues/3604
+	// We fetch the ExternalSecret resource above, however the status subresource is inconsistent.
+	// We have to explicitly fetch it, otherwise it may be missing and will cause
+	// unexpected side effects.
+	err = r.SubResource("status").Get(ctx, &externalSecret, &externalSecret)
+	if err != nil {
+		log.Error(err, "failed to get status subresource")
+		return ctrl.Result{}, err
+	}
+
 	timeSinceLastRefresh := 0 * time.Second
 	if !externalSecret.Status.RefreshTime.IsZero() {
 		timeSinceLastRefresh = time.Since(externalSecret.Status.RefreshTime.Time)


### PR DESCRIPTION
Towards https://github.com/external-secrets/external-secrets/issues/3604: 
It appears, that the status subresource is slightly inconsistent. This leads to unexpected behaviour, where a secret is reconciled where it shouldn't. This is problematic in combination with a generator resource and usage of the `immutable` field on the secret.

### Proof of work

To reproduce the problem, run the following commands. It is a race condition!:

```
while true; do
k apply -f ./issue-3604.yaml >/dev/null; sleep 1;
k get es;
k delete -f ./issue-3604 > /dev/null
done
```

Once you see `SecretSyncedError` you triggered the bug.

```yaml
apiVersion: external-secrets.io/v1beta1
kind: ExternalSecret
metadata:
  name: es-5-test
spec:
  dataFrom:
  - sourceRef:
      generatorRef:
        apiVersion: generators.external-secrets.io/v1alpha1
        kind: Password
        name: password-generator
  refreshInterval: 0m
  target:
    immutable: true
    name: es-5-test
    template:
      data:
        password: '{{ .password }}'
        username: someone
---
apiVersion: generators.external-secrets.io/v1alpha1
kind: Password
metadata:
  name: password-generator
spec:
  allowRepeat: true
  length: 16
  noUpper: false
  symbolCharacters: ~!%^&*()_+-={}|[]\<>?,./
```
