### PR TITLE
docs: fix typo in the AWS Secrets manager provider docs

### DIFF
--- a/docs/snippets/provider-aws-access.md
+++ b/docs/snippets/provider-aws-access.md
@@ -6,7 +6,7 @@
 
 Note: If you are using Parameter Store replace `service: SecretsManager` with `service: ParameterStore` in all examples below.
 
-This is basicially a zero-configuration authentication method that inherits the credentials from the runtime environment using the [aws sdk default credential chain](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default).
+This is basically a zero-configuration authentication method that inherits the credentials from the runtime environment using the [aws sdk default credential chain](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default).
 
 You can attach a role to the pod using [IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html), [kiam](https://github.com/uswitch/kiam) or [kube2iam](https://github.com/jtblin/kube2iam). When no other authentication method is configured in the `Kind=Secretstore` this role is used to make all API calls against AWS Secrets Manager or SSM Parameter Store.
 


### PR DESCRIPTION
Fix a typo