### PR TITLE
fix: ignore NoSecretErr in generator state

### DIFF
--- a/pkg/generator/statemanager/statemanager.go
+++ b/pkg/generator/statemanager/statemanager.go
@@ -77,6 +77,9 @@ func New(ctx context.Context, client client.Client, scheme *runtime.Scheme, name
 func (m *Manager) Rollback() error {
 	var errs []error
 	for _, item := range m.queue {
+		if item.Rollback == nil {
+			continue
+		}
 		if err := item.Rollback(); err != nil {
 			errs = append(errs, err)
 		}
@@ -88,6 +91,9 @@ func (m *Manager) Rollback() error {
 func (m *Manager) Commit() error {
 	var errs []error
 	for _, item := range m.queue {
+		if item.Commit == nil {
+			continue
+		}
 		if err := item.Commit(); err != nil {
 			errs = append(errs, err)
 		}


### PR DESCRIPTION
## Problem Statement

See #4421. 

(1) The `NoSecretErr` should cause the generator state to commit. This happens in a transition from: having an ExternalSecret with generator state and then applying a change to it using a simple `extract` and dropping the use of the generator. Then this state change (delete generated value) should be committed and not rolled back.

(2) When no generator with state is used, the `Commit()` is a no-op since there is no state.
