### PR TITLE
fix: bump image digest to fix e2e tests

### DIFF
--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.6-bookworm@sha256:ef8c5c733079ac219c77edab604c425d748c740d8699530ea6aced9de79aea40 AS builder
+FROM golang:1.24.6-bookworm@sha256:2679c15c940573aded505b2f2fbbd4e718b5172327aae3ab9f43a10a5c700dfc AS builder
 
 ENV KUBECTL_VERSION="v1.28.3"
 ENV HELM_VERSION="v3.13.1"


### PR DESCRIPTION
This PR bumps the e2e test image digest to the latest version.

the one on main fails to build, [see here](https://github.com/external-secrets/external-secrets/actions/runs/16890686139/job/47852912829): 

```
#9 [builder 5/9] COPY go.mod go.sum ./
#9 DONE 0.0s

#8 [builder 6/9] RUN go mod download && go mod verify
#8 0.057 go: go.mod requires go >= 1.24.6 (running go 1.24.5; GOTOOLCHAIN=local)
#8 ERROR: process "/bin/sh -c go mod download && go mod verify" did not complete successfully: exit code: 1
------
 > [builder 6/9] RUN go mod download && go mod verify:
------
failed to solve: rpc error: code = Unknown desc = process "/bin/sh -c go mod download && go mod verify" did not complete successfully: exit code: 1
make[1]: *** [Makefile:65: e2e-image] Error 1
```