### PR TITLE
fix webhook provider docs

### DIFF
--- a/docs/provider/webhook.md
+++ b/docs/provider/webhook.md
@@ -116,7 +116,7 @@ spec:
 ```
 If `secretKey` is not provided, the whole secret is provided JSON encoded.
 
-The secret will be added to the `remoteRef` object so that it is retrievable in the templating engine. The secret will be sent in the body when the body field of the provider is empty. In the rare case that the body should be empty, the provider can be configured to use `'{{ "" }}'` for the body value.
+The secret will be added to the `remoteRef` object so that it is retrievable in the templating engine. The secret will be sent in the body when the body field of the provider is empty. In the rare case that the body should be empty, the provider can be configured to use `{% raw %}'{{ "" }}'{% endraw %}` for the body value.
 
 #### Limitations
 


### PR DESCRIPTION
## Problem Statement

A code block that contain a Go template in #4508 is rendering empty.

## Related Issue

No issue filed. It was something I noticed when reviewing the deployed documentation after #4508 was merged. I verified this fix locally by running `make docs.serve` and reviewing the rendered documentation.

## Proposed Changes

Wrap a code block in a raw template so that the template in the block will render as expected.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
