### PR TITLE
fix: allow SecretStoreRef to fetch cabundle from a secret in another namespace

### DIFF
--- a/pkg/common/webhook/webhook.go
+++ b/pkg/common/webhook/webhook.go
@@ -269,6 +269,7 @@ func (w *Webhook) GetCertFromSecret(provider *Spec) ([]byte, error) {
 		w.StoreKind,
 		w.Namespace,
 		&secretRef,
+		false,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/provider/akeyless/akeyless_api.go
+++ b/pkg/provider/akeyless/akeyless_api.go
@@ -382,7 +382,7 @@ func (a *akeylessBase) getK8SServiceAccountJWT(ctx context.Context, kubernetesAu
 			tokenRef = kubernetesAuth.SecretRef.DeepCopy()
 			tokenRef.Key = "token"
 		}
-		jwt, err := resolvers.SecretKeyRef(ctx, a.kube, a.storeKind, a.namespace, tokenRef)
+		jwt, err := resolvers.SecretKeyRef(ctx, a.kube, a.storeKind, a.namespace, tokenRef, true)
 		if err != nil {
 			return "", err
 		}
@@ -414,7 +414,7 @@ func (a *akeylessBase) getJWTFromServiceAccount(ctx context.Context, serviceAcco
 			Name:      tokenRef.Name,
 			Namespace: &ref.Namespace,
 			Key:       "token",
-		})
+		}, true)
 		if err != nil {
 			continue
 		}

--- a/pkg/provider/akeyless/auth.go
+++ b/pkg/provider/akeyless/auth.go
@@ -41,33 +41,15 @@ func (a *akeylessBase) TokenFromSecretRef(ctx context.Context) (string, error) {
 		return a.GetToken(ctx, auth.AccessID, "k8s", auth.K8sConfName, auth)
 	}
 
-	accessID, err := resolvers.SecretKeyRef(
-		ctx,
-		a.kube,
-		a.storeKind,
-		a.namespace,
-		&prov.Auth.SecretRef.AccessID,
-	)
+	accessID, err := resolvers.SecretKeyRef(ctx, a.kube, a.storeKind, a.namespace, &prov.Auth.SecretRef.AccessID, true)
 	if err != nil {
 		return "", fmt.Errorf(errFetchAccessIDSecret, err)
 	}
-	accessType, err := resolvers.SecretKeyRef(
-		ctx,
-		a.kube,
-		a.storeKind,
-		a.namespace,
-		&prov.Auth.SecretRef.AccessType,
-	)
+	accessType, err := resolvers.SecretKeyRef(ctx, a.kube, a.storeKind, a.namespace, &prov.Auth.SecretRef.AccessType, true)
 	if err != nil {
 		return "", fmt.Errorf(errFetchAccessTypeSecret, err)
 	}
-	accessTypeParam, err := resolvers.SecretKeyRef(
-		ctx,
-		a.kube,
-		a.storeKind,
-		a.namespace,
-		&prov.Auth.SecretRef.AccessTypeParam,
-	)
+	accessTypeParam, err := resolvers.SecretKeyRef(ctx, a.kube, a.storeKind, a.namespace, &prov.Auth.SecretRef.AccessTypeParam, true)
 	if err != nil {
 		return "", fmt.Errorf(errFetchAccessTypeParamSecret, err)
 	}

