### PR TITLE
fix: sonar configs

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,17 @@
+sonar.organization=external-secrets
+sonar.projectKey=external-secrets_external-secrets
+
+# Path to sources
+sonar.sources=.
+sonar.exclusions=**/*_test.go, **/zz_generated.deepcopy.go, e2e/**
+
+# Path to tests
+sonar.tests=.
+sonar.test.inclusions=**/*_test.go, e2e/**
+
+# Issues to ignore
+sonar.issue.ignore.multicriteria=g1
+
+# Ignore "Define a constant instead of duplicating this literal" in tests
+sonar.issue.ignore.multicriteria.g1.ruleKey=go:S1192
+sonar.issue.ignore.multicriteria.g1.resourceKey=**/*_test.go, e2e/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,0 @@
-# Ignore duplications in test files.
-sonar.issue.ignore.multicriteria=1
-sonar.issue.ignore.multicriteria.1.resourceKey=**/*_test.go
-sonar.issue.ignore.multicriteria.1.ruleKey=go:S1192


### PR DESCRIPTION
## Problem Statement

We tried in https://github.com/external-secrets/external-secrets/pull/4320 and https://github.com/external-secrets/external-secrets/pull/4329 to disable the sonar duplicate literal check in tests, but that did not work.

The issue was that we were creating a `sonar-project.properties` file (used for CI-triggered sonar), rather than a `.sonarcloud.propertie` file (for their 'managed' one):

- see: https://docs.sonarsource.com/sonarqube-cloud/advanced-setup/analysis-parameters/#setting-configuration-in-a-file

## Proposed Changes

Used the correct file name, and set other recommended parameters based on:

- https://docs.sonarsource.com/sonarqube-server/10.6/analyzing-source-code/languages/go/
- https://github.com/redhat-developer/odo/blob/main/.sonarcloud.properties
- https://github.com/thomaspoignant/go-feature-flag/blob/main/.sonarcloud.properties

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] My changes have reasonable test coverage
- [X] All tests pass with `make test`
- [X] I ensured my PR is ready for review with `make reviewable`
