### PR TITLE
feat: webhook secrets must be labeled

### DIFF
--- a/pkg/common/webhook/webhook.go
+++ b/pkg/common/webhook/webhook.go
@@ -64,9 +64,9 @@ func (w *Webhook) getStoreSecret(ctx context.Context, ref SecretKeySelector) (*c
 		return nil, fmt.Errorf("failed to get clustersecretstore webhook secret %s: %w", ref.Name, err)
 	}
 	if w.EnforceLabels {
-		expected, ok := secret.Labels["generators.external-secrets.io/type"]
+		expected, ok := secret.Labels["external-secrets.io/type"]
 		if !ok {
-			return nil, fmt.Errorf("secret does not contain needed label to be used on webhook generator")
+			return nil, fmt.Errorf("secret does not contain needed label 'external-secrets.io/type: webhook'. Update secret label to use it with webhook")
 		}
 		if expected != "webhook" {
 			return nil, fmt.Errorf("secret type is not 'webhook'")

--- a/pkg/provider/webhook/webhook.go
+++ b/pkg/provider/webhook/webhook.go
@@ -70,6 +70,7 @@ func (p *Provider) NewClient(_ context.Context, store esv1beta1.GenericStore, ku
 		wh:        wh,
 		storeKind: store.GetObjectKind().GroupVersionKind().Kind,
 	}
+	whClient.wh.EnforceLabels = true
 	if whClient.storeKind == esv1beta1.ClusterSecretStoreKind {
 		whClient.wh.ClusterScoped = true
 	}


### PR DESCRIPTION
BREAKING CHANGE: Webhook secrets now must be labeled for Webhook SecretStore

BREAKING CHANGE: Generator webhook labels changed

## Problem Statement

What is the problem you're trying to solve?

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
