### PR TITLE
docs: Fix `namespaceRegexes` in full-cluster-secret-store.yaml

### DIFF
--- a/docs/snippets/full-cluster-secret-store.yaml
+++ b/docs/snippets/full-cluster-secret-store.yaml
@@ -151,8 +151,8 @@ spec:
         - "namespace-a"
         - "namespace-b"
 
-    # Namespace regex is helpful for namespace naming convention or when an external tool auto generate namespaces with prefix
-    - namespacesRegex:
+    # Namespace regexes are useful for policy management or when external tools auto-generate namespaces with prefixes/suffixes
+    - namespaceRegexes:
         - "namespace-a-.*" # All namespaces prefixed by namespace-a- will work
         - "namespace-b-.*" # All namespaces prefixed by namespace-b- will work
 


### PR DESCRIPTION
## Problem Statement

This fixes a typo on https://external-secrets.io/v0.9.20/api/clustersecretstore/, in which the property is incorrectly called `namespacesRegex`

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
