### PR TITLE
docs: typo fix in api/generator/quay.md

### DIFF
--- a/docs/api/generator/quay.md
+++ b/docs/api/generator/quay.md
@@ -10,7 +10,7 @@
 
 ## Authentication
 
-To configure Robot Account federation, your cluster must have a publicly available [OIDC service account issuer](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-issuer-discovery) endpoint for Quay to validate tokens against against. You can determine the issuer and subject fields by creating and decoding a service account token for the service account you wish to federate with (this is the service account you will use in `spec.serviceAccountRef`). For example, if federating with the `default` service account in the `default` namespace:
+To configure Robot Account federation, your cluster must have a publicly available [OIDC service account issuer](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-issuer-discovery) endpoint for Quay to validate tokens against. You can determine the issuer and subject fields by creating and decoding a service account token for the service account you wish to federate with (this is the service account you will use in `spec.serviceAccountRef`). For example, if federating with the `default` service account in the `default` namespace:
 
 Obtain issuer:
 


### PR DESCRIPTION
## Problem Statement

repeated word `against` typo fix in docs.

## Related Issue

n/a

## Proposed Changes

per PR resolve typo.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [n/a] My changes have reasonable test coverage
- [n/a] All tests pass with `make test`
- [n/a] I ensured my PR is ready for review with `make reviewable`
