### PR TITLE
fix: add push secret refreshInterval defaulting

### DIFF
--- a/apis/externalsecrets/v1alpha1/pushsecret_types.go
+++ b/apis/externalsecrets/v1alpha1/pushsecret_types.go
@@ -73,6 +73,7 @@ const (
 // PushSecretSpec configures the behavior of the PushSecret.
 type PushSecretSpec struct {
 	// The Interval to which External Secrets will try to push a secret definition
+	// +kubebuilder:default="1h"
 	RefreshInterval *metav1.Duration `json:"refreshInterval,omitempty"`
 
 	SecretStoreRefs []PushSecretStoreRef `json:"secretStoreRefs"`

--- a/config/crds/bases/external-secrets.io_pushsecrets.yaml
+++ b/config/crds/bases/external-secrets.io_pushsecrets.yaml
@@ -100,6 +100,7 @@ spec:
                 - None
                 type: string
               refreshInterval:
+                default: 1h
                 description: The Interval to which External Secrets will try to push
                   a secret definition
                 type: string

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -7526,6 +7526,7 @@ spec:
                     - None
                   type: string
                 refreshInterval:
+                  default: 1h
                   description: The Interval to which External Secrets will try to push a secret definition
                   type: string
                 secretStoreRefs:


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?

## Related Issue

Fixes https://github.com/external-secrets/external-secrets/issues/4397


```yaml
Spec:
  Data:
    Conversion Strategy:  None
    Match:
      Remote Ref:
        Property:    username
        Remote Key:  git-sync-secret-copy
      Secret Key:    username
  Deletion Policy:   None
  Refresh Interval:  1h
  Secret Store Refs:
    Kind:  SecretStore
    Name:  secret-store-name
  Selector:
    Secret:
      Name:       git-sync-secret
  Update Policy:  Replace
```

With a thing like this:

```yaml
apiVersion: external-secrets.io/v1alpha1
kind: PushSecret
metadata:
  name: example-push-secret
spec:
  secretStoreRefs:
    - name: secret-store-name
      kind: SecretStore
  selector:
    secret:
      name: git-sync-secret
  data:
    - match:
        secretKey: username
        remoteRef:
          remoteKey: git-sync-secret-copy
          property: username
```

The purpose is to avoid a nil pointer when checking `shouldRefresh` in push secret reconciler.

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
