### PR TITLE
fix: fix slice init length

### DIFF
--- a/pkg/provider/azure/keyvault/keyvault_test.go
+++ b/pkg/provider/azure/keyvault/keyvault_test.go
@@ -1415,11 +1415,8 @@ func TestAzureKeyVaultSecretManagerGetAllSecrets(t *testing.T) {
 			Attributes: &enabledAtt,
 		}
 
-		secretList := make([]keyvault.SecretItem, 0)
-		secretList = append(secretList, secretItem)
-
 		list := keyvault.SecretListResult{
-			Value: &secretList,
+			Value: &[]keyvault.SecretItem{secretItem},
 		}
 
 		resultPage := keyvault.NewSecretListResultPage(list, getNextPage)
@@ -1447,11 +1444,8 @@ func TestAzureKeyVaultSecretManagerGetAllSecrets(t *testing.T) {
 			Attributes: &enabledAtt,
 		}
 
-		secretList := make([]keyvault.SecretItem, 1)
-		secretList = append(secretList, secretItemOne, secretItemTwo)
-
 		list := keyvault.SecretListResult{
-			Value: &secretList,
+			Value: &[]keyvault.SecretItem{secretItemOne, secretItemTwo},
 		}
 
 		resultPage := keyvault.NewSecretListResultPage(list, getNextPage)
@@ -1475,11 +1469,8 @@ func TestAzureKeyVaultSecretManagerGetAllSecrets(t *testing.T) {
 			Tags:       map[string]*string{"environment": &environment},
 		}
 
-		secretList := make([]keyvault.SecretItem, 0)
-		secretList = append(secretList, secretItem)
-
 		list := keyvault.SecretListResult{
-			Value: &secretList,
+			Value: &[]keyvault.SecretItem{secretItem},
 		}
 
 		resultPage := keyvault.NewSecretListResultPage(list, getNextPage)
@@ -1505,11 +1496,8 @@ func TestAzureKeyVaultSecretManagerGetAllSecrets(t *testing.T) {
 			Tags:       map[string]*string{"environment": &environment, "author": &author},
 		}
 
-		secretList := make([]keyvault.SecretItem, 0)
-		secretList = append(secretList, secretItem)
-
 		list := keyvault.SecretListResult{
-			Value: &secretList,
+			Value: &[]keyvault.SecretItem{secretItem},
 		}
 
 		resultPage := keyvault.NewSecretListResultPage(list, getNextPage)


### PR DESCRIPTION
## Problem Statement


The intention here should be to initialize a slice with a capacity of  1 rather than initializing the length of this slice.


## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
