### PR TITLE
Doppler provider: Add etag caching support

### DIFF
--- a/pkg/provider/doppler/client.go
+++ b/pkg/provider/doppler/client.go
@@ -58,6 +58,7 @@ type Client struct {
 	store     *esv1.DopplerProvider
 	namespace string
 	storeKind string
+	cache     map[string]*dClient.CacheEntry
 }
 
 // SecretsClientInterface defines the required Doppler Client methods.


### PR DESCRIPTION
## Problem Statement

The Doppler provider makes a massive number of requests and none of them were using Doppler's etag caching mechanism. Additionally, ExternalSecrets with multiple secrets that generated individual secret fetches resulted in an unnecessarily large number of requests.

## Proposed Changes

Start sending the last known etag when fetching secrets and use a cached response if the etag hasn't changed. Additionally, don't perform requests if we last made one less than `minRefreshInterval` seconds ago. This should significantly reduce the number of requests being issued, reducing load on Doppler servers and also reducing the chances a user will hit API rate limiting.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
