### PR TITLE
docs: Remove references to pemCertificate and pemPrivateKey functions 

### DIFF
--- a/docs/guides/templating-v1.md
+++ b/docs/guides/templating-v1.md
@@ -18,7 +18,7 @@ You can use templates to inject your secrets into a configuration file that you 
 
 You can also use pre-defined functions to extract data from your secrets. Here: extract key/cert from a pkcs12 archive and store it as PEM.
 ``` yaml
-{% include 'pkcs12-template-v1-external-secret.yaml' %}
+{% include 'pkcs12-template-v2-external-secret.yaml' %}
 ```
 
 ### TemplateFrom

--- a/docs/snippets/gcpsm-tls-externalsecret.yaml
+++ b/docs/snippets/gcpsm-tls-externalsecret.yaml
@@ -14,8 +14,8 @@ spec:
     template:
       type: kubernetes.io/tls
       data:
-        tls.crt: "{{ .mysecret | pkcs12cert | pemCertificate }}"
-        tls.key: "{{ .mysecret | pkcs12key | pemPrivateKey }}"
+        tls.crt: "{{ .mysecret | pkcs12cert }}"
+        tls.key: "{{ .mysecret | pkcs12key }}"
 
   data:
   # this is a pkcs12 archive that contains


### PR DESCRIPTION
## Problem Statement

The documents are outdated when it comes to templating an `ExternalSecret` and decoding a .p12/.pfx file.

## Related Issue

Fixes #3260 

## Proposed Changes

I'm trying to update the docs such that they don't reference the unused functions `pemCertificate` and `pemPrivateKey`. 

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
