### PR TITLE
fix: do not import gpg key from forked repo

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -74,6 +74,9 @@ jobs:
       id-token: write  # gives the action the ability to mint the OIDC token necessary to request a Sigstore signing certificate
       attestations: write # this permission is necessary to persist the attestation
     runs-on: ubuntu-latest
+    if: |
+      github.ref == 'refs/heads/main' ||
+      startsWith(github.ref, 'refs/heads/release-')
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -90,20 +93,13 @@ jobs:
           version: v3.4.2
 
       - name: Generate chart
-        run: |
-          make helm.generate
+        run: make helm.generate
       - name: Import GPG key
-        if: |
-          github.ref == 'refs/heads/main' ||
-          startsWith(github.ref, 'refs/heads/release-')
         run: |
           echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --dearmor --output keyring.gpg
           echo -n "${{ secrets.GPG_PASSPHRASE }}" > passphrase-file.txt
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 # v1.6.0
-        if: |
-          github.ref == 'refs/heads/main' ||
-          startsWith(github.ref, 'refs/heads/release-')
         env:
           CR_KEY: external-secrets <external-secrets@external-secrets.io>
           CR_KEYRING: keyring.gpg

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -93,6 +93,9 @@ jobs:
         run: |
           make helm.generate
       - name: Import GPG key
+        if: |
+          github.ref == 'refs/heads/main' ||
+          startsWith(github.ref, 'refs/heads/release-')
         run: |
           echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --dearmor --output keyring.gpg
           echo -n "${{ secrets.GPG_PASSPHRASE }}" > passphrase-file.txt

--- a/deploy/charts/external-secrets/Chart.yaml
+++ b/deploy/charts/external-secrets/Chart.yaml
@@ -13,7 +13,6 @@ icon: https://raw.githubusercontent.com/external-secrets/external-secrets/main/a
 maintainers:
   - name: mcavoyk
     email: kellinmcavoy@gmail.com
-
 dependencies:
   - name: bitwarden-sdk-server
     version: v0.3.1


### PR DESCRIPTION
WRT: https://kubernetes.slack.com/archives/C047LA9MUPJ/p1731958028445619

The import-gpg step fails for PRs from forked repos. The key does not exist there and is not needed.

This PR was made from a forked repo.