### PR TITLE
Switch off generators crds

### DIFF
--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -92,6 +92,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | crds.createClusterGenerator | bool | `true` | If true, create CRDs for Cluster Generator. |
 | crds.createClusterPushSecret | bool | `true` | If true, create CRDs for Cluster Push Secret. |
 | crds.createClusterSecretStore | bool | `true` | If true, create CRDs for Cluster Secret Store. |
+| crds.createGenerators | bool | `true` | If true, create CRDs for Generators. |
 | crds.createPushSecret | bool | `true` | If true, create CRDs for Push Secret. |
 | createOperator | bool | `true` | Specifies whether an external secret operator deployment be created. |
 | deploymentAnnotations | object | `{}` | Annotations to add to Deployment |

--- a/deploy/charts/external-secrets/values.schema.json
+++ b/deploy/charts/external-secrets/values.schema.json
@@ -279,6 +279,9 @@
                 "createClusterSecretStore": {
                     "type": "boolean"
                 },
+                "createGenerators": {
+                    "type": "boolean"
+                },
                 "createPushSecret": {
                     "type": "boolean"
                 }

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -45,6 +45,8 @@ crds:
   createClusterPushSecret: true
   # -- If true, create CRDs for Push Secret.
   createPushSecret: true
+  # -- If true, create CRDs for Generators.
+  createGenerators: true
   annotations: {}
   conversion:
     # -- Conversion is disabled by default as we stopped supporting v1alpha1.


### PR DESCRIPTION
Description
We intend to use ESO (as for now) only for pulling secrets from secret store. Currently, when installing the External Secrets Operator (ESO) with Helm chart, Custom Resource Definitions (CRDs) for all supported generators are installed by default, regardless if they are used or not. This introduces unnecessary CRDs into the cluster and potentially increases the surface area for misconfiguration.

Proposed Solution
Add Helm value that allows users to choose if they want to install the generator's CRDs.

Describe alternatives you've considered
I know that one can set the installCRDs to false but that does not install any CRDs. We still want to use the ExternalSecret and SecretStore resources to pull the secrets into the namespace.

One could define Kyverno policy blocking the generators to be referenced in the ExternalSecret resource but that feels like an unnecessary extra configuration for those who don't use generators.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
