### PR TITLE
Implement SecretExists in AWS ParameterStore

### DIFF
--- a/pkg/provider/aws/parameterstore/parameterstore.go
+++ b/pkg/provider/aws/parameterstore/parameterstore.go
@@ -152,7 +152,7 @@ func (pm *ParameterStore) DeleteSecret(ctx context.Context, remoteRef esv1beta1.
 }
 
 func (pm *ParameterStore) SecretExists(ctx context.Context, pushSecretRef esv1beta1.PushSecretRemoteRef) (bool, error) {
-	secretName := pushSecretRef.GetRemoteKey()
+	secretName := pm.prefix + pushSecretRef.GetRemoteKey()
 
 	secretValue := ssm.GetParameterInput{
 		Name: &secretName,

--- a/pkg/provider/aws/parameterstore/parameterstore.go
+++ b/pkg/provider/aws/parameterstore/parameterstore.go
@@ -151,8 +151,30 @@ func (pm *ParameterStore) DeleteSecret(ctx context.Context, remoteRef esv1beta1.
 	return nil
 }
 
-func (pm *ParameterStore) SecretExists(_ context.Context, _ esv1beta1.PushSecretRemoteRef) (bool, error) {
-	return false, errors.New("not implemented")
+func (pm *ParameterStore) SecretExists(ctx context.Context, pushSecretRef esv1beta1.PushSecretRemoteRef) (bool, error) {
+	secretName := pushSecretRef.GetRemoteKey()
+
+	secretValue := ssm.GetParameterInput{
+		Name: &secretName,
+	}
+
+	_, err := pm.client.GetParameterWithContext(ctx, &secretValue)
+
+	if err != nil {
+		var aerr awserr.Error
+		if ok := errors.As(err, &aerr); !ok {
+			return false, err
+		}
+		if aerr.Code() == ssm.ErrCodeResourceNotFoundException {
+			return false, nil
+		}
+		if aerr.Code() == ssm.ErrCodeParameterNotFound {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
 }
 
 func (pm *ParameterStore) PushSecret(ctx context.Context, secret *corev1.Secret, data esv1beta1.PushSecretData) error {


### PR DESCRIPTION
## Problem Statement
`PushSecret` with AWS parameter store doesn't support `updatePolicy: IfNotExists`

## Related Issue

Fixes #...

## Proposed Changes
This PR implements the `SecretExists` function within `ParameterStore` to ensure that external secrets will only create the parameter if it doesn't exist in AWS. 

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
