### PR TITLE
fix: not releasing helm charts when its already released

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -69,17 +69,44 @@ jobs:
       - name: Run unitests
         if: steps.list-changed.outputs.changed == 'true'
         run: make helm.test
-
+  check-release:
+    permissions:
+        contents: read
+    outputs:
+      release_exists: ${{ steps.check_release.outputs.release_exists }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        with:
+          egress-policy: audit
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+      - name: Check if release already exists
+        id: check_release
+        run: |
+          // query github for releases
+          release_version=$(yq .version deploy/charts/external-secrets/Chart.yaml)
+          release_status=$(curl --silent -w "%{http_code}" --output /dev/null "https://api.github.com/repos/external-secrets/external-secrets/releases/tags/helm-chart-${release_version}")
+          if [ $release_status -eq 200 ]; then
+            echo "Release already exists"
+            echo "release_exists='true'">> $GITHUB_OUTPUT
+          else 
+            echo "Release does not exist"
+            echo "release_exists='false'" >> $GITHUB_OUTPUT
+          fi
   release:
+    needs:
+      - check-release
+    if: needs.check-release.outputs.release_exists == 'false' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-'))
     permissions:
       contents: write  # for helm/chart-releaser-action to push chart release and create a release
       packages: write  # to push OCI chart package to GitHub Registry
       id-token: write  # gives the action the ability to mint the OIDC token necessary to request a Sigstore signing certificate
       attestations: write # this permission is necessary to persist the attestation
     runs-on: ubuntu-latest
-    if: |
-      github.ref == 'refs/heads/main' ||
-      startsWith(github.ref, 'refs/heads/release-')
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
@@ -95,6 +122,7 @@ jobs:
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
       - name: Set up Helm
         uses: azure/setup-helm@f382f75448129b3be48f8121b9857be18d815a82 # v3.4
         with:
@@ -102,10 +130,12 @@ jobs:
 
       - name: Generate chart
         run: make helm.generate
+
       - name: Import GPG key
         run: |
           echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --dearmor --output keyring.gpg
           echo -n "${{ secrets.GPG_PASSPHRASE }}" > passphrase-file.txt
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         env:
@@ -124,7 +154,7 @@ jobs:
         uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
         with:
           version: v3.14.2 # remember to also update for the first job (lint-and-test)
-
+          
       - name: Login to GHCR
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:


### PR DESCRIPTION
## Problem Statement

Helm chart releases are overwriting every time a new commit reaches main.
this fixes it.

## Related Issue

Fixes #4760

## Proposed Changes

New Job checking release existence prior to continuing with pipeline.
