### PR TITLE
fix: conversion setting on bundle crds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ ARCH ?= amd64 arm64 ppc64le
 BUILD_ARGS ?= CGO_ENABLED=0
 DOCKER_BUILD_ARGS ?=
 DOCKERFILE ?= Dockerfile
-
+DOCKER ?= docker
 # default target is build
 .DEFAULT_GOAL := all
 .PHONY: all
@@ -179,7 +179,7 @@ tilt-up: tilt manifests ## Generates the local manifests that tilt will use to d
 
 helm.docs: ## Generate helm docs
 	@cd $(HELM_DIR); \
-	docker run --rm -v $(shell pwd)/$(HELM_DIR):/helm-docs -u $(shell id -u) docker.io/jnorwood/helm-docs:v1.7.0
+	$(DOCKER) run --rm -v $(shell pwd)/$(HELM_DIR):/helm-docs -u $(shell id -u) docker.io/jnorwood/helm-docs:v1.7.0
 
 HELM_VERSION ?= $(shell helm show chart $(HELM_DIR) | grep 'version:' | sed 's/version: //g')
 
@@ -253,16 +253,16 @@ docker.tag:  ## Emit IMAGE_TAG
 
 .PHONY: docker.build
 docker.build: $(addprefix build-,$(ARCH)) ## Build the docker image
-	@$(INFO) docker build
-	echo docker build -f $(DOCKERFILE) . $(DOCKER_BUILD_ARGS) -t $(IMAGE_NAME):$(IMAGE_TAG)
-	DOCKER_BUILDKIT=1 docker build -f $(DOCKERFILE) . $(DOCKER_BUILD_ARGS) -t $(IMAGE_NAME):$(IMAGE_TAG)
-	@$(OK) docker build
+	@$(INFO) $(DOCKER) build
+	echo $(DOCKER) build -f $(DOCKERFILE) . $(DOCKER_BUILD_ARGS) -t $(IMAGE_NAME):$(IMAGE_TAG)
+	DOCKER_BUILDKIT=1 $(DOCKER) build -f $(DOCKERFILE) . $(DOCKER_BUILD_ARGS) -t $(IMAGE_NAME):$(IMAGE_TAG)
+	@$(OK) $(DOCKER) build
 
 .PHONY: docker.push
 docker.push: ## Push the docker image to the registry
-	@$(INFO) docker push
-	@docker push $(IMAGE_NAME):$(IMAGE_TAG)
-	@$(OK) docker push
+	@$(INFO) $(DOCKER) push
+	@$(DOCKER) push $(IMAGE_NAME):$(IMAGE_TAG)
+	@$(OK) $(DOCKER) push
 
 # RELEASE_TAG is tag to promote. Default is promoting to main branch, but can be overriden
 # to promote a tag to a specific version.
@@ -272,14 +272,14 @@ SOURCE_TAG ?= $(VERSION)$(TAG_SUFFIX)
 .PHONY: docker.promote
 docker.promote: ## Promote the docker image to the registry
 	@$(INFO) promoting $(SOURCE_TAG) to $(RELEASE_TAG)
-	docker manifest inspect --verbose $(IMAGE_NAME):$(SOURCE_TAG) > .tagmanifest
+	$(DOCKER) manifest inspect --verbose $(IMAGE_NAME):$(SOURCE_TAG) > .tagmanifest
 	for digest in $$(jq -r 'if type=="array" then .[].Descriptor.digest else .Descriptor.digest end' < .tagmanifest); do \
-		docker pull $(IMAGE_NAME)@$$digest; \
+		$(DOCKER) pull $(IMAGE_NAME)@$$digest; \
 	done
-	docker manifest create $(IMAGE_NAME):$(RELEASE_TAG) \
+	$(DOCKER) manifest create $(IMAGE_NAME):$(RELEASE_TAG) \
 		$$(jq -j '"--amend $(IMAGE_NAME)@" + if type=="array" then .[].Descriptor.digest else .Descriptor.digest end + " "' < .tagmanifest)
-	docker manifest push $(IMAGE_NAME):$(RELEASE_TAG)
-	@$(OK) docker push $(RELEASE_TAG) \
+	$(DOCKER) manifest push $(IMAGE_NAME):$(RELEASE_TAG)
+	@$(OK) $(DOCKER) push $(RELEASE_TAG) \
 
 # ====================================================================================
 # Terraform

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -1453,8 +1453,7 @@ spec:
       storage: false
       subresources:
         status: {}
