### PR TITLE
chore(deps): Update bitwarden-sdk-server helm dependency

### DIFF
--- a/deploy/charts/external-secrets/Chart.lock
+++ b/deploy/charts/external-secrets/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: bitwarden-sdk-server
   repository: oci://ghcr.io/external-secrets/charts
-  version: v0.3.1
-digest: sha256:2d01e9083fc32c18dca4f9614625e0172e338a663138c2670e5b911645b6b8ee
-generated: "2024-09-20T12:57:07.63511+02:00"
+  version: v0.4.2
+digest: sha256:f42125872b54ab57ac22a14a3b6c9efcc862857195ccf1214ef63b433adcedfc
+generated: "2025-05-25T21:50:21.520319528+01:00"

--- a/deploy/charts/external-secrets/Chart.yaml
+++ b/deploy/charts/external-secrets/Chart.yaml
@@ -15,6 +15,6 @@ maintainers:
     email: kellinmcavoy@gmail.com
 dependencies:
   - name: bitwarden-sdk-server
-    version: v0.3.1
+    version: v0.4.2
     repository: oci://ghcr.io/external-secrets/charts
     condition: bitwarden-sdk-server.enabled


### PR DESCRIPTION
## Problem Statement

Bump version to the latest version

The current version is pretty old and newer version has updates to the chart and to bitwarden-sdk-server itself

## Related Issue

Updated Helm chart provides an update that would help with #4824 

## Proposed Changes

Bump Helm dependency

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
