### PR TITLE
feat(helm): Add control of response to missing prometheus CRDs

### DIFF
--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -184,6 +184,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | serviceMonitor.metricRelabelings | list | `[]` | Metric relabel configs to apply to samples before ingestion. [Metric Relabeling](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs) |
 | serviceMonitor.namespace | string | `""` | namespace where you want to install ServiceMonitors |
 | serviceMonitor.relabelings | list | `[]` | Relabel configs to apply to samples before ingestion. [Relabeling](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) |
+| serviceMonitor.renderMode | string | `"skipIfMissing"` | How should we react to missing CRD "`monitoring.coreos.com/v1/ServiceMonitor`" Possible values: - `skipIfMissing`: Only render ServiceMonitor resources if CRD is present, skip if missing. - `failIfMissing`: Fail Helm install if CRD is not present. - `alwaysRender` : Always render ServiceMonitor resources, do not check for CRD. @schema enum: - skipIfMissing - failIfMissing - alwaysRender @schema |
 | serviceMonitor.scrapeTimeout | string | `"25s"` | Timeout if metrics can't be retrieved in given time interval |
 | strategy | object | `{}` | Set deployment strategy |
 | tolerations | list | `[]` |  |

--- a/deploy/charts/external-secrets/templates/NOTES.txt
+++ b/deploy/charts/external-secrets/templates/NOTES.txt
@@ -1,3 +1,4 @@
+{{- $shouldRenderStr := include "external-secrets.shouldRenderServiceMonitor" . | trim }}
 external-secrets has been deployed successfully in namespace {{ template "external-secrets.namespace" . }}!
 
 In order to begin using ExternalSecrets, you will need to set up a SecretStore
@@ -5,3 +6,7 @@ or ClusterSecretStore resource (for example, by creating a 'vault' SecretStore).
 
 More information on the different types of SecretStores and how to configure them
 can be found in our Github: {{ .Chart.Home }}
+
+{{- if and .Values.serviceMonitor.enabled (eq $shouldRenderStr "false") -}}
+WARNING: ServiceMonitors were not deployed due to missing CRD monitoring.coreos.com/v1/ServiceMonitor
+{{- end -}}

--- a/deploy/charts/external-secrets/templates/cert-controller-service.yaml
+++ b/deploy/charts/external-secrets/templates/cert-controller-service.yaml
@@ -1,4 +1,9 @@
-{{- if and .Values.certController.create ( or .Values.certController.metrics.service.enabled ( and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) .Values.serviceMonitor.enabled )) (not .Values.webhook.certManager.enabled) }}
+{{- $shouldRenderStr := include "external-secrets.shouldRenderServiceMonitor" . | trim }}
+{{- if and .Values.certController.create
+         (or .Values.certController.metrics.service.enabled
+             (and (eq $shouldRenderStr "true")
+                  .Values.serviceMonitor.enabled))
+         (not .Values.webhook.certManager.enabled) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/deploy/charts/external-secrets/templates/service.yaml
+++ b/deploy/charts/external-secrets/templates/service.yaml
@@ -1,4 +1,5 @@
-{{- if or (and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) .Values.serviceMonitor.enabled) .Values.metrics.service.enabled -}}
+{{- $shouldRenderStr := include "external-secrets.shouldRenderServiceMonitor" . | trim }}
+{{- if or .Values.metrics.service.enabled (and .Values.serviceMonitor.enabled (eq $shouldRenderStr "true")) -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/deploy/charts/external-secrets/templates/servicemonitor.yaml
+++ b/deploy/charts/external-secrets/templates/servicemonitor.yaml
@@ -1,4 +1,5 @@
-{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) .Values.serviceMonitor.enabled -}}
+{{- $shouldRenderStr := include "external-secrets.shouldRenderServiceMonitor" . | trim }}
+{{- if and .Values.serviceMonitor.enabled (eq $shouldRenderStr "true") }}
 apiVersion: "monitoring.coreos.com/v1"
 kind: ServiceMonitor
 metadata:

--- a/deploy/charts/external-secrets/templates/webhook-service.yaml
+++ b/deploy/charts/external-secrets/templates/webhook-service.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.webhook.create .Values.webhook.service.enabled }}
+{{- $shouldRenderStr := include "external-secrets.shouldRenderServiceMonitor" . | trim }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -24,12 +25,14 @@ spec:
     targetPort: webhook
     protocol: TCP
     name: webhook
-  {{- if or .Values.webhook.metrics.service.enabled ( and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) .Values.serviceMonitor.enabled ) }}
+{{- if or .Values.webhook.metrics.service.enabled 
+         (and .Values.serviceMonitor.enabled 
+              (eq $shouldRenderStr "true")) }}
   - port: {{ .Values.webhook.metrics.service.port }}
     protocol: TCP
     targetPort: metrics
     name: metrics
