### PR TITLE
fix: v1 templates with metadata + always cleanup orphaned secrets

### DIFF
--- a/apis/externalsecrets/v1beta1/externalsecret_types.go
+++ b/apis/externalsecrets/v1beta1/externalsecret_types.go
@@ -465,11 +465,12 @@ const (
 	// ConditionReasonSecretMissing indicates that the secret is missing.
 	ConditionReasonSecretMissing = "SecretMissing"
 
-	ReasonUpdateFailed = "UpdateFailed"
-	ReasonDeprecated   = "ParameterDeprecated"
-	ReasonCreated      = "Created"
-	ReasonUpdated      = "Updated"
-	ReasonDeleted      = "Deleted"
+	ReasonUpdateFailed          = "UpdateFailed"
+	ReasonDeprecated            = "ParameterDeprecated"
+	ReasonCreated               = "Created"
+	ReasonUpdated               = "Updated"
+	ReasonDeleted               = "Deleted"
+	ReasonMissingProviderSecret = "MissingProviderSecret"
 )
 
 type ExternalSecretStatus struct {

--- a/docs/guides/templating-v1.md
+++ b/docs/guides/templating-v1.md
@@ -4,6 +4,10 @@
 
     Templating Engine v1 is **deprecated** and will be removed in the future. Please migrate to engine v2 and take a look at our [upgrade guide](templating.md#migrating-from-v1) for changes.
 
+!!! note
+
+    Templating Engine v1 does NOT support templating the `spec.target.template.metadata` fields, or the keys of the `spec.target.template.data` map, it will treat them as plain strings.
+    To use templates in annotations/labels/data-keys, please use Templating Engine v2.
 
 With External Secrets Operator you can transform the data from the external secret provider before it is stored as `Kind=Secret`. You can do this with the `Spec.Target.Template`.
 
@@ -18,7 +22,7 @@ You can use templates to inject your secrets into a configuration file that you 
 
 You can also use pre-defined functions to extract data from your secrets. Here: extract key/cert from a pkcs12 archive and store it as PEM.
 ``` yaml
-{% include 'pkcs12-template-v2-external-secret.yaml' %}
+{% include 'pkcs12-template-v1-external-secret.yaml' %}
 ```
 
 ### TemplateFrom

--- a/docs/snippets/pkcs12-template-v1-external-secret.yaml
+++ b/docs/snippets/pkcs12-template-v1-external-secret.yaml
@@ -13,6 +13,7 @@ spec:
     # this is how the Kind=Secret will look like
     template:
       type: kubernetes.io/tls
+      engineVersion: v1
       data:
         tls.crt: "{{ .mysecret | pkcs12cert | pemCertificate }}"
         tls.key: "{{ .mysecret | pkcs12key | pemPrivateKey }}"

--- a/pkg/controllers/externalsecret/externalsecret_controller_secret.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller_secret.go
@@ -49,55 +49,68 @@ func (r *Reconciler) getProviderSecretData(ctx context.Context, externalSecret *
 		var err error
 
 		if remoteRef.Find != nil {
-			secretMap, err = r.handleFindAllSecrets(ctx, externalSecret, remoteRef, mgr, i)
+			secretMap, err = r.handleFindAllSecrets(ctx, externalSecret, remoteRef, mgr)
+			if err != nil {
+				err = fmt.Errorf("error processing spec.dataFrom[%d].find, err: %w", i, err)
+			}
 		} else if remoteRef.Extract != nil {
-			secretMap, err = r.handleExtractSecrets(ctx, externalSecret, remoteRef, mgr, i)
+			secretMap, err = r.handleExtractSecrets(ctx, externalSecret, remoteRef, mgr)
+			if err != nil {
+				err = fmt.Errorf("error processing spec.dataFrom[%d].extract, err: %w", i, err)
+			}
 		} else if remoteRef.SourceRef != nil && remoteRef.SourceRef.GeneratorRef != nil {
-			secretMap, err = r.handleGenerateSecrets(ctx, externalSecret.Namespace, remoteRef, i)
+			secretMap, err = r.handleGenerateSecrets(ctx, externalSecret.Namespace, remoteRef)
+			if err != nil {
+				err = fmt.Errorf("error processing spec.dataFrom[%d].sourceRef.generatorRef, err: %w", i, err)
+			}
 		}
+
 		if errors.Is(err, esv1beta1.NoSecretErr) && externalSecret.Spec.Target.DeletionPolicy != esv1beta1.DeletionPolicyRetain {
-			r.recorder.Event(
-				externalSecret,
-				v1.EventTypeNormal,
-				esv1beta1.ReasonDeleted,
-				fmt.Sprintf("secret does not exist at provider using .dataFrom[%d]", i),
-			)
+			r.recorder.Eventf(externalSecret, v1.EventTypeNormal, esv1beta1.ReasonMissingProviderSecret, eventMissingProviderSecret, i)
 			continue
 		}
 		if err != nil {
 			return nil, err
 		}
+
 		providerData = utils.MergeByteMap(providerData, secretMap)
 	}
 
 	for i, secretRef := range externalSecret.Spec.Data {
-		err := r.handleSecretData(ctx, i, *externalSecret, secretRef, providerData, mgr)
+		err := r.handleSecretData(ctx, *externalSecret, secretRef, providerData, mgr)
 		if errors.Is(err, esv1beta1.NoSecretErr) && externalSecret.Spec.Target.DeletionPolicy != esv1beta1.DeletionPolicyRetain {
-			r.recorder.Event(externalSecret, v1.EventTypeNormal, esv1beta1.ReasonDeleted, fmt.Sprintf("secret does not exist at provider using .data[%d] key=%s", i, secretRef.RemoteRef.Key))
+			r.recorder.Eventf(externalSecret, v1.EventTypeNormal, esv1beta1.ReasonMissingProviderSecret, eventMissingProviderSecretKey, i, secretRef.RemoteRef.Key)
 			continue
 		}
 		if err != nil {
-			return nil, fmt.Errorf("error retrieving secret at .data[%d], key: %s, err: %w", i, secretRef.RemoteRef.Key, err)
+			return nil, fmt.Errorf("error processing spec.data[%d] (key: %s), err: %w", i, secretRef.RemoteRef.Key, err)
 		}
 	}
 
 	return providerData, nil
 }
 
-func (r *Reconciler) handleSecretData(ctx context.Context, i int, externalSecret esv1beta1.ExternalSecret, secretRef esv1beta1.ExternalSecretData, providerData map[string][]byte, cmgr *secretstore.Manager) error {
+func (r *Reconciler) handleSecretData(ctx context.Context, externalSecret esv1beta1.ExternalSecret, secretRef esv1beta1.ExternalSecretData, providerData map[string][]byte, cmgr *secretstore.Manager) error {
 	client, err := cmgr.Get(ctx, externalSecret.Spec.SecretStoreRef, externalSecret.Namespace, toStoreGenSourceRef(secretRef.SourceRef))
 	if err != nil {
 		return err
 	}
+
+	// get a single secret from the store
 	secretData, err := client.GetSecret(ctx, secretRef.RemoteRef)
 	if err != nil {
 		return err
 	}
+
+	// decode the secret if needed
 	secretData, err = utils.Decode(secretRef.RemoteRef.DecodingStrategy, secretData)
 	if err != nil {
-		return fmt.Errorf(errDecode, "spec.data", i, err)
+		return fmt.Errorf(errDecode, secretRef.RemoteRef.DecodingStrategy, err)
 	}
+
+	// store the secret data
 	providerData[secretRef.SecretKey] = secretData
+
 	return nil
 }
 
@@ -110,83 +123,108 @@ func toStoreGenSourceRef(ref *esv1beta1.StoreSourceRef) *esv1beta1.StoreGenerato
 	}
 }
 
