### PR TITLE
fix(AWS): add chart to secretKey pattern

### DIFF
--- a/apis/externalsecrets/v1/externalsecret_types.go
+++ b/apis/externalsecrets/v1/externalsecret_types.go
@@ -213,7 +213,7 @@ type ExternalSecretData struct {
 	// The key in the Kubernetes Secret to store the value.
 	// +kubebuilder:validation:MinLength:=1
 	// +kubebuilder:validation:MaxLength:=253
-	// +kubebuilder:validation:Pattern:=^[-._a-zA-Z0-9]+$
+	// +kubebuilder:validation:Pattern:=^[-._!a-zA-Z0-9]+$
 	SecretKey string `json:"secretKey"`
 
 	// RemoteRef points to the remote secret and defines

--- a/apis/externalsecrets/v1beta1/externalsecret_types.go
+++ b/apis/externalsecrets/v1beta1/externalsecret_types.go
@@ -213,7 +213,7 @@ type ExternalSecretData struct {
 	// The key in the Kubernetes Secret to store the value.
 	// +kubebuilder:validation:MinLength:=1
 	// +kubebuilder:validation:MaxLength:=253
-	// +kubebuilder:validation:Pattern:=^[-._a-zA-Z0-9]+$
+	// +kubebuilder:validation:Pattern:=^[-._!a-zA-Z0-9]+$
 	SecretKey string `json:"secretKey"`
 
 	// RemoteRef points to the remote secret and defines

--- a/config/crds/bases/external-secrets.io_clusterexternalsecrets.yaml
+++ b/config/crds/bases/external-secrets.io_clusterexternalsecrets.yaml
@@ -135,7 +135,7 @@ spec:
                             value.
                           maxLength: 253
                           minLength: 1
-                          pattern: ^[-._a-zA-Z0-9]+$
+                          pattern: ^[-._!a-zA-Z0-9]+$
                           type: string
                         sourceRef:
                           description: |-
@@ -896,7 +896,7 @@ spec:
                             value.
                           maxLength: 253
                           minLength: 1
-                          pattern: ^[-._a-zA-Z0-9]+$
+                          pattern: ^[-._!a-zA-Z0-9]+$
                           type: string
                         sourceRef:
                           description: |-

--- a/config/crds/bases/external-secrets.io_externalsecrets.yaml
+++ b/config/crds/bases/external-secrets.io_externalsecrets.yaml
@@ -115,7 +115,7 @@ spec:
                       description: The key in the Kubernetes Secret to store the value.
                       maxLength: 253
                       minLength: 1
-                      pattern: ^[-._a-zA-Z0-9]+$
+                      pattern: ^[-._!a-zA-Z0-9]+$
                       type: string
                     sourceRef:
                       description: |-
@@ -734,7 +734,7 @@ spec:
                       description: The key in the Kubernetes Secret to store the value.
                       maxLength: 253
                       minLength: 1
-                      pattern: ^[-._a-zA-Z0-9]+$
+                      pattern: ^[-._!a-zA-Z0-9]+$
                       type: string
                     sourceRef:
                       description: |-

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -126,7 +126,7 @@ spec:
                             description: The key in the Kubernetes Secret to store the value.
                             maxLength: 253
                             minLength: 1
-                            pattern: ^[-._a-zA-Z0-9]+$
+                            pattern: ^[-._!a-zA-Z0-9]+$
                             type: string
                           sourceRef:
                             description: |-
@@ -846,7 +846,7 @@ spec:
                             description: The key in the Kubernetes Secret to store the value.
                             maxLength: 253
                             minLength: 1
-                            pattern: ^[-._a-zA-Z0-9]+$
+                            pattern: ^[-._!a-zA-Z0-9]+$
                             type: string
                           sourceRef:
                             description: |-
@@ -10444,7 +10444,7 @@ spec:
                         description: The key in the Kubernetes Secret to store the value.
                         maxLength: 253
                         minLength: 1
-                        pattern: ^[-._a-zA-Z0-9]+$
+                        pattern: ^[-._!a-zA-Z0-9]+$
                         type: string
                       sourceRef:
                         description: |-
@@ -11040,7 +11040,7 @@ spec:
                         description: The key in the Kubernetes Secret to store the value.
                         maxLength: 253
                         minLength: 1
-                        pattern: ^[-._a-zA-Z0-9]+$
+                        pattern: ^[-._!a-zA-Z0-9]+$
                         type: string
                       sourceRef:
                         description: |-


### PR DESCRIPTION
## Problem Statement

AWS Secrets Manager secret name may contains `!`, for example when using managed credentials on AWS DocumentDB 

## Related Issue

Seems to be a regression introduced in v0.16.0

## Proposed Changes

Ad the `!` back to the allowed pattern regex

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [?] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
