### PR TITLE
Add ability to use RetrySettings in the VaultDynamicSecret generator

### DIFF
--- a/apis/generators/v1alpha1/generator_vault.go
+++ b/apis/generators/v1alpha1/generator_vault.go
@@ -41,6 +41,10 @@ type VaultDynamicSecretSpec struct {
 	// +kubebuilder:default=Data
 	ResultType VaultDynamicSecretResultType `json:"resultType,omitempty"`
 
+	// Used to configure http retries if failed
+	// +optional
+	RetrySettings *esv1beta1.SecretStoreRetrySettings `json:"retrySettings,omitempty"`
+
 	// Vault provider common spec
 	Provider *esv1beta1.VaultProvider `json:"provider"`
 

--- a/apis/generators/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/generators/v1alpha1/zz_generated.deepcopy.go
@@ -1035,6 +1035,11 @@ func (in *VaultDynamicSecretSpec) DeepCopyInto(out *VaultDynamicSecretSpec) {
 		*out = new(apiextensionsv1.JSON)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.RetrySettings != nil {
+		in, out := &in.RetrySettings, &out.RetrySettings
+		*out = new(v1beta1.SecretStoreRetrySettings)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Provider != nil {
 		in, out := &in.Provider, &out.Provider
 		*out = new(v1beta1.VaultProvider)

--- a/config/crds/bases/generators.external-secrets.io_vaultdynamicsecrets.yaml
+++ b/config/crds/bases/generators.external-secrets.io_vaultdynamicsecrets.yaml
@@ -710,6 +710,15 @@ spec:
                 - Data
                 - Auth
                 type: string
+              retrySettings:
+                description: Used to configure http retries if failed
+                properties:
+                  maxRetries:
+                    format: int32
+                    type: integer
+                  retryInterval:
+                    type: string
+                type: object
             required:
             - path
             - provider

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -12848,6 +12848,15 @@ spec:
                     - Data
                     - Auth
                   type: string
+                retrySettings:
+                  description: Used to configure http retries if failed
+                  properties:
+                    maxRetries:
+                      format: int32
+                      type: integer
+                    retryInterval:
+                      type: string
+                  type: object
               required:
                 - path
                 - provider

--- a/pkg/generator/vault/vault.go
+++ b/pkg/generator/vault/vault.go
@@ -71,7 +71,7 @@ func (g *Generator) generate(ctx context.Context, c *provider.Provider, jsonSpec
 	if res == nil || res.Spec.Provider == nil {
 		return nil, errors.New("no Vault provider config in spec")
 	}
-	cl, err := c.NewGeneratorClient(ctx, kube, corev1, res.Spec.Provider, namespace)
+	cl, err := c.NewGeneratorClient(ctx, kube, corev1, res.Spec.Provider, namespace, res.Spec.RetrySettings)
 	if err != nil {
 		return nil, fmt.Errorf(errVaultClient, err)
 	}

--- a/pkg/provider/vault/provider.go
+++ b/pkg/provider/vault/provider.go
@@ -96,8 +96,8 @@ func (p *Provider) NewClient(ctx context.Context, store esv1beta1.GenericStore, 
 	return p.newClient(ctx, store, kube, clientset.CoreV1(), namespace)
 }
 
-func (p *Provider) NewGeneratorClient(ctx context.Context, kube kclient.Client, corev1 typedcorev1.CoreV1Interface, vaultSpec *esv1beta1.VaultProvider, namespace string) (util.Client, error) {
-	vStore, cfg, err := p.prepareConfig(ctx, kube, corev1, vaultSpec, nil, namespace, resolvers.EmptyStoreKind)
+func (p *Provider) NewGeneratorClient(ctx context.Context, kube kclient.Client, corev1 typedcorev1.CoreV1Interface, vaultSpec *esv1beta1.VaultProvider, namespace string, retrySettings *esv1beta1.SecretStoreRetrySettings) (util.Client, error) {
+	vStore, cfg, err := p.prepareConfig(ctx, kube, corev1, vaultSpec, retrySettings, namespace, resolvers.EmptyStoreKind)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Problem Statement

I would like to use retry logic in the VaultDynamicSecret generator to ensure that if vault is failing token will be renewed before next retry interval

## Related Issue

Fixes #4075

## Proposed Changes

Add RetrySettings to the VaultDynamicSecret spec and pass it to the configuration builder.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
