### PR TITLE
bump e2e pipeline

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,6 +20,7 @@ env:
   # Common users. We can't run a step 'if secrets.GHCR_USERNAME != ""' but we can run
   # a step 'if env.GHCR_USERNAME' != ""', so we copy these to succinctly test whether
   # credentials have been provided before trying to run steps that need them.
+  TARGET_SHA: ${{ github.event.client_payload.slash_command.args.named.sha }}
   GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
   GCP_SM_SA_JSON: ${{ secrets.GCP_SM_SA_JSON}}
   GCP_GKE_ZONE: ${{ secrets.GCP_GKE_ZONE}}
@@ -83,12 +84,13 @@ jobs:
     - name: Fork based /ok-to-test checkout
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
-        ref: 'refs/pull/${{ github.event.client_payload.pull_request.number }}/merge'
+        ref: '${{ env.TARGET_SHA }}'
 
     - name: Fetch History
       run: git fetch --prune --unshallow
 
-    - uses: ./.github/actions/e2e
+    - id: e2e
+      uses: ./.github/actions/e2e
 
     # Update check run called "integration-fork"
     - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
@@ -123,3 +125,28 @@ jobs:
             conclusion: process.env.conclusion
           });
           return result;
+    - name: Find Comment
+      if: always()
+      uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
+      id: fc
+      with:
+        issue-number: ${{ github.event.client_payload.pull_request.number }}
+        body-includes: /ok-to-test sha=${{ env.TARGET_SHA }}
+    - name: Update on Succeess
+      if: always() && steps.fc.outputs.comment-id != '' &&  steps.e2e.conclusion == 'success'
+      uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+      with:
+        issue-number: ${{ github.event.client_payload.pull_request.number }}
+        body: |
+            [Bot] - :white_check_mark: [e2e tests pass](https://github.com/external-secrets/external-secrets/actions/runs/${{ steps.update-check-run.outputs.result.id }})
+        reactions: +1
+        edit-mode: append
+    - name: Update on Failure
+      if: always() && steps.fc.outputs.comment-id != '' &&  steps.e2e.conclusion != 'success'
+      uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+      with:
+        issue-number: ${{ github.event.client_payload.pull_request.number }}
+        body: |
+            [Bot] - :x: [e2e tests failed](https://github.com/external-secrets/external-secrets/actions/runs/${{ steps.update-check-run.outputs.result.id }})
+        reactions: -1
+        edit-mode: append


### PR DESCRIPTION
## Problem Statement
e2e test results generated with /ok-to-test are hard to track, and target only the PR tip.
This PR fixes it
## Related Issue

Fixes #3465

## Proposed Changes
## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
