### PR TITLE
Exclude unused resources from rbac

### DIFF
--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -126,6 +126,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | nameOverride | string | `""` |  |
 | namespaceOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
+| openshiftFinalizers | bool | `true` | If true the OpenShift finalizer permissions will be added to RBAC |
 | podAnnotations | object | `{}` | Annotations to add to Pod |
 | podDisruptionBudget | object | `{"enabled":false,"minAvailable":1}` | Pod disruption budget - for more details see https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
 | podLabels | object | `{}` |  |

--- a/deploy/charts/external-secrets/templates/rbac.yaml
+++ b/deploy/charts/external-secrets/templates/rbac.yaml
@@ -31,22 +31,34 @@ rules:
     resources:
     - "externalsecrets"
     - "externalsecrets/status"
+    {{- if .Values.openshiftFinalizers }}
     - "externalsecrets/finalizers"
+    {{- end }}
     - "secretstores"
     - "secretstores/status"
+    {{- if .Values.openshiftFinalizers }}
     - "secretstores/finalizers"
+    {{- end }}
     - "clustersecretstores"
     - "clustersecretstores/status"
+    {{- if .Values.openshiftFinalizers }}
     - "clustersecretstores/finalizers"
+    {{- end }}
     - "clusterexternalsecrets"
     - "clusterexternalsecrets/status"
+    {{- if .Values.openshiftFinalizers }}
     - "clusterexternalsecrets/finalizers"
+    {{- end }}
     - "pushsecrets"
     - "pushsecrets/status"
+    {{- if .Values.openshiftFinalizers }}
     - "pushsecrets/finalizers"
+    {{- end }}
     - "clusterpushsecrets"
     - "clusterpushsecrets/status"
+    {{- if .Values.openshiftFinalizers }}
     - "clusterpushsecrets/finalizers"
+    {{- end }}
     verbs:
     - "get"
     - "update"

--- a/deploy/charts/external-secrets/templates/rbac.yaml
+++ b/deploy/charts/external-secrets/templates/rbac.yaml
@@ -17,11 +17,19 @@ rules:
     - "external-secrets.io"
     resources:
     - "secretstores"
+    {{- if .Values.processClusterStore }}
     - "clustersecretstores"
+    {{- end }}
     - "externalsecrets"
+    {{- if .Values.processClusterExternalSecret }}
     - "clusterexternalsecrets"
+    {{- end }}
+    {{- if .Values.processPushSecret }}
     - "pushsecrets"
+    {{- end }}
+    {{- if .Values.processClusterPushSecret }}
     - "clusterpushsecrets"
+    {{- end }}
     verbs:
     - "get"
     - "list"
@@ -39,25 +47,33 @@ rules:
     {{- if .Values.openshiftFinalizers }}
     - "secretstores/finalizers"
     {{- end }}
+    {{- if .Values.processClusterStore }}
     - "clustersecretstores"
     - "clustersecretstores/status"
     {{- if .Values.openshiftFinalizers }}
     - "clustersecretstores/finalizers"
     {{- end }}
+    {{- end }}
+    {{- if .Values.processClusterExternalSecret }}
     - "clusterexternalsecrets"
     - "clusterexternalsecrets/status"
     {{- if .Values.openshiftFinalizers }}
     - "clusterexternalsecrets/finalizers"
     {{- end }}
+    {{- end }}
+    {{- if .Values.processPushSecret }}
     - "pushsecrets"
     - "pushsecrets/status"
     {{- if .Values.openshiftFinalizers }}
     - "pushsecrets/finalizers"
     {{- end }}
+    {{- end }}
+    {{- if .Values.processClusterPushSecret }}
     - "clusterpushsecrets"
     - "clusterpushsecrets/status"
     {{- if .Values.openshiftFinalizers }}
     - "clusterpushsecrets/finalizers"
+    {{- end }}
     {{- end }}
     verbs:
     - "get"
@@ -146,6 +162,7 @@ rules:
     - "create"
     - "update"
     - "delete"
+  {{- if .Values.processPushSecret }}
   - apiGroups:
     - "external-secrets.io"
     resources:
@@ -154,6 +171,7 @@ rules:
     - "create"
     - "update"
     - "delete"
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if and .Values.scopedNamespace .Values.scopedRBAC }}
@@ -177,9 +195,15 @@ rules:
     resources:
       - "externalsecrets"
       - "secretstores"
+      {{- if .Values.processClusterStore }}
       - "clustersecretstores"
+      {{- end }}
+      {{- if .Values.processPushSecret }}
       - "pushsecrets"
+      {{- end }}
+      {{- if .Values.processClusterPushSecret }}
       - "clusterpushsecrets"
+      {{- end }}
     verbs:
       - "get"
       - "watch"
@@ -225,9 +249,15 @@ rules:
     resources:
       - "externalsecrets"
       - "secretstores"
+      {{- if .Values.processClusterStore }}
       - "clustersecretstores"
+      {{- end }}
+      {{- if .Values.processPushSecret }}
       - "pushsecrets"
+      {{- end }}
+      {{- if .Values.processClusterPushSecret }}
       - "clusterpushsecrets"
+      {{- end }}
     verbs:
       - "create"
       - "delete"
@@ -345,7 +375,9 @@ rules:
     - "external-secrets.io"
     resources:
     - "externalsecrets"
+    {{- if .Values.processPushSecret }}
     - "pushsecrets"
+    {{- end }}
     verbs:
     - "get"
     - "list"

--- a/deploy/charts/external-secrets/values.schema.json
+++ b/deploy/charts/external-secrets/values.schema.json
@@ -434,6 +434,9 @@
             "properties": {},
             "type": "object"
         },
+        "openshiftFinalizers": {
+            "type": "boolean"
+        },
         "podAnnotations": {
             "properties": {},
             "type": "object"

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -78,6 +78,9 @@ scopedNamespace: ""
 # and implicitly disable cluster stores and cluster external secrets
 scopedRBAC: false
 
+# -- If true the OpenShift finalizer permissions will be added to RBAC
+openshiftFinalizers: true
+
 # -- if true, the operator will process cluster external secret. Else, it will ignore them.
 processClusterExternalSecret: true
 


### PR DESCRIPTION
> [!WARNING]
> This PR is based on #4570

## Problem Statement

The current Helm chart assigns resources in the RBAC definition even if they are not used by the controller

## Proposed Changes

Based on the configuration, even if (for example) `processClusterExternalSecret` is set to `false` the controller is assigned permissions to manage ClusterExternalSecret resources. This is highly undesired in clusters with multiple installed ES instances.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
