### PR TITLE
fix: remove crds from bundle

### DIFF
--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -1454,15 +1454,7 @@ spec:
       subresources:
         status: {}
   conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions:
-        - v1
-      clientConfig:
-        service:
-          name: kubernetes
-          namespace: default
-          path: /convert
+    strategy: None
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1980,15 +1972,7 @@ spec:
       subresources:
         status: {}
   conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions:
-        - v1
-      clientConfig:
-        service:
-          name: kubernetes
-          namespace: default
-          path: /convert
+    strategy: None
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -10156,15 +10140,7 @@ spec:
       subresources:
         status: {}
   conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions:
-        - v1
-      clientConfig:
-        service:
-          name: kubernetes
-          namespace: default
-          path: /convert
+    strategy: None
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -11374,15 +11350,7 @@ spec:
       subresources:
         status: {}
   conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions:
-        - v1
-      clientConfig:
-        service:
-          name: kubernetes
-          namespace: default
-          path: /convert
+    strategy: None
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -11858,15 +11826,7 @@ spec:
       subresources:
         status: {}
   conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions:
-        - v1
-      clientConfig:
-        service:
-          name: kubernetes
-          namespace: default
-          path: /convert
+    strategy: None
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -20034,15 +19994,7 @@ spec:
       subresources:
         status: {}
   conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions:
-        - v1
-      clientConfig:
-        service:
-          name: kubernetes
-          namespace: default
-          path: /convert
+    strategy: None
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -20251,15 +20203,7 @@ spec:
       subresources:
         status: {}
   conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions:
-        - v1
-      clientConfig:
-        service:
-          name: kubernetes
-          namespace: default
-          path: /convert
+    strategy: None
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -22022,15 +21966,7 @@ spec:
       subresources:
         status: {}
   conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions:
-        - v1
-      clientConfig:
-        service:
-          name: kubernetes
-          namespace: default
-          path: /convert
+    strategy: None
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -22227,15 +22163,7 @@ spec:
       subresources:
         status: {}
   conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions:
-        - v1
-      clientConfig:
-        service:
-          name: kubernetes
-          namespace: default
-          path: /convert
+    strategy: None
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -22303,15 +22231,7 @@ spec:
       subresources:
         status: {}
   conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions:
-        - v1
-      clientConfig:
-        service:
-          name: kubernetes
-          namespace: default
-          path: /convert
+    strategy: None
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -22446,15 +22366,7 @@ spec:
       subresources:
         status: {}
   conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions:
-        - v1
-      clientConfig:
-        service:
-          name: kubernetes
-          namespace: default
-          path: /convert
+    strategy: None
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -22559,15 +22471,7 @@ spec:
       storage: true
       subresources: {}
   conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions:
-        - v1
-      clientConfig:
-        service:
-          name: kubernetes
-          namespace: default
-          path: /convert
+    strategy: None
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -22682,15 +22586,7 @@ spec:
       subresources:
         status: {}
   conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions:
-        - v1
-      clientConfig:
-        service:
-          name: kubernetes
-          namespace: default
-          path: /convert
+    strategy: None
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -22824,15 +22720,7 @@ spec:
       subresources:
         status: {}
   conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions:
-        - v1
-      clientConfig:
-        service:
-          name: kubernetes
-          namespace: default
-          path: /convert
+    strategy: None
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -22922,15 +22810,7 @@ spec:
       subresources:
         status: {}
   conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions:
-        - v1
-      clientConfig:
-        service:
-          name: kubernetes
-          namespace: default
-          path: /convert
+    strategy: None
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -23020,15 +22900,7 @@ spec:
       subresources:
         status: {}
   conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions:
-        - v1
-      clientConfig:
-        service:
-          name: kubernetes
-          namespace: default
-          path: /convert
+    strategy: None
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -23239,15 +23111,7 @@ spec:
       subresources:
         status: {}
   conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions:
-        - v1
-      clientConfig:
-        service:
-          name: kubernetes
-          namespace: default
-          path: /convert
+    strategy: None
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -23300,15 +23164,7 @@ spec:
       subresources:
         status: {}
   conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions:
-        - v1
-      clientConfig:
-        service:
-          name: kubernetes
-          namespace: default
-          path: /convert
+    strategy: None
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -24164,15 +24020,7 @@ spec:
       subresources:
         status: {}
   conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions:
-        - v1
-      clientConfig:
-        service:
-          name: kubernetes
-          namespace: default
-          path: /convert
+    strategy: None
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -24326,12 +24174,4 @@ spec:
       subresources:
         status: {}
   conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions:
-        - v1
-      clientConfig:
-        service:
-          name: kubernetes
-          namespace: default
-          path: /convert
+    strategy: None

--- a/hack/crd.generate.sh
+++ b/hack/crd.generate.sh
@@ -34,5 +34,5 @@ done
 
 shopt -s extglob
 yq e \
-    '.spec.conversion.strategy = "Webhook" | .spec.conversion.webhook.conversionReviewVersions = ["v1"] | .spec.conversion.webhook.clientConfig.service.name = "kubernetes" | .spec.conversion.webhook.clientConfig.service.namespace = "default" |	.spec.conversion.webhook.clientConfig.service.path = "/convert"' \
+    '.spec.conversion.strategy = "None"' \
     "${CRD_DIR}"/bases/!(kustomization).yaml > "${BUNDLE_YAML}"


### PR DESCRIPTION
This should fix some of the issues in #4662  - users that are installing crds with `kubectl apply -f` or `kustomize` are always adding crds with conversion enabled.