### PR TITLE
feat: increase verbosity of error message during validation

### DIFF
--- a/e2e/suites/provider/cases/vault/vault.go
+++ b/e2e/suites/provider/cases/vault/vault.go
@@ -292,7 +292,7 @@ func testInvalidMtlsStore(tc *framework.TestCase) {
 		Expect(string(ss.Status.Conditions[0].Type)).Should(Equal("Ready"))
 		Expect(string(ss.Status.Conditions[0].Status)).Should(Equal("False"))
 		Expect(ss.Status.Conditions[0].Reason).Should(Equal("ValidationFailed"))
-		Expect(ss.Status.Conditions[0].Message).Should(Equal(fmt.Sprintf("unable to validate store: %s", err)))
+		Expect(ss.Status.Conditions[0].Message).Should(ContainSubstring("unable to validate store"))
 		return true, nil
 	})
 	Expect(err).ToNot(HaveOccurred())

--- a/e2e/suites/provider/cases/vault/vault.go
+++ b/e2e/suites/provider/cases/vault/vault.go
@@ -292,7 +292,7 @@ func testInvalidMtlsStore(tc *framework.TestCase) {
 		Expect(string(ss.Status.Conditions[0].Type)).Should(Equal("Ready"))
 		Expect(string(ss.Status.Conditions[0].Status)).Should(Equal("False"))
 		Expect(ss.Status.Conditions[0].Reason).Should(Equal("ValidationFailed"))
-		Expect(ss.Status.Conditions[0].Message).Should(Equal("unable to validate store"))
+		Expect(ss.Status.Conditions[0].Message).Should(Equal(fmt.Sprintf("unable to validate store: %s", err)))
 		return true, nil
 	})
 	Expect(err).ToNot(HaveOccurred())

--- a/pkg/controllers/secretstore/common.go
+++ b/pkg/controllers/secretstore/common.go
@@ -35,7 +35,7 @@ const (
 	errValidationFailed    = "could not validate provider: %w"
 	errPatchStatus         = "unable to patch status: %w"
 	errUnableCreateClient  = "unable to create client"
-	errUnableValidateStore = "unable to validate store"
+	errUnableValidateStore = "unable to validate store: %s"
 	errUnableGetProvider   = "unable to get store provider"
 
 	msgStoreValidated = "store validated"
@@ -103,7 +103,7 @@ func validateStore(ctx context.Context, namespace, controllerClass string, store
 	}
 	validationResult, err := cl.Validate()
 	if err != nil && validationResult != esapi.ValidationResultUnknown {
-		cond := NewSecretStoreCondition(esapi.SecretStoreReady, v1.ConditionFalse, esapi.ReasonValidationFailed, errUnableValidateStore)
+		cond := NewSecretStoreCondition(esapi.SecretStoreReady, v1.ConditionFalse, esapi.ReasonValidationFailed, fmt.Sprintf(errUnableValidateStore, err))
 		SetExternalSecretCondition(store, *cond, gaugeVecGetter)
 		recorder.Event(store, v1.EventTypeWarning, esapi.ReasonValidationFailed, err.Error())
 		return fmt.Errorf(errValidationFailed, err)


### PR DESCRIPTION
## Problem Statement

Some who don't have access to the logs, will be unable to identify errors that are from validation.

![clack1](https://github.com/user-attachments/assets/068cd91c-863a-4fff-b399-faec0f1bee97)


This addition increases the verbosity of that error.

## Related Issue

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
