### PR TITLE
docs: fix dataFrom.find in ExternalSecret api example

### DIFF
--- a/docs/snippets/full-external-secret.yaml
+++ b/docs/snippets/full-external-secret.yaml
@@ -108,8 +108,6 @@ spec:
         target: "rewriting-${1}-with-groups"
   - find:
       path: path-to-filter
-          source: "exp-(.*?)-ression"
-          target: "rewriting-${1}-with-groups"
       name:
         regexp: ".*foobar.*"
       tags:


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?

The [`ExternalSecret` example](https://external-secrets.io/latest/api/externalsecret/#example) has two incorrect lines under dataFrom.find:
```
    rewrite:
    - regexp:
        source: "exp-(.*?)-ression"
        target: "rewriting-${1}-with-groups"
  - find:
      path: path-to-filter
          source: "exp-(.*?)-ression"
          target: "rewriting-${1}-with-groups"
      name:
        regexp: ".*foobar.*"
```

