### PR TITLE
fix(vault): Treat tokens expiring in <60s as expired

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -7,6 +7,7 @@
 - [Container Solutions](http://container-solutions.com/)
 - [DaangnPay](https://www.daangnpay.com/)
 - [Epidemic Sound](https://www.epidemicsound.com/)
+- [Elastic](https://www.elastic.co/)
 - [Fivetran](https://www.fivetran.com)
 - [Form3](https://www.form3.tech/)
 - [GoTo](https://www.goto.com/)


### PR DESCRIPTION
## Problem Statement

Without this, it's possible to hit a TOCTOU issue where `checkToken()` sees a valid token, but it expires before the actual operation is performed. This condition is only reachable when the experimental caching feature is enabled.

60 seconds was chosen as a sane (but arbitrary) value. It should be more than enough to cover the amount of time between `checkToken()` and the actual operation.

## Related Issue

(None reported)

## Proposed Changes

Treat close-to-expiring tokens as if they were expired already.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
