### PR TITLE
fix(helm): grafana dashboard: add widget for sum of not ready secrets

### DIFF
--- a/deploy/charts/external-secrets/files/monitoring/grafana-dashboard.json
+++ b/deploy/charts/external-secrets/files/monitoring/grafana-dashboard.json
@@ -2007,6 +2007,116 @@
       ],
       "title": "Controllers",
       "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "id": 150,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 25
+          },
+          "id": 151,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.0.2",
+          "targets": [
+            {
+              "editorMode": "code",
+              "expr": "sum(externalsecret_status_condition{condition=\"Ready\", status=\"False\"})",
+              "legendFormat": "Not ready amount",
+              "range": true,
+              "refId": "A",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              }
+            }
+          ],
+          "title": "Secrets not ready",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Secrets",
+      "type": "row"
     }
   ],
   "refresh": "",
@@ -2054,6 +2164,6 @@
   "timezone": "",
   "title": "External Secrets Operator",
   "uid": "n4IdKaJVk",
-  "version": 10,
+  "version": 11,
   "weekStart": ""
 }


### PR DESCRIPTION
What is the problem you're trying to solve?

Improving grafana experience to debug external-secrets status

## Related Issue

-

## Proposed Changes

A new widget: 
<img width="1690" height="438" alt="Screenshot 2025-07-31 at 11 58 54" src="https://github.com/user-attachments/assets/ace7f97c-0880-4c75-b839-edcb99e78221" />

Note: I am not sure what is the direction you want for the dashboard, do not hesitate to ask me something else! I want to share what we do for ESO operations.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
