### PR TITLE
Make CRD categories useful

### DIFF
--- a/apis/externalsecrets/v1alpha1/externalsecret_types.go
+++ b/apis/externalsecrets/v1alpha1/externalsecret_types.go
@@ -235,7 +235,7 @@ type ExternalSecretStatus struct {
 // ExternalSecret is the Schema for the external-secrets API.
 // +kubebuilder:subresource:status
 // +kubebuilder:deprecatedversion
-// +kubebuilder:resource:scope=Namespaced,categories={externalsecrets},shortName=es
+// +kubebuilder:resource:scope=Namespaced,categories={external-secrets},shortName=es
 // +kubebuilder:printcolumn:name="Store",type=string,JSONPath=`.spec.secretStoreRef.name`
 // +kubebuilder:printcolumn:name="Refresh Interval",type=string,JSONPath=`.spec.refreshInterval`
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].reason`

--- a/apis/externalsecrets/v1alpha1/pushsecret_types.go
+++ b/apis/externalsecrets/v1alpha1/pushsecret_types.go
@@ -198,7 +198,8 @@ type PushSecretStatus struct {
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].reason`
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Namespaced,categories={pushsecrets}
+// +kubebuilder:metadata:labels="external-secrets.io/component=controller"
+// +kubebuilder:resource:scope=Namespaced,categories={external-secrets}
 
 type PushSecret struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/externalsecrets/v1alpha1/secretstore_types.go
+++ b/apis/externalsecrets/v1alpha1/secretstore_types.go
@@ -136,7 +136,7 @@ type SecretStoreStatus struct {
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].reason`
 // +kubebuilder:subresource:status
 // +kubebuilder:deprecatedversion
-// +kubebuilder:resource:scope=Namespaced,categories={externalsecrets},shortName=ss
+// +kubebuilder:resource:scope=Namespaced,categories={external-secrets},shortName=ss
 type SecretStore struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -161,7 +161,7 @@ type SecretStoreList struct {
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].reason`
 // +kubebuilder:deprecatedversion
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Cluster,categories={externalsecrets},shortName=css
+// +kubebuilder:resource:scope=Cluster,categories={external-secrets},shortName=css
 type ClusterSecretStore struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/externalsecrets/v1beta1/clusterexternalsecret_types.go
+++ b/apis/externalsecrets/v1beta1/clusterexternalsecret_types.go
@@ -100,7 +100,7 @@ type ClusterExternalSecretStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
-// +kubebuilder:resource:scope=Cluster,categories={externalsecrets},shortName=ces
+// +kubebuilder:resource:scope=Cluster,categories={external-secrets},shortName=ces
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:labels="external-secrets.io/component=controller"
 // +kubebuilder:printcolumn:name="Store",type=string,JSONPath=`.spec.externalSecretSpec.secretStoreRef.name`

