### PR TITLE
[OnePasswordSDKProvider] Enable specifying the vault by UUID

### DIFF
--- a/apis/externalsecrets/v1/secretstore_onepassword_sdk_types.go
+++ b/apis/externalsecrets/v1/secretstore_onepassword_sdk_types.go
@@ -36,7 +36,7 @@ type IntegrationInfo struct {
 
 // OnePasswordSDKProvider configures a store to sync secrets using the 1Password sdk.
 type OnePasswordSDKProvider struct {
-	// Vault defines the vault's name to access. Do NOT add op:// prefix. This will be done automatically.
+	// Vault defines the vault's name or uuid to access. Do NOT add op:// prefix. This will be done automatically.
 	Vault string `json:"vault"`
 	// IntegrationInfo specifies the name and version of the integration built using the 1Password Go SDK.
 	// If you don't know which name and version to use, use `DefaultIntegrationName` and `DefaultIntegrationVersion`, respectively.

--- a/config/crds/bases/external-secrets.io_clustersecretstores.yaml
+++ b/config/crds/bases/external-secrets.io_clustersecretstores.yaml
@@ -2702,8 +2702,8 @@ spec:
                             type: string
                         type: object
                       vault:
-                        description: Vault defines the vault's name to access. Do
-                          NOT add op:// prefix. This will be done automatically.
+                        description: Vault defines the vault's name or uuid to access.
+                          Do NOT add op:// prefix. This will be done automatically.
                         type: string
                     required:
                     - auth

--- a/config/crds/bases/external-secrets.io_secretstores.yaml
+++ b/config/crds/bases/external-secrets.io_secretstores.yaml
@@ -2702,8 +2702,8 @@ spec:
                             type: string
                         type: object
                       vault:
-                        description: Vault defines the vault's name to access. Do
-                          NOT add op:// prefix. This will be done automatically.
+                        description: Vault defines the vault's name or uuid to access.
+                          Do NOT add op:// prefix. This will be done automatically.
                         type: string
                     required:
                     - auth

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -4474,7 +4474,7 @@ spec:
                               type: string
                           type: object
                         vault:
-                          description: Vault defines the vault's name to access. Do NOT add op:// prefix. This will be done automatically.
+                          description: Vault defines the vault's name or uuid to access. Do NOT add op:// prefix. This will be done automatically.
                           type: string
                       required:
                         - auth
@@ -14521,7 +14521,7 @@ spec:
                               type: string
                           type: object
                         vault:
-                          description: Vault defines the vault's name to access. Do NOT add op:// prefix. This will be done automatically.
+                          description: Vault defines the vault's name or uuid to access. Do NOT add op:// prefix. This will be done automatically.
                           type: string
                       required:
                         - auth

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -6096,7 +6096,7 @@ string
 </em>
 </td>
 <td>
-<p>Vault defines the vault&rsquo;s name to access. Do NOT add op:// prefix. This will be done automatically.</p>
+<p>Vault defines the vault&rsquo;s name or uuid to access. Do NOT add op:// prefix. This will be done automatically.</p>
 </td>
 </tr>
 <tr>

--- a/pkg/provider/onepasswordsdk/client.go
+++ b/pkg/provider/onepasswordsdk/client.go
@@ -324,21 +324,21 @@ func (p *Provider) PushSecret(ctx context.Context, secret *corev1.Secret, ref es
 	return nil
 }
 
-func (p *Provider) GetVault(ctx context.Context, name string) (string, error) {
+func (p *Provider) GetVault(ctx context.Context, titleOrUuid string) (string, error) {
 	vaults, err := p.client.VaultsAPI.List(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to list vaults: %w", err)
 	}
 
 	for _, v := range vaults {
-		if v.Title == name {
+		if v.Title == titleOrUuid || v.ID == titleOrUuid {
 			// cache the ID so we don't have to repeat this lookup.
 			p.vaultID = v.ID
 			return v.ID, nil
 		}
 	}
 
-	return "", fmt.Errorf("vault %s not found", name)
+	return "", fmt.Errorf("vault %s not found", titleOrUuid)
 }
 
 func (p *Provider) findItem(ctx context.Context, name string) (onepassword.Item, error) {

--- a/pkg/provider/onepasswordsdk/client_test.go
+++ b/pkg/provider/onepasswordsdk/client_test.go
@@ -25,7 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
+	v1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
 	"github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
 )
 
@@ -588,6 +588,33 @@ func TestDeleteItemField(t *testing.T) {
 
 			testCase.assertError(t, p.DeleteSecret(ctx, testCase.ref))
 			testCase.assertLister(t, lister)
+		})
+	}
+}
+
+func TestGetVault(t *testing.T) {
+	fc := &fakeClient{
+		listAllResult: []onepassword.VaultOverview{
+			{
+				ID:    "vault-id",
+				Title: "vault-title",
+			},
+		},
+	}
+
+	p := &Provider{
+		client: &onepassword.Client{
+			VaultsAPI: fc,
+		},
+	}
+
+	titleOrUuids := []string{"vault-title", "vault-id"}
+
+	for _, titleOrUuid := range titleOrUuids {
+		t.Run(titleOrUuid, func(t *testing.T) {
+			vaultID, err := p.GetVault(context.Background(), titleOrUuid)
+			require.NoError(t, err)
+			require.Equal(t, fc.listAllResult[0].ID, vaultID)
 		})
 	}
 }


### PR DESCRIPTION
## Problem Statement

SecretStore in onepasswordsdk only allows specifying a vault by its Title, and does not support specifying it by UUID.

For example, the following manifest will result in an error:

https://github.com/external-secrets/external-secrets/blob/cb0d91ed2b124513e62e367efcdd61c41a32f159/pkg/provider/onepasswordsdk/provider.go#L83

```yaml
apiVersion: external-secrets.io/v1
kind: ClusterSecretStore
metadata: ...
spec:
  provider:
    onepasswordSDK:
      # vault: "vault-title"  # <- title is OK
      vault: "aaaaaaaaaaaaa1111111111111" # <- uuid is NG
      auth:
        serviceAccountSecretRef: ...
```

## Related Issue

N/A (No issue created)

## Proposed Changes

- Modified the GetVault function to check for a match against both the Title and UUID of the vault. This allows users to specify the vault using either identifier.
- Added a TestGetVault function to verify that the vault is retrieved correctly whether the Title or UUID is provided.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`

---

This is my first contribution to this project. I hope it's helpful. 🙇‍♂️ 
