### PR TITLE
remove days from refreshInterval docs

### DIFF
--- a/apis/externalsecrets/v1beta1/externalsecret_types.go
+++ b/apis/externalsecrets/v1beta1/externalsecret_types.go
@@ -372,7 +372,7 @@ type ExternalSecretSpec struct {
 	// RefreshInterval is the amount of time before the values are read again from the SecretStore provider,
 	// specified as Golang Duration strings.
 	// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
-	// Example values: "1h", "2h30m", "5d", "10s"
+	// Example values: "1h", "2h30m", "10s"
 	// May be set to zero to fetch and create it once. Defaults to 1h.
 	// +kubebuilder:default="1h"
 	RefreshInterval *metav1.Duration `json:"refreshInterval,omitempty"`

--- a/config/crds/bases/external-secrets.io_clusterexternalsecrets.yaml
+++ b/config/crds/bases/external-secrets.io_clusterexternalsecrets.yaml
@@ -408,7 +408,7 @@ spec:
                       RefreshInterval is the amount of time before the values are read again from the SecretStore provider,
                       specified as Golang Duration strings.
                       Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
-                      Example values: "1h", "2h30m", "5d", "10s"
+                      Example values: "1h", "2h30m", "10s"
                       May be set to zero to fetch and create it once. Defaults to 1h.
                     type: string
                   secretStoreRef:

--- a/config/crds/bases/external-secrets.io_externalsecrets.yaml
+++ b/config/crds/bases/external-secrets.io_externalsecrets.yaml
@@ -703,7 +703,7 @@ spec:
                   RefreshInterval is the amount of time before the values are read again from the SecretStore provider,
                   specified as Golang Duration strings.
                   Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
-                  Example values: "1h", "2h30m", "5d", "10s"
+                  Example values: "1h", "2h30m", "10s"
                   May be set to zero to fetch and create it once. Defaults to 1h.
                 type: string
               secretStoreRef:

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -388,7 +388,7 @@ spec:
                         RefreshInterval is the amount of time before the values are read again from the SecretStore provider,
                         specified as Golang Duration strings.
                         Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
-                        Example values: "1h", "2h30m", "5d", "10s"
+                        Example values: "1h", "2h30m", "10s"
                         May be set to zero to fetch and create it once. Defaults to 1h.
                       type: string
                     secretStoreRef:
@@ -7868,7 +7868,7 @@ spec:
                     RefreshInterval is the amount of time before the values are read again from the SecretStore provider,
                     specified as Golang Duration strings.
                     Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
-                    Example values: "1h", "2h30m", "5d", "10s"
+                    Example values: "1h", "2h30m", "10s"
                     May be set to zero to fetch and create it once. Defaults to 1h.
                   type: string
                 secretStoreRef:

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -3154,7 +3154,7 @@ Kubernetes meta/v1.Duration
 <p>RefreshInterval is the amount of time before the values are read again from the SecretStore provider,
 specified as Golang Duration strings.
 Valid time units are &ldquo;ns&rdquo;, &ldquo;us&rdquo; (or &ldquo;µs&rdquo;), &ldquo;ms&rdquo;, &ldquo;s&rdquo;, &ldquo;m&rdquo;, &ldquo;h&rdquo;
-Example values: &ldquo;1h&rdquo;, &ldquo;2h30m&rdquo;, &ldquo;5d&rdquo;, &ldquo;10s&rdquo;
+Example values: &ldquo;1h&rdquo;, &ldquo;2h30m&rdquo;, &ldquo;10s&rdquo;
 May be set to zero to fetch and create it once. Defaults to 1h.</p>
 </td>
 </tr>
@@ -3896,7 +3896,7 @@ Kubernetes meta/v1.Duration
 <p>RefreshInterval is the amount of time before the values are read again from the SecretStore provider,
 specified as Golang Duration strings.
 Valid time units are &ldquo;ns&rdquo;, &ldquo;us&rdquo; (or &ldquo;µs&rdquo;), &ldquo;ms&rdquo;, &ldquo;s&rdquo;, &ldquo;m&rdquo;, &ldquo;h&rdquo;
-Example values: &ldquo;1h&rdquo;, &ldquo;2h30m&rdquo;, &ldquo;5d&rdquo;, &ldquo;10s&rdquo;
+Example values: &ldquo;1h&rdquo;, &ldquo;2h30m&rdquo;, &ldquo;10s&rdquo;
 May be set to zero to fetch and create it once. Defaults to 1h.</p>
 </td>
 </tr>


### PR DESCRIPTION
removing "5d" from refreshInvterval as is not supported by go's time.Duration parser.

## Problem Statement

Typo in docs saying giving an example of 5d as an allowed value for refreshInterval. But go's time.Duration parser does not support days.
![image](https://github.com/user-attachments/assets/6dcdbad4-9c41-440e-a6e7-d528d6ba7f6d)

## Related Issue

Fixes #4426 update docs: refreshInterval can not be set to days

## Proposed Changes

Removed "5d", from docs/api/spec.md https://external-secrets.io/latest/api/spec/

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
