### PR TITLE
fix: restrict the token permission update to the push chart step

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -71,8 +71,6 @@ jobs:
     permissions:
       contents: write  # for helm/chart-releaser-action to push chart release and create a release
       packages: write  # to push OCI chart package to GitHub Registry
-      id-token: write  # gives the action the ability to mint the OIDC token necessary to request a Sigstore signing certificate
-      attestations: write # this permission is necessary to persist the attestation
     runs-on: ubuntu-latest
     if: |
       github.ref == 'refs/heads/main' ||
@@ -130,6 +128,9 @@ jobs:
           cosign-release: 'v2.4.1'
 
       - name: Push chart to GHCR
+        permissions:
+          id-token: write  # gives the action the ability to mint the OIDC token necessary to request a Sigstore signing certificate
+          attestations: write # this permission is necessary to persist the attestation
         id: push_chart
         run: |
           shopt -s nullglob
@@ -140,11 +141,11 @@ jobs:
             chart_name=$(helm show chart "${pkg}" | yq .name)
             # helm push fails when registry path contains Uppercase letters
             chart_registry="ghcr.io/${GITHUB_REPOSITORY_OWNER}/charts"
-            
+
             helm_push_output=$(helm push "${pkg}" "oci://${chart_registry}" 2>&1)
             digest=$(echo "$helm_push_output" | grep -o 'sha256:[a-z0-9]*')
             echo "$helm_push_output"
-            
+
             artifact_digest_uri="${chart_registry}/${chart_name}@${digest}"
             cosign sign --yes "$artifact_digest_uri"
             cosign verify "$artifact_digest_uri" \


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?

## Related Issue

Fixes https://github.com/external-secrets/external-secrets/security/code-scanning/41

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
