### PR TITLE
fix: only replace data if it is in the middle of the path

### DIFF
--- a/pkg/provider/vault/client_get.go
+++ b/pkg/provider/vault/client_get.go
@@ -221,7 +221,7 @@ func (c *client) buildMetadataPath(path string) (string, error) {
 			return "", errors.New(errPathInvalid)
 		}
 		if c.store.Path == nil {
-			path = strings.Replace(path, "data", "metadata", 1)
+			path = strings.Replace(path, "/data/", "/metadata/", 1)
 			url = path
 		} else {
 			url = fmt.Sprintf("%s/metadata/%s", *c.store.Path, path)


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?

## Related Issue

Fixes https://github.com/external-secrets/external-secrets/issues/3116

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
