### PR TITLE
feat(helm): Add flag to disable CRD check for mass server-side apply

### DIFF
--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -175,6 +175,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | serviceMonitor.namespace | string | `""` | namespace where you want to install ServiceMonitors |
 | serviceMonitor.relabelings | list | `[]` | Relabel configs to apply to samples before ingestion. [Relabeling](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) |
 | serviceMonitor.scrapeTimeout | string | `"25s"` | Timeout if metrics can't be retrieved in given time interval |
+| serviceMonitor.trustCRDsExist | bool | `false` | Should we just trust the CRDs exist rather than querying the API server? |
 | tolerations | list | `[]` |  |
 | topologySpreadConstraints | list | `[]` |  |
 | webhook.affinity | object | `{}` |  |

--- a/deploy/charts/external-secrets/templates/_helpers.tpl
+++ b/deploy/charts/external-secrets/templates/_helpers.tpl
@@ -66,7 +66,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- with .Values.commonLabels }}
 {{ toYaml . }}
 {{- end }}
-{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) .Values.serviceMonitor.enabled }}
+{{- if .Values.serviceMonitor.enabled }}
 app.kubernetes.io/metrics: "webhook"
 {{- with .Values.webhook.service.labels }}
 {{ toYaml . }}
@@ -106,7 +106,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- with .Values.commonLabels }}
 {{ toYaml . }}
 {{- end }}
-{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) .Values.serviceMonitor.enabled }}
+{{- if .Values.serviceMonitor.enabled }}
 app.kubernetes.io/metrics: "cert-controller"
 {{- end }}
 {{- end }}
@@ -219,3 +219,12 @@ Render the securityContext based on the provided securityContext
 {{- end -}}
 {{- omit $adaptedContext "enabled" | toYaml -}}
 {{- end -}}
+
+{{/* Check for prometheus-operator CRDs */}}
+{{- if .Values.serviceMonitor.enabled -}}
+  {{- if not .Values.serviceMonitor.trustCRDsExist }}
+      {{- if not (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+          {{ fail "Service Monitor requires monitoring.coreos.com/v1 CRDs. Please refer to https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml or set .Values.serviceMonitor.trustCRDsExist=true" }}
+      {{- end }}
+  {{- end }}
+{{- end }}

--- a/deploy/charts/external-secrets/templates/cert-controller-service.yaml
+++ b/deploy/charts/external-secrets/templates/cert-controller-service.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.certController.create ( or .Values.certController.metrics.service.enabled ( and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) .Values.serviceMonitor.enabled )) (not .Values.webhook.certManager.enabled) }}
+{{- if and .Values.certController.create ( or .Values.certController.metrics.service.enabled .Values.serviceMonitor.enabled ) (not .Values.webhook.certManager.enabled) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/deploy/charts/external-secrets/templates/service.yaml
+++ b/deploy/charts/external-secrets/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if or (and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) .Values.serviceMonitor.enabled) .Values.metrics.service.enabled -}}
+{{- if or .Values.serviceMonitor.enabled .Values.metrics.service.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/deploy/charts/external-secrets/templates/servicemonitor.yaml
+++ b/deploy/charts/external-secrets/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) .Values.serviceMonitor.enabled -}}
+{{- if .Values.serviceMonitor.enabled -}}
 apiVersion: "monitoring.coreos.com/v1"
 kind: ServiceMonitor
 metadata:

--- a/deploy/charts/external-secrets/templates/webhook-service.yaml
+++ b/deploy/charts/external-secrets/templates/webhook-service.yaml
@@ -24,7 +24,7 @@ spec:
     targetPort: {{ .Values.webhook.port }}
     protocol: TCP
     name: webhook
-  {{- if or .Values.webhook.metrics.service.enabled ( and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) .Values.serviceMonitor.enabled ) }}
+  {{- if or .Values.webhook.metrics.service.enabled .Values.serviceMonitor.enabled }}
   - port: {{ .Values.webhook.metrics.service.port }}
     protocol: TCP
     targetPort: metrics

--- a/deploy/charts/external-secrets/values.schema.json
+++ b/deploy/charts/external-secrets/values.schema.json
@@ -652,6 +652,9 @@
                 },
                 "scrapeTimeout": {
                     "type": "string"
+                },
+                "trustCRDsExist": {
+                    "type": "boolean"
                 }
             },
             "type": "object"

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -191,6 +191,9 @@ serviceMonitor:
   # -- Specifies whether to create a ServiceMonitor resource for collecting Prometheus metrics
   enabled: false
 
+  # -- Should we just trust the CRDs exist rather than querying the API server?
+  trustCRDsExist: false
+
   # -- namespace where you want to install ServiceMonitors
   namespace: ""
 


### PR DESCRIPTION
## Problem Statement

When using a mass deployment tool (like `kluctl`) helm may be rendered locally before being submitted. In this two step process the CRDs are not yet deployed and thus the chart fails to render. The ability to pre-render the templates simplifies generation of the manifests for offline review or pass through `kustomize`. This sort of gitops workflow does all the renders in one step for review, then the apply in another step once the differences are approved.

## Related Issue

Fixes #...

## Proposed Changes

Adding a flag to `values.yaml` to ignore the check for existing CRDs.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
