### PR TITLE
[feature] added Prometheus Status metric for the PushSecret objects

### DIFF
--- a/docs/api/metrics.md
+++ b/docs/api/metrics.md
@@ -26,7 +26,7 @@ The Operator has [the controller-runtime metrics inherited from kubebuilder](htt
 | `externalsecret_status_condition`              | Gauge     | The status condition of a specific External Secret                                                                                                                                                                      |
 | `externalsecret_reconcile_duration`            | Gauge     | The duration time to reconcile the External Secret                                                                                                                                                                      |
 
-## External Secret Metrics
+## Push Secret Metrics
 | Name                                    | Type  | Description                                             |
 |-----------------------------------------|-------|---------------------------------------------------------|
 | `pushsecret_status_condition`   | Gauge | The status condition of a specific Push Secret |

--- a/docs/api/metrics.md
+++ b/docs/api/metrics.md
@@ -26,6 +26,12 @@ The Operator has [the controller-runtime metrics inherited from kubebuilder](htt
 | `externalsecret_status_condition`              | Gauge     | The status condition of a specific External Secret                                                                                                                                                                      |
 | `externalsecret_reconcile_duration`            | Gauge     | The duration time to reconcile the External Secret                                                                                                                                                                      |
 
+## External Secret Metrics
+| Name                                    | Type  | Description                                             |
+|-----------------------------------------|-------|---------------------------------------------------------|
+| `pushsecret_status_condition`   | Gauge | The status condition of a specific Push Secret |
+| `pushsecret_reconcile_duration` | Gauge | The duration time to reconcile the Push Secret |
+
 ## Cluster Secret Store Metrics
 | Name                                    | Type  | Description                                             |
 |-----------------------------------------|-------|---------------------------------------------------------|

--- a/pkg/controllers/pushsecret/psmetrics/psmetrics.go
+++ b/pkg/controllers/pushsecret/psmetrics/psmetrics.go
@@ -16,14 +16,17 @@ package psmetrics
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
+	esapi "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
 	ctrlmetrics "github.com/external-secrets/external-secrets/pkg/controllers/metrics"
 )
 
 const (
 	PushSecretSubsystem            = "pushsecret"
 	PushSecretReconcileDurationKey = "reconcile_duration"
+	PushSecretStatusConditionKey   = "status_condition"
 )
 
 var gaugeVecMetrics = map[string]*prometheus.GaugeVec{}
@@ -31,17 +34,67 @@ var gaugeVecMetrics = map[string]*prometheus.GaugeVec{}
 // SetUpMetrics is called at the root to set-up the metric logic using the
 // config flags provided.
 func SetUpMetrics() {
+	pushSecretCondition := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: PushSecretSubsystem,
+		Name:      PushSecretStatusConditionKey,
+		Help:      "The status condition of a specific Push Secret",
+	}, ctrlmetrics.ConditionMetricLabelNames)
+
 	pushSecretReconcileDuration := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Subsystem: PushSecretSubsystem,
 		Name:      PushSecretReconcileDurationKey,
 		Help:      "The duration time to reconcile the Push Secret",
 	}, ctrlmetrics.NonConditionMetricLabelNames)
 
-	metrics.Registry.MustRegister(pushSecretReconcileDuration)
+	metrics.Registry.MustRegister(pushSecretReconcileDuration, pushSecretCondition)
 
 	gaugeVecMetrics = map[string]*prometheus.GaugeVec{
+		PushSecretStatusConditionKey:   pushSecretCondition,
 		PushSecretReconcileDurationKey: pushSecretReconcileDuration,
 	}
+}
+
+func UpdatePushSecretCondition(ps *esapi.PushSecret, condition *esapi.PushSecretStatusCondition, value float64) {
+	psInfo := make(map[string]string)
+	psInfo["name"] = ps.Name
+	psInfo["namespace"] = ps.Namespace
+	for k, v := range ps.Labels {
+		psInfo[k] = v
+	}
+	conditionLabels := ctrlmetrics.RefineConditionMetricLabels(psInfo)
+	pushSecretCondition := GetGaugeVec(PushSecretStatusConditionKey)
+
+	switch condition.Type {
+	case esapi.PushSecretReady:
+		// Toggle opposite Status to 0
+		switch condition.Status {
+		case v1.ConditionFalse:
+			pushSecretCondition.With(ctrlmetrics.RefineLabels(conditionLabels,
+				map[string]string{
+					"condition": string(esapi.PushSecretReady),
+					"status":    string(v1.ConditionTrue),
+				})).Set(0)
+		case v1.ConditionTrue:
+			pushSecretCondition.With(ctrlmetrics.RefineLabels(conditionLabels,
+				map[string]string{
+					"condition": string(esapi.PushSecretReady),
+					"status":    string(v1.ConditionFalse),
+				})).Set(0)
+		case v1.ConditionUnknown:
+			break
+		default:
+			break
+		}
+
+	default:
+		break
+	}
+
+	pushSecretCondition.With(ctrlmetrics.RefineLabels(conditionLabels,
+		map[string]string{
+			"condition": string(condition.Type),
+			"status":    string(condition.Status),
+		})).Set(value)
 }
 
 func GetGaugeVec(key string) *prometheus.GaugeVec {

--- a/pkg/controllers/pushsecret/pushsecret_controller.go
+++ b/pkg/controllers/pushsecret/pushsecret_controller.go
@@ -517,6 +517,7 @@ func setPushSecretCondition(ps *esapi.PushSecret, condition esapi.PushSecretStat
 	currentCond := getPushSecretCondition(ps.Status, condition.Type)
 	if currentCond != nil && currentCond.Status == condition.Status &&
 		currentCond.Reason == condition.Reason && currentCond.Message == condition.Message {
+		psmetrics.UpdatePushSecretCondition(ps, &condition, 1.0)
 		return
 	}
 
@@ -526,6 +527,12 @@ func setPushSecretCondition(ps *esapi.PushSecret, condition esapi.PushSecretStat
 	}
 
 	ps.Status.Conditions = append(filterOutCondition(ps.Status.Conditions, condition.Type), condition)
+
+	if currentCond != nil {
+		psmetrics.UpdatePushSecretCondition(ps, currentCond, 0.0)
+	}
+
+	psmetrics.UpdatePushSecretCondition(ps, &condition, 1.0)
 }
 
 // filterOutCondition returns an empty set of conditions with the provided type.


### PR DESCRIPTION
## Problem Statement

Added a Status metric to the PushSecrets objects similar to a metric for the ExternalSecret objects. It'll help to monitor statuses of PushSecret objects with Prometheus.

## Related Issue

https://github.com/external-secrets/external-secrets/issues/4488

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
