### PR TITLE
Fix ACR External Secret example

### DIFF
--- a/docs/api/generator/acr.md
+++ b/docs/api/generator/acr.md
@@ -18,8 +18,8 @@ You must choose one out of three authentication mechanisms:
 - managed identity
 - workload identity
 
-The generated token will inherit the permissions from the assigned policy. I.e. when you assign a read-only policy all generated tokens will be read-only. 
-You **must** [assign a Azure RBAC role](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments-steps), such as `AcrPush` or `AcrPull` to the service principal in order to be able to authenticate with the Azure container registry API. 
+The generated token will inherit the permissions from the assigned policy. I.e. when you assign a read-only policy all generated tokens will be read-only.
+You **must** [assign a Azure RBAC role](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments-steps), such as `AcrPush` or `AcrPull` to the service principal or managed identity in order to be able to authenticate with the Azure container registry API.
 
 You can scope tokens to a particular repository using `spec.scope`.
 
@@ -33,7 +33,7 @@ If `spec.scope` if it is defined it obtains an ACR access token. If  `spec.scope
 - refresh tokens can are scoped to whatever policy is attached to the identity that creates the acr refresh token
 
 The Scope grammar is defined in the [Docker Registry spec](https://docs.docker.com/registry/spec/auth/scope/).
-Note: You **can not** use a wildcards in the scope parameter, you can match exactly one repository and defined multiple actions like `pull` or `push`.
+Note: You **can not** use wildcards in the scope parameter -- you can match exactly one repository and can define multiple actions like `pull` or `push`.
 
 Example scopes:
 

--- a/docs/snippets/generator-acr-example.yaml
+++ b/docs/snippets/generator-acr-example.yaml
@@ -22,7 +22,7 @@ spec:
             "auths": {
               "myregistry.azurecr.io": {
                 "username": "{{ .username }}",
-                "identitytoken": "{{ .password }}"
+                "password": "{{ .password }}"
               }
             }
           }


### PR DESCRIPTION
## Problem Statement

Following the examples for configuring an External Secret to inject credentials to access an Azure Container Registry did not work. This fixes that by updating the docker config json in the external secret.

## Related Issue

Fixes #3178

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
