### PR TITLE
read secret from secretref namespace if set

### DIFF
--- a/pkg/generator/github/github.go
+++ b/pkg/generator/github/github.go
@@ -160,8 +160,14 @@ func newGHClient(ctx context.Context, k client.Client, n string, hc *http.Client
 	if res.Spec.URL != "" {
 		gh.URL = res.Spec.URL + ghPath
 	}
+
+	ns := n
+	if res.Spec.Auth.PrivateKey.SecretRef.Namespace != nil && *res.Spec.Auth.PrivateKey.SecretRef.Namespace != "" {
+		ns = *res.Spec.Auth.PrivateKey.SecretRef.Namespace
+	}
+
 	secret := &corev1.Secret{}
-	if err := gh.Kube.Get(ctx, client.ObjectKey{Name: res.Spec.Auth.PrivateKey.SecretRef.Name, Namespace: n}, secret); err != nil {
+	if err := gh.Kube.Get(ctx, client.ObjectKey{Name: res.Spec.Auth.PrivateKey.SecretRef.Name, Namespace: ns}, secret); err != nil {
 		return nil, fmt.Errorf("error getting GH pem from secret:%w", err)
 	}
 


### PR DESCRIPTION
## Problem Statement
Related to GitHub generator.
When using `ClusterGenerator` to generate clusterwide GitHub tokens in selected namespaces the private key PEM has to be in each selected namespaces though the `secretRef.namespace` property is set. 

## Related Issue

-

## Proposed Changes

Fetch secret from specified namespace. If not set then the namespace of the referent resource is used (as before).

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
