### PR TITLE
Update docs for ExternalSecrets's refreshInterval

### DIFF
--- a/apis/externalsecrets/v1beta1/externalsecret_types.go
+++ b/apis/externalsecrets/v1beta1/externalsecret_types.go
@@ -342,8 +342,10 @@ type ExternalSecretSpec struct {
 	// +optional
 	Target ExternalSecretTarget `json:"target,omitempty"`
 
-	// RefreshInterval is the amount of time before the values are read again from the SecretStore provider
+	// RefreshInterval is the amount of time before the values are read again from the SecretStore provider,
+	// specified as Golang Duration strings.
 	// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+	// Example values: "1h", "2h30m", "5d", "10s"
 	// May be set to zero to fetch and create it once. Defaults to 1h.
 	// +kubebuilder:default="1h"
 	RefreshInterval *metav1.Duration `json:"refreshInterval,omitempty"`

--- a/config/crds/bases/external-secrets.io_clusterexternalsecrets.yaml
+++ b/config/crds/bases/external-secrets.io_clusterexternalsecrets.yaml
@@ -357,8 +357,10 @@ spec:
                   refreshInterval:
                     default: 1h
                     description: |-
-                      RefreshInterval is the amount of time before the values are read again from the SecretStore provider
+                      RefreshInterval is the amount of time before the values are read again from the SecretStore provider,
+                      specified as Golang Duration strings.
                       Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+                      Example values: "1h", "2h30m", "5d", "10s"
                       May be set to zero to fetch and create it once. Defaults to 1h.
                     type: string
                   secretStoreRef:

--- a/config/crds/bases/external-secrets.io_externalsecrets.yaml
+++ b/config/crds/bases/external-secrets.io_externalsecrets.yaml
@@ -621,8 +621,10 @@ spec:
               refreshInterval:
                 default: 1h
                 description: |-
-                  RefreshInterval is the amount of time before the values are read again from the SecretStore provider
+                  RefreshInterval is the amount of time before the values are read again from the SecretStore provider,
+                  specified as Golang Duration strings.
                   Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+                  Example values: "1h", "2h30m", "5d", "10s"
                   May be set to zero to fetch and create it once. Defaults to 1h.
                 type: string
               secretStoreRef:

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -335,8 +335,10 @@ spec:
                     refreshInterval:
                       default: 1h
                       description: |-
-                        RefreshInterval is the amount of time before the values are read again from the SecretStore provider
+                        RefreshInterval is the amount of time before the values are read again from the SecretStore provider,
+                        specified as Golang Duration strings.
                         Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+                        Example values: "1h", "2h30m", "5d", "10s"
                         May be set to zero to fetch and create it once. Defaults to 1h.
                       type: string
                     secretStoreRef:
@@ -5882,8 +5884,10 @@ spec:
                 refreshInterval:
                   default: 1h
                   description: |-
-                    RefreshInterval is the amount of time before the values are read again from the SecretStore provider
+                    RefreshInterval is the amount of time before the values are read again from the SecretStore provider,
+                    specified as Golang Duration strings.
                     Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+                    Example values: "1h", "2h30m", "5d", "10s"
                     May be set to zero to fetch and create it once. Defaults to 1h.
                   type: string
                 secretStoreRef:

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -2989,8 +2989,10 @@ Kubernetes meta/v1.Duration
 </em>
 </td>
 <td>
-<p>RefreshInterval is the amount of time before the values are read again from the SecretStore provider
+<p>RefreshInterval is the amount of time before the values are read again from the SecretStore provider,
+specified as Golang Duration strings.
 Valid time units are &ldquo;ns&rdquo;, &ldquo;us&rdquo; (or &ldquo;µs&rdquo;), &ldquo;ms&rdquo;, &ldquo;s&rdquo;, &ldquo;m&rdquo;, &ldquo;h&rdquo;
+Example values: &ldquo;1h&rdquo;, &ldquo;2h30m&rdquo;, &ldquo;5d&rdquo;, &ldquo;10s&rdquo;
 May be set to zero to fetch and create it once. Defaults to 1h.</p>
 </td>
 </tr>
@@ -3730,8 +3732,10 @@ Kubernetes meta/v1.Duration
 </em>
 </td>
 <td>
-<p>RefreshInterval is the amount of time before the values are read again from the SecretStore provider
+<p>RefreshInterval is the amount of time before the values are read again from the SecretStore provider,
+specified as Golang Duration strings.
 Valid time units are &ldquo;ns&rdquo;, &ldquo;us&rdquo; (or &ldquo;µs&rdquo;), &ldquo;ms&rdquo;, &ldquo;s&rdquo;, &ldquo;m&rdquo;, &ldquo;h&rdquo;
+Example values: &ldquo;1h&rdquo;, &ldquo;2h30m&rdquo;, &ldquo;5d&rdquo;, &ldquo;10s&rdquo;
 May be set to zero to fetch and create it once. Defaults to 1h.</p>
 </td>
 </tr>


### PR DESCRIPTION
## Problem Statement

Before this change, it was a bit unclear what type of `ExternalSecret.spec.refreshInterval` was.

## Related Issue

Fixes #4079

## Proposed Changes

This change aims to clarify the documentation for `ExternalSecrets.spec.refreshInterval` by adding examples and referring to Go's `Duration` type.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
