### PR TITLE
feat: add prefix definition to all secret keys for aws parameter store

### DIFF
--- a/apis/externalsecrets/v1beta1/secretstore_aws_types.go
+++ b/apis/externalsecrets/v1beta1/secretstore_aws_types.go
@@ -124,4 +124,8 @@ type AWSProvider struct {
 	// AWS STS assume role transitive session tags. Required when multiple rules are used with the provider
 	// +optional
 	TransitiveTagKeys []*string `json:"transitiveTagKeys,omitempty"`
+
+	// Prefix adds a prefix to all retrieved values.
+	// +optional
+	Prefix string `json:"prefix,omitempty"`
 }

--- a/config/crds/bases/external-secrets.io_clustersecretstores.yaml
+++ b/config/crds/bases/external-secrets.io_clustersecretstores.yaml
@@ -2084,6 +2084,9 @@ spec:
                       externalID:
                         description: AWS External ID set on assumed IAM roles
                         type: string
+                      prefix:
+                        description: Prefix adds a prefix to all retrieved values.
+                        type: string
                       region:
                         description: AWS Region to be used for the provider
                         type: string

--- a/config/crds/bases/external-secrets.io_secretstores.yaml
+++ b/config/crds/bases/external-secrets.io_secretstores.yaml
@@ -2084,6 +2084,9 @@ spec:
                       externalID:
                         description: AWS External ID set on assumed IAM roles
                         type: string
+                      prefix:
+                        description: Prefix adds a prefix to all retrieved values.
+                        type: string
                       region:
                         description: AWS Region to be used for the provider
                         type: string

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -2613,6 +2613,9 @@ spec:
                         externalID:
                           description: AWS External ID set on assumed IAM roles
                           type: string
+                        prefix:
+                          description: Prefix adds a prefix to all retrieved values.
+                          type: string
                         region:
                           description: AWS Region to be used for the provider
                           type: string
@@ -8243,6 +8246,9 @@ spec:
                           type: object
                         externalID:
                           description: AWS External ID set on assumed IAM roles
+                          type: string
+                        prefix:
+                          description: Prefix adds a prefix to all retrieved values.
                           type: string
                         region:
                           description: AWS Region to be used for the provider

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -281,6 +281,18 @@ SecretsManager
 <p>AWS STS assume role transitive session tags. Required when multiple rules are used with the provider</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>prefix</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Prefix adds a prefix to all retrieved values.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="external-secrets.io/v1beta1.AWSServiceType">AWSServiceType

