### PR TITLE
Update md5 hashing algorithim to sha3

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -17,7 +17,7 @@ package utils
 import (
 	"bytes"
 	"context"
-	"crypto/md5" //nolint:gosec
+	"crypto/sha3"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
@@ -358,12 +358,10 @@ func IsNil(i any) bool {
 	return false
 }
 
-// ObjectHash calculates md5 sum of the data contained in the secret.
-//
-//nolint:gosec
+// ObjectHash calculates sha3 sum of the data contained in the secret.
 func ObjectHash(object any) string {
 	textualVersion := fmt.Sprintf("%+v", object)
-	return fmt.Sprintf("%x", md5.Sum([]byte(textualVersion)))
+	return fmt.Sprintf("%x", sha3.Sum224([]byte(textualVersion)))
 }
 
 func ErrorContains(out error, want string) bool {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -51,19 +51,19 @@ func TestObjectHash(t *testing.T) {
 		{
 			name:  "A nil should be still working",
 			input: nil,
-			want:  "60046f14c917c18a9a0f923e191ba0dc",
+			want:  "c461202a18e99215f121936fb2452e03843828e448a00a53f285a6fc",
 		},
 		{
 			name:  "We accept a simple scalar value, i.e. string",
 			input: "hello there",
-			want:  "161bc25962da8fed6d2f59922fb642aa",
+			want:  "f78681ec611ebaeea0689bff6c7812a83ff98a7faba986d9af76c999",
 		},
 		{
 			name: "A complex object like a secret is not an issue",
 			input: v1.Secret{Data: map[string][]byte{
 				"xx": []byte("yyy"),
 			}},
-			want: "85eabdeb376371ffc5a658d7a162eba8",
+			want: "9c717e13e4281db3cdad3f56c6e7faab1d7029c4b4fbbf12fbec9b1e",
 		},
 		{
 			name: "map also works",
@@ -71,7 +71,7 @@ func TestObjectHash(t *testing.T) {
 				"foo": []byte("value1"),
 				"bar": []byte("value2"),
 			},
-			want: "caa0155759a6a9b3b6ada5a6883ee2bb",
+			want: "1bed8bcbcb4547ffe19a19cd47d9078e84aa6598266d86b99f992d64",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Problem Statement

MD5 is an outdated algorithm that is no longer considered secure due to its vulnerabilities, which can compromise the reliability of data verification. This is specifically relevant in terms of NIST requirements for FIPS but also the industry at large has been moving away from MD5 for years. 

## Proposed Changes
Switching the hashing algorithm to SHA3 provides a modern algorithm that meets current and future industry requirements. 

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] My changes have reasonable test coverage
- [X] All tests pass with `make test`
- [X] I ensured my PR is ready for review with `make reviewable`
