### PR TITLE
Update docs for namespaceSelectors usage and namespaceSelector deprecation

### DIFF
--- a/docs/api/clusterexternalsecret.md
+++ b/docs/api/clusterexternalsecret.md
@@ -2,7 +2,7 @@
 
 The `ClusterExternalSecret` is a cluster scoped resource that can be used to manage `ExternalSecret` resources in specific namespaces.
 
-With `namespaceSelector` you can select namespaces in which the ExternalSecret should be created.
+With `namespaceSelectors` you can select namespaces in which the ExternalSecret should be created.
 If there is a conflict with an existing resource the controller will error out.
 
 ## Example
@@ -12,3 +12,10 @@ Below is an example of the `ClusterExternalSecret` in use.
 ```yaml
 {% include 'full-cluster-external-secret.yaml' %}
 ```
+
+## Deprecations
+
+### namespaceSelector
+
+The field `namespaceSelector` has been deprecated in favor of `namespaceSelectors` and will be removed in a future
+version.

--- a/docs/snippets/full-cluster-external-secret.yaml
+++ b/docs/snippets/full-cluster-external-secret.yaml
@@ -9,8 +9,17 @@ spec:
 
   # This is a basic label selector to select the namespaces to deploy ExternalSecrets to.
   # you can read more about them here https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements
-  namespaceSelector:
-    matchLabels: 
+  # Deprecated: Use namespaceSelectors instead.
+  # namespaceSelector:
+  #   matchLabels:
+  #     cool: label
+
+  # This is a list of basic label selector to select the namespaces to deploy ExternalSecrets to.
+  # you can read more about them here https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements
+  # The list is OR'd together, so if any of the namespaceSelectors match the namespace,
+  # the ExternalSecret will be deployed to that namespace.
+  namespaceSelectors:
+  - matchLabels:
       cool: label
 
   # How often the ClusterExternalSecret should reconcile itself


### PR DESCRIPTION
## Problem Statement

Updating the documentation to reflect the deprecation of `namespaceSelector` in favor of `namespaceSelectors`

## Related Issue

n/a

## Proposed Changes

This has the documentation updated to use `namespaceSelectors` instead of `namespaceSelector`

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
