### PR TITLE
Add ability to change service type, loadBalancerIP, labels and annotations

### DIFF
--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -216,6 +216,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | webhook.securityContext.runAsNonRoot | bool | `true` |  |
 | webhook.securityContext.runAsUser | int | `1000` |  |
 | webhook.securityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
+| webhook.service | object | `{"annotations":{},"enabled":true,"labels":{},"loadBalancerIP":"","type":"ClusterIP"}` | Manage the service through which the webhook is reached. |
+| webhook.service.annotations | object | `{}` | Custom annotations for the webhook service. |
+| webhook.service.enabled | bool | `true` | Whether the service object should be enabled or not (it is expected to exist). |
+| webhook.service.labels | object | `{}` | Custom labels for the webhook service. |
+| webhook.service.loadBalancerIP | string | `""` | If the webhook service type is LoadBalancer, you can assign a specific load balancer IP here. Check the documentation of your load balancer provider to see if/how this should be used. |
+| webhook.service.type | string | `"ClusterIP"` | The service type of the webhook service. |
 | webhook.serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
 | webhook.serviceAccount.automount | bool | `true` | Automounts the service account token in all containers of the pod |
 | webhook.serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |

--- a/deploy/charts/external-secrets/templates/_helpers.tpl
+++ b/deploy/charts/external-secrets/templates/_helpers.tpl
@@ -66,6 +66,23 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- with .Values.commonLabels }}
 {{ toYaml . }}
 {{- end }}
+{{- with .Values.webhook.service.labels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{- define "external-secrets-webhook.annotations" -}}
+{{- if or .Values.webhook.service.annotations (and .Values.webhook.metrics.service.enabled .Values.webhook.metrics.service.annotations) -}}
+annotations:
+{{- with .Values.webhook.service.annotations }}
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- if .Values.webhook.metrics.service.enabled }}
+{{- with .Values.webhook.metrics.service.annotations }}
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{- define "external-secrets-webhook-metrics.labels" -}}

--- a/deploy/charts/external-secrets/templates/webhook-service.yaml
+++ b/deploy/charts/external-secrets/templates/webhook-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.webhook.create }}
+{{- if and .Values.webhook.create .Values.webhook.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -7,19 +7,17 @@ metadata:
   labels:
     {{- include "external-secrets-webhook.labels" . | nindent 4 }}
     external-secrets.io/component: webhook
-  {{- if .Values.webhook.metrics.service.enabled }}
-  {{- with .Values.webhook.metrics.service.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-  {{- end }}
+  {{- include "external-secrets-webhook.annotations" . | nindent 2 }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.webhook.service.type }}
   {{- if .Values.service.ipFamilyPolicy }}
   ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
   {{- end }}
   {{- if .Values.service.ipFamilies }}
   ipFamilies: {{ .Values.service.ipFamilies | toYaml | nindent 2 }}
+  {{- end }}
+  {{- with .Values.webhook.service.loadBalancerIP }}
+  loadBalancerIP: {{ . }}
   {{- end }}
   ports:
   - port: 443

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -404,6 +404,20 @@ webhook:
       #   cpu: 10m
       #   memory: 32Mi
 
+  # -- Manage the service through which the webhook is reached.
+  service:
+    # -- Whether the service object should be enabled or not (it is expected to exist).
+    enabled: true
+    # -- Custom annotations for the webhook service.
+    annotations: {}
+    # -- Custom labels for the webhook service.
+    labels: {}
+    # -- The service type of the webhook service.
+    type: ClusterIP
+    # -- If the webhook service type is LoadBalancer, you can assign a specific load balancer IP here.
+    # Check the documentation of your load balancer provider to see if/how this should be used.
+    loadBalancerIP: ""
+
 certController:
   # -- Specifies whether a certificate controller deployment be created.
   create: true


### PR DESCRIPTION
## Problem Statement

See #3802

## Related Issue

Fixes #3802

## Proposed Changes

Add a block of values to `webhook.service` to specify the `type` and `loadBalancerIP`, which are not customizable now.

Also, for good measure, extend this block with options to specify custom labels an annotations. Specifying custom labels was impossible without adding the label to everything. Custom annotations were possible, but only through `webhook.metrics.service`, which is confusing and misleading IMO given that the webhook service isn't just for metrics.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [-] All tests pass with `make test`
- [-] I ensured my PR is ready for review with `make reviewable`
