### PR TITLE
Fix certificate revisionHistoryLimit invalid quote

### DIFF
--- a/deploy/charts/external-secrets/templates/webhook-certificate.yaml
+++ b/deploy/charts/external-secrets/templates/webhook-certificate.yaml
@@ -27,7 +27,7 @@ spec:
   renewBefore: {{ . | quote }}
   {{- end }}
   {{- with .Values.webhook.certManager.cert.revisionHistoryLimit }}
-  revisionHistoryLimit: {{ . | quote }}
+  revisionHistoryLimit: {{ . }}
   {{- end }}
   secretName: {{ include "external-secrets.fullname" . }}-webhook
 {{- end }}


### PR DESCRIPTION
## Problem Statement

Fix implementation of revisionHistoryLimit on certificate

## Related Issue

Fixes https://github.com/external-secrets/external-secrets/pull/4292#issuecomment-2666082738 (Thanks to @knechtionscoding for initial change)

## Proposed Changes

Keep provided value as int (as described in the docs - https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificateSpec) instead of string

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
