### PR TITLE
fix: handle managed identity ClientID or ResourceID in acr generator

### DIFF
--- a/docs/api/generator/acr.md
+++ b/docs/api/generator/acr.md
@@ -9,7 +9,6 @@ The token is generated for a particular ACR registry defined in `spec.registry`.
 | username | username for the `docker login` command |
 | password | password for the `docker login` command |
 
-
 ## Authentication
 
 You must choose one out of three authentication mechanisms:
@@ -20,6 +19,8 @@ You must choose one out of three authentication mechanisms:
 
 The generated token will inherit the permissions from the assigned policy. I.e. when you assign a read-only policy all generated tokens will be read-only.
 You **must** [assign a Azure RBAC role](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments-steps), such as `AcrPush` or `AcrPull` to the service principal or managed identity in order to be able to authenticate with the Azure container registry API.
+
+You can also use a kubelet managed identity with the default `AcrPull` role to authenticate to the integrated Azure Container Registry.
 
 You can scope tokens to a particular repository using `spec.scope`.
 
@@ -49,6 +50,13 @@ repository:my-repository:pull
 ```
 
 Example `ExternalSecret` that references the ACR generator:
+
 ```yaml
 {% include 'generator-acr-example.yaml' %}
+```
+
+Example using AKS kubelet managed identity to create [Argo CD helm chart repository](https://argo-cd.readthedocs.io/en/latest/operator-manual/declarative-setup/#helm-chart-repositories) secret:
+
+```yaml
+{% include 'generator-acr-argocd-helm-repo.yaml' %}
 ```

--- a/docs/snippets/generator-acr-argocd-helm-repo.yaml
+++ b/docs/snippets/generator-acr-argocd-helm-repo.yaml
@@ -1,0 +1,38 @@
+{% raw %}
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: ACRAccessToken
+metadata:
+  name: azurecr
+spec:
+  tenantId: 11111111-2222-3333-4444-111111111111
+  registry: example.azurecr.io
+  auth:
+    managedIdentity:
+      identityId: 11111111-2222-3333-4444-111111111111
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: azurecr-credentials
+spec:
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: ACRAccessToken
+          name: azurecr
+  refreshInterval: 3h
+  target:
+    name: azurecr-credentials
+    template:
+      metadata:
+        labels:
+          argocd.argoproj.io/secret-type: repository
+      data:
+        name: "example.azurecr.io"
+        url: "example.azurecr.io"
+        username: "{{ .username }}"
+        password: "{{ .password }}"
+        enableOCI: "true"
+        type: "helm"
+{% endraw %}

--- a/docs/snippets/generator-acr.yaml
+++ b/docs/snippets/generator-acr.yaml
@@ -28,9 +28,9 @@ spec:
           name: az-secret
           key: clientid
 
-    # option 2:
+    # option 2: use a managed identity Client ID
     managedIdentity:
-      identityId: "xxxxx"
+      identityId: 11111111-2222-3333-4444-111111111111
 
     # option 3:
     workloadIdentity:

--- a/pkg/generator/acr/acr.go
+++ b/pkg/generator/acr/acr.go
@@ -282,10 +282,10 @@ func accessTokenForWorkloadIdentity(ctx context.Context, crClient client.Client,
 }
 
 func accessTokenForManagedIdentity(ctx context.Context, envType v1beta1.AzureEnvironmentType, identityID string) (string, error) {
-	// handle workload identity
+	// handle managed identity
 	creds, err := azidentity.NewManagedIdentityCredential(
 		&azidentity.ManagedIdentityCredentialOptions{
-			ID: azidentity.ResourceID(identityID),
+			ID: azidentity.ClientID(identityID),
 		},
 	)
 	if err != nil {

--- a/pkg/generator/acr/acr.go
+++ b/pkg/generator/acr/acr.go
@@ -283,11 +283,17 @@ func accessTokenForWorkloadIdentity(ctx context.Context, crClient client.Client,
 
 func accessTokenForManagedIdentity(ctx context.Context, envType v1beta1.AzureEnvironmentType, identityID string) (string, error) {
 	// handle managed identity
-	creds, err := azidentity.NewManagedIdentityCredential(
-		&azidentity.ManagedIdentityCredentialOptions{
+	var opts *azidentity.ManagedIdentityCredentialOptions
+	if strings.Contains(identityID, "/") {
+		opts = &azidentity.ManagedIdentityCredentialOptions{
+			ID: azidentity.ResourceID(identityID),
+		}
+	} else {
+		opts = &azidentity.ManagedIdentityCredentialOptions{
 			ID: azidentity.ClientID(identityID),
-		},
-	)
+		}
+	}
+	creds, err := azidentity.NewManagedIdentityCredential(opts)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Problem Statement
Trying to use ACR generator with kubelet managed identity as described in [docs ](https://external-secrets.io/latest/api/generator/acr)

```yaml
apiVersion: generators.external-secrets.io/v1alpha1
kind: ACRAccessToken
metadata:
  name: my-azurecr
spec:
  tenantId: 11111111-2222-3333-4444-111111111111
  registry: example.azurecr.io
  environmentType: "PublicCloud"
  auth:
    managedIdentity:
      identityId: "xxxxx" # Supposed to be managed identity client ID as in Azure Key Vault provider
```

Got such in logs
```log
ManagedIdentityCredential authentication failed. the requested identity isn't assigned to this resource\nGET http://169.254.169.254/metadata/identity/oauth2/token
```

## Proposed Changes

Check if the `identityID` contains a "/" and set the `ManagedIdentityCredentialOptions` accordingly, using `ResourceID` or `ClientID` as appropriate.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