-  conversion:
-    strategy: None
+  conversion: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1971,8 +1970,7 @@ spec:
       storage: true
       subresources:
         status: {}
-  conversion:
-    strategy: None
+  conversion: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -10139,8 +10137,7 @@ spec:
       storage: false
       subresources:
         status: {}
-  conversion:
-    strategy: None
+  conversion: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -11349,8 +11346,7 @@ spec:
       storage: false
       subresources:
         status: {}
-  conversion:
-    strategy: None
+  conversion: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -11825,8 +11821,7 @@ spec:
       storage: true
       subresources:
         status: {}
-  conversion:
-    strategy: None
+  conversion: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -19993,8 +19988,7 @@ spec:
       storage: false
       subresources:
         status: {}
-  conversion:
-    strategy: None
+  conversion: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -20202,8 +20196,7 @@ spec:
       storage: true
       subresources:
         status: {}
-  conversion:
-    strategy: None
+  conversion: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -21965,8 +21958,7 @@ spec:
       storage: true
       subresources:
         status: {}
-  conversion:
-    strategy: None
+  conversion: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -22162,8 +22154,7 @@ spec:
       storage: true
       subresources:
         status: {}
-  conversion:
-    strategy: None
+  conversion: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -22230,8 +22221,7 @@ spec:
       storage: true
       subresources:
         status: {}
-  conversion:
-    strategy: None
+  conversion: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -22365,8 +22355,7 @@ spec:
       storage: true
       subresources:
         status: {}
-  conversion:
-    strategy: None
+  conversion: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -22470,8 +22459,7 @@ spec:
       served: true
       storage: true
       subresources: {}
-  conversion:
-    strategy: None
+  conversion: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -22585,8 +22573,7 @@ spec:
       storage: true
       subresources:
         status: {}
-  conversion:
-    strategy: None
+  conversion: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -22719,8 +22706,7 @@ spec:
       storage: true
       subresources:
         status: {}
-  conversion:
-    strategy: None
+  conversion: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -22809,8 +22795,7 @@ spec:
       storage: true
       subresources:
         status: {}
-  conversion:
-    strategy: None
+  conversion: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -22899,8 +22884,7 @@ spec:
       storage: true
       subresources:
         status: {}
-  conversion:
-    strategy: None
+  conversion: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -23110,8 +23094,7 @@ spec:
       storage: true
       subresources:
         status: {}
-  conversion:
-    strategy: None
+  conversion: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -23163,8 +23146,7 @@ spec:
       storage: true
       subresources:
         status: {}
-  conversion:
-    strategy: None
+  conversion: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -24019,8 +24001,7 @@ spec:
       storage: true
       subresources:
         status: {}
-  conversion:
-    strategy: None
+  conversion: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -24173,5 +24154,4 @@ spec:
       storage: true
       subresources:
         status: {}
-  conversion:
-    strategy: None
+  conversion: {}

--- a/hack/crd.generate.sh
+++ b/hack/crd.generate.sh
@@ -34,5 +34,5 @@ done
 
 shopt -s extglob
 yq e \
-    '.spec.conversion.strategy = "None"' \
+    '.spec.conversion = {}' \
     "${CRD_DIR}"/bases/!(kustomization).yaml > "${BUNDLE_YAML}"


### PR DESCRIPTION
when users specify `kubectl apply -f`, they need to have `spec.conversion: {}` explicitly. While, with a `helm upgrade`, they need to have no `conversion` set for helm to upgrade the manifest.

With helm, the error is:
```
 Required value && cannot patch "webhooks.generators.external-secrets.io" with kind CustomResourceDefinition: CustomResourceDefinition.apiextensions.k8s.io "webhooks.generators.external-secrets.io" is invalid: spec.conversion.strategy: Required value
 ```
 
While with kubectl apply (regardless if server side or client side), the error is:
```
for: "deploy/crds/bundle.yaml": error when patching "deploy/crds/bundle.yaml": CustomResourceDefinition.apiextensions.k8s.io "webhooks.generators.external-secrets.io" is invalid: [spec.conversion.webhookClientConfig: Forbidden: should not be set when strategy is not set to Webhook, spec.conversion.conversionReviewVersions: Forbidden: should not be set when strategy is not set to Webhook]
```

I think this covers most of the ways people would apply this patch, so the proposal here is to fix the bundle so that `kubectl apply` works, and opt out (we already did) helm charts from it.


I also did a lot of fixes to Makefile now that I am using `nerdctl` instead of `docker`