### PR TITLE
fix: Fix typo that prevents the Password ClusterGenerator from working

### DIFF
--- a/apis/generators/v1alpha1/types_cluster.go
+++ b/apis/generators/v1alpha1/types_cluster.go
@@ -27,7 +27,7 @@ type ClusterGeneratorSpec struct {
 }
 
 // GeneratorKind represents a kind of generator.
-// +kubebuilder:validation:Enum=ACRAccessToken;ECRAuthorizationToken;Fake;GCRAccessToken;GithubAccessToken;QuayAccessToken'Password;STSSessionToken;UUID;VaultDynamicSecret;Webhook;Grafana
+// +kubebuilder:validation:Enum=ACRAccessToken;ECRAuthorizationToken;Fake;GCRAccessToken;GithubAccessToken;QuayAccessToken;Password;STSSessionToken;UUID;VaultDynamicSecret;Webhook;Grafana
 type GeneratorKind string
 
 const (

--- a/config/crds/bases/generators.external-secrets.io_clustergenerators.yaml
+++ b/config/crds/bases/generators.external-secrets.io_clustergenerators.yaml
@@ -1799,7 +1799,8 @@ spec:
                 - Fake
                 - GCRAccessToken
                 - GithubAccessToken
-                - QuayAccessToken'Password
+                - QuayAccessToken
+                - Password
                 - STSSessionToken
                 - UUID
                 - VaultDynamicSecret

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -15573,7 +15573,8 @@ spec:
                     - Fake
                     - GCRAccessToken
                     - GithubAccessToken
-                    - QuayAccessToken'Password
+                    - QuayAccessToken
+                    - Password
                     - STSSessionToken
                     - UUID
                     - VaultDynamicSecret


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?

A ClusterGenerator resource of kind `Password` or `QuayAccessToken` is failing because of the typo. This is a bug introduced in 0814a4a20256b80196dad5d659ef2f6f67367528.

## Proposed Changes

How do you like to solve the issue and why?

Fix the typo.

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
