### PR TITLE
remove redundant parameter grab call, we already have the data

### DIFF
--- a/pkg/provider/aws/parameterstore/parameterstore.go
+++ b/pkg/provider/aws/parameterstore/parameterstore.go
@@ -308,10 +308,7 @@ func (pm *ParameterStore) findByName(ctx context.Context, ref esv1beta1.External
 			if !matcher.MatchName(*param.Name) {
 				continue
 			}
-			err = pm.fetchAndSet(ctx, data, *param.Name)
-			if err != nil {
-				return nil, err
-			}
+			data[*param.Name] = []byte(*param.Value)
 		}
 		nextToken = it.NextToken
 		if nextToken == nil {


### PR DESCRIPTION
## Problem Statement

`GetParametersByPathWithContext()` already has all the parameters, decrypted. No need to query the API once more to get the same thing.
Looks like `findByName()` is a copy paste from the implementation for `findByTag()`, but in the latter case a different call is used - `DescribeParametersWithContext()` which requires additional `GetParameterWithContext()` call to get the value.

You can test that call easily by using AWS CLI `aws sim get-parameters-by-path --path 'your/ssm/path' --with-decryption` and see the output actually contains everything.

## Related Issue

Haven't open one yet.

## Proposed Changes

The change eliminates a redundant call which in my case is the difference between hitting AWS SSM rate-limits and not.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
