### PR TITLE
Ignore reconciliation errors caused by namespace termination

### DIFF
--- a/pkg/controllers/clusterexternalsecret/clusterexternalsecret_controller.go
+++ b/pkg/controllers/clusterexternalsecret/clusterexternalsecret_controller.go
@@ -42,6 +42,7 @@ import (
 
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 	"github.com/external-secrets/external-secrets/pkg/controllers/clusterexternalsecret/cesmetrics"
+	ctrlerrors "github.com/external-secrets/external-secrets/pkg/controllers/errors"
 	ctrlmetrics "github.com/external-secrets/external-secrets/pkg/controllers/metrics"
 )
 
@@ -153,8 +154,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 
 		if err := r.createOrUpdateExternalSecret(ctx, &clusterExternalSecret, namespace, esName, clusterExternalSecret.Spec.ExternalSecretMetadata); err != nil {
-			log.Error(err, "failed to create or update external secret")
-			failedNamespaces[namespace.Name] = err
+			if !ctrlerrors.IsNamespaceGone(err) {
+				log.Error(err, "failed to create or update external secret")
+				failedNamespaces[namespace.Name] = err
+			}
 			continue
 		}
 

--- a/pkg/controllers/errors/errors.go
+++ b/pkg/controllers/errors/errors.go
@@ -1,0 +1,40 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"errors"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+func IsNamespaceGone(err error) bool {
+	if apierrors.HasStatusCause(err, v1.NamespaceTerminatingCause) {
+		return true
+	} else if !apierrors.IsNotFound(err) {
+		return false
+	}
+
+	// Ensure that the 404 is for a namespace.
+	status, ok := err.(apierrors.APIStatus)
+	if (ok || errors.As(err, &status)) && status.Status().Details != nil {
+		if status.Status().Details.Kind == "namespaces" {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
## Problem Statement

When namespace finalizers are used, it's pretty easy to hit a race condition where a namespace is deleted while the `ClusterExternalSecret` and `ExternalSecret` reconciliation loops are running. When namespaces are regularly being created and deleted, this causes ESO to report a large number of errors, both in the logs and in the prometheus metrics, making it more difficult to identify and monitor actual issues.

## Related Issue

(None reported)

## Proposed Changes

This commit prevents errors caused by namespace deletion from being logged or counting towards the error metrics. These errors are "expected" to happen during namespace deletion and don't represent an issue with the service.

This is the same approach used in Kubernetes itself, for example in the `Deployment`, `Job`, and `EndpointSlice` controllers.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
  - Happy to get some suggestions for this (if tests are needed for this change). Not sure if there's a good way to test for the presence or absence of a log message.
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
