### PR TITLE
docs: Fix formatting in Deprecation Policy notes

### DIFF
--- a/DEPRECATING.md
+++ b/DEPRECATING.md
@@ -49,7 +49,8 @@ We define the following scope that is covered by our deprecation policy. We foll
 ### Non-Scope
 Everything not listed in scope is not subject to this deprecation policy and it is subject to breaking changes, updates at any point in time, and deprecation - **as long as it follows the Deprecation Process listed below**.
 
-This includes, but isn't limited to :
+This includes, but isn't limited to:
+
 * Any feature / specific behavior not in Scope.
 * Source code imports
 * Helm Charts

--- a/DEPRECATING.md
+++ b/DEPRECATING.md
@@ -18,7 +18,7 @@ Secret](https://kubernetes.io/docs/concepts/configuration/secret/).
 
 We follow the [Kubernetes Deprecation Policy](https://kubernetes.io/docs/reference/using-api/deprecation-policy/) and [API Versioning Scheme](https://kubernetes.io/docs/reference/using-api/#api-versioning): alpha, beta, GA.
 
-The project is currently in `beta` state. Please try the `beta` features and provide feedback. After the features exits beta, it may not be practical to make more changes.
+The project is currently in `beta` state. Please try the `beta` features and provide feedback. After the features exit beta, it may not be practical to make more changes.
 
 * alpha
     * The support for a feature may be dropped at any time without notice.

--- a/docs/introduction/deprecation-policy.md
+++ b/docs/introduction/deprecation-policy.md
@@ -2,7 +2,7 @@
 
 We follow the [Kubernetes Deprecation Policy](https://kubernetes.io/docs/reference/using-api/deprecation-policy/) and [API Versioning Scheme](https://kubernetes.io/docs/reference/using-api/#api-versioning): alpha, beta, GA.
 
-The project is currently in `beta` state. Please try the `beta` features and provide feedback. After the features exits beta, it may not be practical to make more changes.
+The project is currently in `beta` state. Please try the `beta` features and provide feedback. After the features exit beta, it may not be practical to make more changes.
 
 * alpha
     * The support for a feature may be dropped at any time without notice.
@@ -33,7 +33,8 @@ We define the following scope that is covered by our deprecation policy. We foll
 ### Non-Scope
 Everything not listed in scope is not subject to this deprecation policy and it is subject to breaking changes, updates at any point in time, and deprecation - **as long as it follows the Deprecation Process listed below**.
 
-This includes, but insn't limited to :
+This includes, but isn't limited to:
+
 * Any feature / specific behavior not in Scope.
 * Source code imports
 * Helm Charts
@@ -42,6 +43,6 @@ This includes, but insn't limited to :
 * Image Signature (including provenance, providers, keys)
 * OLM-specific builds
 
-## Depreaction Process:
+## Deprecation Process:
 
-Deprecation process is described within the [project github repository](https://github.com/external-secrets/external-secrets/blob/main/DEPRECATING.md)
+Deprecation process is described within the [project GitHub repository](https://github.com/external-secrets/external-secrets/blob/main/DEPRECATING.md)


### PR DESCRIPTION
There's a formatting error in the very fine Deprecation Policy guide:

<img width="594" alt="Screenshot 2025-05-18 at 9 31 17 AM" src="https://github.com/user-attachments/assets/7ce2aaa3-825c-4a33-8a39-e392dafdd5fc" />

Thanks for the level of detail in here! I don't know of any better place where Kubernetes Versioning is concisely explained. 🚀

Good luck with your 1.0.0 release!