### PR TITLE
fix: mfa generator length is too much and optional

### DIFF
--- a/docs/snippets/generator-mfa.yaml
+++ b/docs/snippets/generator-mfa.yaml
@@ -3,7 +3,6 @@ kind: MFA
 metadata:
   name: my-mfa-generator
 spec:
-  length: 42
   secret:
     key: token
     name: secret


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