--- a/apis/externalsecrets/v1beta1/externalsecret_types.go
+++ b/apis/externalsecrets/v1beta1/externalsecret_types.go
@@ -454,7 +454,7 @@ type ExternalSecretStatus struct {
 // ExternalSecret is the Schema for the external-secrets API.
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:labels="external-secrets.io/component=controller"
-// +kubebuilder:resource:scope=Namespaced,categories={externalsecrets},shortName=es
+// +kubebuilder:resource:scope=Namespaced,categories={external-secrets},shortName=es
 // +kubebuilder:printcolumn:name="Store",type=string,JSONPath=`.spec.secretStoreRef.name`
 // +kubebuilder:printcolumn:name="Refresh Interval",type=string,JSONPath=`.spec.refreshInterval`
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].reason`

--- a/apis/externalsecrets/v1beta1/secretstore_types.go
+++ b/apis/externalsecrets/v1beta1/secretstore_types.go
@@ -280,7 +280,7 @@ type SecretStoreStatus struct {
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:labels="external-secrets.io/component=controller"
-// +kubebuilder:resource:scope=Namespaced,categories={externalsecrets},shortName=ss
+// +kubebuilder:resource:scope=Namespaced,categories={external-secrets},shortName=ss
 type SecretStore struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -308,7 +308,7 @@ type SecretStoreList struct {
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:labels="external-secrets.io/component=controller"
-// +kubebuilder:resource:scope=Cluster,categories={externalsecrets},shortName=css
+// +kubebuilder:resource:scope=Cluster,categories={external-secrets},shortName=css
 type ClusterSecretStore struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/generators/v1alpha1/generator_acr.go
+++ b/apis/generators/v1alpha1/generator_acr.go
@@ -105,7 +105,7 @@ type AzureACRServicePrincipalAuthSecretRef struct {
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:labels="external-secrets.io/component=controller"
-// +kubebuilder:resource:scope=Namespaced,categories={acraccesstoken},shortName=acraccesstoken
+// +kubebuilder:resource:scope=Namespaced,categories={external-secrets, external-secrets-generators},shortName=acraccesstoken
 type ACRAccessToken struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/generators/v1alpha1/generator_ecr.go
+++ b/apis/generators/v1alpha1/generator_ecr.go
@@ -75,7 +75,7 @@ type AWSJWTAuth struct {
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:labels="external-secrets.io/component=controller"
-// +kubebuilder:resource:scope=Namespaced,categories={ecrauthorizationtoken},shortName=ecrauthorizationtoken
+// +kubebuilder:resource:scope=Namespaced,categories={external-secrets, external-secrets-generators},shortName=ecrauthorizationtoken
 type ECRAuthorizationToken struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/generators/v1alpha1/generator_fake.go
+++ b/apis/generators/v1alpha1/generator_fake.go
@@ -36,7 +36,7 @@ type FakeSpec struct {
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:labels="external-secrets.io/component=controller"
-// +kubebuilder:resource:scope=Namespaced,categories={fake},shortName=fake
+// +kubebuilder:resource:scope=Namespaced,categories={external-secrets, external-secrets-generators},shortName=fake
 type Fake struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/generators/v1alpha1/generator_gcr.go
+++ b/apis/generators/v1alpha1/generator_gcr.go
@@ -53,7 +53,7 @@ type GCPWorkloadIdentity struct {
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:labels="external-secrets.io/component=controller"
-// +kubebuilder:resource:scope=Namespaced,categories={gcraccesstoken},shortName=gcraccesstoken
+// +kubebuilder:resource:scope=Namespaced,categories={external-secrets, external-secrets-generators},shortName=gcraccesstoken
 type GCRAccessToken struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/generators/v1alpha1/generator_github.go
+++ b/apis/generators/v1alpha1/generator_github.go
@@ -42,7 +42,7 @@ type GithubSecretRef struct {
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:labels="external-secrets.io/component=controller"
-// +kubebuilder:resource:scope=Namespaced,categories={githubaccesstoken},shortName=githubaccesstoken
+// +kubebuilder:resource:scope=Namespaced,categories={external-secrets, external-secrets-generators},shortName=githubaccesstoken
 type GithubAccessToken struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/generators/v1alpha1/generator_password.go
+++ b/apis/generators/v1alpha1/generator_password.go
@@ -53,7 +53,7 @@ type PasswordSpec struct {
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:labels="external-secrets.io/component=controller"
-// +kubebuilder:resource:scope=Namespaced,categories={password},shortName=password
+// +kubebuilder:resource:scope=Namespaced,categories={external-secrets, external-secrets-generators},shortName=password
 type Password struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/generators/v1alpha1/generator_uuid.go
+++ b/apis/generators/v1alpha1/generator_uuid.go
@@ -21,13 +21,12 @@ import (
 // UUIDSpec controls the behavior of the uuid generator.
 type UUIDSpec struct{}
 
-// Password generates a random password based on the
-// configuration parameters in spec.
-// You can specify the length, characterset and other attributes.
+// UUID generates a version 1 UUID (e56657e3-764f-11ef-a397-65231a88c216).
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Namespaced,categories={password},shortName=uuids
+// +kubebuilder:metadata:labels="external-secrets.io/component=controller"
+// +kubebuilder:resource:scope=Namespaced,categories={external-secrets, external-secrets-generators},shortName=uuids
 type UUID struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/generators/v1alpha1/generator_vault.go
+++ b/apis/generators/v1alpha1/generator_vault.go
@@ -60,7 +60,7 @@ const (
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:labels="external-secrets.io/component=controller"
-// +kubebuilder:resource:scope=Namespaced,categories={vaultdynamicsecret},shortName=vaultdynamicsecret
+// +kubebuilder:resource:scope=Namespaced,categories={external-secrets, external-secrets-generators},shortName=vaultdynamicsecret
 type VaultDynamicSecret struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/generators/v1alpha1/generator_webhook.go
+++ b/apis/generators/v1alpha1/generator_webhook.go
@@ -113,7 +113,7 @@ type SecretKeySelector struct {
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:labels="external-secrets.io/component=controller"
-// +kubebuilder:resource:scope=Namespaced,categories={webhook},shortName=webhookl
+// +kubebuilder:resource:scope=Namespaced,categories={external-secrets, external-secrets-generators},shortName=webhookl
 type Webhook struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crds/bases/external-secrets.io_clusterexternalsecrets.yaml
+++ b/config/crds/bases/external-secrets.io_clusterexternalsecrets.yaml
@@ -10,7 +10,7 @@ spec:
   group: external-secrets.io
   names:
     categories:
-    - externalsecrets
+    - external-secrets
     kind: ClusterExternalSecret
     listKind: ClusterExternalSecretList
     plural: clusterexternalsecrets

--- a/config/crds/bases/external-secrets.io_clustersecretstores.yaml
+++ b/config/crds/bases/external-secrets.io_clustersecretstores.yaml
@@ -10,7 +10,7 @@ spec:
   group: external-secrets.io
   names:
     categories:
-    - externalsecrets
+    - external-secrets
     kind: ClusterSecretStore
     listKind: ClusterSecretStoreList
     plural: clustersecretstores

--- a/config/crds/bases/external-secrets.io_externalsecrets.yaml
+++ b/config/crds/bases/external-secrets.io_externalsecrets.yaml
@@ -10,7 +10,7 @@ spec:
   group: external-secrets.io
   names:
     categories:
-    - externalsecrets
+    - external-secrets
     kind: ExternalSecret
     listKind: ExternalSecretList
     plural: externalsecrets

--- a/config/crds/bases/external-secrets.io_pushsecrets.yaml
+++ b/config/crds/bases/external-secrets.io_pushsecrets.yaml
@@ -3,12 +3,14 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.3
+  labels:
+    external-secrets.io/component: controller
   name: pushsecrets.external-secrets.io
 spec:
   group: external-secrets.io
   names:
     categories:
-    - pushsecrets
+    - external-secrets
     kind: PushSecret
     listKind: PushSecretList
     plural: pushsecrets

--- a/config/crds/bases/external-secrets.io_secretstores.yaml
+++ b/config/crds/bases/external-secrets.io_secretstores.yaml
@@ -10,7 +10,7 @@ spec:
   group: external-secrets.io
   names:
     categories:
-    - externalsecrets
+    - external-secrets
     kind: SecretStore
     listKind: SecretStoreList
     plural: secretstores

--- a/config/crds/bases/generators.external-secrets.io_acraccesstokens.yaml
+++ b/config/crds/bases/generators.external-secrets.io_acraccesstokens.yaml
@@ -10,7 +10,8 @@ spec:
   group: generators.external-secrets.io
   names:
     categories:
-    - acraccesstoken
+    - external-secrets
+    - external-secrets-generators
     kind: ACRAccessToken
     listKind: ACRAccessTokenList
     plural: acraccesstokens

--- a/config/crds/bases/generators.external-secrets.io_ecrauthorizationtokens.yaml
+++ b/config/crds/bases/generators.external-secrets.io_ecrauthorizationtokens.yaml
@@ -10,7 +10,8 @@ spec:
   group: generators.external-secrets.io
   names:
     categories:
-    - ecrauthorizationtoken
+    - external-secrets
+    - external-secrets-generators
     kind: ECRAuthorizationToken
     listKind: ECRAuthorizationTokenList
     plural: ecrauthorizationtokens

--- a/config/crds/bases/generators.external-secrets.io_fakes.yaml
+++ b/config/crds/bases/generators.external-secrets.io_fakes.yaml
@@ -10,7 +10,8 @@ spec:
   group: generators.external-secrets.io
   names:
     categories:
-    - fake
+    - external-secrets
+    - external-secrets-generators
     kind: Fake
     listKind: FakeList
     plural: fakes

--- a/config/crds/bases/generators.external-secrets.io_gcraccesstokens.yaml
+++ b/config/crds/bases/generators.external-secrets.io_gcraccesstokens.yaml
@@ -10,7 +10,8 @@ spec:
   group: generators.external-secrets.io
   names:
     categories:
-    - gcraccesstoken
+    - external-secrets
+    - external-secrets-generators
     kind: GCRAccessToken
     listKind: GCRAccessTokenList
     plural: gcraccesstokens

--- a/config/crds/bases/generators.external-secrets.io_githubaccesstokens.yaml
+++ b/config/crds/bases/generators.external-secrets.io_githubaccesstokens.yaml
@@ -10,7 +10,8 @@ spec:
   group: generators.external-secrets.io
   names:
     categories:
-    - githubaccesstoken
+    - external-secrets
+    - external-secrets-generators
     kind: GithubAccessToken
     listKind: GithubAccessTokenList
     plural: githubaccesstokens

--- a/config/crds/bases/generators.external-secrets.io_passwords.yaml
+++ b/config/crds/bases/generators.external-secrets.io_passwords.yaml
@@ -10,7 +10,8 @@ spec:
   group: generators.external-secrets.io
   names:
     categories:
-    - password
+    - external-secrets
+    - external-secrets-generators
     kind: Password
     listKind: PasswordList
     plural: passwords

--- a/config/crds/bases/generators.external-secrets.io_uuids.yaml
+++ b/config/crds/bases/generators.external-secrets.io_uuids.yaml
@@ -3,12 +3,15 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.3
+  labels:
+    external-secrets.io/component: controller
   name: uuids.generators.external-secrets.io
 spec:
   group: generators.external-secrets.io
   names:
     categories:
-    - password
+    - external-secrets
+    - external-secrets-generators
     kind: UUID
     listKind: UUIDList
     plural: uuids
@@ -20,10 +23,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: |-
-          Password generates a random password based on the
-          configuration parameters in spec.
-          You can specify the length, characterset and other attributes.
+        description: UUID generates a version 1 UUID (e56657e3-764f-11ef-a397-65231a88c216).
         properties:
           apiVersion:
             description: |-

--- a/config/crds/bases/generators.external-secrets.io_vaultdynamicsecrets.yaml
+++ b/config/crds/bases/generators.external-secrets.io_vaultdynamicsecrets.yaml
@@ -10,7 +10,8 @@ spec:
   group: generators.external-secrets.io
   names:
     categories:
-    - vaultdynamicsecret
+    - external-secrets
+    - external-secrets-generators
     kind: VaultDynamicSecret
     listKind: VaultDynamicSecretList
     plural: vaultdynamicsecrets

--- a/config/crds/bases/generators.external-secrets.io_webhooks.yaml
+++ b/config/crds/bases/generators.external-secrets.io_webhooks.yaml
@@ -10,7 +10,8 @@ spec:
   group: generators.external-secrets.io
   names:
     categories:
-    - webhook
+    - external-secrets
+    - external-secrets-generators
     kind: Webhook
     listKind: WebhookList
     plural: webhooks

--- a/deploy/charts/external-secrets/tests/__snapshot__/crds_test.yaml.snap
+++ b/deploy/charts/external-secrets/tests/__snapshot__/crds_test.yaml.snap
@@ -3518,6 +3518,41 @@ should match snapshot of default values:
                             - database
                             - host
                           type: object
+                        previder:
+                          description: Previder configures this store to sync secrets using the Previder provider
+                          properties:
+                            auth:
+                              description: PreviderAuth contains a secretRef for credentials.
+                              properties:
+                                secretRef:
+                                  description: PreviderAuthSecretRef holds secret references for Previder Vault credentials.
+                                  properties:
+                                    accessToken:
+                                      description: The AccessToken is used for authentication
+                                      properties:
+                                        key:
+                                          description: |-
+                                            The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
+                                            defaulted, in others it may be required.
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
+                                            to the namespace of the referent.
+                                          type: string
+                                      type: object
+                                  required:
+                                    - accessToken
+                                  type: object
+                              type: object
+                            baseUri:
+                              type: string
+                          required:
+                            - auth
+                          type: object
                         pulumi:
                           description: Pulumi configures this store to sync secrets using the Pulumi provider
                           properties:
@@ -3543,7 +3578,7 @@ should match snapshot of default values:
                                   type: object
                               type: object
                             apiUrl:
-                              default: https://api.pulumi.com/api/preview
+                              default: https://api.pulumi.com/api/esc
                               description: APIURL is the URL of the Pulumi API.
                               type: string
                             environment:
@@ -3558,10 +3593,14 @@ should match snapshot of default values:
                                 Organization are a space to collaborate on shared projects and stacks.
                                 To create a new organization, visit https://app.pulumi.com/ and click "New Organization".
                               type: string
+                            project:
+                              description: Project is the name of the Pulumi ESC project the environment belongs to.
+                              type: string
                           required:
                             - accessToken
                             - environment
                             - organization
+                            - project
                           type: object
                         scaleway:
                           description: Scaleway

--- a/deploy/charts/external-secrets/tests/__snapshot__/crds_test.yaml.snap
+++ b/deploy/charts/external-secrets/tests/__snapshot__/crds_test.yaml.snap
@@ -22,7 +22,7 @@ should match snapshot of default values:
       group: external-secrets.io
       names:
         categories:
-          - externalsecrets
+          - external-secrets
         kind: SecretStore
         listKind: SecretStoreList
         plural: secretstores

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -10,7 +10,7 @@ spec:
   group: external-secrets.io
   names:
     categories:
-      - externalsecrets
+      - external-secrets
     kind: ClusterExternalSecret
     listKind: ClusterExternalSecretList
     plural: clusterexternalsecrets
@@ -667,7 +667,7 @@ spec:
   group: external-secrets.io
   names:
     categories:
-      - externalsecrets
+      - external-secrets
     kind: ClusterSecretStore
     listKind: ClusterSecretStoreList
     plural: clustersecretstores
@@ -5298,7 +5298,7 @@ spec:
   group: external-secrets.io
   names:
     categories:
-      - externalsecrets
+      - external-secrets
     kind: ExternalSecret
     listKind: ExternalSecretList
     plural: externalsecrets
@@ -6102,12 +6102,14 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.3
+  labels:
+    external-secrets.io/component: controller
   name: pushsecrets.external-secrets.io
 spec:
   group: external-secrets.io
   names:
     categories:
-      - pushsecrets
+      - external-secrets
     kind: PushSecret
     listKind: PushSecretList
     plural: pushsecrets
@@ -6486,7 +6488,7 @@ spec:
   group: external-secrets.io
   names:
     categories:
-      - externalsecrets
+      - external-secrets
     kind: SecretStore
     listKind: SecretStoreList
     plural: secretstores
@@ -11117,7 +11119,8 @@ spec:
   group: generators.external-secrets.io
   names:
     categories:
-      - acraccesstoken
+      - external-secrets
+      - external-secrets-generators
     kind: ACRAccessToken
     listKind: ACRAccessTokenList
     plural: acraccesstokens
@@ -11311,7 +11314,8 @@ spec:
   group: generators.external-secrets.io
   names:
     categories:
-      - ecrauthorizationtoken
+      - external-secrets
+      - external-secrets-generators
     kind: ECRAuthorizationToken
     listKind: ECRAuthorizationTokenList
     plural: ecrauthorizationtokens
@@ -11479,7 +11483,8 @@ spec:
   group: generators.external-secrets.io
   names:
     categories:
-      - fake
+      - external-secrets
+      - external-secrets-generators
     kind: Fake
     listKind: FakeList
     plural: fakes
@@ -11556,7 +11561,8 @@ spec:
   group: generators.external-secrets.io
   names:
     categories:
-      - gcraccesstoken
+      - external-secrets
+      - external-secrets-generators
     kind: GCRAccessToken
     listKind: GCRAccessTokenList
     plural: gcraccesstokens
@@ -11685,7 +11691,8 @@ spec:
   group: generators.external-secrets.io
   names:
     categories:
-      - githubaccesstoken
+      - external-secrets
+      - external-secrets-generators
     kind: GithubAccessToken
     listKind: GithubAccessTokenList
     plural: githubaccesstokens
@@ -11788,7 +11795,8 @@ spec:
   group: generators.external-secrets.io
   names:
     categories:
-      - password
+      - external-secrets
+      - external-secrets-generators
     kind: Password
     listKind: PasswordList
     plural: passwords
@@ -11880,12 +11888,15 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.3
+  labels:
+    external-secrets.io/component: controller
   name: uuids.generators.external-secrets.io
 spec:
   group: generators.external-secrets.io
   names:
     categories:
-      - password
+      - external-secrets
+      - external-secrets-generators
     kind: UUID
     listKind: UUIDList
     plural: uuids
@@ -11897,10 +11908,7 @@ spec:
     - name: v1alpha1
       schema:
         openAPIV3Schema:
-          description: |-
-            Password generates a random password based on the
-            configuration parameters in spec.
-            You can specify the length, characterset and other attributes.
+          description: UUID generates a version 1 UUID (e56657e3-764f-11ef-a397-65231a88c216).
           properties:
             apiVersion:
               description: |-
@@ -11950,7 +11958,8 @@ spec:
   group: generators.external-secrets.io
   names:
     categories:
-      - vaultdynamicsecret
+      - external-secrets
+      - external-secrets-generators
     kind: VaultDynamicSecret
     listKind: VaultDynamicSecretList
     plural: vaultdynamicsecrets
@@ -12648,7 +12657,8 @@ spec:
   group: generators.external-secrets.io
   names:
     categories:
-      - webhook
+      - external-secrets
+      - external-secrets-generators
     kind: Webhook
     listKind: WebhookList
     plural: webhooks


### PR DESCRIPTION
## Problem Statement

`kubectl get externalsecrets` listed multiple object types instead of only one.

## Related Issue

N/A

## Proposed Changes
some background - https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#categories

* one category for all ES types.
* one category dedicated only to generators.
* add missing controller label on CRDs
* fix UUID description (was referring to password)

## Checklist

- [*] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [*] All commits are signed with `git commit --signoff`
- [*] My changes have reasonable test coverage
- [*] All tests pass with `make test`
- [*] I ensured my PR is ready for review with `make reviewable`
