### PR TITLE
docs(typo): Update doc references from `BitWarden` to `Bitwarden`.

### DIFF
--- a/docs/examples/bitwarden.md
+++ b/docs/examples/bitwarden.md
@@ -14,7 +14,7 @@ To make external-secrets compatible with Bitwarden, we need:
 
 * External Secrets Operator >= 0.8.0
 * Multiple (Cluster)SecretStores using the webhook provider
-* BitWarden CLI image running `bw serve`
+* Bitwarden CLI image running `bw serve`
 
 When you create a new external-secret object, the External Secrets webhook provider will query the Bitwarden CLI pod that is synced with the Bitwarden server.
 

--- a/hack/api-docs/mkdocs.yml
+++ b/hack/api-docs/mkdocs.yml
@@ -148,7 +148,7 @@ nav:
       - FluxCD: examples/gitops-using-fluxcd.md
       - Anchore Engine: examples/anchore-engine-credentials.md
       - Jenkins: examples/jenkins-kubernetes-credentials.md
-      - BitWarden: examples/bitwarden.md
+      - Bitwarden: examples/bitwarden.md
   - Community:
       - Contributing:
           - Developer guide: contributing/devguide.md


### PR DESCRIPTION
## Problem Statement
Typo for **BitWarden**, it should be **Bitwarden**, like how it is references elsewhere in the documentation.
## Related Issue

## Proposed Changes
Updates the references in the docs from `BitWarden` to `Bitwarden`.
How do you like to solve the issue and why?

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [X] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
