### PR TITLE
Delinea provider is listed twice on the documentation page, and Delin…

### DIFF
--- a/hack/api-docs/mkdocs.yml
+++ b/hack/api-docs/mkdocs.yml
@@ -116,7 +116,7 @@ nav:
       - Cloak End 2 End Encrypted Secrets: provider/cloak.md
       - Scaleway: provider/scaleway.md
       - Delinea: provider/delinea.md
-      - Secret Server: provider/delinea.md
+      - Secret Server: provider/secretserver.md
       - Passbolt: provider/passbolt.md
       - Pulumi ESC: provider/pulumi.md
       - Onboardbase: provider/onboardbase.md


### PR DESCRIPTION
…ea Secret Server is missing

## Problem Statement

Delinea provider is listed twice on the documentation page, and Delinea Secret Server is missing

## Related Issue

Fixes #3795 

## Proposed Changes

Adding secretserver.md and removing delinea duplicated entry

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
