### PR TITLE
fix cert auth only fixes #3926

### DIFF
--- a/pkg/provider/kubernetes/auth_test.go
+++ b/pkg/provider/kubernetes/auth_test.go
@@ -250,14 +250,6 @@ func TestSetAuth(t *testing.T) {
 						"cert": []byte("my-cert"),
 						"key":  []byte("my-key"),
 					},
-				}, &corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foobar",
-						Namespace: "default",
-					},
-					Data: map[string][]byte{
-						"token": []byte("mytoken"),
-					},
 				}).Build(),
 				store: &esv1beta1.KubernetesProvider{
 					Server: esv1beta1.KubernetesServer{
@@ -265,13 +257,6 @@ func TestSetAuth(t *testing.T) {
 						CABundle: []byte(caCert),
 					},
 					Auth: esv1beta1.KubernetesAuth{
-						Token: &esv1beta1.TokenAuth{
-							BearerToken: v1.SecretKeySelector{
-								Name:      "foobar",
-								Namespace: pointer.To("shouldnotberelevant"),
-								Key:       "token",
-							},
-						},
 						Cert: &esv1beta1.CertAuth{
 							ClientCert: v1.SecretKeySelector{
 								Name: "mycert",
@@ -286,8 +271,7 @@ func TestSetAuth(t *testing.T) {
 				},
 			},
 			want: &want{
-				Host:        "https://my.test.tld",
-				BearerToken: "mytoken",
+				Host: "https://my.test.tld",
 				TLSClientConfig: rest.TLSClientConfig{
 					CAData:   []byte(caCert),
 					CertData: []byte("my-cert"),


### PR DESCRIPTION
## Problem Statement

Cert auth could not be given without also providing a token

## Related Issue

Fixes #3926

## Proposed Changes

Do not fail when there is no token given

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] My changes have reasonable test coverage
- [X] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
