### PR TITLE
add the resourceNames

### DIFF
--- a/deploy/charts/external-secrets/templates/cert-controller-rbac.yaml
+++ b/deploy/charts/external-secrets/templates/cert-controller-rbac.yaml
@@ -20,6 +20,9 @@ rules:
     - "admissionregistration.k8s.io"
     resources:
     - "validatingwebhookconfigurations"
+    resourceNames:
+    - "secretstore-validate"
+    - "externalsecret-validate"
     verbs:
     - "get"
     - "list"


### PR DESCRIPTION
## Problem Statement

The controller does not need to patch all validating webhook configuration. Therefore, an additional resourceName restriction has been added for the patch and update operations. This can fix potential privilege exploitation issues.

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
