### PR TITLE
fix: improve webhook provider PushSecret handling

### DIFF
--- a/docs/provider/webhook.md
+++ b/docs/provider/webhook.md
@@ -81,6 +81,7 @@ spec:
   provider:
     webhook:
       url: "http://httpbin.org/push?id={{ .remoteRef.remoteKey }}&secret={{ .remoteRef.secretKey }}"
+      body: '{"secret-field": "{{ index .remoteRef .remoteRef.remoteKey }}"}'
       headers:
         Content-Type: application/json
         Authorization: Basic {{ print .auth.username ":" .auth.password | b64enc }}

--- a/pkg/common/webhook/webhook.go
+++ b/pkg/common/webhook/webhook.go
@@ -140,6 +140,33 @@ func (w *Webhook) GetTemplateData(ctx context.Context, ref *esv1beta1.ExternalSe
 	return data, nil
 }
 
+func (w *Webhook) GetTemplatePushData(ctx context.Context, ref esv1beta1.PushSecretData, secrets []Secret, urlEncode bool) (map[string]map[string]string, error) {
+	data := map[string]map[string]string{}
+	if ref != nil {
+		if urlEncode {
+			data["remoteRef"] = map[string]string{
+				"remoteKey": url.QueryEscape(ref.GetRemoteKey()),
+			}
+			if v := ref.GetSecretKey(); v != "" {
+				data["remoteRef"]["secretKey"] = url.QueryEscape(v)
+			}
+		} else {
+			data["remoteRef"] = map[string]string{
+				"remoteKey": ref.GetRemoteKey(),
+			}
+			if v := ref.GetSecretKey(); v != "" {
+				data["remoteRef"]["secretKey"] = v
+			}
+		}
+	}
+
+	if err := w.getTemplatedSecrets(ctx, secrets, data); err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
 func (w *Webhook) getTemplatedSecrets(ctx context.Context, secrets []Secret, data map[string]map[string]string) error {
 	for _, secref := range secrets {
 		if _, ok := data[secref.Name]; !ok {
@@ -197,27 +224,28 @@ func (w *Webhook) PushWebhookData(ctx context.Context, provider *Spec, data []by
 		method = http.MethodPost
 	}
 
-	rawData := map[string]map[string]string{
-		"remoteRef": {
-			"remoteKey": url.QueryEscape(remoteKey.GetRemoteKey()),
-		},
+	escapedData, err := w.GetTemplatePushData(ctx, remoteKey, provider.Secrets, true)
+	if err != nil {
+		return err
 	}
-	if remoteKey.GetSecretKey() != "" {
-		rawData["remoteRef"]["secretKey"] = url.QueryEscape(remoteKey.GetSecretKey())
-	}
+	escapedData["remoteRef"][remoteKey.GetRemoteKey()] = url.QueryEscape(string(data))
 
-	turl, err := ExecuteTemplateString(provider.URL, rawData)
+	rawData, err := w.GetTemplatePushData(ctx, remoteKey, provider.Secrets, false)
+	if err != nil {
+		return err
+	}
+	rawData["remoteRef"][remoteKey.GetRemoteKey()] = string(data)
+
+	url, err := ExecuteTemplateString(provider.URL, escapedData)
 	if err != nil {
 		return fmt.Errorf("failed to parse url: %w", err)
 	}
-
-	dataMap := make(map[string]map[string]string)
-	if err := w.getTemplatedSecrets(ctx, provider.Secrets, dataMap); err != nil {
-		return err
+	body, err := ExecuteTemplate(provider.Body, rawData)
+	if err != nil {
+		return fmt.Errorf("failed to parse body: %w", err)
 	}
 
-	// read the body into the void to prevent remaining garbage to be present
-	if _, err := w.executeRequest(ctx, provider, data, turl, method, dataMap); err != nil {
+	if _, err := w.executeRequest(ctx, provider, body.Bytes(), url, method, rawData); err != nil {
 		return fmt.Errorf("failed to push webhook data: %w", err)
 	}
 

--- a/pkg/provider/webhook/webhook_test.go
+++ b/pkg/provider/webhook/webhook_test.go
@@ -368,6 +368,7 @@ case: good json
 args:
   url: /api/pushsecret?id={{ .remoteRef.remoteKey }}&secret={{ .remoteRef.secretKey }}
   key: testkey
+  body: 'pre {{ .remoteRef.remoteKey }} {{ .remoteRef.testkey }} post'
   secretkey: secretkey
   pushsecret: true
   secret:
@@ -376,6 +377,7 @@ args:
       secretkey: value
 want:
   path: /api/pushsecret?id=testkey&secret=secretkey
+  body: 'pre testkey value post'
   err: ''
 ---
 case: secret key not found
@@ -396,6 +398,7 @@ case: pushing without secret key
 args:
   url: /api/pushsecret?id={{ .remoteRef.remoteKey }}
   key: testkey
+  body: 'pre {{ .remoteRef.remoteKey }} {{ index (.remoteRef.testkey | fromJson) "secretkey" }} post'
   pushsecret: true
   secret:
     name: test-secret
@@ -403,6 +406,22 @@ args:
       secretkey: value
 want:
   path: /api/pushsecret?id=testkey
+  body: 'pre testkey value post'
+  err: ''
+---
+case: pushing without secret key with dynamic resolution
+args:
+  url: /api/pushsecret?id={{ .remoteRef.remoteKey }}
+  key: testkey
+  body: 'pre {{ .remoteRef.remoteKey }} {{ index (index .remoteRef .remoteRef.remoteKey | fromJson) "secretkey" }} post'
+  pushsecret: true
+  secret:
+    name: test-secret
+    data:
+      secretkey: value
+want:
+  path: /api/pushsecret?id=testkey
+  body: 'pre testkey value post'
   err: ''
 ---
 `


### PR DESCRIPTION
Refactor the webhook provider so that the body can be specified as a template. This allows a secret to be sent to a web provider without requiring the web provider to accept the secret in whatever form the secret itself is in; the secret could be provided within a well-formed, provider-specific JSON blob.

## Problem Statement

The webhook provider does not respect the body template of the provider when used with PushSecret, but most web providers will expect data to conform to a schema that the web provider has defined.

## Related Issue

My apologies, I did not create an issue first, because by the time I had tracked down the problem I was encountering, the solution was relatively straightforward.

## Proposed Changes

I would like to be able to specify push a secret using the Webhook provider to update a configuration at the remote web service that needs a secret within a larger document.

If details help: what I'm really doing is managing a certificate with cert-manager and then using External Secrets Operator to provide that certificate to configure a service that allows me to bring my own certificate. The related Kubernetes Secret, of course, has `tls.key` and `tls.crt` fields, and I have to put those values into a JSON blob in the fields that the provider has defined along with some other data.

Note that this change does make it so that the secret is no longer sent in the body by default when the body is empty. It would be relatively straightforward for me to maintain backward compatibility if that's something the maintainers want; just let me know and I'll gladly make the change.

## Checklist

- [/] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [/] All commits are signed with `git commit --signoff`
- [/] My changes have reasonable test coverage
- [/] All tests pass with `make test`
- [/] I ensured my PR is ready for review with `make reviewable`
