### PR TITLE
docs: differentiate between two different bitwarden guides

### DIFF
--- a/docs/examples/bitwarden.md
+++ b/docs/examples/bitwarden.md
@@ -2,6 +2,12 @@
 
 Bitwarden is an integrated open source password management solution for individuals, teams, and business organizations.
 
+!!! note
+
+    This documentation is for Bitwarden **Password Manager**.
+    It is different from [Bitwarden Secrets Manager](https://bitwarden.com/products/secrets-manager/), which enables developers, DevOps, and cybersecurity teams to centrally store, manage, and deploy secrets at scale.
+    To integrate with Bitwarden **Secrets Manager**, reference the [provider documentation](../provider/bitwarden-secrets-manager.md).
+
 ## How does it work?
 
 To make external-secrets compatible with Bitwarden, we need:

--- a/docs/provider/bitwarden-secrets-manager.md
+++ b/docs/provider/bitwarden-secrets-manager.md
@@ -2,6 +2,13 @@
 
 This section describes how to set up the Bitwarden Secrets Manager provider for External Secrets Operator (ESO).
 
+!!! note
+
+    [Bitwarden Secrets Manager](https://bitwarden.com/products/secrets-manager/)
+    enables developers, DevOps, and cybersecurity teams to centrally store, manage, and deploy secrets at scale.
+    This is different from [Bitwarden Password Manager](https://bitwarden.com/products/personal/).
+    To integrate with Bitwarden **Password Manager**, reference the [example documentation](../examples/bitwarden.md).
+
 ### Prerequisites
 
 In order for the bitwarden provider to work, we need a second service. This service is the [Bitwarden SDK Server](https://github.com/external-secrets/bitwarden-sdk-server).


### PR DESCRIPTION
## Problem Statement

There are 2 different documents for two different Bitwarden services.
The services are named similarly and people may get confused.

## Proposed Changes

Add notes to each document explaining the difference.

## Testing Done

Ran `make docs.serve` and verified both pages look good.

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
