### PR TITLE
fix: improve SecretExists in Bitwarden provider

### DIFF
--- a/pkg/provider/bitwarden/client.go
+++ b/pkg/provider/bitwarden/client.go
@@ -141,6 +141,10 @@ func (p *Provider) GetSecret(ctx context.Context, ref esv1beta1.ExternalSecretDa
 		return nil, fmt.Errorf("error getting secret: %w", err)
 	}
 
+	if secret == nil {
+		return nil, fmt.Errorf("no secret found for project id %s and name %s", spec.Provider.BitwardenSecretsManager.ProjectID, ref.Key)
+	}
+
 	// we found our secret, return the value for it
 	return []byte(secret.Value), nil
 }
@@ -202,7 +206,6 @@ func (p *Provider) SecretExists(ctx context.Context, ref esv1beta1.PushSecretRem
 	}
 
 	secret, err := p.findSecretByRef(ctx, ref.GetRemoteKey(), spec.Provider.BitwardenSecretsManager.ProjectID)
-
 	if err != nil {
 		return false, fmt.Errorf("error getting secret: %w", err)
 	}

--- a/pkg/provider/bitwarden/client_test.go
+++ b/pkg/provider/bitwarden/client_test.go
@@ -765,8 +765,7 @@ func TestProviderSecretExists(t *testing.T) {
 					},
 				},
 			},
-			want:    false,
-			wantErr: true, // secret not found
+			want: false,
 		},
 		{
 			name: "invalid name format should error",


### PR DESCRIPTION
## Problem Statement

If we use `updatePolicy: IfNotExists` with a `PushSecret`, it will fail. This is due to `findSecretByRef` returning and error on missing secret, and that makes `SecretExists` return an error.

## Related Issue

None

## Proposed Changes

I made `findSecretByRef` not returning an error on missing secret, and moved that check to `SecretExists` and `DeleteSecret` instead.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
