### PR TITLE
feat(helm): Add optional grafana folder for dashboard

### DIFF
--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -115,7 +115,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | global.topologySpreadConstraints | list | `[]` |  |
 | grafanaDashboard.annotations | object | `{}` | Annotations that ConfigMaps can have to get configured in Grafana, See: sidecar.dashboards.folderAnnotation for specifying the dashboard folder. https://github.com/grafana/helm-charts/tree/main/charts/grafana |
 | grafanaDashboard.enabled | bool | `false` | If true creates a Grafana dashboard. |
+| grafanaDashboard.sidecarFolderLabel | string | `nil` | Lable Grafana uses to see if a folder is requested for the loaded dashboard. |
 | grafanaDashboard.sidecarLabel | string | `"grafana_dashboard"` | Label that ConfigMaps should have to be loaded as dashboards. |
+| grafanaDashboard.sidecarLabelFolderValue | string | `"external-secrets"` | Label value for defining which folder the dashboard should be in. |
 | grafanaDashboard.sidecarLabelValue | string | `"1"` | Label value that ConfigMaps should have to be loaded as dashboards. |
 | hostNetwork | bool | `false` | Run the controller on the host network |
 | image.flavour | string | `""` | The flavour of tag you want to use There are different image flavours available, like distroless and ubi. Please see GitHub release notes for image tags for these flavors. By default, the distroless image is used. |

--- a/deploy/charts/external-secrets/templates/grafana-dashboard.yaml
+++ b/deploy/charts/external-secrets/templates/grafana-dashboard.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ include "external-secrets.namespace" . }}
   labels:
     {{ .Values.grafanaDashboard.sidecarLabel }}: {{ .Values.grafanaDashboard.sidecarLabelValue | quote }}
+    {{- if .Values.grafanaDashboard.sidecarFolderLabel }}
+    {{ .Values.grafanaDashboard.sidecarFolderLabel }}: {{ .Values.grafanaDashboard.sidecarFolderLabelValue | quote }}
+    {{- end }}
     {{- include "external-secrets.labels" . | nindent 4 }}
   {{- with .Values.grafanaDashboard.annotations }}
   annotations:

--- a/deploy/charts/external-secrets/values.schema.json
+++ b/deploy/charts/external-secrets/values.schema.json
@@ -382,6 +382,12 @@
                 },
                 "sidecarLabelValue": {
                     "type": "string"
+                },
+                "sidecarFolderLabel": {
+                    "type": [ "null", "string" ]
+                },
+                "sidecarFolderLabelValue": {
+                    "type": "string"
                 }
             },
             "type": "object"

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -249,6 +249,12 @@ grafanaDashboard:
   # -- Label value that ConfigMaps should have to be loaded as dashboards.
   sidecarLabelValue: "1"
 
+  # -- Lable Grafana uses to see if a folder is requested for the loaded dashboard.
+  sidecarFolderLabel: NULL
+
+  # -- Label value for defining which folder the dashboard should be in.
+  sidecarLabelFolderValue: "external-secrets"
+
   # -- Annotations that ConfigMaps can have to get configured in Grafana,
   # See: sidecar.dashboards.folderAnnotation for specifying the dashboard folder.
   # https://github.com/grafana/helm-charts/tree/main/charts/grafana


### PR DESCRIPTION
## Problem Statement

When importing dashboards from configmap it can be handy to put them into a specific folder

## Related Issue

Fixes #...

## Proposed Changes

Adds two helm options for setting grafana folder (label name and label value)

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
