### PR TITLE
fix(azure-keyvault): remove incorrect suffix from provider URL to fix OpenID discovery call

### DIFF
--- a/pkg/provider/azure/keyvault/keyvault.go
+++ b/pkg/provider/azure/keyvault/keyvault.go
@@ -956,7 +956,7 @@ func NewTokenProvider(ctx context.Context, token, clientID, tenantID, aadEndpoin
 	cred := confidential.NewCredFromAssertionCallback(func(ctx context.Context, aro confidential.AssertionRequestOptions) (string, error) {
 		return token, nil
 	})
-	cClient, err := confidential.New(fmt.Sprintf("%s%s/oauth2/token", aadEndpoint, tenantID), clientID, cred)
+	cClient, err := confidential.New(fmt.Sprintf("%s%s", aadEndpoint, tenantID), clientID, cred)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Problem Statement

As described in #4135, ESO 0.10.6 tries to call a non-existent OpenID discovery endpoint in `NewTokenProvider` (`https://login.microsoftonline.com/<REDACTED>/oauth2/token/v2.0/.well-known/openid-configuration?`), which causes failure in provider authentication.

## Related Issue

Fixes #4135

## Proposed Changes

From I see, instead of `https://login.microsoftonline.com/<REDACTED>/oauth2/token/v2.0/.well-known/openid-configuration?`, the operator should have called `https://login.microsoftonline.com/<REDACTED>/v2.0/.well-known/openid-configuration` as the latter exists and contains all the relevant information about various endpoints.

So, the problem is caused by the `/oauth2/token` suffix passed in `NewTokenProvider`:

```go
cClient, err := confidential.New(fmt.Sprintf("%s%s/oauth2/token", aadEndpoint, tenantID), clientID, cred)
```

We can fix it by removing the suffix:

```go
cClient, err := confidential.New(fmt.Sprintf("%s%s", aadEndpoint, tenantID), clientID, cred)
```

I haven't tracked down it all to an exact change in the repository, but since the line hasn't been changed for quite a while, my guess is that the authentication library no longer strips the suffix. I believe it should have never been there in the first place.

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] My changes have reasonable test coverage
- [X] All tests pass with `make test`
- [X] I ensured my PR is ready for review with `make reviewable`
