### PR TITLE
RELEASE BLOCKER: fix: flux and e2e tests not using the right image names for caching on local kind cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
     <img src="assets/eso-logo-large.png" width="30%" align="center" alt="external-secrets">
 </p>
 
+
 # External Secrets
 
 ![ci](https://github.com/external-secrets/external-secrets/actions/workflows/ci.yml/badge.svg?branch=main)

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -9,6 +9,13 @@ export E2E_IMAGE_NAME ?= ghcr.io/external-secrets/external-secrets-e2e
 export GINKGO_LABELS ?= !managed
 export TEST_SUITES ?= provider generator flux argocd
 
+# Image registry for build/push image targets
+# Overwrite what is being set in the main Makeilfe because
+# this is what the Helm chart is using.
+export IMAGE_REGISTRY = oci.external-secrets.io
+export IMAGE_REPO     = external-secrets/external-secrets
+export IMAGE_NAME = $(IMAGE_REGISTRY)/$(IMAGE_REPO)
+
 start-kind: ## Start kind cluster
 	kind create cluster \
 	  --name external-secrets \


### PR DESCRIPTION
## Problem Statement

What happens if when the test is running it loads images into the kind cluster. But the flux test is actually using the helm chart which contains a different repository so it failed to find the right image.

I fixed that by overwriting the image that is being used for e2e testing.

Why not just fix the Flux test? 

Because I want to make sure that the proxy repository is working with ALL of the tests, while the original Makefile is still building the ghcr.io repository images.

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
