### PR TITLE
Document secret ownership behaviour of AWS SecretsManager

### DIFF
--- a/docs/guides/pushsecrets.md
+++ b/docs/guides/pushsecrets.md
@@ -10,6 +10,9 @@ By default, the secret created in the secret provided will not be deleted even a
 {% include 'full-pushsecret.yaml' %}
 ```
 
+!!! note
+    Whenever using the `kind=PushSecret` with an existing secret in AWS, make sure to tag it with `managed-by=external-secrets`. Without this tag, ESO will **not** replace the secret value. This tag is used to determine if ESO has ownership over the resource.
+
 ## Backup use case
 
 An interesting use case for `kind=PushSecret` is backing up your current secret from one provider to another one.


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?

Document the behaviour of `PushSecret` only being able to `replace` an existing secret value if a specfic tag is set to the secret that determines the ownership of that secret.

## Related Issue

Fixes https://github.com/external-secrets/external-secrets/issues/3703

## Proposed Changes

How do you like to solve the issue and why?

This 'issue' is not a real problem. The missing documentation is more of what would ideally be fixed to avoid users spending hours troubelshooting an issue like this.

This PR adds a note in the `PushSecret` guide page:
![image](https://github.com/user-attachments/assets/8f103bf3-0bc7-4f48-9b26-d2a24a58a6b4)


## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
