### PR TITLE
fix: aws secretmanager's SecretExists returns true for non-existent secrets

### DIFF
--- a/pkg/provider/aws/secretsmanager/secretsmanager.go
+++ b/pkg/provider/aws/secretsmanager/secretsmanager.go
@@ -230,7 +230,7 @@ func (sm *SecretsManager) handleSecretError(err error) (bool, error) {
 		return false, err
 	}
 	if aerr.Code() == awssm.ErrCodeResourceNotFoundException {
-		return true, nil
+		return false, nil
 	}
 	return false, err
 }

--- a/pkg/provider/aws/secretsmanager/secretsmanager_test.go
+++ b/pkg/provider/aws/secretsmanager/secretsmanager_test.go
@@ -1359,7 +1359,7 @@ func TestSecretExists(t *testing.T) {
 				wantError: true,
 			},
 		},
-		"SecretExistsReturnsTrueForNonExistingSecret": {
+		"SecretExistsReturnsFalseForNonExistingSecret": {
 			args: args{
 				store: makeValidSecretStore().Spec.Provider.AWS,
 				client: fakesm.Client{
@@ -1369,7 +1369,7 @@ func TestSecretExists(t *testing.T) {
 			},
 			want: want{
 				err:       nil,
-				wantError: true,
+				wantError: false,
 			},
 		},
 		"SecretExistsReturnsFalseForErroredSecret": {


### PR DESCRIPTION
## Problem Statement

The AWS Provider's SecretManager has a SecretExists function that currently returns `true` when a secret does not exist. Not sure why this was implemented in such a way. This PR fixes that to return `false` when a secret does not exist and alters the unit tests as well.

## Related Issue

Fixes #3682 

## Proposed Changes

How do you like to solve the issue and why?
Change the `handleSecretError` to return false in case the secret does not exist error pops up, hence returning false in the `SecretExists` function.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
