### PR TITLE
fix: error in order of function call UpdateEnvironment

### DIFF
--- a/pkg/provider/pulumi/pulumi.go
+++ b/pkg/provider/pulumi/pulumi.go
@@ -105,7 +105,7 @@ func (c *client) PushSecret(_ context.Context, secret *corev1.Secret, data esv1b
 	if err := mergo.Merge(&updatePayload.Values.AdditionalProperties, oldValues); err != nil {
 		return fmt.Errorf(errPushSecrets, err)
 	}
-	_, err = c.escClient.UpdateEnvironment(c.authCtx, c.organization, c.environment, c.project, updatePayload)
+	_, err = c.escClient.UpdateEnvironment(c.authCtx, c.organization, c.project, c.environment, updatePayload)
 	if err != nil {
 		return fmt.Errorf(errPushSecrets, err)
 	}


### PR DESCRIPTION
## Problem Statement

There was an error in the order of a function call in the `PushSecret` implementation of the Pulumi ESC provider

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
