### PR TITLE
fix: use server-side apply for CRD installation in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ manifests: helm.generate ## Generate manifests from helm chart
 	helm template external-secrets $(HELM_DIR) -f deploy/manifests/helm-values.yaml > $(OUTPUT_DIR)/deploy/manifests/external-secrets.yaml
 
 crds.install: generate ## Install CRDs into a cluster. This is for convenience
-	kubectl apply -f $(BUNDLE_DIR)
+	kubectl apply -f $(BUNDLE_DIR) --server-side
 
 crds.uninstall: ## Uninstall CRDs from a cluster. This is for convenience
 	kubectl delete -f $(BUNDLE_DIR)


### PR DESCRIPTION
## Problem Statement
Upon running `crds.install` on a new kind cluster a following error is produced

```
➜ make crds.install
21:10:36 [ OK ] Finished generating deepcopy and crds
kubectl apply -f deploy/crds
customresourcedefinition.apiextensions.k8s.io/clusterexternalsecrets.external-secrets.io created
customresourcedefinition.apiextensions.k8s.io/clusterpushsecrets.external-secrets.io created
customresourcedefinition.apiextensions.k8s.io/externalsecrets.external-secrets.io created
customresourcedefinition.apiextensions.k8s.io/pushsecrets.external-secrets.io created
customresourcedefinition.apiextensions.k8s.io/acraccesstokens.generators.external-secrets.io created
customresourcedefinition.apiextensions.k8s.io/clustergenerators.generators.external-secrets.io created
customresourcedefinition.apiextensions.k8s.io/ecrauthorizationtokens.generators.external-secrets.io created
customresourcedefinition.apiextensions.k8s.io/fakes.generators.external-secrets.io created
customresourcedefinition.apiextensions.k8s.io/gcraccesstokens.generators.external-secrets.io created
customresourcedefinition.apiextensions.k8s.io/generatorstates.generators.external-secrets.io created
customresourcedefinition.apiextensions.k8s.io/githubaccesstokens.generators.external-secrets.io created
customresourcedefinition.apiextensions.k8s.io/grafanas.generators.external-secrets.io created
customresourcedefinition.apiextensions.k8s.io/mfas.generators.external-secrets.io created
customresourcedefinition.apiextensions.k8s.io/passwords.generators.external-secrets.io created
customresourcedefinition.apiextensions.k8s.io/quayaccesstokens.generators.external-secrets.io created
customresourcedefinition.apiextensions.k8s.io/sshkeys.generators.external-secrets.io created
customresourcedefinition.apiextensions.k8s.io/stssessiontokens.generators.external-secrets.io created
customresourcedefinition.apiextensions.k8s.io/uuids.generators.external-secrets.io created
customresourcedefinition.apiextensions.k8s.io/vaultdynamicsecrets.generators.external-secrets.io created
customresourcedefinition.apiextensions.k8s.io/webhooks.generators.external-secrets.io created
Error from server (Invalid): error when creating "deploy/crds/bundle.yaml": CustomResourceDefinition.apiextensions.k8s.io "clustersecretstores.external-secrets.io" is invalid: metadata.annotations: Too long: must have at most 262144 bytes
Error from server (Invalid): error when creating "deploy/crds/bundle.yaml": CustomResourceDefinition.apiextensions.k8s.io "secretstores.external-secrets.io" is invalid: metadata.annotations: Too long: must have at most 262144 bytes
make: *** [crds.install] Error 1

```


## Proposed Changes

Add server-side-apply for kubectl command. 

## Checklist

- [x ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x ] All commits are signed with `git commit --signoff`
- [x ] My changes have reasonable test coverage
- [x ] All tests pass with `make test`
- [x ] I ensured my PR is ready for review with `make reviewable`
