### PR TITLE
chore: updates default oci

### DIFF
--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -47,7 +47,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | certController.hostNetwork | bool | `false` | Run the certController on the host network |
 | certController.image.flavour | string | `""` |  |
 | certController.image.pullPolicy | string | `"IfNotPresent"` |  |
-| certController.image.repository | string | `"ghcr.io/external-secrets/external-secrets"` |  |
+| certController.image.repository | string | `"oci.external-secrets.io/external-secrets/external-secrets"` |  |
 | certController.image.tag | string | `""` |  |
 | certController.imagePullSecrets | list | `[]` |  |
 | certController.log | object | `{"level":"info","timeEncoding":"epoch"}` | Specifices Log Params to the Webhook |
@@ -111,7 +111,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | hostNetwork | bool | `false` | Run the controller on the host network |
 | image.flavour | string | `""` | The flavour of tag you want to use There are different image flavours available, like distroless and ubi. Please see GitHub release notes for image tags for these flavors. By default, the distroless image is used. |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"ghcr.io/external-secrets/external-secrets"` |  |
+| image.repository | string | `"oci.external-secrets.io/external-secrets/external-secrets"` |  |
 | image.tag | string | `""` | The image tag to use. The default is the chart appVersion. |
 | imagePullSecrets | list | `[]` |  |
 | installCRDs | bool | `true` | If set, install and upgrade CRDs through helm chart. |
@@ -185,7 +185,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | webhook.hostNetwork | bool | `false` | Specifies if webhook pod should use hostNetwork or not. |
 | webhook.image.flavour | string | `""` | The flavour of tag you want to use |
 | webhook.image.pullPolicy | string | `"IfNotPresent"` |  |
-| webhook.image.repository | string | `"ghcr.io/external-secrets/external-secrets"` |  |
+| webhook.image.repository | string | `"oci.external-secrets.io/external-secrets/external-secrets"` |  |
 | webhook.image.tag | string | `""` | The image tag to use. The default is the chart appVersion. |
 | webhook.imagePullSecrets | list | `[]` |  |
 | webhook.log | object | `{"level":"info","timeEncoding":"epoch"}` | Specifices Log Params to the Webhook |

--- a/deploy/charts/external-secrets/tests/__snapshot__/cert_controller_test.yaml.snap
+++ b/deploy/charts/external-secrets/tests/__snapshot__/cert_controller_test.yaml.snap
@@ -41,7 +41,7 @@ should match snapshot of default values:
                 - --loglevel=info
                 - --zap-time-encoding=epoch
                 - --enable-partial-cache=true
-              image: ghcr.io/external-secrets/external-secrets:v0.10.3
+              image: oci.external-secrets.io/external-secrets/external-secrets:v0.10.3
               imagePullPolicy: IfNotPresent
               name: cert-controller
               ports:

--- a/deploy/charts/external-secrets/tests/__snapshot__/controller_test.yaml.snap
+++ b/deploy/charts/external-secrets/tests/__snapshot__/controller_test.yaml.snap
@@ -34,7 +34,7 @@ should match snapshot of default values:
                 - --metrics-addr=:8080
                 - --loglevel=info
                 - --zap-time-encoding=epoch
-              image: ghcr.io/external-secrets/external-secrets:v0.10.3
+              image: oci.external-secrets.io/external-secrets/external-secrets:v0.10.3
               imagePullPolicy: IfNotPresent
               name: external-secrets
               ports:

--- a/deploy/charts/external-secrets/tests/__snapshot__/webhook_test.yaml.snap
+++ b/deploy/charts/external-secrets/tests/__snapshot__/webhook_test.yaml.snap
@@ -39,7 +39,7 @@ should match snapshot of default values:
                 - --healthz-addr=:8081
                 - --loglevel=info
                 - --zap-time-encoding=epoch
-              image: ghcr.io/external-secrets/external-secrets:v0.10.3
+              image: oci.external-secrets.io/external-secrets/external-secrets:v0.10.3
               imagePullPolicy: IfNotPresent
               name: webhook
               ports:

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -21,7 +21,7 @@ bitwarden-sdk-server:
 revisionHistoryLimit: 10
 
 image:
-  repository: ghcr.io/external-secrets/external-secrets
+  repository: oci.external-secrets.io/external-secrets/external-secrets
   pullPolicy: IfNotPresent
   # -- The image tag to use. The default is the chart appVersion.
   tag: ""
@@ -259,7 +259,7 @@ webhook:
   # -- Specifies if webhook pod should use hostNetwork or not.
   hostNetwork: false
   image:
-    repository: ghcr.io/external-secrets/external-secrets
+    repository: oci.external-secrets.io/external-secrets/external-secrets
     pullPolicy: IfNotPresent
     # -- The image tag to use. The default is the chart appVersion.
     tag: ""
@@ -417,7 +417,7 @@ certController:
   revisionHistoryLimit: 10
 
   image:
-    repository: ghcr.io/external-secrets/external-secrets
+    repository: oci.external-secrets.io/external-secrets/external-secrets
     pullPolicy: IfNotPresent
     tag: ""
     flavour: ""

--- a/e2e/framework/addon/eso.go
+++ b/e2e/framework/addon/eso.go
@@ -43,12 +43,24 @@ func NewESO(mutators ...MutationFunc) *ESO {
 					Value: os.Getenv("VERSION"),
 				},
 				{
+					Key:   "webhook.image.repository",
+					Value: "ghcr.io/external-secrets/external-secrets",
+				},
+				{
 					Key:   "certController.image.tag",
 					Value: os.Getenv("VERSION"),
 				},
 				{
+					Key:   "certController.image.repository",
+					Value: "ghcr.io/external-secrets/external-secrets",
+				},
+				{
 					Key:   "image.tag",
 					Value: os.Getenv("VERSION"),
+				},
+				{
+					Key:   "image.repository",
+					Value: "ghcr.io/external-secrets/external-secrets",
 				},
 				{
 					Key:   "extraArgs.loglevel",


### PR DESCRIPTION
Updates Default OCI registry to use scarf

## Related Issue
towards #3872 

## Proposed Changes
Changes default value to use our own dns.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
