### PR TITLE
Cache separate vault clients for each namespace if necessary

### DIFF
--- a/pkg/provider/vault/auth_test.go
+++ b/pkg/provider/vault/auth_test.go
@@ -137,7 +137,7 @@ func TestSetAuthNamespace(t *testing.T) {
 				t.Error(err.Error())
 			}
 
-			client, err := getVaultClient(prov, tc.args.store, cfg)
+			client, err := getVaultClient(prov, tc.args.store, cfg, "default")
 			if err != nil {
 				t.Errorf("vault.useAuthNamespace: failed to create client: %s", err.Error())
 			}

--- a/pkg/provider/vault/client_push.go
+++ b/pkg/provider/vault/client_push.go
@@ -90,9 +90,6 @@ func (c *client) PushSecret(ctx context.Context, secret *corev1.Secret, data esv
 		return fmt.Errorf("error encoding vault secret: %w", err)
 	}
 	vaultSecretValue := bytes.TrimSpace(buf.Bytes())
-	if err != nil {
-		return fmt.Errorf("error marshaling vault secret: %w", err)
-	}
 	if bytes.Equal(vaultSecretValue, value) {
 		return nil
 	}

--- a/pkg/provider/vault/provider_test.go
+++ b/pkg/provider/vault/provider_test.go
@@ -798,4 +798,5 @@ func TestCacheWithReferentSpec(t *testing.T) {
 
 func resetCache() {
 	enableCache = false
+	clientCache = nil
 }

--- a/pkg/provider/vault/provider_test.go
+++ b/pkg/provider/vault/provider_test.go
@@ -707,3 +707,95 @@ func vaultTest(t *testing.T, _ string, tc testCase) {
 		t.Errorf("\n%s\nvault.New(...): -want error, +got error:\n%s", tc.reason, diff)
 	}
 }
+
+func TestCache(t *testing.T) {
+	t.Cleanup(resetCache)
+	enableCache = true
+	initCache(defaultCacheSize)
+
+	prov := &Provider{
+		NewVaultClient: fake.ClientWithLoginMock,
+	}
+
+	namespace := "default"
+
+	store := makeClusterSecretStore(func(s *esv1.SecretStore) {
+		s.Spec.Provider.Vault.Auth.Kubernetes.ServiceAccountRef = &esmeta.ServiceAccountSelector{
+			Name:      "vault-sa",
+			Namespace: &namespace, // fixed namespace!
+		}
+	})
+
+	// first request creates a new client:
+	c1, err := getVaultClient(prov, store, nil, namespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// seconds request should retrieve cached client instance:
+	c2, err := getVaultClient(prov, store, nil, namespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if c1 != c2 {
+		t.Fatal("Expected a cached client instance")
+	}
+
+	// third request should retrieve cached client instance even when using a different namespace,
+	// because the ClusterSecretStore references a ServiceAccount of a specific namespace:
+	c3, err := getVaultClient(prov, store, nil, "another-namespace")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c3 != c1 {
+		t.Fatal("Expected a cached client instance")
+	}
+}
+
+func TestCacheWithReferentSpec(t *testing.T) {
+	t.Cleanup(resetCache)
+	enableCache = true
+	initCache(defaultCacheSize)
+
+	prov := &Provider{
+		NewVaultClient: fake.ClientWithLoginMock,
+	}
+
+	store := makeClusterSecretStore(func(s *esv1.SecretStore) {
+		s.Spec.Provider.Vault.Auth.Kubernetes.ServiceAccountRef = &esmeta.ServiceAccountSelector{
+			Name: "vault-sa",
+			// No fixed namespace!
+		}
+	})
+
+	// first request creates a new client:
+	c1, err := getVaultClient(prov, store, nil, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// seconds request should retrieve cached client instance:
+	c2, err := getVaultClient(prov, store, nil, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if c1 != c2 {
+		t.Fatal("Expected a cached client instance")
+	}
+
+	// third request should retrieve a new client instance,
+	// because the ServiceAccount namespace depends on the namespace of the referent:
+	c3, err := getVaultClient(prov, store, nil, "another-namespace")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c3 == c1 {
+		t.Fatal("Expected a new client instance")
+	}
+}
+
+func resetCache() {
+	enableCache = false
+}


### PR DESCRIPTION
## Problem Statement

When enabling `--experimental-enable-vault-token-cache` I encountered persisting 403 status errors when connecting to our Vault server. Please read the thread starting at https://github.com/external-secrets/external-secrets/discussions/3132#discussioncomment-12605322 to catch up with the discussion around this issue.

While debugging this, I realized that this issue only appears when using a ClusterSecretStore that references a namespaced auth-token where the namespace is not fixed, like this:

```yaml
      auth:
        jwt:
          path: jwt-kube
          role: eso-default
          kubernetesServiceAccountToken:
            serviceAccountRef:
              name: default  # Every namespace has its own default service-account
```

^ Note that the `serviceAccountRef` does not state a fixed `namespace`. The namespace of the `default` service account is decided later, based on the namespace of the `ExternalSecret` that uses this `ClusterSecretStore`.

When configuring it like this, ESO will currently generate the **same** cache key for every namespace, because it currently uses the namespace of the `ClusterSecretStore` (which is obviously always the empty string), even though the auth-token needs to be different for every namespace that contains ExternalSecrets.

Thanks to @gusfcarvalho who encouraged me to create this PR.


## Related Issue

No issue yet. See the linked discussion above. Please let be know if you absolutely need an issue for tracking this PR.

## Proposed Changes

In `pkg/provider/vault/provider.go` I found the existing function `isReferentSpec` that I *think* does exactly what I needed to fix this: This function seems to return "true" in cases where the configured vault-auth is referencing an auth-token that is based on the namespace of the referencing ExternalSecret. 

If this function returns true, I just use namespace of the requesting ExternalSecret object as part of the cache-key.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
