### PR TITLE
Bump helm-docs image version to v1.7.0 in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ tilt-up: tilt manifests ## Generates the local manifests that tilt will use to d
 
 helm.docs: ## Generate helm docs
 	@cd $(HELM_DIR); \
-	docker run --rm -v $(shell pwd)/$(HELM_DIR):/helm-docs -u $(shell id -u) jnorwood/helm-docs:v1.5.0
+	docker run --rm -v $(shell pwd)/$(HELM_DIR):/helm-docs -u $(shell id -u) jnorwood/helm-docs:v1.7.0
 
 HELM_VERSION ?= $(shell helm show chart $(HELM_DIR) | grep 'version:' | sed 's/version: //g')
 

--- a/deploy/charts/external-secrets/tests/__snapshot__/crds_test.yaml.snap
+++ b/deploy/charts/external-secrets/tests/__snapshot__/crds_test.yaml.snap
@@ -2161,6 +2161,134 @@ should match snapshot of default values:
                           required:
                             - vaultUrl
                           type: object
+                        beyondtrust:
+                          description: Beyondtrust configures this store to sync secrets using Password Safe provider.
+                          properties:
+                            auth:
+                              description: Auth configures how the operator authenticates with Beyondtrust.
+                              properties:
+                                certificate:
+                                  description: Content of the certificate (cert.pem) for use when authenticating with an OAuth client Id using a Client Certificate.
+                                  properties:
+                                    secretRef:
+                                      description: SecretRef references a key in a secret that will be used as value.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
+                                            defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
+                                            to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                    value:
+                                      description: Value can be specified directly to set a value without using a secret.
+                                      type: string
+                                  type: object
+                                certificateKey:
+                                  description: Certificate private key (key.pem). For use when authenticating with an OAuth client Id
+                                  properties:
+                                    secretRef:
+                                      description: SecretRef references a key in a secret that will be used as value.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
+                                            defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
+                                            to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                    value:
+                                      description: Value can be specified directly to set a value without using a secret.
+                                      type: string
+                                  type: object
+                                clientId:
+                                  properties:
+                                    secretRef:
+                                      description: SecretRef references a key in a secret that will be used as value.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
+                                            defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
+                                            to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                    value:
+                                      description: Value can be specified directly to set a value without using a secret.
+                                      type: string
+                                  type: object
+                                clientSecret:
+                                  properties:
+                                    secretRef:
+                                      description: SecretRef references a key in a secret that will be used as value.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
+                                            defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
+                                            to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                    value:
+                                      description: Value can be specified directly to set a value without using a secret.
+                                      type: string
+                                  type: object
+                              required:
+                                - clientId
+                                - clientSecret
+                              type: object
+                            server:
+                              description: Auth configures how API server works.
+                              properties:
+                                apiUrl:
+                                  type: string
+                                clientTimeOutSeconds:
+                                  description: Timeout specifies a time limit for requests made by this Client. The timeout includes connection time, any redirects, and reading the response body. Defaults to 45 seconds.
+                                  type: integer
+                                retrievalType:
+                                  description: The secret retrieval type. SECRET = Secrets Safe (credential, text, file). MANAGED_ACCOUNT = Password Safe account associated with a system.
+                                  type: string
+                                separator:
+                                  description: A character that separates the folder names.
+                                  type: string
+                                verifyCA:
+                                  type: boolean
+                              required:
+                                - apiUrl
+                                - verifyCA
+                              type: object
+                          required:
+                            - auth
+                            - server
+                          type: object
                         bitwardensecretsmanager:
                           description: BitwardenSecretsManager configures this store to sync secrets using BitwardenSecretsManager provider
                           properties:
@@ -2204,6 +2332,30 @@ should match snapshot of default values:
                                 Base64 encoded certificate for the bitwarden server sdk. The sdk MUST run with HTTPS to make sure no MITM attack
                                 can be performed.
                               type: string
+                            caProvider:
+                              description: 'see: https://external-secrets.io/latest/spec/#external-secrets.io/v1alpha1.CAProvider'
+                              properties:
+                                key:
+                                  description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                                  type: string
+                                name:
+                                  description: The name of the object located at the provider type.
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace the Provider type is in.
+                                    Can only be defined when used in a ClusterSecretStore.
+                                  type: string
+                                type:
+                                  description: The type of provider to use such as "Secret", or "ConfigMap".
+                                  enum:
+                                    - Secret
+                                    - ConfigMap
+                                  type: string
+                              required:
+                                - name
+                                - type
+                              type: object
                             identityURL:
                               type: string
                             organizationID:
@@ -2214,7 +2366,6 @@ should match snapshot of default values:
                               type: string
                           required:
                             - auth
-                            - caBundle
                             - organizationID
                             - projectID
                           type: object


### PR DESCRIPTION
## Problem Statement

The current helm-docs image version (v1.5.0) in the Makefile only supports amd64 architecture, making "make reviewable" not runnable on Linux VMs on MacOS ARM systems without additional changes.

## Related Issue
Fixes #3750 

## Proposed Changes

Update the helm-docs image version in the Makefile from v1.5.0 to v1.7.0. This change will enable "make reviewable" to run on MacOS ARM-based systems without additional modifications.
The proposed solution involves updating the following line in the Makefile:
`@docker run --rm -v $(shell pwd)/$(HELM_DIR):/helm-docs -u $(shell id -u) jnorwood/helm-docs:v1.7.0`

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
