### PR TITLE
feat(helm): Offer the possiblity to disable aggreate-to-view and aggregate-to-edit on default ClusterRoles

### DIFF
--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -141,6 +141,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | processClusterPushSecret | bool | `true` | if true, the operator will process cluster push secret. Else, it will ignore them. |
 | processClusterStore | bool | `true` | if true, the operator will process cluster store. Else, it will ignore them. |
 | processPushSecret | bool | `true` | if true, the operator will process push secret. Else, it will ignore them. |
+| rbac.aggregateToEdit | bool | `true` | Specifies whether permissions are aggregated to the edit ClusterRole |
+| rbac.aggregateToView | bool | `true` | Specifies whether permissions are aggregated to the view ClusterRole |
 | rbac.create | bool | `true` | Specifies whether role and rolebinding resources should be created. |
 | rbac.servicebindings.create | bool | `true` | Specifies whether a clusterrole to give servicebindings read access should be created. |
 | replicaCount | int | `1` |  |

--- a/deploy/charts/external-secrets/templates/rbac.yaml
+++ b/deploy/charts/external-secrets/templates/rbac.yaml
@@ -186,8 +186,12 @@ metadata:
   {{- end }}
   labels:
     {{- include "external-secrets.labels" . | nindent 4 }}
+    {{- if .Values.rbac.aggregateToView }}
     rbac.authorization.k8s.io/aggregate-to-view: "true"
+    {{- end }}
+    {{- if .Values.rbac.aggregateToEdit }}
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    {{- end }}
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
   - apiGroups:
@@ -241,7 +245,9 @@ metadata:
   {{- end }}
   labels:
     {{- include "external-secrets.labels" . | nindent 4 }}
+    {{- if .Values.rbac.aggregateToEdit }}
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    {{- end }}
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
   - apiGroups:

--- a/deploy/charts/external-secrets/tests/rbac_test.yaml
+++ b/deploy/charts/external-secrets/tests/rbac_test.yaml
@@ -1,0 +1,32 @@
+suite: test rbac
+templates:
+  - rbac.yaml
+tests:
+  - it: should remove the labels aggregate-to-view to the view ClusterRole
+    set:
+      rbac:
+        aggregateToView: false
+    asserts:
+      - notExists:
+          path: metadata.labels["rbac.authorization.k8s.io/aggregate-to-view"]
+        documentSelector:
+          kind: ClusterRole
+          path: metadata.name
+          value: RELEASE-NAME-external-secrets-view
+  - it: should remove the labels aggregate-to-edit to the view and edit ClusterRoles
+    set:
+      rbac:
+        aggregateToEdit: false
+    asserts:
+      - notExists:
+          path: metadata.labels["rbac.authorization.k8s.io/aggregate-to-edit"]
+        documentSelector:
+          kind: ClusterRole
+          path: metadata.name
+          value: RELEASE-NAME-external-secrets-view
+      - notExists:
+          path: metadata.labels["rbac.authorization.k8s.io/aggregate-to-edit"]
+        documentSelector:
+          kind: ClusterRole
+          path: metadata.name
+          value: RELEASE-NAME-external-secrets-edit

--- a/deploy/charts/external-secrets/values.schema.json
+++ b/deploy/charts/external-secrets/values.schema.json
@@ -503,6 +503,12 @@
         },
         "rbac": {
             "properties": {
+                "aggregateToEdit": {
+                    "type": "boolean"
+                },
+                "aggregateToView": {
+                    "type": "boolean"
+                },
                 "create": {
                     "type": "boolean"
                 },

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -130,6 +130,12 @@ rbac:
     # -- Specifies whether a clusterrole to give servicebindings read access should be created.
     create: true
 
+  # -- Specifies whether permissions are aggregated to the view ClusterRole
+  aggregateToView: true
+
+  # -- Specifies whether permissions are aggregated to the edit ClusterRole
+  aggregateToEdit: true
+
 ## -- Extra environment variables to add to container.
 extraEnv: []
 


### PR DESCRIPTION
## Problem Statement

View and edit permissions are aggregated to the view and edit default ClusterRoles.  
Clusters admins would like to have the possiblity to disable this functionnality, so they can attach the default edit ClusterRole to a user, while blocking him from modifying an ExternalSecret

## Related Issue

Fixes #4159

## Proposed Changes

Adding the `aggregateToView` and `aggregateToEdit` booleans under the `rbac` object 

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
