### PR TITLE
Add cross-namepsace credential support for ClusterGenerator resources

### DIFF
--- a/apis/generators/v1alpha1/generator_interfaces.go
+++ b/apis/generators/v1alpha1/generator_interfaces.go
@@ -36,7 +36,8 @@ type Generator interface {
 		ctx context.Context,
 		obj *apiextensions.JSON,
 		kube client.Client,
-		namespace string,
+		sourceNamespace string,
+		destinationNamespace string,
 	) (map[string][]byte, GeneratorProviderState, error)
 
 	// Cleanup deletes any resources created during the Generate phase.
@@ -47,7 +48,8 @@ type Generator interface {
 		obj *apiextensions.JSON,
 		status GeneratorProviderState,
 		kube client.Client,
-		namespace string,
+		sourceNamespace string,
+		destinationNamespace string,
 	) error
 }
 

--- a/apis/generators/v1alpha1/generator_state_types.go
+++ b/apis/generators/v1alpha1/generator_state_types.go
@@ -53,6 +53,12 @@ type GeneratorStateSpec struct {
 	Resource *apiextensions.JSON `json:"resource"`
 	// State is the state that was produced by the generator implementation.
 	State *apiextensions.JSON `json:"state"`
+
+	// The namespace that should be used when accessing existing resources,
+	// such as secrets for existing credentials. If not set, then
+	// the namespace of each external secret that references this generator
+	// will be used.
+	SourceNamespace string `json:"sourceNamespace,omitempty"`
 }
 
 type GeneratorStateConditionType string

--- a/apis/generators/v1alpha1/types_cluster.go
+++ b/apis/generators/v1alpha1/types_cluster.go
@@ -24,6 +24,12 @@ type ClusterGeneratorSpec struct {
 
 	// Generator the spec for this generator, must match the kind.
 	Generator GeneratorSpec `json:"generator"`
+
+	// The namespace that should be used when accessing existing resources,
+	// such as secrets for existing credentials. If not set, then
+	// the namespace of each external secret that references this generator
+	// will be used.
+	SourceNamespace string `json:"sourceNamespace,omitempty"`
 }
 
 // GeneratorKind represents a kind of generator.

--- a/config/crds/bases/generators.external-secrets.io_clustergenerators.yaml
+++ b/config/crds/bases/generators.external-secrets.io_clustergenerators.yaml
@@ -1808,6 +1808,13 @@ spec:
                 - Webhook
                 - Grafana
                 type: string
+              sourceNamespace:
+                description: |-
+                  The namespace that should be used when accessing existing resources,
+                  such as secrets for existing credentials. If not set, then
+                  the namespace of each external secret that references this generator
+                  will be used.
+                type: string
             required:
             - generator
             - kind

--- a/config/crds/bases/generators.external-secrets.io_generatorstates.yaml
+++ b/config/crds/bases/generators.external-secrets.io_generatorstates.yaml
@@ -67,6 +67,13 @@ spec:
                   in the manifest should be available at the time of garbage collection. If that is not the case deletion will
                   be blocked by a finalizer.
                 x-kubernetes-preserve-unknown-fields: true
+              sourceNamespace:
+                description: |-
+                  The namespace that should be used when accessing existing resources,
+                  such as secrets for existing credentials. If not set, then
+                  the namespace of each external secret that references this generator
+                  will be used.
+                type: string
               state:
                 description: State is the state that was produced by the generator
                   implementation.

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -15735,6 +15735,13 @@ spec:
                     - Webhook
                     - Grafana
                   type: string
+                sourceNamespace:
+                  description: |-
+                    The namespace that should be used when accessing existing resources,
+                    such as secrets for existing credentials. If not set, then
+                    the namespace of each external secret that references this generator
+                    will be used.
+                  type: string
               required:
                 - generator
                 - kind
@@ -16248,6 +16255,13 @@ spec:
                     in the manifest should be available at the time of garbage collection. If that is not the case deletion will
                     be blocked by a finalizer.
                   x-kubernetes-preserve-unknown-fields: true
+                sourceNamespace:
+                  description: |-
+                    The namespace that should be used when accessing existing resources,
+                    such as secrets for existing credentials. If not set, then
+                    the namespace of each external secret that references this generator
+                    will be used.
+                  type: string
                 state:
                   description: State is the state that was produced by the generator implementation.
                   x-kubernetes-preserve-unknown-fields: true

