### PR TITLE
feat: non standard templating delimiters

### DIFF
--- a/pkg/template/v2/template_test.go
+++ b/pkg/template/v2/template_test.go
@@ -150,6 +150,8 @@ func TestExecute(t *testing.T) {
 		expectedStringData  map[string]string
 		expectedLabels      map[string]string
 		expectedAnnotations map[string]string
+		leftDelimiter       string
+		rightDelimiter      string
 		expErr              string
 		expLblErr           string
 		expAnnoErr          string
@@ -488,6 +490,21 @@ func TestExecute(t *testing.T) {
 				"foo": "1234",
 			},
 		},
+		{
+			name: "NonStandardDelimiters",
+			stringDataTpl: map[string][]byte{
+				"foo": []byte("<< .secret | b64dec >>"),
+			},
+			leftDelimiter:  "<<",
+			rightDelimiter: ">>",
+			data: map[string][]byte{
+				"secret": []byte("MTIzNA=="),
+				"env":    []byte("ZGV2"),
+			},
+			expectedStringData: map[string]string{
+				"foo": "1234",
+			},
+		},
 	}
 
 	for i := range tbl {
@@ -497,6 +514,12 @@ func TestExecute(t *testing.T) {
 				Data:       make(map[string][]byte),
 				StringData: make(map[string]string),
 				ObjectMeta: v1.ObjectMeta{Labels: make(map[string]string), Annotations: make(map[string]string)},
+			}
+			if row.leftDelimiter != "" {
+				leftDelim = row.leftDelimiter
+			}
+			if row.rightDelimiter != "" {
+				rightDelim = row.rightDelimiter
 			}
 			err := Execute(row.tpl, row.data, esapi.TemplateScopeValues, esapi.TemplateTargetData, sec)
 			if !ErrorContains(err, row.expErr) {


### PR DESCRIPTION
## Problem Statement

I am tired of issues related to templating conflicts with helm. This addresses that by allowing users to change default templating keys from external-secrets templating engine

## Related Issue

Fixes my sanity
Fixes #4544

## Proposed Changes
* controller level flag for templating delimiters (left and right)
* default values to prevent breaking changes
## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
