### PR TITLE
docs: pin CRDs version in FluxCD example, bump api versions

### DIFF
--- a/docs/snippets/gitops/deployment-crds.yaml
+++ b/docs/snippets/gitops/deployment-crds.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: external-secrets-crds

--- a/docs/snippets/gitops/deployment-crs.yaml
+++ b/docs/snippets/gitops/deployment-crs.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: external-secrets-crs

--- a/docs/snippets/gitops/deployment.yaml
+++ b/docs/snippets/gitops/deployment.yaml
@@ -1,21 +1,21 @@
 # How to manage values files. Ref: https://fluxcd.io/docs/guides/helmreleases/#refer-to-values-inside-the-chart
 # How to inject values: https://fluxcd.io/docs/guides/helmreleases/#cloud-storage
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: external-secrets
   namespace: flux-system
 spec:
   # Override Release name to avoid the pattern Namespace-Release
-  # Ref: https://fluxcd.io/docs/components/helm/api/#helm.toolkit.fluxcd.io/v2beta1.HelmRelease
+  # Ref: https://fluxcd.io/flux/components/helm/api/v2/#helm.toolkit.fluxcd.io/v2.HelmRelease
   releaseName: external-secrets
   targetNamespace: external-secrets
   interval: 10m
   chart:
     spec:
       chart: external-secrets
-      version: 0.9.4
+      version: 0.10.3
       sourceRef:
         kind: HelmRepository
         name: external-secrets
@@ -23,6 +23,6 @@ spec:
   values:
     installCRDs: false
 
-  # Ref: https://fluxcd.io/docs/components/helm/api/#helm.toolkit.fluxcd.io/v2beta1.Install
+  # Ref: https://fluxcd.io/flux/components/helm/api/v2/#helm.toolkit.fluxcd.io/v2.Install
   install:
     createNamespace: true

--- a/docs/snippets/gitops/repositories.yaml
+++ b/docs/snippets/gitops/repositories.yaml
@@ -1,5 +1,5 @@
 # Reference to Helm repository
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: external-secrets
@@ -8,7 +8,7 @@ spec:
   interval: 10m
   url: https://charts.external-secrets.io
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
   name: external-secrets
@@ -16,5 +16,5 @@ metadata:
 spec:
   interval: 10m
   ref:
-    branch: main
+    tag: v0.10.3
   url: http://github.com/external-secrets/external-secrets


### PR DESCRIPTION
## Problem Statement

Pin CRDs version in FluxCD example docs to line up with helm chart version

## Related Issue

Fixes #3885 

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
