### PR TITLE
fix: refresh interval values

### DIFF
--- a/design/004-datafrom-key-rewrite.md
+++ b/design/004-datafrom-key-rewrite.md
@@ -51,7 +51,7 @@ metadata:
   name: sample
   namespace: default
 spec:
-  refreshInterval: 1m
+  refreshInterval: 1h
   target:
    name: foobar
   secretStoreRef:

--- a/docs/provider/beyondtrust.md
+++ b/docs/provider/beyondtrust.md
@@ -107,7 +107,7 @@ kind: ExternalSecret
 metadata:
   name: beyondtrust-external-secret
 spec:
-  refreshInterval: 300s
+  refreshInterval: 1h
   secretStoreRef:
     kind: SecretStore
     name: secretstore-beyondtrust

--- a/docs/provider/bitwarden-secrets-manager.md
+++ b/docs/provider/bitwarden-secrets-manager.md
@@ -65,7 +65,7 @@ kind: ExternalSecret
 metadata:
   name: bitwarden
 spec:
-  refreshInterval: 10s
+  refreshInterval: 1h
   secretStoreRef:
     # This name must match the metadata.name in the `SecretStore`
     name: bitwarden-secretsmanager
@@ -91,7 +91,7 @@ kind: ExternalSecret
 metadata:
   name: bitwarden
 spec:
-  refreshInterval: 10s
+  refreshInterval: 1h
   secretStoreRef:
     # This name must match the metadata.name in the `SecretStore`
     name: bitwarden-secretsmanager
@@ -118,7 +118,7 @@ kind: PushSecret
 metadata:
   name: pushsecret-bitwarden # Customisable
 spec:
-  refreshInterval: 10s # Refresh interval for which push secret will reconcile
+  refreshInterval: 1h # Refresh interval for which push secret will reconcile
   secretStoreRefs: # A list of secret stores to push secrets to
     - name: bitwarden-secretsmanager
       kind: SecretStore

--- a/docs/provider/chef.md
+++ b/docs/provider/chef.md
@@ -97,7 +97,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets
 spec:
-  refreshInterval: 15m
+  refreshInterval: 1h
   secretStoreRef:
     name: vivid-clustersecretstore # name of ClusterSecretStore
     kind: ClusterSecretStore

--- a/docs/provider/delinea.md
+++ b/docs/provider/delinea.md
@@ -47,7 +47,7 @@ kind: ExternalSecret
 metadata:
     name: secret
 spec:
-    refreshInterval: 20s
+    refreshInterval: 1h
     secretStoreRef:
         kind: SecretStore
         name: secret-store

--- a/docs/provider/device42.md
+++ b/docs/provider/device42.md
@@ -45,7 +45,7 @@ kind: ExternalSecret
 metadata:
   name: device42-external-secret
 spec:
-  refreshInterval: 5m
+  refreshInterval: 1h
   secretStoreRef:
     kind: SecretStore
     name: device42-secret-store

--- a/docs/provider/kubernetes.md
+++ b/docs/provider/kubernetes.md
@@ -255,7 +255,7 @@ kind: PushSecret
 metadata:
   name: example
 spec:
-  refreshInterval: 10s
+  refreshInterval: 1h
   secretStoreRefs:
     - name: k8s-store-remote-ns
       kind: SecretStore

--- a/docs/provider/pulumi.md
+++ b/docs/provider/pulumi.md
@@ -65,7 +65,7 @@ kind: ExternalSecret
 metadata:
   name: secret
 spec:
-  refreshInterval: 5m
+  refreshInterval: 1h
   secretStoreRef:
     kind: SecretStore
     name: secret-store
@@ -111,7 +111,7 @@ kind: PushSecret
 metadata:
   name: push-secret-example
 spec:
-  refreshInterval: 10s
+  refreshInterval: 1h
   selector:
     secret:
       name: <NAME_OF_KUBE_SECRET>

--- a/docs/provider/scaleway.md
+++ b/docs/provider/scaleway.md
@@ -38,7 +38,7 @@ kind: ExternalSecret
 metadata:
     name: secret
 spec:
-    refreshInterval: 20s
+    refreshInterval: 1h
     secretStoreRef:
         kind: SecretStore
         name: secret-store

