### PR TITLE
Change wrong YAML TLS keys in documentation

### DIFF
--- a/docs/snippets/full-secret-store.yaml
+++ b/docs/snippets/full-secret-store.yaml
@@ -64,11 +64,11 @@ spec:
         key: "cert-key"
       # client side related TLS communication, when the Vault server requires mutual authentication
       tls:
-        clientCert:
+        certSecretRef:
           namespace: ...
           name: "my-cert-secret"
           key: "tls.crt"
-        secretRef:
+        keySecretRef:
           namespace: ...
           name: "my-cert-secret"
           key: "tls.key"


### PR DESCRIPTION
## Problem Statement

YAML TLS Keys in example are wrong

## Related Issue

Fixes #4130

## Proposed Changes

Replaced wrong keys with the right ones

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] My changes have reasonable test coverage
- [X] All tests pass with `make test`
- [X] I ensured my PR is ready for review with `make reviewable`
