### PR TITLE
fix: ClusterExternalSecrets were not able to adopt externalSecret after update to v1

### DIFF
--- a/pkg/controllers/clusterexternalsecret/clusterexternalsecret_controller.go
+++ b/pkg/controllers/clusterexternalsecret/clusterexternalsecret_controller.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -278,7 +279,7 @@ func (r *Reconciler) deleteOutdatedExternalSecrets(ctx context.Context, namespac
 
 func isExternalSecretOwnedBy(es *esv1.ExternalSecret, cesName string) bool {
 	owner := metav1.GetControllerOf(es)
-	return owner != nil && owner.APIVersion == esv1.SchemeGroupVersion.String() && owner.Kind == esv1.ClusterExtSecretKind && owner.Name == cesName
+	return owner != nil && schema.FromAPIVersionAndKind(owner.APIVersion, owner.Kind).GroupKind().String() == esv1.ClusterExtSecretGroupKind && owner.Name == cesName
 }
 
 func getRemovedNamespaces(currentNSs []v1.Namespace, provisionedNSs []string) []string {


### PR DESCRIPTION

## Problem Statement

When checking if an ExternalSecret is owned by a ClusterExternalSecret, the full apiversion is used. When migrating from v1beta1 to v1, the controller behave as is the ExternalSecret is no longer owned and won't update it.

## Related Issue

Fixes #4708

## Proposed Changes

Instead of comparing the `apiVersion` field of the owner, we use `GroupKind` like it's done in the `ExternalSecrets`'s controller.

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] My changes have reasonable test coverage
- [X] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
