### PR TITLE
chore: upgrade go from 1.24.2 to 1.24.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets
 
-go 1.24.2
+go 1.24.4
 
 replace github.com/Masterminds/sprig/v3 => github.com/external-secrets/sprig/v3 v3.3.0
 


### PR DESCRIPTION
## Problem Statement

CI fails due to newly published vulnerability in go 1.24.2 stdlib causing vulnerability scanning to error

## Related Issue

Fixes #4909 

## Proposed Changes

Upgrade go from 1.24.2 to 1.24.4.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
