### PR TITLE
fix: pass in namespace to managed cache for cluster scope if rbac is restricted

### DIFF
--- a/cmd/controller/root.go
+++ b/cmd/controller/root.go
@@ -165,7 +165,7 @@ var rootCmd = &cobra.Command{
 		// if we are already caching all secrets, we don't need to use the special client.
 		secretClient := mgr.GetClient()
 		if enableManagedSecretsCache && !enableSecretsCache {
-			secretClient, err = ctrlcommon.BuildManagedSecretClient(mgr)
+			secretClient, err = ctrlcommon.BuildManagedSecretClient(mgr, namespace)
 			if err != nil {
 				setupLog.Error(err, "unable to create managed secret client")
 				os.Exit(1)

--- a/pkg/controllers/common/common.go
+++ b/pkg/controllers/common/common.go
@@ -32,7 +32,7 @@ import (
 )
 
 // BuildManagedSecretClient creates a new client that only sees secrets with the "managed" label.
-func BuildManagedSecretClient(mgr ctrl.Manager) (client.Client, error) {
+func BuildManagedSecretClient(mgr ctrl.Manager, namespace string) (client.Client, error) {
 	// secrets we manage will have the `reconcile.external-secrets.io/managed=true` label
 	managedLabelReq, _ := labels.NewRequirement(esv1beta1.LabelManaged, selection.Equals, []string{esv1beta1.LabelManagedValue})
 	managedLabelSelector := labels.NewSelector().Add(*managedLabelReq)
@@ -52,6 +52,12 @@ func BuildManagedSecretClient(mgr ctrl.Manager) (client.Client, error) {
 		// and helps avoid people mistakenly using the secret client for other resources
 		ReaderFailOnMissingInformer: true,
 	}
+	if namespace != "" {
+		secretCacheOpts.DefaultNamespaces = map[string]cache.Config{
+			namespace: {},
+		}
+	}
+
 	secretCache, err := cache.New(mgr.GetConfig(), secretCacheOpts)
 	if err != nil {
 		return nil, err

--- a/pkg/controllers/externalsecret/suite_test.go
+++ b/pkg/controllers/externalsecret/suite_test.go
@@ -104,7 +104,7 @@ var _ = BeforeSuite(func() {
 
 	// by default, we use a separate cached client for secrets that are managed by the controller
 	// so we should test under the same conditions
-	secretClient, err := ctrlcommon.BuildManagedSecretClient(k8sManager)
+	secretClient, err := ctrlcommon.BuildManagedSecretClient(k8sManager, "")
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&Reconciler{


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?

## Related Issue

Fixes https://github.com/external-secrets/external-secrets/issues/4481

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
