### PR TITLE
docs: updated k8s support for ESO v0.9

### DIFF
--- a/docs/introduction/stability-support.md
+++ b/docs/introduction/stability-support.md
@@ -19,7 +19,7 @@ We want to cover the following cases:
 
 | ESO Version | Kubernetes Version | Release Date | End of Life    |
 | ----------- | ------------------ | ------------ | -------------- |
-| 0.9.x       | 1.19 → 1.29        | Jun 22, 2023 | Release of 1.1 |
+| 0.9.x       | 1.19 → 1.30        | Jun 22, 2023 | Release of 1.1 |
 | 0.8.x       | 1.19 → 1.28        | Mar 16, 2023 | Release of 1.0 |
 | 0.7.x       | 1.19 → 1.26        | Dec 11, 2022 | Jun 22, 2023   |
 | 0.6.x       | 1.19 → 1.24        | Oct 9, 2022  | Mar 16, 2023   |


### PR DESCRIPTION
## Problem Statement
ESO v0.9 supports K8s v1.30 as per [this makefile](https://github.com/external-secrets/external-secrets/blob/v0.9.19/Makefile?rgh-link-date=2024-07-05T14%3A16%3A00Z#L325), however the docs do not reflect this. Currently it reads as no ESO version is compatible with K8s 1.30

I have also tested ESO v0.9.19 with an EKS 1.30 cluster and nothing seemed inoperable.

## Related Issue

Closes: https://github.com/external-secrets/external-secrets/issues/3658

## Proposed Changes
Updated the docs

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
