### PR TITLE
fix: report 404 secrets correctly in Gitlab provider

### DIFF
--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -310,14 +310,16 @@ func (g *gitlabBase) GetSecret(_ context.Context, ref esv1.ExternalSecretDataRem
 		return nil, err
 	}
 
-	err = g.ResolveGroupIds()
-	if err != nil {
+	if err := g.ResolveGroupIds(); err != nil {
 		return nil, err
 	}
 
 	var result []byte
 	if resp.StatusCode < 300 {
 		result, err = extractVariable(ref, data.Value)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	for i := len(g.store.GroupIDs) - 1; i >= 0; i-- {


### PR DESCRIPTION
## Problem Statement

In gitlab provider, if non existent secret key is provided, it will not report any error but simply store an empty value in resulting kubernetes secret.  Introduced by https://github.com/external-secrets/external-secrets/pull/4379/files

## Related Issue

Fixes https://github.com/external-secrets/external-secrets/issues/4682

## Proposed Changes

How do you like to solve the issue and why?
In the present code there are 2 shadowing present 
https://github.com/external-secrets/external-secrets/blob/3c847e36c35b770063fa73fb3ed004097453cb41/pkg/provider/gitlab/gitlab.go#L307-L341

one at the beginning where we are getting 404 (it gets shadowed by `err = g.ResolveGroupIds()`). 

Second, in case there is a good match, the error of `result, err = extractVariable(ref, data.Value)` is ignored. 

Overall I am not too happy with the state of the flow maybe some major refactoring should be done? (i.e. errors checking at the end where its not even clear to what they are referring to, etc). 

If someone can point me to the direction of how to set a fake 404 response it would be appreciated, I am not too familiar with current testing suite. 

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