-  {{- end }}
+{{- end }}
   selector:
     {{- include "external-secrets-webhook.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/deploy/charts/external-secrets/tests/cert_controller_test.yaml
+++ b/deploy/charts/external-secrets/tests/cert_controller_test.yaml
@@ -145,7 +145,7 @@ tests:
       serviceMonitor.enabled: true
     capabilities:
       apiVersions:
-        - "monitoring.coreos.com/v1"
+        - "monitoring.coreos.com/v1/ServiceMonitor"
     templates:
       - cert-controller-service.yaml
     asserts:
@@ -154,6 +154,35 @@ tests:
       - equal:
           path: metadata.labels["app.kubernetes.io/metrics"]
           value: "cert-controller"
+  - it: should render service with metrics label when APIVersions are not present, serviceMonitor is enabled, and serviceMonitor.renderMode is alwaysRender
+    set:
+      serviceMonitor.enabled: true
+      serviceMonitor.renderMode: alwaysRender
+    templates:
+      - cert-controller-service.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.labels["app.kubernetes.io/metrics"]
+          value: "cert-controller"
+  - it: should fail if APIVersions is missing, serviceMonitor is enabled, and serviceMonitor.renderMode is failIfMissing
+    set:
+      serviceMonitor.enabled: true
+      serviceMonitor.renderMode: failIfMissing
+    templates:
+      - cert-controller-service.yaml
+    asserts:
+      - failedTemplate: {}
+  - it: should not render service when APIVersions is not present, serviceMonitor is enabled, and and serviceMonitor.renderMode is skipIfMissing
+    set:
+      serviceMonitor.enabled: true
+      serviceMonitor.renderMode: skipIfMissing
+    templates:
+      - cert-controller-service.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
   - it: should not render service when APIVersions is not present but serviceMonitor is enabled
     set:
       serviceMonitor.enabled: true
@@ -167,7 +196,7 @@ tests:
       serviceMonitor.enabled: false
     capabilities:
       apiVersions:
-        - "monitoring.coreos.com/v1"
+        - "monitoring.coreos.com/v1/ServiceMonitor"
     templates:
       - cert-controller-service.yaml
     asserts:

--- a/deploy/charts/external-secrets/tests/service_monitor_test.yaml
+++ b/deploy/charts/external-secrets/tests/service_monitor_test.yaml
@@ -7,10 +7,30 @@ tests:
       serviceMonitor.enabled: true
     capabilities:
       apiVersions:
-        - "monitoring.coreos.com/v1"
+        - "monitoring.coreos.com/v1/ServiceMonitor"
     asserts:
       - hasDocuments:
           count: 3
+  - it: should render service monitor when APIVersions is not present, serviceMonitor is enabled, and shouldRenderServiceMonitor is alwaysRender
+    set:
+      serviceMonitor.enabled: true
+      serviceMonitor.renderMode: alwaysRender
+    asserts:
+      - hasDocuments:
+          count: 3
+  - it: should fail if APIVersions is missing, serviceMonitor is enabled, and serviceMonitor.renderMode is failIfMissing
+    set:
+      serviceMonitor.enabled: true
+      serviceMonitor.renderMode: failIfMissing
+    asserts:
+      - failedTemplate: {}
+  - it: should not render service monitor when APIVersions is not present, serviceMonitor is enabled, and serviceMonitor.renderMode is skipIfMissing
+    set:
+      serviceMonitor.enabled: true
+      serviceMonitor.renderMode: skipIfMissing
+    asserts:
+      - hasDocuments:
+          count: 0
   - it: should not render service monitor when APIVersions is not present but serviceMonitor is enabled
     set:
       serviceMonitor.enabled: true
@@ -22,7 +42,7 @@ tests:
       serviceMonitor.enabled: false
     capabilities:
       apiVersions:
-        - "monitoring.coreos.com/v1"
+        - "monitoring.coreos.com/v1/ServiceMonitor"
     asserts:
       - hasDocuments:
           count: 0

--- a/deploy/charts/external-secrets/tests/service_test.yaml
+++ b/deploy/charts/external-secrets/tests/service_test.yaml
@@ -15,12 +15,29 @@ tests:
       serviceMonitor.enabled: true
     capabilities:
       apiVersions:
-        - "monitoring.coreos.com/v1"
+        - "monitoring.coreos.com/v1/ServiceMonitor"
     templates:
       - service.yaml
     asserts:
       - hasDocuments:
           count: 1
+  - it: should fail if APIVersions is missing, serviceMonitor is enabled, and serviceMonitor.renderMode is failIfMissing
+    set:
+      serviceMonitor.enabled: true
+      serviceMonitor.renderMode: failIfMissing
+    templates:
+      - service.yaml
+    asserts:
+      - failedTemplate: {}
+  - it: should not render service when APIVersions is not present, serviceMonitor is enabled, and serviceMonitor.renderMode is skipIfMissing
+    set:
+      serviceMonitor.enabled: true
+      serviceMonitor.renderMode: skipIfMissing
+    templates:
+      - service.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
   - it: should not render service when APIVersions is not present but serviceMonitor is enabled
     set:
       serviceMonitor.enabled: true
@@ -34,7 +51,7 @@ tests:
       serviceMonitor.enabled: false
     capabilities:
       apiVersions:
-        - "monitoring.coreos.com/v1"
+        - "monitoring.coreos.com/v1/ServiceMonitor"
     templates:
       - service.yaml
     asserts:

--- a/deploy/charts/external-secrets/tests/webhook_test.yaml
+++ b/deploy/charts/external-secrets/tests/webhook_test.yaml
@@ -219,7 +219,7 @@ tests:
       serviceMonitor.enabled: true
     capabilities:
       apiVersions:
-        - "monitoring.coreos.com/v1"
+        - "monitoring.coreos.com/v1/ServiceMonitor"
     templates:
       - webhook-service.yaml
     asserts:
@@ -229,6 +229,39 @@ tests:
       - equal:
           path: metadata.labels["app.kubernetes.io/metrics"]
           value: "webhook"
+  - it: should expose metrics port and metrics label when APIVersions is not present, serviceMonitor is enabled, and serviceMonitor.renderMode is alwaysRender
+    set:
+      serviceMonitor.enabled: true
+      serviceMonitor.renderMode: alwaysRender
+    templates:
+      - webhook-service.yaml
+    asserts:
+      - equal:
+          path: spec.ports[1].name
+          value: metrics
+      - equal:
+          path: metadata.labels["app.kubernetes.io/metrics"]
+          value: "webhook"
+  - it: should fail if APIVersions is missing, serviceMonitor is enabled, and serviceMonitor.renderMode is failIfMissing
+    set:
+      serviceMonitor.enabled: true
+      serviceMonitor.renderMode: failIfMissing
+    templates:
+      - webhook-service.yaml
+    asserts:
+      - failedTemplate: {}
+  - it: should not expose metrics port nor metrics label when APIVersions is not present, serviceMonitor is enabled, and serviceMonitor.renderMode is skipIfMissing
+    set:
+      serviceMonitor.enabled: true
+      serviceMonitor.renderMode: skipIfMissing
+    templates:
+      - webhook-service.yaml
+    asserts:
+      - lengthEqual:
+          path: spec.ports
+          count: 1
+      - isNull:
+          path: metadata.labels["app.kubernetes.io/metrics"]
   - it: should not expose metrics port nor metrics label when APIVersions is not present but serviceMonitor is enabled
     set:
       serviceMonitor.enabled: true
@@ -245,7 +278,7 @@ tests:
       serviceMonitor.enabled: false
     capabilities:
       apiVersions:
-        - "monitoring.coreos.com/v1"
+        - "monitoring.coreos.com/v1/ServiceMonitor"
     templates:
       - webhook-service.yaml
     asserts:

--- a/deploy/charts/external-secrets/values.schema.json
+++ b/deploy/charts/external-secrets/values.schema.json
@@ -670,6 +670,14 @@
                 "relabelings": {
                     "type": "array"
                 },
+                "renderMode": {
+                    "type": "string",
+                    "enum": [
+                        "skipIfMissing",
+                        "failIfMissing",
+                        "alwaysRender"
+                    ]
+                },
                 "scrapeTimeout": {
                     "type": "string"
                 }

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -194,6 +194,21 @@ serviceMonitor:
   # -- Specifies whether to create a ServiceMonitor resource for collecting Prometheus metrics
   enabled: false
 
+  # -- How should we react to missing CRD "`monitoring.coreos.com/v1/ServiceMonitor`"
+  #
+  # Possible values:
+  # - `skipIfMissing`: Only render ServiceMonitor resources if CRD is present, skip if missing.
+  # - `failIfMissing`: Fail Helm install if CRD is not present.
+  # - `alwaysRender` : Always render ServiceMonitor resources, do not check for CRD.
+
+  # @schema
+  # enum:
+  # - skipIfMissing
+  # - failIfMissing
+  # - alwaysRender
+  # @schema
+  renderMode: skipIfMissing   # @schema enum: [skipIfMissing, failIfMissing, alwaysRender]
+
   # -- namespace where you want to install ServiceMonitors
   namespace: ""
 


### PR DESCRIPTION
## Problem Statement

Currently the `ServiceMonitor` resources are only rendered if (a) `.serviceMonitor.enabled` is `true` and (b) the Prometheus Operator CRDs are detected.

If either condition is `false` then they are not. When doing an offline render to review the diff (`kluctl`) or deploying as one big server side apply, a user can request the `ServiceMonitor` resources, but not get them.  Furthermore, this behavior is silent.

## Related Issue

Fixes #...

## Proposed Changes

This PR adds a ternary option which allows the user to decide how to respond.  A user can select from `skipIfMissing`, `failIfMissing`, or `alwaysRender`.  The default is `skipIfMissing` currently as that is the existing behavior.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
