### PR TITLE
docs: fix pento website url in the docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 [![cs-logo](./pictures/cs_logo.png)](https://container-solutions.com)
 [![External Secrets inc.](./pictures/ESI_Logo.svg)](https://externalsecrets.com)
 [![Form3](./pictures/form3_logo.png)](https://www.form3.tech/)
-[![Pento](./pictures/pento_logo.png)](https://pento.io)
+[![Pento](./pictures/pento_logo.png)](https://www.pento.io)
 
 # Introduction
 


### PR DESCRIPTION
## Problem Statement

The current URL resolves to a 404 page.

<img width="747" alt="Screenshot 2025-04-10 at 10 31 46 PM" src="https://github.com/user-attachments/assets/52a577d1-58c8-433f-824a-124fadb36f03" />

## Proposed Changes

Fixing URL. New page: https://www.pento.io

<img width="1629" alt="Screenshot 2025-04-10 at 10 32 30 PM" src="https://github.com/user-attachments/assets/41aa8bc3-a914-43c7-91f9-c0b447009976" />


## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
