### PR TITLE
Adds codepath for removing finalizers

### DIFF
--- a/pkg/controllers/pushsecret/pushsecret_controller.go
+++ b/pkg/controllers/pushsecret/pushsecret_controller.go
@@ -138,6 +138,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			}
 		}
 	case esapi.PushSecretDeletionPolicyNone:
+		if controllerutil.ContainsFinalizer(&ps, pushSecretFinalizer) {
+			controllerutil.RemoveFinalizer(&ps, pushSecretFinalizer)
+			if err := r.Client.Update(ctx, &ps, &client.UpdateOptions{}); err != nil {
+				return ctrl.Result{}, fmt.Errorf("could not update finalizers: %w", err)
+			}
+		}
 	default:
 	}
 


### PR DESCRIPTION
See #3609.

## Problem Statement

A PushSecret created with `DeletionPolicy==Delete` and later updated with `DeletionPolicy==None` has no codepath to remove its finalizers.

## Related Issue

Fixes #3609

## Proposed Changes

Populate `case DeletionPolicyNone:` with an unconditional removal of the finalizer.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
