### PR TITLE
fix: group variables not taking account of environments

### DIFF
--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -255,8 +255,10 @@ func (g *gitlabBase) GetSecret(_ context.Context, ref esv1.ExternalSecretDataRem
 	// 	"masked": true,
 	// 	"environment_scope": "*"
 	// }
+	var gopts *gitlab.GetGroupVariableOptions
 	var vopts *gitlab.GetProjectVariableOptions
 	if g.store.Environment != "" {
+		gopts = &gitlab.GetGroupVariableOptions{Filter: &gitlab.VariableFilter{EnvironmentScope: g.store.Environment}}
 		vopts = &gitlab.GetProjectVariableOptions{Filter: &gitlab.VariableFilter{EnvironmentScope: g.store.Environment}}
 	}
 
@@ -282,7 +284,7 @@ func (g *gitlabBase) GetSecret(_ context.Context, ref esv1.ExternalSecretDataRem
 			return result, nil
 		}
 
-		groupVar, resp, err := g.groupVariablesClient.GetVariable(groupID, ref.Key, nil)
+		groupVar, resp, err := g.groupVariablesClient.GetVariable(groupID, ref.Key, gopts)
 		metrics.ObserveAPICall(constants.ProviderGitLab, constants.CallGitLabGroupGetVariable, err)
 		if resp.StatusCode >= 400 && resp.StatusCode != http.StatusNotFound && err != nil {
 			return nil, err


### PR DESCRIPTION
## Problem Statement

Gitlab Group Variables call was not taking environment filtering.

## Related Issue

Fixes #3379

## Proposed Changes

Implements environment filtering on gitlab group call

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
