### PR TITLE
chore(deps): bump go to 1.23.6

### DIFF
--- a/.github/workflows/e2e-managed.yml
+++ b/.github/workflows/e2e-managed.yml
@@ -7,7 +7,7 @@ permissions:
 
 env:
   # Common versions
-  GO_VERSION: '1.21'
+  GO_VERSION: '1.23'
   GINKGO_VERSION: 'v2.8.0'
   DOCKER_BUILDX_VERSION: 'v0.4.2'
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,7 @@ name: e2e tests
 
 env:
   # Common versions
-  GO_VERSION: '1.21'
+  GO_VERSION: '1.23'
   GINKGO_VERSION: 'v2.8.0'
   DOCKER_BUILDX_VERSION: 'v0.4.2'
   KIND_VERSION: 'v0.17.0'

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets-e2e
 
-go 1.23.4
+go 1.23.6
 
 replace (
 	github.com/Masterminds/sprig/v3 => github.com/external-secrets/sprig/v3 v3.3.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets
 
-go 1.23.4
+go 1.23.6
 
 replace github.com/Masterminds/sprig/v3 => github.com/external-secrets/sprig/v3 v3.3.0
 


### PR DESCRIPTION
## Problem Statement
Fix CVEs in go 1.23.4; pick up latest release

```
% grype oci.external-secrets.io/external-secrets/external-secrets:v0.14.0
 ✔ Parsed image                                                                                                                                                                                                                   sha256:e07c2f7fa754d06774dc736bbedcdcda9c9e8c27da723bce77e8daafbdc44bba
 ✔ Cataloged contents                                                                                                                                                                                                                    c80502a6121fcd2c463695dc8bf3baeb76705abbdaefb1edef886411cd6e1086
   ├── ✔ Packages                        [234 packages]
   ├── ✔ File digests                    [940 files]
   ├── ✔ File metadata                   [940 locations]
   └── ✔ Executables                     [1 executables]
 ✔ Scanned for vulnerabilities     [3 vulnerability matches]
   ├── by severity: 0 critical, 0 high, 2 medium, 0 low, 0 negligible (1 unknown)
   └── by status:   3 fixed, 0 not-fixed, 0 ignored
NAME    INSTALLED  FIXED-IN                      TYPE       VULNERABILITY   SEVERITY
stdlib  go1.23.4   1.22.11, 1.23.5, 1.24.0-rc.2  go-module  CVE-2024-45341  Medium
stdlib  go1.23.4   1.22.11, 1.23.5, 1.24.0-rc.2  go-module  CVE-2024-45336  Medium
stdlib  go1.23.4   1.22.12, 1.23.6, 1.24.0-rc.3  go-module  CVE-2025-22866  Unknown
```

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
