### PR TITLE
Reduce refreshInterval example for ACR

### DIFF
--- a/docs/snippets/generator-acr-example.yaml
+++ b/docs/snippets/generator-acr-example.yaml
@@ -11,7 +11,7 @@ spec:
           apiVersion: generators.external-secrets.io/v1alpha1
           kind: ACRAccessToken
           name: my-azurecr
-  refreshInterval: 12h
+  refreshInterval: 3h
   target:
     name: azurecr-credentials
     template:


### PR DESCRIPTION
## Problem Statement

The old example used a `refreshInterval` value of 12h for the ACR access token. This change reduces that to 3h instead, since that is the expiration time for Service Principal authentication tokens:

https://learn.microsoft.com/en-us/azure/container-registry/container-registry-authentication?tabs=azure-cli#service-principal

Service principals are not the only way to authenticate towards ACR. In fact, two other ways (`managedIdentity` and `workloadIdentity`) are also outlined in the docs. I was unable to find any documentation in Azure for the default expiration time for those tokens, so as far as I know it is always 3 hours. Thus I think we should reflect this in our examples.

## Related Issue

n/a

## Proposed Changes

I like concrete examples that work out-of-the-box. API details can always be found in the spec for those that need it.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
