### PR TITLE
add kube context

### DIFF
--- a/apis/externalsecrets/v1/secretstore_aws_types.go
+++ b/apis/externalsecrets/v1/secretstore_aws_types.go
@@ -125,6 +125,11 @@ type AWSProvider struct {
 	// +optional
 	TransitiveTagKeys []string `json:"transitiveTagKeys,omitempty"`
 
+	// InjectKubernetesContext, when true, automatically adds STS session tags identifying the calling namespace,
+	// and the SecretStore name.
+	// +optional
+	InjectKubernetesContext bool `json:"injectKubernetesContext,omitempty"`
+
 	// Prefix adds a prefix to all retrieved values.
 	// +optional
 	Prefix string `json:"prefix,omitempty"`

--- a/apis/externalsecrets/v1beta1/secretstore_aws_types.go
+++ b/apis/externalsecrets/v1beta1/secretstore_aws_types.go
@@ -125,6 +125,11 @@ type AWSProvider struct {
 	// +optional
 	TransitiveTagKeys []*string `json:"transitiveTagKeys,omitempty"`
 
+	// InjectKubernetesContext, when true, automatically adds STS session tags identifying the calling namespace,
+	// and the SecretStore name.
+	// +optional
+	InjectKubernetesContext bool `json:"injectKubernetesContext,omitempty"`
+
 	// Prefix adds a prefix to all retrieved values.
 	// +optional
 	Prefix string `json:"prefix,omitempty"`

--- a/config/crds/bases/external-secrets.io_clustersecretstores.yaml
+++ b/config/crds/bases/external-secrets.io_clustersecretstores.yaml
@@ -609,6 +609,11 @@ spec:
                       externalID:
                         description: AWS External ID set on assumed IAM roles
                         type: string
+                      injectKubernetesContext:
+                        description: |-
+                          InjectKubernetesContext, when true, automatically adds STS session tags identifying the calling namespace,
+                          and the SecretStore name.
+                        type: boolean
                       prefix:
                         description: Prefix adds a prefix to all retrieved values.
                         type: string
@@ -5212,6 +5217,11 @@ spec:
                       externalID:
                         description: AWS External ID set on assumed IAM roles
                         type: string
+                      injectKubernetesContext:
+                        description: |-
+                          InjectKubernetesContext, when true, automatically adds STS session tags identifying the calling namespace,
+                          and the SecretStore name.
+                        type: boolean
                       prefix:
                         description: Prefix adds a prefix to all retrieved values.
                         type: string

--- a/config/crds/bases/external-secrets.io_secretstores.yaml
+++ b/config/crds/bases/external-secrets.io_secretstores.yaml
@@ -609,6 +609,11 @@ spec:
                       externalID:
                         description: AWS External ID set on assumed IAM roles
                         type: string
+                      injectKubernetesContext:
+                        description: |-
+                          InjectKubernetesContext, when true, automatically adds STS session tags identifying the calling namespace,
+                          and the SecretStore name.
+                        type: boolean
                       prefix:
                         description: Prefix adds a prefix to all retrieved values.
                         type: string
@@ -5212,6 +5217,11 @@ spec:
                       externalID:
                         description: AWS External ID set on assumed IAM roles
                         type: string
+                      injectKubernetesContext:
+                        description: |-
+                          InjectKubernetesContext, when true, automatically adds STS session tags identifying the calling namespace,
+                          and the SecretStore name.
+                        type: boolean
                       prefix:
                         description: Prefix adds a prefix to all retrieved values.
                         type: string

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -2578,6 +2578,11 @@ spec:
                         externalID:
                           description: AWS External ID set on assumed IAM roles
                           type: string
+                        injectKubernetesContext:
+                          description: |-
+                            InjectKubernetesContext, when true, automatically adds STS session tags identifying the calling namespace,
+                            and the SecretStore name.
+                          type: boolean
                         prefix:
                           description: Prefix adds a prefix to all retrieved values.
                           type: string
@@ -6876,6 +6881,11 @@ spec:
                         externalID:
                           description: AWS External ID set on assumed IAM roles
                           type: string
+                        injectKubernetesContext:
+                          description: |-
+                            InjectKubernetesContext, when true, automatically adds STS session tags identifying the calling namespace,
+                            and the SecretStore name.
+                          type: boolean
                         prefix:
                           description: Prefix adds a prefix to all retrieved values.
                           type: string
@@ -12789,6 +12799,11 @@ spec:
                         externalID:
                           description: AWS External ID set on assumed IAM roles
                           type: string
+                        injectKubernetesContext:
+                          description: |-
+                            InjectKubernetesContext, when true, automatically adds STS session tags identifying the calling namespace,
+                            and the SecretStore name.
+                          type: boolean
                         prefix:
                           description: Prefix adds a prefix to all retrieved values.
                           type: string
@@ -17087,6 +17102,11 @@ spec:
                         externalID:
                           description: AWS External ID set on assumed IAM roles
                           type: string
+                        injectKubernetesContext:
+                          description: |-
+                            InjectKubernetesContext, when true, automatically adds STS session tags identifying the calling namespace,
+                            and the SecretStore name.
+                          type: boolean
                         prefix:
                           description: Prefix adds a prefix to all retrieved values.
                           type: string

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -283,6 +283,19 @@ SecretsManager
 </tr>
 <tr>
 <td>
+<code>injectKubernetesContext</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>InjectKubernetesContext, when true, automatically adds STS session tags identifying the calling namespace,
+and the SecretStore name.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>prefix</code></br>
 <em>
 string


### PR DESCRIPTION
## Problem Statement

I'd like eso to inject kube related context so that they can be filtered on in iam policies. 

## Related Issue

Fixes https://github.com/external-secrets/external-secrets/issues/4989 

## Proposed Changes

Have the eso inject values via session tags. 

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
