### PR TITLE
feat(aws): Enable setting custom endpoints for AWS ECR for ECRAuthori…

### DIFF
--- a/docs/snippets/provider-aws-access.md
+++ b/docs/snippets/provider-aws-access.md
@@ -191,3 +191,5 @@ Use the following environment variables to point the controller to your custom e
 | AWS_SECRETSMANAGER_ENDPOINT | Endpoint for the Secrets Manager Service. The controller uses this endpoint to fetch secrets from AWS Secrets Manager.                                               |
 | AWS_SSM_ENDPOINT            | Endpoint for the AWS Secure Systems Manager. The controller uses this endpoint to fetch secrets from SSM Parameter Store.                                            |
 | AWS_STS_ENDPOINT            | Endpoint for the Security Token Service. The controller uses this endpoint when creating a session and when doing `assumeRole` or `assumeRoleWithWebIdentity` calls. |
+| AWS_ECR_ENDPOINT            | Endpoint for the ECR Service. The controller uses this endpoint to fetch authorization tokens from ECR.                                                              |
+| AWS_ECR_PUBLIC_ENDPOINT     | Endpoint for the Public ECR Service. The controller uses this endpoint to fetch authorization tokens from ECR.                                                       |

--- a/pkg/provider/aws/auth/resolver.go
+++ b/pkg/provider/aws/auth/resolver.go
@@ -24,6 +24,8 @@ const (
 	SecretsManagerEndpointEnv = "AWS_SECRETSMANAGER_ENDPOINT"
 	STSEndpointEnv            = "AWS_STS_ENDPOINT"
 	SSMEndpointEnv            = "AWS_SSM_ENDPOINT"
+	ECREndpointEnv            = "AWS_ECR_ENDPOINT"
+	ECRPublicEndpointEnv      = "AWS_ECR_PUBLIC_ENDPOINT"
 )
 
 // ResolveEndpoint returns a ResolverFunc with
@@ -38,6 +40,12 @@ func ResolveEndpoint() endpoints.ResolverFunc {
 	}
 	if v := os.Getenv(STSEndpointEnv); v != "" {
 		customEndpoints["sts"] = v
+	}
+	if v := os.Getenv(ECREndpointEnv); v != "" {
+		customEndpoints["api.ecr"] = v
+	}
+	if v := os.Getenv(ECRPublicEndpointEnv); v != "" {
+		customEndpoints["api.ecr-public"] = v
 	}
 	return ResolveEndpointWithServiceMap(customEndpoints)
 }

--- a/pkg/provider/aws/auth/resolver_test.go
+++ b/pkg/provider/aws/auth/resolver_test.go
@@ -41,6 +41,16 @@ func TestResolver(t *testing.T) {
 			service: "sts",
 			url:     "http://sts.foo",
 		},
+		{
+			env:     ECREndpointEnv,
+			service: "api.ecr",
+			url:     "http://ecr.foo",
+		},
+		{
+			env:     ECRPublicEndpointEnv,
+			service: "api.ecr-public",
+			url:     "http://ecr-public.foo",
+		},
 	}
 
 	for _, item := range tbl {


### PR DESCRIPTION
…zationToken generator

## Problem Statement

The external-secrets AWS provider currently allows setting custom endpoints for the STS, SSM, and SecretsManager services. However, the ECRAuthorizationToken generator does not currently support custom endpoints for the ECR/ECR Public services. 

## Related Issue

No corresponding issue.

## Proposed Changes

Expose environment variables for ECR and ECR public services similar to the existing custom endpoint overrides. 

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