--- a/pkg/controllers/externalsecret/externalsecret_controller.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller.go
@@ -801,7 +801,7 @@ func shouldSkipUnmanagedStore(ctx context.Context, namespace string, r *Reconcil
 
 		// verify that generator's controllerClass matches
 		if ref.SourceRef != nil && ref.SourceRef.GeneratorRef != nil {
-			_, obj, err := resolvers.GeneratorRef(ctx, r.Client, r.Scheme, namespace, ref.SourceRef.GeneratorRef)
+			_, obj, _, err := resolvers.GeneratorRef(ctx, r.Client, r.Scheme, namespace, ref.SourceRef.GeneratorRef)
 			if err != nil {
 				if apierrors.IsNotFound(err) {
 					// skip non-existent generators

--- a/pkg/controllers/generatorstate/generatorstate_controller.go
+++ b/pkg/controllers/generatorstate/generatorstate_controller.go
@@ -96,7 +96,12 @@ func (r *Reconciler) handleFinalizer(ctx context.Context, generatorState *genv1a
 			return false, fmt.Errorf("could not get generator: %w", err)
 		}
 
-		if err := gen.Cleanup(ctx, generatorState.Spec.Resource, generatorState.Spec.State, r.Client, generatorState.Namespace); err != nil {
+		sourceNamespace := generatorState.Spec.SourceNamespace
+		if sourceNamespace == "" {
+			sourceNamespace = generatorState.Namespace
+		}
+
+		if err := gen.Cleanup(ctx, generatorState.Spec.Resource, generatorState.Spec.State, r.Client, sourceNamespace, generatorState.Namespace); err != nil {
 			r.markAsFailed("could not cleanup generator state", err, generatorState)
 			return false, fmt.Errorf("could not cleanup generator state: %w", err)
 		}

--- a/pkg/generator/acr/acr.go
+++ b/pkg/generator/acr/acr.go
@@ -70,7 +70,7 @@ const (
 // * access tokens are scoped to a specific repository or action (pull,push)
 // * refresh tokens can are scoped to whatever policy is attached to the identity that creates the acr refresh token
 // details can be found here: https://github.com/Azure/acr/blob/main/docs/AAD-OAuth.md#overview
-func (g *Generator) Generate(ctx context.Context, jsonSpec *apiextensions.JSON, crClient client.Client, namespace string) (map[string][]byte, genv1alpha1.GeneratorProviderState, error) {
+func (g *Generator) Generate(ctx context.Context, jsonSpec *apiextensions.JSON, crClient client.Client, sourceNamespace, _ string) (map[string][]byte, genv1alpha1.GeneratorProviderState, error) {
 	cfg, err := ctrlcfg.GetConfig()
 	if err != nil {
 		return nil, nil, err
@@ -87,13 +87,13 @@ func (g *Generator) Generate(ctx context.Context, jsonSpec *apiextensions.JSON, 
 		ctx,
 		jsonSpec,
 		crClient,
-		namespace,
+		sourceNamespace,
 		kubeClient,
 		fetchACRAccessToken,
 		fetchACRRefreshToken)
 }
 
-func (g *Generator) Cleanup(ctx context.Context, jsonSpec *apiextensions.JSON, _ genv1alpha1.GeneratorProviderState, crClient client.Client, namespace string) error {
+func (g *Generator) Cleanup(ctx context.Context, jsonSpec *apiextensions.JSON, _ genv1alpha1.GeneratorProviderState, crClient client.Client, _, _ string) error {
 	return nil
 }
 
@@ -101,7 +101,7 @@ func (g *Generator) generate(
 	ctx context.Context,
 	jsonSpec *apiextensions.JSON,
 	crClient client.Client,
-	namespace string,
+	sourceNamespace string,
 	kubeClient kubernetes.Interface,
 	fetchAccessToken accessTokenFetcher,
 	fetchRefreshToken refreshTokenFetcher) (map[string][]byte, genv1alpha1.GeneratorProviderState, error) {
@@ -118,7 +118,7 @@ func (g *Generator) generate(
 		accessToken, err = g.accessTokenForServicePrincipal(
 			ctx,
 			crClient,
-			namespace,
+			sourceNamespace,
 			res.Spec.EnvironmentType,
 			res.Spec.TenantID,
 			res.Spec.Auth.ServicePrincipal.SecretRef.ClientID,
@@ -137,7 +137,7 @@ func (g *Generator) generate(
 			kubeClient.CoreV1(),
 			res.Spec.EnvironmentType,
 			res.Spec.Auth.WorkloadIdentity.ServiceAccountRef,
-			namespace,
+			sourceNamespace,
 		)
 	} else {
 		return nil, nil, errors.New("unexpeted configuration")

--- a/pkg/generator/ecr/ecr.go
+++ b/pkg/generator/ecr/ecr.go
@@ -46,11 +46,11 @@ const (
 	errGetPublicToken  = "unable to get public authorization token: %w"
 )
 
-func (g *Generator) Generate(ctx context.Context, jsonSpec *apiextensions.JSON, kube client.Client, namespace string) (map[string][]byte, genv1alpha1.GeneratorProviderState, error) {
-	return g.generate(ctx, jsonSpec, kube, namespace, ecrPrivateFactory, ecrPublicFactory)
+func (g *Generator) Generate(ctx context.Context, jsonSpec *apiextensions.JSON, kube client.Client, sourceNamespace, _ string) (map[string][]byte, genv1alpha1.GeneratorProviderState, error) {
+	return g.generate(ctx, jsonSpec, kube, sourceNamespace, ecrPrivateFactory, ecrPublicFactory)
 }
 
-func (g *Generator) Cleanup(ctx context.Context, jsonSpec *apiextensions.JSON, _ genv1alpha1.GeneratorProviderState, crClient client.Client, namespace string) error {
+func (g *Generator) Cleanup(ctx context.Context, jsonSpec *apiextensions.JSON, _ genv1alpha1.GeneratorProviderState, crClient client.Client, _, _ string) error {
 	return nil
 }
 
@@ -58,7 +58,7 @@ func (g *Generator) generate(
 	ctx context.Context,
 	jsonSpec *apiextensions.JSON,
 	kube client.Client,
-	namespace string,
+	sourceNamespace string,
 	ecrPrivateFunc ecrPrivateFactoryFunc,
 	ecrPublicFunc ecrPublicFactoryFunc,
 ) (map[string][]byte, genv1alpha1.GeneratorProviderState, error) {
@@ -78,7 +78,7 @@ func (g *Generator) generate(
 		res.Spec.Role,
 		res.Spec.Region,
 		kube,
-		namespace,
+		sourceNamespace,
 		awsauth.DefaultSTSProvider,
 		awsauth.DefaultJWTProvider)
 	if err != nil {

--- a/pkg/generator/fake/fake.go
+++ b/pkg/generator/fake/fake.go
@@ -34,7 +34,7 @@ const (
 	errGetToken  = "unable to get authorization token: %w"
 )
 
-func (g *Generator) Generate(_ context.Context, jsonSpec *apiextensions.JSON, _ client.Client, _ string) (map[string][]byte, genv1alpha1.GeneratorProviderState, error) {
+func (g *Generator) Generate(_ context.Context, jsonSpec *apiextensions.JSON, _ client.Client, _, _ string) (map[string][]byte, genv1alpha1.GeneratorProviderState, error) {
 	if jsonSpec == nil {
 		return nil, nil, errors.New(errNoSpec)
 	}
@@ -49,7 +49,7 @@ func (g *Generator) Generate(_ context.Context, jsonSpec *apiextensions.JSON, _ 
 	return out, nil, nil
 }
 
-func (g *Generator) Cleanup(ctx context.Context, jsonSpec *apiextensions.JSON, _ genv1alpha1.GeneratorProviderState, crClient client.Client, namespace string) error {
+func (g *Generator) Cleanup(ctx context.Context, jsonSpec *apiextensions.JSON, _ genv1alpha1.GeneratorProviderState, crClient client.Client, _, _ string) error {
 	return nil
 }
 

--- a/pkg/generator/fake/fake_test.go
+++ b/pkg/generator/fake/fake_test.go
@@ -25,10 +25,9 @@ import (
 
 func TestGenerate(t *testing.T) {
 	type args struct {
-		ctx       context.Context
-		jsonSpec  *apiextensions.JSON
-		kube      client.Client
-		namespace string
+		ctx      context.Context
+		jsonSpec *apiextensions.JSON
+		kube     client.Client
 	}
 	tests := []struct {
 		name    string
@@ -79,7 +78,7 @@ func TestGenerate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := &Generator{}
-			got, _, err := g.Generate(tt.args.ctx, tt.args.jsonSpec, tt.args.kube, tt.args.namespace)
+			got, _, err := g.Generate(tt.args.ctx, tt.args.jsonSpec, tt.args.kube, "", "")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Generator.Generate() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/generator/gcr/gcr.go
+++ b/pkg/generator/gcr/gcr.go
@@ -41,17 +41,17 @@ const (
 	errGetToken  = "unable to get authorization token: %w"
 )
 
-func (g *Generator) Generate(ctx context.Context, jsonSpec *apiextensions.JSON, kube client.Client, namespace string) (map[string][]byte, genv1alpha1.GeneratorProviderState, error) {
+func (g *Generator) Generate(ctx context.Context, jsonSpec *apiextensions.JSON, kube client.Client, sourceNamespace, _ string) (map[string][]byte, genv1alpha1.GeneratorProviderState, error) {
 	return g.generate(
 		ctx,
 		jsonSpec,
 		kube,
-		namespace,
+		sourceNamespace,
 		secretmanager.NewTokenSource,
 	)
 }
 
-func (g *Generator) Cleanup(ctx context.Context, jsonSpec *apiextensions.JSON, _ genv1alpha1.GeneratorProviderState, crClient client.Client, namespace string) error {
+func (g *Generator) Cleanup(ctx context.Context, jsonSpec *apiextensions.JSON, _ genv1alpha1.GeneratorProviderState, crClient client.Client, _, _ string) error {
 	return nil
 }
 
@@ -59,7 +59,7 @@ func (g *Generator) generate(
 	ctx context.Context,
 	jsonSpec *apiextensions.JSON,
 	kube client.Client,
-	namespace string,
+	sourceNamespace string,
 	tokenSource tokenSourceFunc) (map[string][]byte, genv1alpha1.GeneratorProviderState, error) {
 	if jsonSpec == nil {
 		return nil, nil, errors.New(errNoSpec)
@@ -71,7 +71,7 @@ func (g *Generator) generate(
 	ts, err := tokenSource(ctx, esv1beta1.GCPSMAuth{
 		SecretRef:        (*esv1beta1.GCPSMAuthSecretRef)(res.Spec.Auth.SecretRef),
 		WorkloadIdentity: (*esv1beta1.GCPWorkloadIdentity)(res.Spec.Auth.WorkloadIdentity),
-	}, res.Spec.ProjectID, resolvers.EmptyStoreKind, kube, namespace)
+	}, res.Spec.ProjectID, resolvers.EmptyStoreKind, kube, sourceNamespace)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/generator/github/github.go
+++ b/pkg/generator/github/github.go
@@ -60,16 +60,16 @@ const (
 	httpClientTimeout = 5 * time.Second
 )
 
-func (g *Generator) Generate(ctx context.Context, jsonSpec *apiextensions.JSON, kube client.Client, namespace string) (map[string][]byte, genv1alpha1.GeneratorProviderState, error) {
+func (g *Generator) Generate(ctx context.Context, jsonSpec *apiextensions.JSON, kube client.Client, sourceNamespace, _ string) (map[string][]byte, genv1alpha1.GeneratorProviderState, error) {
 	return g.generate(
 		ctx,
 		jsonSpec,
 		kube,
-		namespace,
+		sourceNamespace,
 	)
 }
 
-func (g *Generator) Cleanup(ctx context.Context, jsonSpec *apiextensions.JSON, _ genv1alpha1.GeneratorProviderState, crClient client.Client, namespace string) error {
+func (g *Generator) Cleanup(ctx context.Context, jsonSpec *apiextensions.JSON, _ genv1alpha1.GeneratorProviderState, crClient client.Client, _, _ string) error {
 	return nil
 }
 
@@ -77,14 +77,14 @@ func (g *Generator) generate(
 	ctx context.Context,
 	jsonSpec *apiextensions.JSON,
 	kube client.Client,
-	namespace string) (map[string][]byte, genv1alpha1.GeneratorProviderState, error) {
+	sourceNamespace string) (map[string][]byte, genv1alpha1.GeneratorProviderState, error) {
 	if jsonSpec == nil {
 		return nil, nil, errors.New(errNoSpec)
 	}
 	ctx, cancel := context.WithTimeout(ctx, contextTimeout)
 	defer cancel()
 
-	gh, err := newGHClient(ctx, kube, namespace, g.httpClient, jsonSpec)
+	gh, err := newGHClient(ctx, kube, sourceNamespace, g.httpClient, jsonSpec)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating request: %w", err)
 	}

--- a/pkg/generator/grafana/grafana.go
+++ b/pkg/generator/grafana/grafana.go
@@ -35,13 +35,13 @@ import (
 
 type Grafana struct{}
 
-func (w *Grafana) Generate(ctx context.Context, jsonSpec *apiextensions.JSON, kclient client.Client, ns string) (map[string][]byte, genv1alpha1.GeneratorProviderState, error) {
+func (w *Grafana) Generate(ctx context.Context, jsonSpec *apiextensions.JSON, kclient client.Client, sourceNamespace, _ string) (map[string][]byte, genv1alpha1.GeneratorProviderState, error) {
 	gen, err := parseSpec(jsonSpec.Raw)
 	if err != nil {
 		return nil, nil, err
 	}
-	secret, err := resolvers.SecretKeyRef(ctx, kclient, resolvers.EmptyStoreKind, ns, &esmeta.SecretKeySelector{
-		Namespace: &ns,
+	secret, err := resolvers.SecretKeyRef(ctx, kclient, resolvers.EmptyStoreKind, sourceNamespace, &esmeta.SecretKeySelector{
+		Namespace: &sourceNamespace,
 		Name:      gen.Spec.Auth.Token.Name,
 		Key:       gen.Spec.Auth.Token.Key,
 	})
@@ -76,7 +76,7 @@ func (w *Grafana) Generate(ctx context.Context, jsonSpec *apiextensions.JSON, kc
 	return tokenResponse(state, res.Payload.Key)
 }
 
-func (w *Grafana) Cleanup(ctx context.Context, jsonSpec *apiextensions.JSON, previousStatus genv1alpha1.GeneratorProviderState, kclient client.Client, ns string) error {
+func (w *Grafana) Cleanup(ctx context.Context, jsonSpec *apiextensions.JSON, previousStatus genv1alpha1.GeneratorProviderState, kclient client.Client, sourceNamespace, _ string) error {
 	if previousStatus == nil {
 		return fmt.Errorf("missing previous status")
 	}
@@ -88,7 +88,7 @@ func (w *Grafana) Cleanup(ctx context.Context, jsonSpec *apiextensions.JSON, pre
 	if err != nil {
 		return err
 	}
-	cl, err := newClient(ctx, gen, kclient, ns)
+	cl, err := newClient(ctx, gen, kclient, sourceNamespace)
 	if err != nil {
 		return err
 	}

--- a/pkg/generator/password/password.go
+++ b/pkg/generator/password/password.go
@@ -49,14 +49,14 @@ type generateFunc func(
 	allowRepeat bool,
 ) (string, error)
 
-func (g *Generator) Generate(_ context.Context, jsonSpec *apiextensions.JSON, _ client.Client, _ string) (map[string][]byte, genv1alpha1.GeneratorProviderState, error) {
+func (g *Generator) Generate(_ context.Context, jsonSpec *apiextensions.JSON, _ client.Client, _, _ string) (map[string][]byte, genv1alpha1.GeneratorProviderState, error) {
 	return g.generate(
 		jsonSpec,
 		generateSafePassword,
 	)
 }
 
-func (g *Generator) Cleanup(_ context.Context, jsonSpec *apiextensions.JSON, state genv1alpha1.GeneratorProviderState, _ client.Client, _ string) error {
+func (g *Generator) Cleanup(_ context.Context, jsonSpec *apiextensions.JSON, state genv1alpha1.GeneratorProviderState, _ client.Client, _, _ string) error {
 	return nil
 }
 

--- a/pkg/generator/quay/quay.go
+++ b/pkg/generator/quay/quay.go
@@ -52,16 +52,16 @@ const (
 	httpClientTimeout = 5 * time.Second
 )
 
-func (g *Generator) Generate(ctx context.Context, jsonSpec *apiextensions.JSON, kube client.Client, namespace string) (map[string][]byte, genv1alpha1.GeneratorProviderState, error) {
+func (g *Generator) Generate(ctx context.Context, jsonSpec *apiextensions.JSON, kube client.Client, sourceNamespace, _ string) (map[string][]byte, genv1alpha1.GeneratorProviderState, error) {
 	return g.generate(
 		ctx,
 		jsonSpec,
 		kube,
-		namespace,
+		sourceNamespace,
 	)
 }
 
-func (g *Generator) Cleanup(_ context.Context, jsonSpec *apiextensions.JSON, state genv1alpha1.GeneratorProviderState, _ client.Client, _ string) error {
+func (g *Generator) Cleanup(_ context.Context, jsonSpec *apiextensions.JSON, state genv1alpha1.GeneratorProviderState, _ client.Client, _, _ string) error {
 	return nil
 }
 
@@ -69,7 +69,7 @@ func (g *Generator) generate(
 	ctx context.Context,
 	jsonSpec *apiextensions.JSON,
 	_ client.Client,
-	namespace string) (map[string][]byte, genv1alpha1.GeneratorProviderState, error) {
+	sourceNamespace string) (map[string][]byte, genv1alpha1.GeneratorProviderState, error) {
 	if jsonSpec == nil {
 		return nil, nil, errors.New(errNoSpec)
 	}
@@ -79,7 +79,7 @@ func (g *Generator) generate(
 	}
 
 	// Fetch the service account token
-	token, err := fetchServiceAccountToken(ctx, res.Spec.ServiceAccountRef, namespace)
+	token, err := fetchServiceAccountToken(ctx, res.Spec.ServiceAccountRef, sourceNamespace)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to fetch service account token: %w", err)
 	}

--- a/pkg/generator/sts/sts.go
+++ b/pkg/generator/sts/sts.go
@@ -41,15 +41,15 @@ const (
 	errGetToken   = "unable to get authorization token: %w"
 )
 
-func (g *Generator) Generate(ctx context.Context, jsonSpec *apiextensions.JSON, kube client.Client, namespace string) (map[string][]byte, genv1alpha1.GeneratorProviderState, error) {
-	return g.generate(ctx, jsonSpec, kube, namespace, stsFactory)
+func (g *Generator) Generate(ctx context.Context, jsonSpec *apiextensions.JSON, kube client.Client, sourceNamespace, _ string) (map[string][]byte, genv1alpha1.GeneratorProviderState, error) {
+	return g.generate(ctx, jsonSpec, kube, sourceNamespace, stsFactory)
 }
 
 func (g *Generator) generate(
 	ctx context.Context,
 	jsonSpec *apiextensions.JSON,
 	kube client.Client,
-	namespace string,
+	sourceNamespace string,
 	stsFunc stsFactoryFunc,
 ) (map[string][]byte, genv1alpha1.GeneratorProviderState, error) {
 	if jsonSpec == nil {
@@ -68,7 +68,7 @@ func (g *Generator) generate(
 		res.Spec.Role,
 		res.Spec.Region,
 		kube,
-		namespace,
+		sourceNamespace,
 		awsauth.DefaultSTSProvider,
 		awsauth.DefaultJWTProvider)
 	if err != nil {
@@ -97,7 +97,7 @@ func (g *Generator) generate(
 	}, nil, nil
 }
 
-func (g *Generator) Cleanup(_ context.Context, jsonSpec *apiextensions.JSON, state genv1alpha1.GeneratorProviderState, _ client.Client, _ string) error {
+func (g *Generator) Cleanup(_ context.Context, jsonSpec *apiextensions.JSON, state genv1alpha1.GeneratorProviderState, _ client.Client, _, _ string) error {
 	return nil
 }
 

--- a/pkg/generator/uuid/uuid.go
+++ b/pkg/generator/uuid/uuid.go
@@ -29,14 +29,14 @@ type Generator struct{}
 
 type generateFunc func() (string, error)
 
-func (g *Generator) Generate(_ context.Context, jsonSpec *apiextensions.JSON, _ client.Client, _ string) (map[string][]byte, genv1alpha1.GeneratorProviderState, error) {
+func (g *Generator) Generate(_ context.Context, jsonSpec *apiextensions.JSON, _ client.Client, _, _ string) (map[string][]byte, genv1alpha1.GeneratorProviderState, error) {
 	return g.generate(
 		jsonSpec,
 		generateUUID,
 	)
 }
 
-func (g *Generator) Cleanup(_ context.Context, jsonSpec *apiextensions.JSON, state genv1alpha1.GeneratorProviderState, _ client.Client, _ string) error {
+func (g *Generator) Cleanup(_ context.Context, jsonSpec *apiextensions.JSON, state genv1alpha1.GeneratorProviderState, _ client.Client, _, _ string) error {
 	return nil
 }
 

--- a/pkg/generator/webhook/webhook.go
+++ b/pkg/generator/webhook/webhook.go
@@ -31,7 +31,7 @@ type Webhook struct {
 	url string
 }
 
-func (w *Webhook) Generate(ctx context.Context, jsonSpec *apiextensions.JSON, kclient client.Client, ns string) (map[string][]byte, genv1alpha1.GeneratorProviderState, error) {
+func (w *Webhook) Generate(ctx context.Context, jsonSpec *apiextensions.JSON, kclient client.Client, sourceNamespace, _ string) (map[string][]byte, genv1alpha1.GeneratorProviderState, error) {
 	w.wh.EnforceLabels = true
 	w.wh.ClusterScoped = false
 	provider, err := parseSpec(jsonSpec.Raw)
@@ -39,7 +39,7 @@ func (w *Webhook) Generate(ctx context.Context, jsonSpec *apiextensions.JSON, kc
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to parse provider spec: %w", err)
 	}
-	w.wh.Namespace = ns
+	w.wh.Namespace = sourceNamespace
 	w.url = provider.URL
 	w.wh.Kube = kclient
 	w.wh.HTTP, err = w.wh.GetHTTPClient(ctx, provider)
@@ -50,7 +50,7 @@ func (w *Webhook) Generate(ctx context.Context, jsonSpec *apiextensions.JSON, kc
 	return data, nil, err
 }
 
-func (w *Webhook) Cleanup(_ context.Context, jsonSpec *apiextensions.JSON, state genv1alpha1.GeneratorProviderState, _ client.Client, _ string) error {
+func (w *Webhook) Cleanup(_ context.Context, jsonSpec *apiextensions.JSON, state genv1alpha1.GeneratorProviderState, _ client.Client, _, _ string) error {
 	return nil
 }
 

--- a/pkg/generator/webhook/webhook_test.go
+++ b/pkg/generator/webhook/webhook_test.go
@@ -221,7 +221,7 @@ func runTestCase(tc testCase, t *testing.T) {
 }
 
 func testGenerate(tc testCase, t *testing.T, client genv1alpha1.Generator, testStore *apiextensions.JSON) {
-	secretmap, _, err := client.Generate(context.Background(), testStore, nil, "testnamespace")
+	secretmap, _, err := client.Generate(context.Background(), testStore, nil, "testnamespace", "doNotUseDestinationNamespace")
 	errStr := ""
 	if err != nil {
 		errStr = err.Error()


### PR DESCRIPTION
## Problem Statement

`ClusterGenerator` resources can only access credentials in the namespace of their referring `ExternalSecret`.

## Related Issue

[Comments left on the original ClusterGenerator PR](https://github.com/external-secrets/external-secrets/pull/4140#issuecomment-2497667695)

## Proposed Changes

Currently, whenever an `ExternalSecret` references a `ClusterGenerator`, the generators use the namespace of the `ExternalSecret` when looking up in-cluster resources, such as credential secrets. This PR adds a new field to the `ClusterGenerator` CRD, `sourceNamespace`, which tells the generator what namespace should be used when lookup up k8s resources.

This is intended to be backwards compatible and preserves existing behavior. If a `ClusterGenerator` does not have the `sourceNamespace` field set, it will continue to use the `ExternalSecret`'s namepace. The relatively new `GeneratorState` resource also records the source namespace for cleanup, and will default to its own namespace (current behavior) if the value is unset.

### Security impact
Because this now allows cross-namespace access, identities with access to create `ClusterGenerator` resources could exploit the resource to gain access to secrets in namespaces that they wouldn't normally have access to. IMO this is not unreasonable, as many commonly used cluster-scoped resources have similar implications.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
