### PR TITLE
docs: add raw markdown tags to PushSecret example in Google Secrets Manager documentation

### DIFF
--- a/docs/provider/google-secrets-manager.md
+++ b/docs/provider/google-secrets-manager.md
@@ -123,6 +123,7 @@ By default, the PushSecret spec will replace any existing labels on the existing
 Example of using the `mergePolicy` field:
 
 ```yaml
+{% raw %}
 apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
@@ -151,6 +152,7 @@ spec:
         secretKey: bestpokemon
         remoteRef:
           remoteKey: best-pokemon
+{% endraw %}
 ```
 
 ### Secret Replication and Encryption Configuration


### PR DESCRIPTION
## Problem Statement

The problem is that the template syntax in the `provider/google-secrets-manager.md` file was causing a macro syntax error due to the use of dot notation within the double curly braces.

WARNING -  [macros] - ERROR # _Macro Syntax Error_

_File_: `provider/google-secrets-manager.md`

_Line 143 in Markdown file:_ **unexpected '.'**
```markdown
      bestpokemon: "{{ .bestpokemon }}"
```

## Related Issue

No Issue opened regarding this small bug

## Proposed Changes

I have fixed the issue by wrapping the template code with `{% raw %} ... {% endraw %}` to prevent the template engine from interpreting the dot notation.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`