--- a/docs/provider/secretserver.md
+++ b/docs/provider/secretserver.md
@@ -53,7 +53,7 @@ kind: ExternalSecret
 metadata:
     name: secret-server-external-secret
 spec:
-    refreshInterval: 15s
+    refreshInterval: 1h
     secretStoreRef:
         kind: SecretStore
         name: secret-server-store

--- a/docs/snippets/akeyless-push-secret.yaml
+++ b/docs/snippets/akeyless-push-secret.yaml
@@ -3,7 +3,7 @@ kind: PushSecret
 metadata:
  name: push-secret
 spec:
- refreshInterval: 5s
+ refreshInterval: 1h
  updatePolicy: Replace
  deletionPolicy: Delete
  secretStoreRefs:

--- a/docs/snippets/aws-anchore-engine-access-credentials-external-secret.yaml
+++ b/docs/snippets/aws-anchore-engine-access-credentials-external-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: anchore-access-credentials
   namespace: ci
 spec:
-  refreshInterval: 1m
+  refreshInterval: 1h
   secretStoreRef:
     name: cluster-secrets-store
     kind: ClusterSecretStore

--- a/docs/snippets/aws-jenkins-credential-github-ssh-external-secret.yaml
+++ b/docs/snippets/aws-jenkins-credential-github-ssh-external-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: github-ssh-access
   namespace: ci
 spec:
-  refreshInterval: 1m
+  refreshInterval: 1h
   secretStoreRef:
     name: cluster-parameter-store
     kind: ClusterSecretStore

--- a/docs/snippets/aws-jenkins-credential-sonarqube-api-token-external-secret.yaml
+++ b/docs/snippets/aws-jenkins-credential-sonarqube-api-token-external-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: sonarqube-api-token
   namespace: ci
 spec:
-  refreshInterval: 1m
+  refreshInterval: 1h
   secretStoreRef:
     name: cluster-secrets-store
     kind: ClusterSecretStore

--- a/docs/snippets/aws-jenkins-credentials-harbor-chart-robot-external-secret.yaml
+++ b/docs/snippets/aws-jenkins-credentials-harbor-chart-robot-external-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: harbor-chart-robot
   namespace: ci
 spec:
-  refreshInterval: 1m
+  refreshInterval: 1h
   secretStoreRef:
     name: cluster-secrets-store
     kind: ClusterSecretStore

--- a/docs/snippets/aws-pm-push-secret-with-metadata.yaml
+++ b/docs/snippets/aws-pm-push-secret-with-metadata.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default # Same of the SecretStores
 spec:
   deletionPolicy: Delete # the provider' secret will be deleted if the PushSecret is deleted
-  refreshInterval: 10s # Refresh interval for which push secret will reconcile
+  refreshInterval: 1h # Refresh interval for which push secret will reconcile
   secretStoreRefs: # A list of secret stores to push secrets to
     - name: aws-parameterstore
       kind: SecretStore

--- a/docs/snippets/aws-sm-external-secret.yaml
+++ b/docs/snippets/aws-sm-external-secret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: example
 spec:
-  refreshInterval: 1m
+  refreshInterval: 1h
   secretStoreRef:
     name: aws-secretsmanager
     kind: SecretStore

--- a/docs/snippets/aws-sm-push-secret-with-metadata.yaml
+++ b/docs/snippets/aws-sm-push-secret-with-metadata.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: teamb # Same of the SecretStores
 spec:
   deletionPolicy: Delete
-  refreshInterval: 10s # Refresh interval for which push secret will reconcile
+  refreshInterval: 1h # Refresh interval for which push secret will reconcile
   secretStoreRefs: # A list of secret stores to push secrets to
     - name: teamb-secret-store
       kind: SecretStore

--- a/docs/snippets/azkv-pushsecret-certificate.yaml
+++ b/docs/snippets/azkv-pushsecret-certificate.yaml
@@ -21,7 +21,7 @@ metadata:
   name: pushsecret-example
   namespace: default
 spec:
-  refreshInterval: 10s # Refresh interval for which push secret will reconcile
+  refreshInterval: 1h # Refresh interval for which push secret will reconcile
   deletionPolicy: Delete
   secretStoreRefs: # A list of secret stores to push secrets to
     - name: azure-store

--- a/docs/snippets/azkv-pushsecret-key.yaml
+++ b/docs/snippets/azkv-pushsecret-key.yaml
@@ -11,7 +11,7 @@ metadata:
   name: pushsecret-example
   namespace: default
 spec:
