### PR TITLE
Commenting secrets manifest from hashicorp vault integration #3661

### DIFF
--- a/docs/provider/hashicorp-vault.md
+++ b/docs/provider/hashicorp-vault.md
@@ -89,12 +89,13 @@ spec:
       property: dev
 
 ---
-# will create a secret with:
-kind: Secret
-metadata:
-  name: example-sync
-data:
-  foobar: czNjcjN0
+# That will automatically create a Kubernetes Secret with:
+# apiVersion: v1
+# kind: Secret
+# metadata:
+#  name: example-sync
+# data:
+#  foobar: czNjcjN0
 ```
 
 Keep in mind that fetching the labels with `metadataPolicy: Fetch` only works with KV sercrets engine version v2.


### PR DESCRIPTION
## Problem Statement

Misspasted Kubernets manifest in sample code.

## Related Issue

Fixes #3661

## Proposed Changes

Commenting misspasted manifest just to example (didatically) which resource will be created after deploy the external secret component.

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] My changes have reasonable test coverage
- [X] All tests pass with `make test`
- [X] I ensured my PR is ready for review with `make reviewable`
