### PR TITLE
fix: add uuid in edit and view clusterroles

### DIFF
--- a/deploy/charts/external-secrets/templates/rbac.yaml
+++ b/deploy/charts/external-secrets/templates/rbac.yaml
@@ -229,6 +229,7 @@ rules:
     - "grafanas"
     - "generatorstates"
     - "mfas"
+    - "uuids"
     verbs:
       - "get"
       - "watch"
@@ -288,6 +289,7 @@ rules:
     - "grafanas"
     - "generatorstates"
     - "mfas"
+    - "uuids"
     verbs:
       - "create"
       - "delete"


### PR DESCRIPTION
## Problem Statement

today uuid generator API resource is not present in edit or view cluster roles and therefore people with edit or view role can't use them (in contrary to all other generators)

## Related Issue

Fixes #5016

## Proposed Changes
I've added uuid in the helm chart role

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