-  refreshInterval: 10s # Refresh interval for which push secret will reconcile
+  refreshInterval: 1h # Refresh interval for which push secret will reconcile
   deletionPolicy: Delete
   secretStoreRefs: # A list of secret stores to push secrets to
     - name: azure-store

--- a/docs/snippets/azkv-pushsecret-secret.yaml
+++ b/docs/snippets/azkv-pushsecret-secret.yaml
@@ -11,7 +11,7 @@ metadata:
   name: pushsecret-example
   namespace: default
 spec:
-  refreshInterval: 10s # Refresh interval for which push secret will reconcile
+  refreshInterval: 1h # Refresh interval for which push secret will reconcile
   deletionPolicy: Delete
   secretStoreRefs: # A list of secret stores to push secrets to
     - name: azure-store

--- a/docs/snippets/beyondtrust-external-secret.yaml
+++ b/docs/snippets/beyondtrust-external-secret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
  name: beyondtrust-external-secret
 spec:
- refreshInterval: 300s
+ refreshInterval: 1h
  secretStoreRef:
    kind: SecretStore
    name: secretstore-beyondtrust

--- a/docs/snippets/chef-external-secret.yaml
+++ b/docs/snippets/chef-external-secret.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets
 spec:
-  refreshInterval: 15m
+  refreshInterval: 1h
   secretStoreRef:
     name: vivid-clustersecretstore # name of ClusterSecretStore
     kind: ClusterSecretStore

--- a/docs/snippets/conjur-external-secret-find.yaml
+++ b/docs/snippets/conjur-external-secret-find.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: conjur-find-by-name
 spec:
-  refreshInterval: 10s
+  refreshInterval: 1h
   secretStoreRef:
     # This name must match the metadata.name in the `SecretStore`
     name: conjur

--- a/docs/snippets/conjur-external-secret.yaml
+++ b/docs/snippets/conjur-external-secret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: conjur
 spec:
-  refreshInterval: 10s
+  refreshInterval: 1h
   secretStoreRef:
     # This name must match the metadata.name in the `SecretStore`
     name: conjur

--- a/docs/snippets/device42-external-secret.yaml
+++ b/docs/snippets/device42-external-secret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: device42-find-by-id
 spec:
-  refreshInterval: 10s
+  refreshInterval: 1h
   secretStoreRef:
     # This name must match the metadata.name in the `SecretStore`
     name: device42

--- a/docs/snippets/full-pushsecret-no-key-no-property.yaml
+++ b/docs/snippets/full-pushsecret-no-key-no-property.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default # Same of the SecretStores
 spec:
   deletionPolicy: Delete # the provider' secret will be deleted if the PushSecret is deleted
-  refreshInterval: 10s # Refresh interval for which push secret will reconcile
+  refreshInterval: 1h # Refresh interval for which push secret will reconcile
   secretStoreRefs: # A list of secret stores to push secrets to
     - name: aws-parameterstore
       kind: SecretStore

--- a/docs/snippets/full-pushsecret-no-key-with-property.yaml
+++ b/docs/snippets/full-pushsecret-no-key-with-property.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default # Same of the SecretStores
 spec:
   deletionPolicy: Delete # the provider' secret will be deleted if the PushSecret is deleted
-  refreshInterval: 10s # Refresh interval for which push secret will reconcile
+  refreshInterval: 1h # Refresh interval for which push secret will reconcile
   secretStoreRefs: # A list of secret stores to push secrets to
     - name: aws-parameterstore
       kind: SecretStore

--- a/docs/snippets/full-pushsecret.yaml
+++ b/docs/snippets/full-pushsecret.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   updatePolicy: Replace # Policy to overwrite existing secrets in the provider on sync
   deletionPolicy: Delete # the provider' secret will be deleted if the PushSecret is deleted
-  refreshInterval: 10s # Refresh interval for which push secret will reconcile
+  refreshInterval: 1h # Refresh interval for which push secret will reconcile
   secretStoreRefs: # A list of secret stores to push secrets to
     - name: aws-parameterstore
       kind: SecretStore

--- a/docs/snippets/ibm-external-secret-by-name.yaml
+++ b/docs/snippets/ibm-external-secret-by-name.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: database-credentials
 spec:
