### PR TITLE
fix: sonar ignore duplication warning in test files only

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,2 +1,4 @@
 # Ignore duplications in test files.
-sonar.cpd.exclusions = **/*_test.go
+sonar.issue.ignore.multicriteria=1
+sonar.issue.ignore.multicriteria.1.resourceKey=**/*_test.go
+sonar.issue.ignore.multicriteria.1.ruleKey=go:S1192


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
