### PR TITLE
doc: enhance best practices for cluster-wide resources reconciliation

### DIFF
--- a/docs/guides/security-best-practices.md
+++ b/docs/guides/security-best-practices.md
@@ -31,23 +31,35 @@ spec:
 
 ### 3. Selectively Disable Reconciliation of Cluster-Wide Resources
 
-ESO allows you to selectively disable the reconciliation of cluster-wide resources such as `ClusterSecretStore`, `ClusterExternalSecret`, and `PushSecret`. You can disable the installation of CRDs in the Helm chart or disable reconciliation in the core-controller using the following options:
+ESO allows you to selectively disable the reconciliation of cluster-wide resources `ClusterSecretStore`, `ClusterExternalSecret`, and `PushSecret`.
+You can disable the installation of CRDs and reconciliation in the Helm chart, or disable reconciliation in the core controller.
 
-To disable CRD installation:
+To disable reconciliation in the Helm chart:
 
 ```yaml
-# disable cluster-wide resources & push secret
+processClusterExternalSecret: false
+processClusterStore: false
+processPushSecret: false
+```
+
+To disable CRD installation in the Helm chart:
+
+```yaml
 crds:
   createClusterExternalSecret: false
   createClusterSecretStore: false
   createPushSecret: false
 ```
 
-To disable reconciliation in the core-controller:
+Note that disabling CRD installation for a cluster-wide resource does not automatically disable its reconciliation.
+The core controller will issue error logs if the CRD is not installed but the reconciliation is not disabled.
+
+To disable reconciliation in the core controller, set the following flags:
 
 ```
---enable-cluster-external-secret-reconciler
---enable-cluster-store-reconciler
+--enable-cluster-external-secret-reconciler=false
+--enable-cluster-store-reconciler=false
+--enable-push-secret-reconciler=false
 ```
 
 ### 4. Implement Namespace-Scoped Installation


### PR DESCRIPTION
## Problem Statement

The description of options for controlling the reconciliation and CRD installation of cluster-wide resources in the "Security Best Practices" guide is incomplete.

- If the CRD installation is disabled in the Helm chart but the reconcilers are not, the core controller produces errors in its logs because it cannot find the CRDs.
- The docs don't explain how to disable reconciliation in the Helm chart. There's an easy-to-miss naming inconsistency between the Helm chart key for `ClusterSecretStore` CRD installation and reconciliation (the latter following the name of the core controller flag rather than the resource name), which makes listing the options in full especially useful.
- The core controller flags have to be set to `false` to disable reconciliation.

## Related Issue

N/A

## Proposed Changes

I've completed the description by adding missing options. Instead of running `make test`, I've built and verified the generated docs.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