-  refreshInterval: 60m
+  refreshInterval: 1h
   secretStoreRef:
     name: ibm-store
     kind: SecretStore

--- a/docs/snippets/ibm-external-secret.yaml
+++ b/docs/snippets/ibm-external-secret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: database-credentials
 spec:
-  refreshInterval: 60m
+  refreshInterval: 1h
   secretStoreRef:
     name: ibm-store
     kind: SecretStore

--- a/docs/snippets/keepersecurity-external-secret.yaml
+++ b/docs/snippets/keepersecurity-external-secret.yaml
@@ -21,7 +21,7 @@ metadata:
   name: regcred
   namespace: external-secrets
 spec:
-  refreshInterval: 1m
+  refreshInterval: 1h
   secretStoreRef:
     name: keeper
     kind: ClusterSecretStore
@@ -49,7 +49,7 @@ metadata:
   name: config
   namespace: external-secrets
 spec:
-  refreshInterval: 1m
+  refreshInterval: 1h
   secretStoreRef:
     name: keeper
     kind: ClusterSecretStore

--- a/docs/snippets/onboardbase-fetch-all-secrets.yaml
+++ b/docs/snippets/onboardbase-fetch-all-secrets.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: service-name-secrets
 spec:
-  refreshInterval: 10m
+  refreshInterval: 1h
   secretStoreRef:
     name: onboardbase-external-secret-store
     kind: SecretStore

--- a/docs/snippets/onboardbase-fetch-secret.yaml
+++ b/docs/snippets/onboardbase-fetch-secret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: service-name-secrets
 spec:
-  refreshInterval: 10m
+  refreshInterval: 1h
   secretStoreRef:
     name: onboardbase-external-secret-store
     kind: SecretStore

--- a/docs/snippets/onboardbase-filtered-secrets.yaml
+++ b/docs/snippets/onboardbase-filtered-secrets.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: service-name-secrets
 spec:
-  refreshInterval: 10m
+  refreshInterval: 1h
   secretStoreRef:
     name: onboardbase-external-secret-store
     kind: SecretStore

--- a/docs/snippets/vault-anchore-engine-access-credentials-external-secret.yaml
+++ b/docs/snippets/vault-anchore-engine-access-credentials-external-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: anchore-access-credentials
   namespace: security
 spec:
-  refreshInterval: 1m
+  refreshInterval: 1h
   secretStoreRef:
     name: vault-backend
     kind: ClusterSecretStore

--- a/docs/snippets/vault-jenkins-credential-github-ssh-access-external-secret.yaml
+++ b/docs/snippets/vault-jenkins-credential-github-ssh-access-external-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: github-ssh-access
   namespace: ci
 spec:
-  refreshInterval: 1m
+  refreshInterval: 1h
   secretStoreRef:
     name: vault-backend
     kind: ClusterSecretStore

--- a/docs/snippets/vault-jenkins-credential-harbor-chart-robot-external-secret.yaml
+++ b/docs/snippets/vault-jenkins-credential-harbor-chart-robot-external-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: harbor-chart-robot
   namespace: ci
 spec:
-  refreshInterval: 1m
+  refreshInterval: 1h
   secretStoreRef:
     name: vault-backend
     kind: ClusterSecretStore

--- a/docs/snippets/vault-jenkins-credential-sonarqube-api-token-external-secret.yaml
+++ b/docs/snippets/vault-jenkins-credential-sonarqube-api-token-external-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: sonarqube-api-token
   namespace: ci
 spec:
-  refreshInterval: 1m
+  refreshInterval: 1h
   secretStoreRef:
     name: vault-backend
     kind: ClusterSecretStore

--- a/docs/snippets/vault-pushsecret.yaml
+++ b/docs/snippets/vault-pushsecret.yaml
@@ -13,7 +13,7 @@ metadata:
   name: pushsecret-example
   namespace: default
 spec:
-  refreshInterval: 10s
+  refreshInterval: 1h
   secretStoreRefs:
     - name: vault-secretstore
       kind: SecretStore


### PR DESCRIPTION
## Problem Statement

Our docs have several `refreshInterval` of low values like `10s`. Users that just copy our examples for a baseline then start to have external-secrets overloaded with jobs with no real use-case.

This PR changes these values to the default value of `1h`.