### PR TITLE
fix: handle empty template engine version

### DIFF
--- a/pkg/template/engine.go
+++ b/pkg/template/engine.go
@@ -27,7 +27,10 @@ type ExecFunc func(tpl, data map[string][]byte, scope esapi.TemplateScope, targe
 
 func EngineForVersion(version esapi.TemplateEngineVersion) (ExecFunc, error) {
 	switch version {
-	case esapi.TemplateEngineV1:
+	// NOTE: the version can be empty if the ExternalSecret was created with version 0.4.3 or earlier,
+	//       all versions after this will default to "v1" (for v1alpha1 ES) or "v2" (for v1beta1 ES).
+	//       so if we encounter an empty version, we must default to the v1 engine.
+	case esapi.TemplateEngineV1, "":
 		return v1.Execute, nil
 	case esapi.TemplateEngineV2:
 		return v2.Execute, nil


### PR DESCRIPTION
## Problem Statement

In https://github.com/external-secrets/external-secrets/pull/4174, we accidentally introduced an issue for users who upgrade from very old versions of External Secrets.

The issue was that the `spec.target.template.engineVersion` can actually be empty. We only added that field with the default "v1" in https://github.com/external-secrets/external-secrets/pull/701 (which was included in external-secrets 0.4.3), so ExternalSecrets created in older versions will not have any `engineVersion` set.

This just means we need to assume that an empty `engineVersion` is "v1".

## Related Issue

N/A

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] My changes have reasonable test coverage
- [X] All tests pass with `make test`
- [X] I ensured my PR is ready for review with `make reviewable`
