### PR TITLE
fix: leaving out managed id is not an invalid config

### DIFF
--- a/pkg/generator/acr/acr.go
+++ b/pkg/generator/acr/acr.go
@@ -297,11 +297,12 @@ func accessTokenForManagedIdentity(ctx context.Context, envType esv1.AzureEnviro
 		opts = &azidentity.ManagedIdentityCredentialOptions{
 			ID: azidentity.ResourceID(identityID),
 		}
-	} else {
+	} else if identityID != "" {
 		opts = &azidentity.ManagedIdentityCredentialOptions{
 			ID: azidentity.ClientID(identityID),
 		}
 	}
+	// lacking option ID, az will default to `id := managedidentity.SystemAssigned()`.
 	creds, err := azidentity.NewManagedIdentityCredential(opts)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?

## Related Issue

Fixes https://github.com/external-secrets/external-secrets/issues/4889

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
