### PR TITLE
fix: allows result.jsonpath to be templated on datafrom calls

### DIFF
--- a/pkg/provider/webhook/webhook.go
+++ b/pkg/provider/webhook/webhook.go
@@ -217,6 +217,15 @@ func (w *WebHook) GetSecretMap(ctx context.Context, ref esv1.ExternalSecretDataR
 	if err != nil {
 		return nil, fmt.Errorf(errFailedToGetStore, err)
 	}
+	data, err := w.wh.GetTemplateData(ctx, &ref, provider.Secrets, false)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get template data: %w", err)
+	}
+	resultJSONPath, err := webhook.ExecuteTemplateString(provider.Result.JSONPath, data)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get templated json path: %w", err)
+	}
+	provider.Result.JSONPath = resultJSONPath
 	return w.wh.GetSecretMap(ctx, provider, &ref)
 }
 

--- a/pkg/provider/webhook/webhook_test.go
+++ b/pkg/provider/webhook/webhook_test.go
@@ -191,6 +191,34 @@ want:
     thesecret: secret-value
     alsosecret: another-value
 ---
+case: templated jsonpath good json map
+args:
+  url: /api/getsecret?id={{ .remoteRef.key }}&version={{ .remoteRef.version }}
+  key: testkey
+  version: 1
+  jsonpath: $.{{printf "result" }}
+  response: '{"result":{"thesecret":"secret-value","alsosecret":"another-value"}}'
+want:
+  path: /api/getsecret?id=testkey&version=1
+  err: ''
+  resultmap:
+    thesecret: secret-value
+    alsosecret: another-value
+---
+case: templated jsonpath invalid template
+args:
+  url: /api/getsecret?id={{ .remoteRef.key }}&version={{ .remoteRef.version }}
+  key: testkey
+  version: 1
+  jsonpath: $.{{printf 'result' }}
+  response: '{"result":{"thesecret":"secret-value","alsosecret":"another-value"}}'
+want:
+  path: /api/getsecret?id=testkey&version=1
+  err: "cannot get templated json path"
+  resultmap:
+    thesecret: secret-value
+    alsosecret: another-value
+---
 case: good json map string
 args:
   url: /api/getsecret?id={{ .remoteRef.key }}&version={{ .remoteRef.version }}


### PR DESCRIPTION
## Problem Statement

Webhook provider does not allow `result.JsonPath` to be templated when calls come from `dataFrom` - even though it is stated in the docs it should be possible.

This PR fixes this by, well, templating the jsonPath :)

## Related Issue

Fixes #4801

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