-func (r *Reconciler) handleGenerateSecrets(ctx context.Context, namespace string, remoteRef esv1beta1.ExternalSecretDataFromRemoteRef, i int) (map[string][]byte, error) {
+func (r *Reconciler) handleGenerateSecrets(ctx context.Context, namespace string, remoteRef esv1beta1.ExternalSecretDataFromRemoteRef) (map[string][]byte, error) {
 	gen, obj, err := resolvers.GeneratorRef(ctx, r.Client, r.Scheme, namespace, remoteRef.SourceRef.GeneratorRef)
 	if err != nil {
-		return nil, fmt.Errorf("unable to resolve generator: %w", err)
+		return nil, err
 	}
-	// We still pass the namespace to the generate function because it needs to create
-	// namespace based objects.
+
+	// use the generator
 	secretMap, err := gen.Generate(ctx, obj, r.Client, namespace)
 	if err != nil {
-		return nil, fmt.Errorf(errGenerate, i, err)
+		return nil, fmt.Errorf(errGenerate, err)
 	}
+
+	// rewrite the keys if needed
 	secretMap, err = utils.RewriteMap(remoteRef.Rewrite, secretMap)
 	if err != nil {
-		return nil, fmt.Errorf(errRewrite, i, err)
+		return nil, fmt.Errorf(errRewrite, err)
 	}
-	if !utils.ValidateKeys(secretMap) {
-		return nil, fmt.Errorf(errInvalidKeys, "generator", i)
+
+	// validate the keys
+	err = utils.ValidateKeys(secretMap)
+	if err != nil {
+		return nil, fmt.Errorf(errInvalidKeys, err)
 	}
+
 	return secretMap, err
 }
 
-func (r *Reconciler) handleExtractSecrets(ctx context.Context, externalSecret *esv1beta1.ExternalSecret, remoteRef esv1beta1.ExternalSecretDataFromRemoteRef, cmgr *secretstore.Manager, i int) (map[string][]byte, error) {
+//nolint:dupl
+func (r *Reconciler) handleExtractSecrets(ctx context.Context, externalSecret *esv1beta1.ExternalSecret, remoteRef esv1beta1.ExternalSecretDataFromRemoteRef, cmgr *secretstore.Manager) (map[string][]byte, error) {
 	client, err := cmgr.Get(ctx, externalSecret.Spec.SecretStoreRef, externalSecret.Namespace, remoteRef.SourceRef)
 	if err != nil {
 		return nil, err
 	}
+
+	// get multiple secrets from the store
 	secretMap, err := client.GetSecretMap(ctx, *remoteRef.Extract)
 	if err != nil {
 		return nil, err
 	}
+
+	// rewrite the keys if needed
 	secretMap, err = utils.RewriteMap(remoteRef.Rewrite, secretMap)
 	if err != nil {
-		return nil, fmt.Errorf(errRewrite, i, err)
+		return nil, fmt.Errorf(errRewrite, err)
 	}
 	if len(remoteRef.Rewrite) == 0 {
 		secretMap, err = utils.ConvertKeys(remoteRef.Extract.ConversionStrategy, secretMap)
 		if err != nil {
-			return nil, fmt.Errorf(errConvert, err)
+			return nil, fmt.Errorf(errConvert, remoteRef.Extract.ConversionStrategy, err)
 		}
 	}
-	if !utils.ValidateKeys(secretMap) {
-		return nil, fmt.Errorf(errInvalidKeys, "extract", i)
+
+	// validate the keys
+	err = utils.ValidateKeys(secretMap)
+	if err != nil {
+		return nil, fmt.Errorf(errInvalidKeys, err)
 	}
+
+	// decode the secrets if needed
 	secretMap, err = utils.DecodeMap(remoteRef.Extract.DecodingStrategy, secretMap)
 	if err != nil {
-		return nil, fmt.Errorf(errDecode, "spec.dataFrom", i, err)
+		return nil, fmt.Errorf(errDecode, remoteRef.Extract.DecodingStrategy, err)
 	}
+
 	return secretMap, err
 }
 
-func (r *Reconciler) handleFindAllSecrets(ctx context.Context, externalSecret *esv1beta1.ExternalSecret, remoteRef esv1beta1.ExternalSecretDataFromRemoteRef, cmgr *secretstore.Manager, i int) (map[string][]byte, error) {
+//nolint:dupl
+func (r *Reconciler) handleFindAllSecrets(ctx context.Context, externalSecret *esv1beta1.ExternalSecret, remoteRef esv1beta1.ExternalSecretDataFromRemoteRef, cmgr *secretstore.Manager) (map[string][]byte, error) {
 	client, err := cmgr.Get(ctx, externalSecret.Spec.SecretStoreRef, externalSecret.Namespace, remoteRef.SourceRef)
 	if err != nil {
 		return nil, err
 	}
+
+	// get all secrets from the store that match the selector
 	secretMap, err := client.GetAllSecrets(ctx, *remoteRef.Find)
 	if err != nil {
 		return nil, err
 	}
+
+	// rewrite the keys if needed
 	secretMap, err = utils.RewriteMap(remoteRef.Rewrite, secretMap)
 	if err != nil {
-		return nil, fmt.Errorf(errRewrite, i, err)
+		return nil, fmt.Errorf(errRewrite, err)
 	}
 	if len(remoteRef.Rewrite) == 0 {
-		// ConversionStrategy is deprecated. Use RewriteMap instead.
-		r.recorder.Event(externalSecret, v1.EventTypeWarning, esv1beta1.ReasonDeprecated, fmt.Sprintf("dataFrom[%d].find.conversionStrategy=%v is deprecated and will be removed in further releases. Use dataFrom.rewrite instead", i, remoteRef.Find.ConversionStrategy))
 		secretMap, err = utils.ConvertKeys(remoteRef.Find.ConversionStrategy, secretMap)
 		if err != nil {
-			return nil, fmt.Errorf(errConvert, err)
+			return nil, fmt.Errorf(errConvert, remoteRef.Find.ConversionStrategy, err)
 		}
 	}
-	if !utils.ValidateKeys(secretMap) {
-		return nil, fmt.Errorf(errInvalidKeys, "find", i)
+
+	// validate the keys
+	err = utils.ValidateKeys(secretMap)
+	if err != nil {
+		return nil, fmt.Errorf(errInvalidKeys, err)
 	}
+
+	// decode the secrets if needed
 	secretMap, err = utils.DecodeMap(remoteRef.Find.DecodingStrategy, secretMap)
 	if err != nil {
-		return nil, fmt.Errorf(errDecode, "spec.dataFrom", i, err)
+		return nil, fmt.Errorf(errDecode, remoteRef.Find.DecodingStrategy, err)
 	}
 	return secretMap, err
 }

--- a/pkg/controllers/externalsecret/externalsecret_controller_template.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller_template.go
@@ -79,18 +79,23 @@ func (r *Reconciler) applyTemplate(ctx context.Context, es *esv1beta1.ExternalSe
 	if err != nil {
 		return fmt.Errorf(errFetchTplFrom, err)
 	}
-	// explicitly defined template.Data takes precedence over templateFrom
+
+	// apply data templates
+	// NOTE: explicitly defined template.data templates take precedence over templateFrom
 	err = p.MergeMap(es.Spec.Target.Template.Data, esv1beta1.TemplateTargetData)
 	if err != nil {
 		return fmt.Errorf(errExecTpl, err)
 	}
 
-	// get template data for labels
+	// apply templates for labels
+	// NOTE: this only works for v2 templates
 	err = p.MergeMap(es.Spec.Target.Template.Metadata.Labels, esv1beta1.TemplateTargetLabels)
 	if err != nil {
 		return fmt.Errorf(errExecTpl, err)
 	}
-	// get template data for annotations
+
+	// apply template for annotations
+	// NOTE: this only works for v2 templates
 	err = p.MergeMap(es.Spec.Target.Template.Metadata.Annotations, esv1beta1.TemplateTargetAnnotations)
 	if err != nil {
 		return fmt.Errorf(errExecTpl, err)

--- a/pkg/template/engine.go
+++ b/pkg/template/engine.go
@@ -14,6 +14,8 @@ limitations under the License.
 package template
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 
 	esapi "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
@@ -30,8 +32,5 @@ func EngineForVersion(version esapi.TemplateEngineVersion) (ExecFunc, error) {
 	case esapi.TemplateEngineV2:
 		return v2.Execute, nil
 	}
-
-	// in case we run with a old v1alpha1 CRD
-	// we must return v1 as default
-	return v1.Execute, nil
+	return nil, fmt.Errorf("unsupported template engine version: %s", version)
 }


### PR DESCRIPTION
## Problem Statement

This PR makes the following changes:

1. Fixes an issue that prevented v1 templates from defining metadata/annotations (I think this was present before 0.11):
     - https://github.com/external-secrets/external-secrets/issues/4172
     - https://github.com/external-secrets/external-secrets/issues/1910
     - __NOTE:__ this PR also updates the docs for v1 templating to explain that annotations/labels are not templated in v1
3. We now always check if there are orphaned secrets when `creationPolicy=Owner`:
      - Previously, we only checked when we first created a new target secret, but if that failed, we would not retry on the next reconcile.
      - Because we are using the partial secret cache to check for orphaned secrets, it should not have a significant performance penalty, and will not make any new API call.
4. Improves the secret key validation in `dataFrom`, to also prevent keys being longer than 253 characters.
5. Improves the error messages when there is an error in one of the `spec.dataFrom[]` elements 
6. We now correctly set the `Reason` of Events for ExternalSecrets in following situations:
     - `Created` New target Secret created
     - `Deleted` Existing target Secret deleted
     - `Updated` Existing target Secret updated
     - `MissingProviderSecret` when `deletionPolicy != Retain` and an expected provider secret does not exist
         - Previously this was incorrectly marked as `Deleted`, even though the target secret was not being deleted.

## Related Issue

fixes https://github.com/external-secrets/external-secrets/issues/4172

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] My changes have reasonable test coverage
- [X] All tests pass with `make test`
- [X] I ensured my PR is ready for review with `make reviewable`
