### PR TITLE
fix(webhook): perform conversion of data

### DIFF
--- a/pkg/common/webhook/webhook.go
+++ b/pkg/common/webhook/webhook.go
@@ -35,6 +35,7 @@ import (
 	"github.com/external-secrets/external-secrets/pkg/constants"
 	"github.com/external-secrets/external-secrets/pkg/metrics"
 	"github.com/external-secrets/external-secrets/pkg/template/v2"
+	"github.com/external-secrets/external-secrets/pkg/utils"
 	"github.com/external-secrets/external-secrets/pkg/utils/resolvers"
 )
 
@@ -106,12 +107,11 @@ func (w *Webhook) GetSecretMap(ctx context.Context, provider *Spec, ref *esv1bet
 	}
 	// Change the map of generic objects to a map of byte arrays
 	values := make(map[string][]byte)
-	for rKey, rValue := range jsonvalue {
-		jVal, ok := rValue.(string)
-		if !ok {
-			return nil, fmt.Errorf("failed to get response (wrong type in key '%s': %T)", rKey, rValue)
+	for rKey := range jsonvalue {
+		values[rKey], err = utils.GetByteValueFromMap(jsonvalue, rKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get response for key '%s': %w", rKey, err)
 		}
-		values[rKey] = []byte(jVal)
 	}
 	return values, nil
 }

--- a/pkg/provider/webhook/webhook_test.go
+++ b/pkg/provider/webhook/webhook_test.go
@@ -299,6 +299,34 @@ want:
   path: /api/getsecret?id=testkey&version=1
   err: ''
   result: "RE/DACTED=="
+---
+case: good json with mixed fields and jsonpath filter
+args:
+  url: /api/getsecret?id={{ .remoteRef.key }}&version={{ .remoteRef.version }}
+  key: testkey
+  version: 1
+  jsonpath: $.result.thesecret
+  response: '{"result":{"thesecret":"secret-value","alsosecret":"another-value", "id": 1234, "weight": 1.5}}'
+want:
+  path: /api/getsecret?id=testkey&version=1
+  err: ''
+  result: secret-value
+---
+case: good json with mixed fields to map
+args:
+  url: /api/getsecret?id={{ .remoteRef.key }}&version={{ .remoteRef.version }}
+  key: testkey
+  version: 1
+  jsonpath: $.result
+  response: '{"result":{"thesecret":"secret-value","alsosecret":"another-value", "id": 1234, "weight": 1.5}}'
+want:
+  path: /api/getsecret?id=testkey&version=1
+  err: ''
+  resultmap:
+    thesecret: secret-value
+    alsosecret: another-value
+    id: 1234
+    weight: 1.5
 `
 
 func TestWebhookGetSecret(t *testing.T) {


### PR DESCRIPTION
## Problem Statement

The webhook provider incorrectly assumes that the server's returned JSON object has values that are all strings. 

## Related Issue

Fixes #3239

## Proposed Changes

Use the conversion functions provided by utils that the other providers use.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
