### PR TITLE
fix: release check output is not a string

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -92,14 +92,14 @@ jobs:
           if [ $release_status -eq 200 ]; then
             echo "Release already exists"
             echo "release_exists='true'">> $GITHUB_OUTPUT
-          else 
+          else
             echo "Release does not exist"
             echo "release_exists='false'" >> $GITHUB_OUTPUT
           fi
   release:
     needs:
       - check-release
-    if: needs.check-release.outputs.release_exists == 'false' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-'))
+    if: ! needs.check-release.outputs.release_exists && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-'))
     permissions:
       contents: write  # for helm/chart-releaser-action to push chart release and create a release
       packages: write  # to push OCI chart package to GitHub Registry
@@ -153,7 +153,7 @@ jobs:
         uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
         with:
           version: v3.14.2 # remember to also update for the first job (lint-and-test)
-          
+
       - name: Login to GHCR
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?

Test run of the correct syntax https://github.com/Skarlso/test/actions/runs/15037317909

## Related Issue

Fixes https://github.com/external-secrets/external-secrets/issues/4781

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
