### PR TITLE
Clarify the implications of setting refreshInterval to 0

### DIFF
--- a/docs/api/externalsecret.md
+++ b/docs/api/externalsecret.md
@@ -13,9 +13,9 @@ When the controller reconciles the `ExternalSecret` it will use the `spec.templa
 
 ## Update Behavior
 
-The `Kind=Secret` is updated when:
+The `Kind=Secret` is updated when one of the following conditions is met and `spec.refreshInterval` is not `0`:
 
-* the `spec.refreshInterval` has passed and is not `0`
+* the `spec.refreshInterval` has passed
 * the `ExternalSecret`'s `labels` or `annotations` are changed
 * the `ExternalSecret`'s `spec` has been changed
 


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?

The documentation is very clear about when an ExternalSecret is updated, but it differs from the implementation in case 
`spec.refreshInterval` is set to 0. Somewhat surprisingly (to me at least) even setting the annotation from the FAQ `kubectl annotate es my-es force-sync=$(date +%s) --overwrite` is skipped when `spec.refreshInterval` is `0`

This change was introduced with https://github.com/external-secrets/external-secrets/pull/4086 and confirmed in the discussion here https://github.com/external-secrets/external-secrets/issues/3979

## Proposed Changes

If this behaviour is not considered a bug, then the documentation should to mention it explicitly.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
