### PR TITLE
docs: Improvements in the ExternalSecret comments in API section

### DIFF
--- a/docs/snippets/full-external-secret.yaml
+++ b/docs/snippets/full-external-secret.yaml
@@ -32,17 +32,18 @@ spec:
     # It is immutable
     name: application-config
 
-    # Enum with values: 'Owner', 'Merge', or 'None'
-    # Default value of 'Owner'
-    # Owner creates the secret and sets .metadata.ownerReferences of the resource
-    # Merge does not create the secret, but merges in the data fields to the secret
-    # None does not create a secret (future use with injector)
-    creationPolicy: 'Merge'
+    # Specifies the ExternalSecret ownership details in the created Secret. Options:
+    # - Owner: (default) Creates the Secret and sets .metadata.ownerReferences. If the ExternalSecret is deleted, the Secret will also be deleted.
+    # - Merge: Does not create the Secret but merges data fields into the existing Secret (expects the Secret to already exist).
+    # - Orphan: Creates the Secret but does not set .metadata.ownerReferences. If the Secret already exists, it will be updated.
+    # - None: Does not create or update the Secret (reserved for future use with injector).
+    creationPolicy: Merge
 
-    # DeletionPolicy defines how/when to delete the Secret in Kubernetes
-    # if the provider secret gets deleted.
-    # Valid values are Delete, Merge, Retain
-    deletionPolicy: "Retain"
+    # Specifies what happens to the Secret when data fields are deleted from the provider (e.g., Vault, AWS Parameter Store). Options:
+    # - Retain: (default) Retains the Secret if all Secret data fields have been deleted from the provider.
+    # - Delete: Removes the Secret if all Secret data fields from the provider are deleted.
+    # - Merge: Removes keys from the Secret but not the Secret itself.
+    deletionPolicy: Retain
 
     # Specify a blueprint for the resulting Kind=Secret
     template:


### PR DESCRIPTION


## Problem Statement

In the _[API » External Secret » Example](https://external-secrets.io/v0.9.20/api/externalsecret/#example)_ documentation page, the comments for the `.spec.target.creationPolicy` parameter do not mention the `Orphan` option. Additionally, the comments for the `.spec.target.deletionPolicy` parameter lack a description of the available options.

## Related Issue

Fixes: https://github.com/external-secrets/external-secrets/issues/3724

## Proposed Changes

Re-write the comments for the `.spec.target.creationPolicy` and `.spec.target.deletionPolicy` parameters to clearly explain their functionality and list the available options using straightforward language.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
