### PR TITLE
fix: typo on delete method for repo

### DIFF
--- a/pkg/provider/github/repo_secrets.go
+++ b/pkg/provider/github/repo_secrets.go
@@ -38,5 +38,5 @@ func (g *Client) repoListSecretsFn(ctx context.Context) (*github.Secrets, *githu
 }
 
 func (g *Client) repoDeleteSecretsFn(ctx context.Context, remoteRef esv1.PushSecretRemoteRef) (*github.Response, error) {
-	return g.baseClient.DeleteRepoSecret(ctx, g.provider.Organization, g.provider.Environment, remoteRef.GetRemoteKey())
+	return g.baseClient.DeleteRepoSecret(ctx, g.provider.Organization, g.provider.Repository, remoteRef.GetRemoteKey())
 }


### PR DESCRIPTION
## Problem Statement

There is a typo on repo declaration for github actions provider. This PR fixes it. 

## Related Issue

Fixes #4744

## Proposed Changes

Fix Typo :)

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
