### PR TITLE
use subtests in webprovider unit tests

### DIFF
--- a/pkg/provider/webhook/webhook_test.go
+++ b/pkg/provider/webhook/webhook_test.go
@@ -541,7 +541,6 @@ func runTestCase(tc testCase, t *testing.T) {
 		} else {
 			testPushSecret(tc, t, client)
 		}
-
 	})
 }
 


### PR DESCRIPTION
## Problem Statement

I was trying to analyze expected behaviors and improve tests in https://github.com/external-secrets/external-secrets/pull/4508.

## Related Issue

This was just a small change I made locally while working on #4508, but didn't want to include it there and mix up a separate concern there.

## Proposed Changes

Use subtests in webhook provider unit tests to make it easier to identify failing tests as well as run them in isolation.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
