### PR TITLE
adds Helm value option to disable OpenShift finalizers in RBAC

### DIFF
--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -126,6 +126,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | nameOverride | string | `""` |  |
 | namespaceOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
+| openshiftFinalizers | bool | `true` | If true the OpenShift finalizer permissions will be added to RBAC |
 | podAnnotations | object | `{}` | Annotations to add to Pod |
 | podDisruptionBudget | object | `{"enabled":false,"minAvailable":1}` | Pod disruption budget - for more details see https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
 | podLabels | object | `{}` |  |

--- a/deploy/charts/external-secrets/templates/rbac.yaml
+++ b/deploy/charts/external-secrets/templates/rbac.yaml
@@ -31,22 +31,34 @@ rules:
     resources:
     - "externalsecrets"
     - "externalsecrets/status"
+    {{- if .Values.openshiftFinalizers }}
     - "externalsecrets/finalizers"
+    {{- end }}
     - "secretstores"
     - "secretstores/status"
+    {{- if .Values.openshiftFinalizers }}
     - "secretstores/finalizers"
+    {{- end }}
     - "clustersecretstores"
     - "clustersecretstores/status"
+    {{- if .Values.openshiftFinalizers }}
     - "clustersecretstores/finalizers"
+    {{- end }}
     - "clusterexternalsecrets"
     - "clusterexternalsecrets/status"
+    {{- if .Values.openshiftFinalizers }}
     - "clusterexternalsecrets/finalizers"
+    {{- end }}
     - "pushsecrets"
     - "pushsecrets/status"
+    {{- if .Values.openshiftFinalizers }}
     - "pushsecrets/finalizers"
+    {{- end }}
     - "clusterpushsecrets"
     - "clusterpushsecrets/status"
+    {{- if .Values.openshiftFinalizers }}
     - "clusterpushsecrets/finalizers"
+    {{- end }}
     verbs:
     - "get"
     - "update"

--- a/deploy/charts/external-secrets/values.schema.json
+++ b/deploy/charts/external-secrets/values.schema.json
@@ -434,6 +434,9 @@
             "properties": {},
             "type": "object"
         },
+        "openshiftFinalizers": {
+            "type": "boolean"
+        },
         "podAnnotations": {
             "properties": {},
             "type": "object"

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -78,6 +78,9 @@ scopedNamespace: ""
 # and implicitly disable cluster stores and cluster external secrets
 scopedRBAC: false
 
+# -- If true the OpenShift finalizer permissions will be added to RBAC
+openshiftFinalizers: true
+
 # -- if true, the operator will process cluster external secret. Else, it will ignore them.
 processClusterExternalSecret: true
 


### PR DESCRIPTION
## Problem Statement

Vanilla kubernetes has no API endpoints for `finalizers`. This causes issues in our scoped RBAC deployment.

## Related Issue

Fixes #...

## Proposed Changes

This PR adds an option to disable the finalisers from being included in Role/ClusterRole

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