--- a/pkg/provider/aws/parameterstore/fake/fake.go
+++ b/pkg/provider/aws/parameterstore/fake/fake.go
@@ -26,13 +26,14 @@ import (
 
 // Client implements the aws parameterstore interface.
 type Client struct {
-	GetParameterWithContextFn        GetParameterWithContextFn
-	GetParametersByPathWithContextFn GetParametersByPathWithContextFn
-	PutParameterWithContextFn        PutParameterWithContextFn
-	PutParameterWithContextCalledN   int
-	DeleteParameterWithContextFn     DeleteParameterWithContextFn
-	DescribeParametersWithContextFn  DescribeParametersWithContextFn
-	ListTagsForResourceWithContextFn ListTagsForResourceWithContextFn
+	GetParameterWithContextFn           GetParameterWithContextFn
+	GetParametersByPathWithContextFn    GetParametersByPathWithContextFn
+	PutParameterWithContextFn           PutParameterWithContextFn
+	PutParameterWithContextCalledN      int
+	PutParameterWithContextFnCalledWith [][]*ssm.PutParameterInput
+	DeleteParameterWithContextFn        DeleteParameterWithContextFn
+	DescribeParametersWithContextFn     DescribeParametersWithContextFn
+	ListTagsForResourceWithContextFn    ListTagsForResourceWithContextFn
 }
 
 type GetParameterWithContextFn func(aws.Context, *ssm.GetParameterInput, ...request.Option) (*ssm.GetParameterOutput, error)
@@ -88,6 +89,7 @@ func NewDescribeParametersWithContextFn(output *ssm.DescribeParametersOutput, er
 
 func (sm *Client) PutParameterWithContext(ctx aws.Context, input *ssm.PutParameterInput, options ...request.Option) (*ssm.PutParameterOutput, error) {
 	sm.PutParameterWithContextCalledN++
+	sm.PutParameterWithContextFnCalledWith = append(sm.PutParameterWithContextFnCalledWith, []*ssm.PutParameterInput{input})
 	return sm.PutParameterWithContextFn(ctx, input, options...)
 }
 

--- a/pkg/provider/aws/parameterstore/parameterstore.go
+++ b/pkg/provider/aws/parameterstore/parameterstore.go
@@ -60,6 +60,7 @@ type ParameterStore struct {
 	sess         *session.Session
 	client       PMInterface
 	referentAuth bool
+	prefix       string
 }
 
 // PMInterface is a subset of the parameterstore api.
@@ -79,11 +80,12 @@ const (
 )
 
 // New constructs a ParameterStore Provider that is specific to a store.
-func New(sess *session.Session, cfg *aws.Config, referentAuth bool) (*ParameterStore, error) {
+func New(sess *session.Session, cfg *aws.Config, prefix string, referentAuth bool) (*ParameterStore, error) {
 	return &ParameterStore{
 		sess:         sess,
 		referentAuth: referentAuth,
 		client:       ssm.New(sess, cfg),
+		prefix:       prefix,
 	}, nil
 }
 
@@ -105,7 +107,7 @@ func (pm *ParameterStore) getTagsByName(ctx aws.Context, ref *ssm.GetParameterOu
 }
 
 func (pm *ParameterStore) DeleteSecret(ctx context.Context, remoteRef esv1beta1.PushSecretRemoteRef) error {
-	secretName := remoteRef.GetRemoteKey()
+	secretName := pm.prefix + remoteRef.GetRemoteKey()
 	secretValue := ssm.GetParameterInput{
 		Name: &secretName,
 	}
@@ -179,7 +181,7 @@ func (pm *ParameterStore) PushSecret(ctx context.Context, secret *corev1.Secret,
 	}
 
 	stringValue := string(value)
-	secretName := data.GetRemoteKey()
+	secretName := pm.prefix + data.GetRemoteKey()
 
 	secretRequest := ssm.PutParameterInput{
 		Name:      &secretName,
@@ -469,7 +471,7 @@ func (pm *ParameterStore) GetSecret(ctx context.Context, ref esv1beta1.ExternalS
 func (pm *ParameterStore) getParameterTags(ctx context.Context, ref esv1beta1.ExternalSecretDataRemoteRef) (*ssm.GetParameterOutput, error) {
 	param := ssm.GetParameterOutput{
 		Parameter: &ssm.Parameter{
-			Name: parameterNameWithVersion(ref),
+			Name: pm.parameterNameWithVersion(ref),
 		},
 	}
 	tags, err := pm.getTagsByName(ctx, &param)
@@ -490,7 +492,7 @@ func (pm *ParameterStore) getParameterTags(ctx context.Context, ref esv1beta1.Ex
 
 func (pm *ParameterStore) getParameterValue(ctx context.Context, ref esv1beta1.ExternalSecretDataRemoteRef) (*ssm.GetParameterOutput, error) {
 	out, err := pm.client.GetParameterWithContext(ctx, &ssm.GetParameterInput{
-		Name:           parameterNameWithVersion(ref),
+		Name:           pm.parameterNameWithVersion(ref),
 		WithDecryption: aws.Bool(true),
 	})
 
@@ -521,8 +523,8 @@ func (pm *ParameterStore) GetSecretMap(ctx context.Context, ref esv1beta1.Extern
 	return secretData, nil
 }
 
-func parameterNameWithVersion(ref esv1beta1.ExternalSecretDataRemoteRef) *string {
-	name := ref.Key
+func (pm *ParameterStore) parameterNameWithVersion(ref esv1beta1.ExternalSecretDataRemoteRef) *string {
+	name := pm.prefix + ref.Key
 	if ref.Version != "" {
 		// see docs: https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-versions.html#reference-parameter-version
 		name += ":" + ref.Version

--- a/pkg/provider/aws/provider.go
+++ b/pkg/provider/aws/provider.go
@@ -156,7 +156,7 @@ func newClient(ctx context.Context, store esv1beta1.GenericStore, kube client.Cl
 		case esv1beta1.AWSServiceSecretsManager:
 			return secretsmanager.New(sess, cfg, prov.SecretsManager, true)
 		case esv1beta1.AWSServiceParameterStore:
-			return parameterstore.New(sess, cfg, true)
+			return parameterstore.New(sess, cfg, storeSpec.Provider.AWS.Prefix, true)
 		}
 		return nil, fmt.Errorf(errUnknownProviderService, prov.Service)
 	}
@@ -195,7 +195,7 @@ func newClient(ctx context.Context, store esv1beta1.GenericStore, kube client.Cl
 	case esv1beta1.AWSServiceSecretsManager:
 		return secretsmanager.New(sess, cfg, prov.SecretsManager, false)
 	case esv1beta1.AWSServiceParameterStore:
-		return parameterstore.New(sess, cfg, false)
+		return parameterstore.New(sess, cfg, storeSpec.Provider.AWS.Prefix, false)
 	}
 	return nil, fmt.Errorf(errUnknownProviderService, prov.Service)
 }


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?

## Related Issue

Fixes https://github.com/external-secrets/external-secrets/issues/1649

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
