### PR TITLE
Update client_push.go

### DIFF
--- a/pkg/provider/vault/client_push.go
+++ b/pkg/provider/vault/client_push.go
@@ -40,7 +40,7 @@ func (c *client) PushSecret(ctx context.Context, secret *corev1.Secret, data esv
 	metadata := data.GetMetadata()
 
 	// custom metadata
-	custom_metadata := map[string]string{
+	customMetadata := map[string]string{
 		"managed-by": "external-secrets",
 	}
 
@@ -59,7 +59,7 @@ func (c *client) PushSecret(ctx context.Context, secret *corev1.Secret, data esv
 				// transfer data
 				for key, value := range metadataSection {
 					// key by key copy
-					custom_metadata[key] = value
+					customMetadata[key] = value
 				}
 			}
 		}
@@ -81,7 +81,7 @@ func (c *client) PushSecret(ctx context.Context, secret *corev1.Secret, data esv
 	}
 
 	label := map[string]any{
-		"custom_metadata": custom_metadata,
+		"custom_metadata": customMetadata,
 	}
 
 	secretVal := make(map[string]any)


### PR DESCRIPTION
**Enhancement for External Secret Operator: Custom Metadata Support in HashiCorp Vault**

**Description:**
This enhancement introduces the use of the `spec.data.metadata` field when creating secrets from PushSecret, allowing for the population of custom metadata in HashiCorp Vault. This feature provides greater flexibility and control over secret management.

**Key Changes:**
- **Custom Metadata Support:** Utilizes the `spec.data.metadata` field to populate custom metadata in HashiCorp Vault.
- **Improved Flexibility:** Enables better organization and management of secrets by including custom metadata, crucial for auditing, tracking, and compliance purposes.

**Benefits:**
- Enhanced secret management capabilities through custom metadata.
- Improved flexibility and control over secret organization.
- Better support for auditing and compliance requirements.