### PR TITLE
add allowEmptyResponse to vaultdynamicsecrets

### DIFF
--- a/apis/generators/v1alpha1/types_vault.go
+++ b/apis/generators/v1alpha1/types_vault.go
@@ -50,6 +50,11 @@ type VaultDynamicSecretSpec struct {
 
 	// Vault path to obtain the dynamic secret from
 	Path string `json:"path"`
+
+	// Do not fail if no secrets are found. Useful for requests where no data is expected.
+	// +optional
+	// +kubebuilder:default=false
+	AllowEmptyResponse bool `json:"allowEmptyResponse,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=Data;Auth

--- a/config/crds/bases/generators.external-secrets.io_clustergenerators.yaml
+++ b/config/crds/bases/generators.external-secrets.io_clustergenerators.yaml
@@ -735,6 +735,11 @@ spec:
                     type: object
                   vaultDynamicSecretSpec:
                     properties:
+                      allowEmptyResponse:
+                        default: false
+                        description: Do not fail if no secrets are found. Useful for
+                          requests where no data is expected.
+                        type: boolean
                       controller:
                         description: |-
                           Used to select the correct ESO controller (think: ingress.ingressClassName)

--- a/config/crds/bases/generators.external-secrets.io_vaultdynamicsecrets.yaml
+++ b/config/crds/bases/generators.external-secrets.io_vaultdynamicsecrets.yaml
@@ -41,6 +41,11 @@ spec:
             type: object
           spec:
             properties:
+              allowEmptyResponse:
+                default: false
+                description: Do not fail if no secrets are found. Useful for requests
+                  where no data is expected.
+                type: boolean
               controller:
                 description: |-
                   Used to select the correct ESO controller (think: ingress.ingressClassName)

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -14541,6 +14541,10 @@ spec:
                       type: object
                     vaultDynamicSecretSpec:
                       properties:
+                        allowEmptyResponse:
+                          default: false
+                          description: Do not fail if no secrets are found. Useful for requests where no data is expected.
+                          type: boolean
                         controller:
                           description: |-
                             Used to select the correct ESO controller (think: ingress.ingressClassName)
@@ -16444,6 +16448,10 @@ spec:
               type: object
             spec:
               properties:
+                allowEmptyResponse:
+                  default: false
+                  description: Do not fail if no secrets are found. Useful for requests where no data is expected.
+                  type: boolean
                 controller:
                   description: |-
                     Used to select the correct ESO controller (think: ingress.ingressClassName)

--- a/pkg/generator/vault/vault.go
+++ b/pkg/generator/vault/vault.go
@@ -81,6 +81,11 @@ func (g *Generator) generate(ctx context.Context, c *provider.Provider, jsonSpec
 	if err != nil {
 		return nil, err
 	}
+
+	if result == nil && res.Spec.AllowEmptyResponse {
+		return nil, nil
+	}
+
 	if result == nil {
 		return nil, fmt.Errorf(errGetSecret, errors.New("empty response from Vault"))
 	}


### PR DESCRIPTION
## Problem Statement

I have a use case to perform a request against vault with no response data.
This PR should allow us to make the custom requests against more vault endpoints.
As there are various endpoints on vault which might return no data, it can be useful for more scenarios in the future.

My use case in detail:
I want to trigger a vault database credential rotation, which has no response. After that get the new credentials.
I cannot perform the operation in a pipeline process beforehand. The goal is to fake a manual rotation with an external secret annotation update, so I can include that in a helm chart deployment.

The use case was successfully tested in a local kubernetes environment.
 
```yaml
---
apiVersion: generators.external-secrets.io/v1alpha1
kind: VaultDynamicSecret
metadata:
  name: "db-rotation"
spec:
  path: "/database/rotate-role/test"
  method: "POST"
  allowEmptyResponse: true
  provider:
    server: "http://vault.default.svc.cluster.local:8200"
    auth:
      userPass:
        path: "userpass"
        username: "test"
        secretRef:
          name: "vault-auth"
          key: "password"
---
apiVersion: generators.external-secrets.io/v1alpha1
kind: VaultDynamicSecret
metadata:
  name: "db-get"
spec:
  path: "/database/static-creds/test"
  method: "GET"
  provider:
    server: "http://vault.default.svc.cluster.local:8200"
    auth:
      userPass:
        path: "userpass"
        username: "test"
        secretRef:
          name: "vault-auth"
          key: "password"
---
apiVersion: external-secrets.io/v1beta1
kind: ExternalSecret
metadata:
  name: "db-rotation"
spec:
  refreshInterval: "3m"
  target:
    name: "db-creds"
  dataFrom:
    - sourceRef:
        generatorRef:
          apiVersion: generators.external-secrets.io/v1alpha1
          kind: VaultDynamicSecret
          name: "db-rotation"
    - sourceRef:
        generatorRef:
          apiVersion: generators.external-secrets.io/v1alpha1
          kind: VaultDynamicSecret
          name: "db-get"
```

## Related Issue

No known issue.

## Proposed Changes

I added the property `allowEmptyResponse` to the `VaultDynamicSecret` resource.
By default it is set to `false`. If `true` no "no-data" error is returned from an empty response.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