--- a/pkg/provider/alibaba/kms.go
+++ b/pkg/provider/alibaba/kms.go
@@ -225,11 +225,11 @@ func newAccessKeyAuth(ctx context.Context, kube kclient.Client, store esv1beta1.
 	storeSpec := store.GetSpec()
 	alibabaSpec := storeSpec.Provider.Alibaba
 	storeKind := store.GetObjectKind().GroupVersionKind().Kind
-	accessKeyID, err := resolvers.SecretKeyRef(ctx, kube, storeKind, namespace, &alibabaSpec.Auth.SecretRef.AccessKeyID)
+	accessKeyID, err := resolvers.SecretKeyRef(ctx, kube, storeKind, namespace, &alibabaSpec.Auth.SecretRef.AccessKeyID, true)
 	if err != nil {
 		return nil, fmt.Errorf(errFetchAccessKeyID, err)
 	}
-	accessKeySecret, err := resolvers.SecretKeyRef(ctx, kube, storeKind, namespace, &alibabaSpec.Auth.SecretRef.AccessKeySecret)
+	accessKeySecret, err := resolvers.SecretKeyRef(ctx, kube, storeKind, namespace, &alibabaSpec.Auth.SecretRef.AccessKeySecret, true)
 	if err != nil {
 		return nil, fmt.Errorf(errFetchAccessKeySecret, err)
 	}

--- a/pkg/provider/aws/auth/auth.go
+++ b/pkg/provider/aws/auth/auth.go
@@ -209,18 +209,18 @@ func NewGeneratorSession(ctx context.Context, auth esv1beta1.AWSAuth, role, regi
 // The namespace of the external secret is used if the ClusterSecretStore does not specify a namespace (referentAuth)
 // If the ClusterSecretStore defines a namespace it will take precedence.
 func credsFromSecretRef(ctx context.Context, auth esv1beta1.AWSAuth, storeKind string, kube client.Client, namespace string) (*credentials.Credentials, error) {
-	sak, err := resolvers.SecretKeyRef(ctx, kube, storeKind, namespace, &auth.SecretRef.SecretAccessKey)
+	sak, err := resolvers.SecretKeyRef(ctx, kube, storeKind, namespace, &auth.SecretRef.SecretAccessKey, true)
 	if err != nil {
 		return nil, fmt.Errorf(errFetchSAKSecret, err)
 	}
-	aks, err := resolvers.SecretKeyRef(ctx, kube, storeKind, namespace, &auth.SecretRef.AccessKeyID)
+	aks, err := resolvers.SecretKeyRef(ctx, kube, storeKind, namespace, &auth.SecretRef.AccessKeyID, true)
 	if err != nil {
 		return nil, fmt.Errorf(errFetchAKIDSecret, err)
 	}
 
 	var sessionToken string
 	if auth.SecretRef.SessionToken != nil {
-		sessionToken, err = resolvers.SecretKeyRef(ctx, kube, storeKind, namespace, auth.SecretRef.SessionToken)
+		sessionToken, err = resolvers.SecretKeyRef(ctx, kube, storeKind, namespace, auth.SecretRef.SessionToken, true)
 		if err != nil {
 			return nil, fmt.Errorf(errFetchSTSecret, err)
 		}

--- a/pkg/provider/azure/keyvault/keyvault.go
+++ b/pkg/provider/azure/keyvault/keyvault.go
@@ -887,11 +887,7 @@ func (a *Azure) authorizerForWorkloadIdentity(ctx context.Context, tokenProvider
 		if a.provider.AuthSecretRef.ClientID == nil {
 			return nil, errors.New(errMissingClientIDSecret)
 		}
-		clientID, err = resolvers.SecretKeyRef(
-			ctx,
-			a.crClient,
-			a.store.GetKind(),
-			a.namespace, a.provider.AuthSecretRef.ClientID)
+		clientID, err = resolvers.SecretKeyRef(ctx, a.crClient, a.store.GetKind(), a.namespace, a.provider.AuthSecretRef.ClientID, true)
 		if err != nil {
 			return nil, err
 		}
@@ -918,11 +914,7 @@ func (a *Azure) authorizerForWorkloadIdentity(ctx context.Context, tokenProvider
 		// We may want to set tenantID explicitly in the `spec.provider.azurekv` section of the SecretStore object
 		// So that is okay if it is not there
 		if a.provider.AuthSecretRef.TenantID != nil {
-			tenantID, err = resolvers.SecretKeyRef(
-				ctx,
-				a.crClient,
-				a.store.GetKind(),
-				a.namespace, a.provider.AuthSecretRef.TenantID)
+			tenantID, err = resolvers.SecretKeyRef(ctx, a.crClient, a.store.GetKind(), a.namespace, a.provider.AuthSecretRef.TenantID, true)
 			if err != nil {
 				return nil, err
 			}
@@ -1041,24 +1033,14 @@ func (a *Azure) authorizerForServicePrincipal(ctx context.Context) (autorest.Aut
 }
 
 func (a *Azure) getAuthorizerFromCredentials(ctx context.Context) (autorest.Authorizer, error) {
-	clientID, err := resolvers.SecretKeyRef(
-		ctx,
-		a.crClient,
-		a.store.GetKind(),
-		a.namespace, a.provider.AuthSecretRef.ClientID,
-	)
+	clientID, err := resolvers.SecretKeyRef(ctx, a.crClient, a.store.GetKind(), a.namespace, a.provider.AuthSecretRef.ClientID, true)
 
 	if err != nil {
 		return nil, err
 	}
 
 	if a.provider.AuthSecretRef.ClientSecret != nil {
-		clientSecret, err := resolvers.SecretKeyRef(
-			ctx,
-			a.crClient,
-			a.store.GetKind(),
-			a.namespace, a.provider.AuthSecretRef.ClientSecret,
-		)
+		clientSecret, err := resolvers.SecretKeyRef(ctx, a.crClient, a.store.GetKind(), a.namespace, a.provider.AuthSecretRef.ClientSecret, true)
 
 		if err != nil {
 			return nil, err
@@ -1071,12 +1053,7 @@ func (a *Azure) getAuthorizerFromCredentials(ctx context.Context) (autorest.Auth
 			a.provider.EnvironmentType,
 		)
 	} else {
-		clientCertificate, err := resolvers.SecretKeyRef(
-			ctx,
-			a.crClient,
-			a.store.GetKind(),
-			a.namespace, a.provider.AuthSecretRef.ClientCertificate,
-		)
+		clientCertificate, err := resolvers.SecretKeyRef(ctx, a.crClient, a.store.GetKind(), a.namespace, a.provider.AuthSecretRef.ClientCertificate, true)
 
 		if err != nil {
 			return nil, err

--- a/pkg/provider/bitwarden/provider.go
+++ b/pkg/provider/bitwarden/provider.go
@@ -49,13 +49,7 @@ func (p *Provider) NewClient(ctx context.Context, store esv1beta1.GenericStore, 
 		return nil, errors.New("no store type or wrong store type")
 	}
 
-	token, err := resolvers.SecretKeyRef(
-		ctx,
-		kube,
-		store.GetKind(),
-		namespace,
-		&storeSpec.Provider.BitwardenSecretsManager.Auth.SecretRef.Credentials,
-	)
+	token, err := resolvers.SecretKeyRef(ctx, kube, store.GetKind(), namespace, &storeSpec.Provider.BitwardenSecretsManager.Auth.SecretRef.Credentials, true)
 	if err != nil {
 		return nil, fmt.Errorf("could not resolve auth credentials: %w", err)
 	}

--- a/pkg/provider/conjur/auth_jwt.go
+++ b/pkg/provider/conjur/auth_jwt.go
@@ -44,12 +44,7 @@ func (c *Client) getJWTToken(ctx context.Context, conjurJWTConfig *esv1beta1.Con
 			tokenRef = conjurJWTConfig.SecretRef.DeepCopy()
 			tokenRef.Key = "token"
 		}
-		jwtToken, err := resolvers.SecretKeyRef(
-			ctx,
-			c.kube,
-			c.StoreKind,
-			c.namespace,
-			tokenRef)
+		jwtToken, err := resolvers.SecretKeyRef(ctx, c.kube, c.StoreKind, c.namespace, tokenRef, true)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/provider/conjur/client.go
+++ b/pkg/provider/conjur/client.go
@@ -114,20 +114,11 @@ func (c *Client) Close(_ context.Context) error {
 
 func (c *Client) conjurClientFromAPIKey(ctx context.Context, config conjurapi.Config, prov *esv1beta1.ConjurProvider) (SecretsClient, error) {
 	config.Account = prov.Auth.APIKey.Account
-	conjUser, secErr := resolvers.SecretKeyRef(
-		ctx,
-		c.kube,
-		c.StoreKind,
-		c.namespace, prov.Auth.APIKey.UserRef)
+	conjUser, secErr := resolvers.SecretKeyRef(ctx, c.kube, c.StoreKind, c.namespace, prov.Auth.APIKey.UserRef, true)
 	if secErr != nil {
 		return nil, fmt.Errorf(errBadServiceUser, secErr)
 	}
-	conjAPIKey, secErr := resolvers.SecretKeyRef(
-		ctx,
-		c.kube,
-		c.StoreKind,
-		c.namespace,
-		prov.Auth.APIKey.APIKeyRef)
+	conjAPIKey, secErr := resolvers.SecretKeyRef(ctx, c.kube, c.StoreKind, c.namespace, prov.Auth.APIKey.APIKeyRef, true)
 	if secErr != nil {
 		return nil, fmt.Errorf(errBadServiceAPIKey, secErr)
 	}

--- a/pkg/provider/delinea/provider.go
+++ b/pkg/provider/delinea/provider.go
@@ -100,7 +100,7 @@ func loadConfigSecret(
 	if err := validateSecretRef(ref); err != nil {
 		return "", err
 	}
-	return resolvers.SecretKeyRef(ctx, kube, storeKind, namespace, ref.SecretRef)
+	return resolvers.SecretKeyRef(ctx, kube, storeKind, namespace, ref.SecretRef, true)
 }
 
 func validateStoreSecretRef(store esv1beta1.GenericStore, ref *esv1beta1.DelineaProviderSecretRef) error {

--- a/pkg/provider/doppler/client.go
+++ b/pkg/provider/doppler/client.go
@@ -70,12 +70,7 @@ type SecretsClientInterface interface {
 }
 
 func (c *Client) setAuth(ctx context.Context) error {
-	token, err := resolvers.SecretKeyRef(
-		ctx,
-		c.kube,
-		c.storeKind,
-		c.namespace,
-		&c.store.Auth.SecretRef.DopplerToken)
+	token, err := resolvers.SecretKeyRef(ctx, c.kube, c.storeKind, c.namespace, &c.store.Auth.SecretRef.DopplerToken, true)
 	if err != nil {
 		return err
 	}

--- a/pkg/provider/fortanix/provider.go
+++ b/pkg/provider/fortanix/provider.go
@@ -58,7 +58,7 @@ func (p *Provider) NewClient(ctx context.Context, store esv1beta1.GenericStore, 
 		return nil, err
 	}
 
-	apiKey, err := resolvers.SecretKeyRef(ctx, kube, store.GetKind(), namespace, config.APIKey.SecretRef)
+	apiKey, err := resolvers.SecretKeyRef(ctx, kube, store.GetKind(), namespace, config.APIKey.SecretRef, true)
 	if err != nil {
 		return nil, fmt.Errorf(errCannotResolveSecretKeyRef, err)
 	}

--- a/pkg/provider/gcp/secretmanager/auth.go
+++ b/pkg/provider/gcp/secretmanager/auth.go
@@ -50,12 +50,7 @@ func serviceAccountTokenSource(ctx context.Context, auth esv1beta1.GCPSMAuth, st
 	if sr == nil {
 		return nil, nil
 	}
-	credentials, err := resolvers.SecretKeyRef(
-		ctx,
-		kube,
-		storeKind,
-		namespace,
-		&auth.SecretRef.SecretAccessKey)
+	credentials, err := resolvers.SecretKeyRef(ctx, kube, storeKind, namespace, &auth.SecretRef.SecretAccessKey, true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -78,12 +78,7 @@ var log = ctrl.Log.WithName("provider").WithName("gitlab")
 
 // Set gitlabBase credentials to Access Token.
 func (g *gitlabBase) getAuth(ctx context.Context) (string, error) {
-	return resolvers.SecretKeyRef(
-		ctx,
-		g.kube,
-		g.storeKind,
-		g.namespace,
-		&g.store.Auth.SecretRef.AccessToken)
+	return resolvers.SecretKeyRef(ctx, g.kube, g.storeKind, g.namespace, &g.store.Auth.SecretRef.AccessToken, true)
 }
 
 func (g *gitlabBase) DeleteSecret(_ context.Context, _ esv1beta1.PushSecretRemoteRef) error {

--- a/pkg/provider/ibm/provider.go
+++ b/pkg/provider/ibm/provider.go
@@ -85,7 +85,7 @@ type client struct {
 }
 
 func (c *client) setAuth(ctx context.Context) error {
-	apiKey, err := resolvers.SecretKeyRef(ctx, c.kube, c.storeKind, c.namespace, &c.store.Auth.SecretRef.SecretAPIKey)
+	apiKey, err := resolvers.SecretKeyRef(ctx, c.kube, c.storeKind, c.namespace, &c.store.Auth.SecretRef.SecretAPIKey, true)
 	if err != nil {
 		return err
 	}

--- a/pkg/provider/infisical/provider.go
+++ b/pkg/provider/infisical/provider.go
@@ -121,7 +121,7 @@ func GetStoreSecretData(ctx context.Context, store esv1beta1.GenericStore, kube 
 		secretRef.Namespace = secret.Namespace
 	}
 
-	secretData, err := resolvers.SecretKeyRef(ctx, kube, store.GetObjectKind().GroupVersionKind().Kind, namespace, &secretRef)
+	secretData, err := resolvers.SecretKeyRef(ctx, kube, store.GetObjectKind().GroupVersionKind().Kind, namespace, &secretRef, true)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/provider/keepersecurity/provider.go
+++ b/pkg/provider/keepersecurity/provider.go
@@ -111,10 +111,5 @@ func (p *Provider) ValidateStore(store esv1beta1.GenericStore) (admission.Warnin
 }
 
 func getKeeperSecurityAuth(ctx context.Context, store *esv1beta1.KeeperSecurityProvider, kube kclient.Client, storeKind, namespace string) (string, error) {
-	return resolvers.SecretKeyRef(
-		ctx,
-		kube,
-		storeKind,
-		namespace,
-		&store.Auth)
+	return resolvers.SecretKeyRef(ctx, kube, storeKind, namespace, &store.Auth, true)
 }

--- a/pkg/provider/kubernetes/auth.go
+++ b/pkg/provider/kubernetes/auth.go
@@ -131,13 +131,7 @@ func (c *Client) serviceAccountToken(ctx context.Context, serviceAccountRef *esm
 }
 
 func (c *Client) fetchSecretKey(ctx context.Context, ref esmeta.SecretKeySelector) ([]byte, error) {
-	secret, err := resolvers.SecretKeyRef(
-		ctx,
-		c.ctrlClient,
-		c.storeKind,
-		c.namespace,
-		&ref,
-	)
+	secret, err := resolvers.SecretKeyRef(ctx, c.ctrlClient, c.storeKind, c.namespace, &ref, true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/provider/onepassword/onepassword.go
+++ b/pkg/provider/onepassword/onepassword.go
@@ -108,13 +108,7 @@ func (provider *ProviderOnePassword) Capabilities() esv1beta1.SecretStoreCapabil
 // NewClient constructs a 1Password Provider.
 func (provider *ProviderOnePassword) NewClient(ctx context.Context, store esv1beta1.GenericStore, kube kclient.Client, namespace string) (esv1beta1.SecretsClient, error) {
 	config := store.GetSpec().Provider.OnePassword
-	token, err := resolvers.SecretKeyRef(
-		ctx,
-		kube,
-		store.GetKind(),
-		namespace,
-		&config.Auth.SecretRef.ConnectToken,
-	)
+	token, err := resolvers.SecretKeyRef(ctx, kube, store.GetKind(), namespace, &config.Auth.SecretRef.ConnectToken, true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/provider/oracle/oracle.go
+++ b/pkg/provider/oracle/oracle.go
@@ -406,13 +406,7 @@ func getSecretData(ctx context.Context, kube kclient.Client, namespace, storeKin
 	if secretRef.Name == "" {
 		return "", errors.New(errORACLECredSecretName)
 	}
-	secret, err := resolvers.SecretKeyRef(
-		ctx,
-		kube,
-		storeKind,
-		namespace,
-		&secretRef,
-	)
+	secret, err := resolvers.SecretKeyRef(ctx, kube, storeKind, namespace, &secretRef, true)
 	if err != nil {
 		return "", fmt.Errorf(errFetchSAKSecret, err)
 	}

--- a/pkg/provider/passbolt/passbolt.go
+++ b/pkg/provider/passbolt/passbolt.go
@@ -66,24 +66,12 @@ type Client interface {
 func (provider *ProviderPassbolt) NewClient(ctx context.Context, store esv1beta1.GenericStore, kube kclient.Client, namespace string) (esv1beta1.SecretsClient, error) {
 	config := store.GetSpec().Provider.Passbolt
 
-	password, err := resolvers.SecretKeyRef(
-		ctx,
-		kube,
-		store.GetKind(),
-		namespace,
-		config.Auth.PasswordSecretRef,
-	)
+	password, err := resolvers.SecretKeyRef(ctx, kube, store.GetKind(), namespace, config.Auth.PasswordSecretRef, true)
 	if err != nil {
 		return nil, err
 	}
 
-	privateKey, err := resolvers.SecretKeyRef(
-		ctx,
-		kube,
-		store.GetKind(),
-		namespace,
-		config.Auth.PrivateKeySecretRef,
-	)
+	privateKey, err := resolvers.SecretKeyRef(ctx, kube, store.GetKind(), namespace, config.Auth.PrivateKeySecretRef, true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/provider/previder/provider.go
+++ b/pkg/provider/previder/provider.go
@@ -50,7 +50,7 @@ func (s *SecretManager) NewClient(ctx context.Context, store esv1beta1.GenericSt
 	storeSpec := store.GetSpec().Provider.Previder
 
 	storeKind := store.GetObjectKind().GroupVersionKind().Kind
-	accessToken, err := resolvers.SecretKeyRef(ctx, kube, storeKind, namespace, &storeSpec.Auth.SecretRef.AccessToken)
+	accessToken, err := resolvers.SecretKeyRef(ctx, kube, storeKind, namespace, &storeSpec.Auth.SecretRef.AccessToken, true)
 	if err != nil {
 		return nil, fmt.Errorf(accessToken, err)
 	}

--- a/pkg/provider/pulumi/provider.go
+++ b/pkg/provider/pulumi/provider.go
@@ -76,7 +76,7 @@ func (p *Provider) NewClient(ctx context.Context, store esv1beta1.GenericStore, 
 }
 
 func loadAccessTokenSecret(ctx context.Context, ref *esv1beta1.PulumiProviderSecretRef, kube kclient.Client, storeKind, namespace string) (string, error) {
-	acctoken, err := resolvers.SecretKeyRef(ctx, kube, storeKind, namespace, ref.SecretRef)
+	acctoken, err := resolvers.SecretKeyRef(ctx, kube, storeKind, namespace, ref.SecretRef, true)
 	if err != nil {
 		return "", fmt.Errorf(errCannotResolveSecretKeyRef, err)
 	}

--- a/pkg/provider/scaleway/provider.go
+++ b/pkg/provider/scaleway/provider.go
@@ -86,13 +86,7 @@ func loadConfigSecret(ctx context.Context, ref *esv1beta1.ScalewayProviderSecret
 	if ref.SecretRef == nil {
 		return ref.Value, nil
 	}
-	return resolvers.SecretKeyRef(
-		ctx,
-		kube,
-		storeKind,
-		defaultNamespace,
-		ref.SecretRef,
-	)
+	return resolvers.SecretKeyRef(ctx, kube, storeKind, defaultNamespace, ref.SecretRef, true)
 }
 
 func validateSecretRef(store esv1beta1.GenericStore, ref *esv1beta1.ScalewayProviderSecretRef) error {

--- a/pkg/provider/secretserver/provider.go
+++ b/pkg/provider/secretserver/provider.go
@@ -96,7 +96,7 @@ func loadConfigSecret(
 	if err := validateSecretRef(ref); err != nil {
 		return "", err
 	}
-	return resolvers.SecretKeyRef(ctx, kube, storeKind, namespace, ref.SecretRef)
+	return resolvers.SecretKeyRef(ctx, kube, storeKind, namespace, ref.SecretRef, true)
 }
 
 func validateStoreSecretRef(store esv1beta1.GenericStore, ref *esv1beta1.SecretServerProviderRef) error {

--- a/pkg/provider/senhasegura/auth/iso.go
+++ b/pkg/provider/senhasegura/auth/iso.go
@@ -77,13 +77,7 @@ func Authenticate(ctx context.Context, store esv1beta1.GenericStore, provider *e
 IsoSessionFromSecretRef initialize an ISO OAuth2 flow with .spec.provider.senhasegura.auth.isoSecretRef parameters.
 */
 func (s *SenhaseguraIsoSession) IsoSessionFromSecretRef(ctx context.Context, provider *esv1beta1.SenhaseguraProvider, store esv1beta1.GenericStore, kube client.Client, namespace string) (*SenhaseguraIsoSession, error) {
-	secret, err := resolvers.SecretKeyRef(
-		ctx,
-		kube,
-		store.GetKind(),
-		namespace,
-		&provider.Auth.ClientSecret,
-	)
+	secret, err := resolvers.SecretKeyRef(ctx, kube, store.GetKind(), namespace, &provider.Auth.ClientSecret, true)
 	if err != nil {
 		return &SenhaseguraIsoSession{}, err
 	}

--- a/pkg/provider/vault/auth_approle.go
+++ b/pkg/provider/vault/auth_approle.go
@@ -51,7 +51,7 @@ func (c *client) requestTokenWithAppRoleRef(ctx context.Context, appRole *esv1be
 	if appRole.RoleID != "" { // use roleId from CRD, if configured
 		roleID = strings.TrimSpace(appRole.RoleID)
 	} else if appRole.RoleRef != nil { // use RoleID from Secret, if configured
-		roleID, err = resolvers.SecretKeyRef(ctx, c.kube, c.storeKind, c.namespace, appRole.RoleRef)
+		roleID, err = resolvers.SecretKeyRef(ctx, c.kube, c.storeKind, c.namespace, appRole.RoleRef, true)
 		if err != nil {
 			return err
 		}
@@ -59,7 +59,7 @@ func (c *client) requestTokenWithAppRoleRef(ctx context.Context, appRole *esv1be
 		return errors.New(errInvalidAppRoleID)
 	}
 
-	secretID, err := resolvers.SecretKeyRef(ctx, c.kube, c.storeKind, c.namespace, &appRole.SecretRef)
+	secretID, err := resolvers.SecretKeyRef(ctx, c.kube, c.storeKind, c.namespace, &appRole.SecretRef, true)
 	if err != nil {
 		return err
 	}

--- a/pkg/provider/vault/auth_cert.go
+++ b/pkg/provider/vault/auth_cert.go
@@ -46,12 +46,12 @@ func setCertAuthToken(ctx context.Context, v *client, cfg *vault.Config) (bool, 
 }
 
 func (c *client) requestTokenWithCertAuth(ctx context.Context, certAuth *esv1beta1.VaultCertAuth, cfg *vault.Config) error {
-	clientKey, err := resolvers.SecretKeyRef(ctx, c.kube, c.storeKind, c.namespace, &certAuth.SecretRef)
+	clientKey, err := resolvers.SecretKeyRef(ctx, c.kube, c.storeKind, c.namespace, &certAuth.SecretRef, true)
 	if err != nil {
 		return err
 	}
 
-	clientCert, err := resolvers.SecretKeyRef(ctx, c.kube, c.storeKind, c.namespace, &certAuth.ClientCert)
+	clientCert, err := resolvers.SecretKeyRef(ctx, c.kube, c.storeKind, c.namespace, &certAuth.ClientCert, true)
 	if err != nil {
 		return err
 	}

--- a/pkg/provider/vault/auth_jwt.go
+++ b/pkg/provider/vault/auth_jwt.go
@@ -47,7 +47,7 @@ func (c *client) requestTokenWithJwtAuth(ctx context.Context, jwtAuth *esv1beta1
 	var jwt string
 	var err error
 	if jwtAuth.SecretRef != nil {
-		jwt, err = resolvers.SecretKeyRef(ctx, c.kube, c.storeKind, c.namespace, jwtAuth.SecretRef)
+		jwt, err = resolvers.SecretKeyRef(ctx, c.kube, c.storeKind, c.namespace, jwtAuth.SecretRef, true)
 	} else if k8sServiceAccountToken := jwtAuth.KubernetesServiceAccountToken; k8sServiceAccountToken != nil {
 		audiences := k8sServiceAccountToken.Audiences
 		if audiences == nil {

--- a/pkg/provider/vault/auth_kubernetes.go
+++ b/pkg/provider/vault/auth_kubernetes.go
@@ -99,7 +99,7 @@ func getJwtString(ctx context.Context, v *client, kubernetesAuth *esv1beta1.Vaul
 			tokenRef = kubernetesAuth.SecretRef.DeepCopy()
 			tokenRef.Key = "token"
 		}
-		jwt, err := resolvers.SecretKeyRef(ctx, v.kube, v.storeKind, v.namespace, tokenRef)
+		jwt, err := resolvers.SecretKeyRef(ctx, v.kube, v.storeKind, v.namespace, tokenRef, true)
 		if err != nil {
 			return "", err
 		}
@@ -141,7 +141,7 @@ func (c *client) secretKeyRefForServiceAccount(ctx context.Context, serviceAccou
 			Name:      tokenRef.Name,
 			Namespace: &ref.Namespace,
 			Key:       "token",
-		})
+		}, true)
 		if err != nil {
 			continue
 		}

--- a/pkg/provider/vault/auth_ldap.go
+++ b/pkg/provider/vault/auth_ldap.go
@@ -40,7 +40,7 @@ func setLdapAuthToken(ctx context.Context, v *client) (bool, error) {
 
 func (c *client) requestTokenWithLdapAuth(ctx context.Context, ldapAuth *esv1beta1.VaultLdapAuth) error {
 	username := strings.TrimSpace(ldapAuth.Username)
-	password, err := resolvers.SecretKeyRef(ctx, c.kube, c.storeKind, c.namespace, &ldapAuth.SecretRef)
+	password, err := resolvers.SecretKeyRef(ctx, c.kube, c.storeKind, c.namespace, &ldapAuth.SecretRef, true)
 	if err != nil {
 		return err
 	}

--- a/pkg/provider/vault/auth_token.go
+++ b/pkg/provider/vault/auth_token.go
@@ -23,7 +23,7 @@ import (
 func setSecretKeyToken(ctx context.Context, v *client) (bool, error) {
 	tokenRef := v.store.Auth.TokenSecretRef
 	if tokenRef != nil {
-		token, err := resolvers.SecretKeyRef(ctx, v.kube, v.storeKind, v.namespace, tokenRef)
+		token, err := resolvers.SecretKeyRef(ctx, v.kube, v.storeKind, v.namespace, tokenRef, true)
 		if err != nil {
 			return true, err
 		}

--- a/pkg/provider/vault/auth_userpass.go
+++ b/pkg/provider/vault/auth_userpass.go
@@ -40,7 +40,7 @@ func setUserPassAuthToken(ctx context.Context, v *client) (bool, error) {
 
 func (c *client) requestTokenWithUserPassAuth(ctx context.Context, userPassAuth *esv1beta1.VaultUserPassAuth) error {
 	username := strings.TrimSpace(userPassAuth.Username)
-	password, err := resolvers.SecretKeyRef(ctx, c.kube, c.storeKind, c.namespace, &userPassAuth.SecretRef)
+	password, err := resolvers.SecretKeyRef(ctx, c.kube, c.storeKind, c.namespace, &userPassAuth.SecretRef, true)
 	if err != nil {
 		return err
 	}

--- a/pkg/provider/vault/client.go
+++ b/pkg/provider/vault/client.go
@@ -92,7 +92,7 @@ func (c *client) configureClientTLS(ctx context.Context, cfg *vault.Config) erro
 		if clientTLS.KeySecretRef.Key == "" {
 			clientTLS.KeySecretRef.Key = corev1.TLSPrivateKeyKey
 		}
-		clientKey, err := resolvers.SecretKeyRef(ctx, c.kube, c.storeKind, c.namespace, clientTLS.KeySecretRef)
+		clientKey, err := resolvers.SecretKeyRef(ctx, c.kube, c.storeKind, c.namespace, clientTLS.KeySecretRef, true)
 		if err != nil {
 			return err
 		}
@@ -100,7 +100,7 @@ func (c *client) configureClientTLS(ctx context.Context, cfg *vault.Config) erro
 		if clientTLS.CertSecretRef.Key == "" {
 			clientTLS.CertSecretRef.Key = corev1.TLSCertKey
 		}
-		clientCert, err := resolvers.SecretKeyRef(ctx, c.kube, c.storeKind, c.namespace, clientTLS.CertSecretRef)
+		clientCert, err := resolvers.SecretKeyRef(ctx, c.kube, c.storeKind, c.namespace, clientTLS.CertSecretRef, true)
 		if err != nil {
 			return err
 		}

--- a/pkg/provider/vault/iamauth/iamauth.go
+++ b/pkg/provider/vault/iamauth/iamauth.go
@@ -227,35 +227,17 @@ func CredsFromControllerServiceAccount(ctx context.Context, saname, ns, region s
 // The namespace of the external secret is used if the ClusterSecretStore does not specify a namespace (referentAuth)
 // If the ClusterSecretStore defines a namespace it will take precedence.
 func CredsFromSecretRef(ctx context.Context, auth esv1beta1.VaultIamAuth, storeKind string, kube kclient.Client, namespace string) (*credentials.Credentials, error) {
-	akid, err := resolvers.SecretKeyRef(
-		ctx,
-		kube,
-		storeKind,
-		namespace,
-		&auth.SecretRef.AccessKeyID,
-	)
+	akid, err := resolvers.SecretKeyRef(ctx, kube, storeKind, namespace, &auth.SecretRef.AccessKeyID, true)
 	if err != nil {
 		return nil, err
 	}
-	sak, err := resolvers.SecretKeyRef(
-		ctx,
-		kube,
-		storeKind,
-		namespace,
-		&auth.SecretRef.SecretAccessKey,
-	)
+	sak, err := resolvers.SecretKeyRef(ctx, kube, storeKind, namespace, &auth.SecretRef.SecretAccessKey, true)
 	if err != nil {
 		return nil, err
 	}
 
 	// session token is optional
-	sessionToken, _ := resolvers.SecretKeyRef(
-		ctx,
-		kube,
-		storeKind,
-		namespace,
-		auth.SecretRef.SessionToken,
-	)
+	sessionToken, _ := resolvers.SecretKeyRef(ctx, kube, storeKind, namespace, auth.SecretRef.SessionToken, true)
 	return credentials.NewStaticCredentials(akid, sak, sessionToken), err
 }
 

--- a/pkg/provider/yandex/common/provider.go
+++ b/pkg/provider/yandex/common/provider.go
@@ -116,13 +116,7 @@ func (p *YandexCloudProvider) NewClient(ctx context.Context, store esv1beta1.Gen
 		return nil, err
 	}
 
-	key, err := resolvers.SecretKeyRef(
-		ctx,
-		kube,
-		store.GetKind(),
-		namespace,
-		&input.AuthorizedKey,
-	)
+	key, err := resolvers.SecretKeyRef(ctx, kube, store.GetKind(), namespace, &input.AuthorizedKey, true)
 	if err != nil {
 		return nil, err
 	}
@@ -135,13 +129,7 @@ func (p *YandexCloudProvider) NewClient(ctx context.Context, store esv1beta1.Gen
 
 	var caCertificateData []byte
 	if input.CACertificate != nil {
-		caCert, err := resolvers.SecretKeyRef(
-			ctx,
-			kube,
-			store.GetKind(),
-			namespace,
-			input.CACertificate,
-		)
+		caCert, err := resolvers.SecretKeyRef(ctx, kube, store.GetKind(), namespace, input.CACertificate, true)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/utils/resolvers/secret_ref.go
+++ b/pkg/utils/resolvers/secret_ref.go
@@ -44,17 +44,20 @@ const (
 // A user must pass the namespace of the originating ExternalSecret, as this may differ
 // from the namespace defined in the SecretKeySelector.
 // This func ensures that only a ClusterSecretStore is able to request secrets across namespaces.
+// except when we are loading a CA from a different namespace. In that case, pass
+// enforceNamespaceCheck as false to suppress the check
 func SecretKeyRef(
 	ctx context.Context,
 	c client.Client,
 	storeKind string,
 	esNamespace string,
-	ref *esmeta.SecretKeySelector) (string, error) {
+	ref *esmeta.SecretKeySelector,
+	enforceNamespaceCheck bool) (string, error) {
 	key := types.NamespacedName{
 		Namespace: esNamespace,
 		Name:      ref.Name,
 	}
-	if (storeKind == esv1beta1.ClusterSecretStoreKind) &&
+	if enforceNamespaceCheck && (storeKind == esv1beta1.ClusterSecretStoreKind) &&
 		(ref.Namespace != nil) {
 		key.Namespace = *ref.Namespace
 	}

--- a/pkg/utils/resolvers/secret_ref_test.go
+++ b/pkg/utils/resolvers/secret_ref_test.go
@@ -117,7 +117,7 @@ func TestResolveSecretKeyRef(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			resolvedValue, err := SecretKeyRef(ctx, c, tc.storeKind, tc.namespace, tc.selector)
+			resolvedValue, err := SecretKeyRef(ctx, c, tc.storeKind, tc.namespace, tc.selector, true)
 			if tc.err != nil {
 				assert.EqualError(t, err, tc.err.Error())
 			} else {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -614,7 +614,7 @@ func getCertFromSecret(ctx context.Context, c client.Client, provider *esv1beta1
 		secretRef.Namespace = provider.Namespace
 	}
 
-	cert, err := resolvers.SecretKeyRef(ctx, c, storeKind, namespace, &secretRef)
+	cert, err := resolvers.SecretKeyRef(ctx, c, storeKind, namespace, &secretRef, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve secret key ref: %w", err)
 	}


### PR DESCRIPTION
## Problem Statement

SecretProvider class and webhook cannot load CA from a secret in another namespace. 

## Related Issue

Fixes #4278 

## Proposed Changes

Add a suppress flag which will allow to avoid removing the namespace from the query.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
