### PR TITLE
Improve documentation for webhook auth secrets

### DIFF
--- a/docs/provider/webhook.md
+++ b/docs/provider/webhook.md
@@ -31,6 +31,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: webhook-credentials
+  labels:
+    external-secrets.io/type: webhook #Needed to allow webhook to use this secret
 data:
   username: dGVzdA== # "test"
   password: dGVzdA== # "test"
@@ -105,7 +107,7 @@ spec:
     secret:
       name: test-secret
   data:
-    - conversionStrategy: 
+    - conversionStrategy:
       match:
         secretKey: testsecret
         remoteRef:


### PR DESCRIPTION
Add correct labels to secrets used for authentication in Webhook Providers

## Problem Statement

While using the Webhook Provider I kept getting this issue 
```
"error":"error processing spec.data[0] (key: secretPayload), err: secret does not contain needed label 'external-secrets.io/type: webhook'. Update secret label to use it with webhook"
```

After a while I found this https://github.com/external-secrets/external-secrets/blob/adf4da46ac8351adaf48d6aa260ab80519a52923/docs/snippets/generator-webhook.yaml#L23

And i noticed that this wasn't available in the general documentation.

## Related Issue

-

## Proposed Changes

-

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
