### PR TITLE
feat(gcp): get latest enabled secret

### DIFF
--- a/apis/externalsecrets/v1/secretstore_gcpsm_types.go
+++ b/apis/externalsecrets/v1/secretstore_gcpsm_types.go
@@ -20,6 +20,16 @@ import (
 	esmeta "github.com/external-secrets/external-secrets/apis/meta/v1"
 )
 
+type SecretVersionSelectionPolicy string
+
+const (
+	// SecretVersionSelectionPolicyLatestOrFail means the provider always uses "latest", or fails if that version is disabled/destroyed.
+	SecretVersionSelectionPolicyLatestOrFail SecretVersionSelectionPolicy = "LatestOrFail"
+
+	// SecretVersionSelectionPolicyLatestOrFetch behaves like SecretVersionSelectionPolicyLatestOrFail but falls back to fetching the latest version if the version is DESTROYED or DISABLED
+	SecretVersionSelectionPolicyLatestOrFetch SecretVersionSelectionPolicy = "LatestOrFetch"
+)
+
 type GCPSMAuth struct {
 	// +optional
 	SecretRef *GCPSMAuthSecretRef `json:"secretRef,omitempty"`
@@ -64,10 +74,14 @@ type GCPSMProvider struct {
 	// Location optionally defines a location for a secret
 	Location string `json:"location,omitempty"`
 
-	// GetLatestEnabledSecret if true, the latest enabled secret version will be fetched
+	// SecretVersionSelectionPolicy specifies how the provider selects a secret version
+	// when "latest" is disabled or destroyed.
+	// Possible values are:
+	// - LatestOrFail: the provider always uses "latest", or fails if that version is disabled/destroyed.
+	// - LatestOrFetch: the provider falls back to fetching the latest version if the version is DESTROYED or DISABLED
 	// +optional
-	// +default=false
-	GetLatestEnabledSecret bool `json:"getLatestEnabledSecret,omitempty"`
+	// +kubebuilder:default=LatestOrFail
+	SecretVersionSelectionPolicy SecretVersionSelectionPolicy `json:"secretVersionSelectionPolicy,omitempty"`
 }
 
 // GCPWorkloadIdentityFederation holds the configurations required for generating federated access tokens.

--- a/apis/externalsecrets/v1/secretstore_gcpsm_types.go
+++ b/apis/externalsecrets/v1/secretstore_gcpsm_types.go
@@ -26,7 +26,7 @@ const (
 	// SecretVersionSelectionPolicyLatestOrFail means the provider always uses "latest", or fails if that version is disabled/destroyed.
 	SecretVersionSelectionPolicyLatestOrFail SecretVersionSelectionPolicy = "LatestOrFail"
 
-	// SecretVersionSelectionPolicyLatestOrFetch behaves like SecretVersionSelectionPolicyLatestOrFail but falls back to fetching the latest version if the version is DESTROYED or DISABLED
+	// SecretVersionSelectionPolicyLatestOrFetch behaves like SecretVersionSelectionPolicyLatestOrFail but falls back to fetching the latest version if the version is DESTROYED or DISABLED.
 	SecretVersionSelectionPolicyLatestOrFetch SecretVersionSelectionPolicy = "LatestOrFetch"
 )
 

--- a/apis/externalsecrets/v1/secretstore_gcpsm_types.go
+++ b/apis/externalsecrets/v1/secretstore_gcpsm_types.go
@@ -63,6 +63,11 @@ type GCPSMProvider struct {
 
 	// Location optionally defines a location for a secret
 	Location string `json:"location,omitempty"`
+
+	// GetLatestEnabledSecret if true, the latest enabled secret version will be fetched
+	// +optional
+	// +default=false
+	GetLatestEnabledSecret bool `json:"getLatestEnabledSecret,omitempty"`
 }
 
 // GCPWorkloadIdentityFederation holds the configurations required for generating federated access tokens.

--- a/config/crds/bases/external-secrets.io_clustersecretstores.yaml
+++ b/config/crds/bases/external-secrets.io_clustersecretstores.yaml
@@ -2065,6 +2065,11 @@ spec:
                                 type: object
                             type: object
                         type: object
+                      getLatestEnabledSecret:
+                        default: false
+                        description: GetLatestEnabledSecret if true, the latest enabled
+                          secret version will be fetched
+                        type: boolean
                       location:
                         description: Location optionally defines a location for a
                           secret

--- a/config/crds/bases/external-secrets.io_clustersecretstores.yaml
+++ b/config/crds/bases/external-secrets.io_clustersecretstores.yaml
@@ -2065,17 +2065,21 @@ spec:
                                 type: object
                             type: object
                         type: object
-                      getLatestEnabledSecret:
-                        default: false
-                        description: GetLatestEnabledSecret if true, the latest enabled
-                          secret version will be fetched
-                        type: boolean
                       location:
                         description: Location optionally defines a location for a
                           secret
                         type: string
                       projectID:
                         description: ProjectID project where secret is located
+                        type: string
+                      secretVersionSelectionPolicy:
+                        default: LatestOrFail
+                        description: |-
+                          SecretVersionSelectionPolicy specifies how the provider selects a secret version
+                          when "latest" is disabled or destroyed.
+                          Possible values are:
+                          - LatestOrFail: the provider always uses "latest", or fails if that version is disabled/destroyed.
+                          - LatestOrFetch: the provider falls back to fetching the latest version if the version is DESTROYED or DISABLED
                         type: string
                     type: object
                   github:

--- a/config/crds/bases/external-secrets.io_secretstores.yaml
+++ b/config/crds/bases/external-secrets.io_secretstores.yaml
@@ -2065,6 +2065,11 @@ spec:
                                 type: object
                             type: object
                         type: object
+                      getLatestEnabledSecret:
+                        default: false
+                        description: GetLatestEnabledSecret if true, the latest enabled
+                          secret version will be fetched
+                        type: boolean
                       location:
                         description: Location optionally defines a location for a
                           secret

--- a/config/crds/bases/external-secrets.io_secretstores.yaml
+++ b/config/crds/bases/external-secrets.io_secretstores.yaml
@@ -2065,17 +2065,21 @@ spec:
                                 type: object
                             type: object
                         type: object
-                      getLatestEnabledSecret:
-                        default: false
-                        description: GetLatestEnabledSecret if true, the latest enabled
-                          secret version will be fetched
-                        type: boolean
                       location:
                         description: Location optionally defines a location for a
                           secret
                         type: string
                       projectID:
                         description: ProjectID project where secret is located
+                        type: string
+                      secretVersionSelectionPolicy:
+                        default: LatestOrFail
+                        description: |-
+                          SecretVersionSelectionPolicy specifies how the provider selects a secret version
+                          when "latest" is disabled or destroyed.
+                          Possible values are:
+                          - LatestOrFail: the provider always uses "latest", or fails if that version is disabled/destroyed.
+                          - LatestOrFetch: the provider falls back to fetching the latest version if the version is DESTROYED or DISABLED
                         type: string
                     type: object
                   github:

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -3956,15 +3956,20 @@ spec:
                                   type: object
                               type: object
                           type: object
-                        getLatestEnabledSecret:
-                          default: false
-                          description: GetLatestEnabledSecret if true, the latest enabled secret version will be fetched
-                          type: boolean
                         location:
                           description: Location optionally defines a location for a secret
                           type: string
                         projectID:
                           description: ProjectID project where secret is located
+                          type: string
+                        secretVersionSelectionPolicy:
+                          default: LatestOrFail
+                          description: |-
+                            SecretVersionSelectionPolicy specifies how the provider selects a secret version
+                            when "latest" is disabled or destroyed.
+                            Possible values are:
+                            - LatestOrFail: the provider always uses "latest", or fails if that version is disabled/destroyed.
+                            - LatestOrFetch: the provider falls back to fetching the latest version if the version is DESTROYED or DISABLED
                           type: string
                       type: object
                     github:
@@ -15095,15 +15100,20 @@ spec:
                                   type: object
                               type: object
                           type: object
-                        getLatestEnabledSecret:
-                          default: false
-                          description: GetLatestEnabledSecret if true, the latest enabled secret version will be fetched
-                          type: boolean
                         location:
                           description: Location optionally defines a location for a secret
                           type: string
                         projectID:
                           description: ProjectID project where secret is located
+                          type: string
+                        secretVersionSelectionPolicy:
+                          default: LatestOrFail
+                          description: |-
+                            SecretVersionSelectionPolicy specifies how the provider selects a secret version
+                            when "latest" is disabled or destroyed.
+                            Possible values are:
+                            - LatestOrFail: the provider always uses "latest", or fails if that version is disabled/destroyed.
+                            - LatestOrFetch: the provider falls back to fetching the latest version if the version is DESTROYED or DISABLED
                           type: string
                       type: object
                     github:

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -3956,6 +3956,10 @@ spec:
                                   type: object
                               type: object
                           type: object
+                        getLatestEnabledSecret:
+                          default: false
+                          description: GetLatestEnabledSecret if true, the latest enabled secret version will be fetched
+                          type: boolean
                         location:
                           description: Location optionally defines a location for a secret
                           type: string
@@ -15091,6 +15095,10 @@ spec:
                                   type: object
                               type: object
                           type: object
+                        getLatestEnabledSecret:
+                          default: false
+                          description: GetLatestEnabledSecret if true, the latest enabled secret version will be fetched
+                          type: boolean
                         location:
                           description: Location optionally defines a location for a secret
                           type: string

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -5269,14 +5269,20 @@ string
 </tr>
 <tr>
 <td>
-<code>getLatestEnabledSecret</code></br>
+<code>secretVersionSelectionPolicy</code></br>
 <em>
-bool
+<a href="#external-secrets.io/v1.SecretVersionSelectionPolicy">
+SecretVersionSelectionPolicy
+</a>
 </em>
 </td>
 <td>
 <em>(Optional)</em>
-<p>GetLatestEnabledSecret if true, the latest enabled secret version will be fetched</p>
+<p>SecretVersionSelectionPolicy specifies how the provider selects a secret version
+when &ldquo;latest&rdquo; is disabled or destroyed.
+Possible values are:
+- LatestOrFail: the provider always uses &ldquo;latest&rdquo;, or fails if that version is disabled/destroyed.
+- LatestOrFetch: the provider falls back to fetching the latest version if the version is DESTROYED or DISABLED</p>
 </td>
 </tr>
 </tbody>
@@ -9183,6 +9189,29 @@ Kubernetes meta/v1.Time
 </td>
 </tr>
 </tbody>
+</table>
+<h3 id="external-secrets.io/v1.SecretVersionSelectionPolicy">SecretVersionSelectionPolicy
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#external-secrets.io/v1.GCPSMProvider">GCPSMProvider</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;LatestOrFail&#34;</p></td>
+<td><p>SecretVersionSelectionPolicyLatestOrFail means the provider always uses &ldquo;latest&rdquo;, or fails if that version is disabled/destroyed.</p>
+</td>
+</tr><tr><td><p>&#34;LatestOrFetch&#34;</p></td>
+<td><p>SecretVersionSelectionPolicyLatestOrFetch behaves like SecretVersionSelectionPolicyLatestOrFail but falls back to fetching the latest version if the version is DESTROYED or DISABLED</p>
+</td>
+</tr></tbody>
 </table>
 <h3 id="external-secrets.io/v1.SecretsClient">SecretsClient
 </h3>

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -5267,6 +5267,18 @@ string
 <p>Location optionally defines a location for a secret</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>getLatestEnabledSecret</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>GetLatestEnabledSecret if true, the latest enabled secret version will be fetched</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="external-secrets.io/v1.GCPWorkloadIdentity">GCPWorkloadIdentity

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -9209,7 +9209,7 @@ Kubernetes meta/v1.Time
 <td><p>SecretVersionSelectionPolicyLatestOrFail means the provider always uses &ldquo;latest&rdquo;, or fails if that version is disabled/destroyed.</p>
 </td>
 </tr><tr><td><p>&#34;LatestOrFetch&#34;</p></td>
-<td><p>SecretVersionSelectionPolicyLatestOrFetch behaves like SecretVersionSelectionPolicyLatestOrFail but falls back to fetching the latest version if the version is DESTROYED or DISABLED</p>
+<td><p>SecretVersionSelectionPolicyLatestOrFetch behaves like SecretVersionSelectionPolicyLatestOrFail but falls back to fetching the latest version if the version is DESTROYED or DISABLED.</p>
 </td>
 </tr></tbody>
 </table>

--- a/docs/provider/google-secrets-manager.md
+++ b/docs/provider/google-secrets-manager.md
@@ -382,14 +382,32 @@ spec:
 
 ## Secret Version Management
 
-### Latest Enabled Secret Fallback
+### Secret Version Selection Policy
 
-The Google Secret Manager provider includes a `getLatestEnabledSecret` flag that controls how the provider handles secret version fallbacks when the default "latest" version is unavailable.
+The Google Secret Manager provider includes a `secretVersionSelectionPolicy` field that controls how the provider handles secret version selection when the default "latest" version is unavailable.
 
-By default, when you request a secret without specifying a version, the provider attempts to fetch the "latest" version. If that version is in a DESTROYED or DISABLED state, the provider automatically falls back to fetching the latest enabled version.
+By default, when you request a secret without specifying a version, the provider attempts to fetch the "latest" version. The `secretVersionSelectionPolicy` determines what happens if that version is in a DESTROYED or DISABLED state.
 
-You can control this behavior using the `getLatestEnabledSecret` flag.
+#### Available Policies
 
-**Note**: When using `getLatestEnabledSecret: true`, the service account requires additional permissions to list secret versions. You'll need to grant the `roles/secretmanager.viewer` role (which includes `secretmanager.versions.list`) or the specific `secretmanager.versions.list` permission in addition to the standard `secretmanager.secretAccessor` role.
+- **`LatestOrFail`** (default): The provider always uses "latest", or fails if that version is disabled/destroyed.
+- **`LatestOrFetch`**: The provider falls back to fetching the latest enabled version if the "latest" version is DESTROYED or DISABLED.
+
+#### Configuration Example
+
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: gcp-secret-store
+spec:
+  provider:
+    gcpsm:
+      projectID: my-project
+      location: us-east1
+      secretVersionSelectionPolicy: LatestOrFetch  # or LatestOrFail (default)
+```
+
+**Note**: When using `secretVersionSelectionPolicy: LatestOrFetch`, the service account requires additional permissions to list secret versions. You'll need to grant the `roles/secretmanager.viewer` role (which includes `secretmanager.versions.list`) or the specific `secretmanager.versions.list` permission in addition to the standard `secretmanager.secretAccessor` role.
 
 ```

--- a/docs/provider/google-secrets-manager.md
+++ b/docs/provider/google-secrets-manager.md
@@ -379,3 +379,17 @@ spec:
       projectID: my-project
       location: us-east1 # uses regional secrets on us-east1
 ```
+
+## Secret Version Management
+
+### Latest Enabled Secret Fallback
+
+The Google Secret Manager provider includes a `getLatestEnabledSecret` flag that controls how the provider handles secret version fallbacks when the default "latest" version is unavailable.
+
+By default, when you request a secret without specifying a version, the provider attempts to fetch the "latest" version. If that version is in a DESTROYED or DISABLED state, the provider automatically falls back to fetching the latest enabled version.
+
+You can control this behavior using the `getLatestEnabledSecret` flag.
+
+**Note**: When using `getLatestEnabledSecret: true`, the service account requires additional permissions to list secret versions. You'll need to grant the `roles/secretmanager.viewer` role (which includes `secretmanager.versions.list`) or the specific `secretmanager.versions.list` permission in addition to the standard `secretmanager.secretAccessor` role.
+
+```

--- a/docs/snippets/full-secret-store.yaml
+++ b/docs/snippets/full-secret-store.yaml
@@ -129,7 +129,7 @@ spec:
             key: secret-access-credentials
       projectID: myproject
       location: us-east1
-      getLatestEnabledSecret: false
+      secretVersionSelectionPolicy: LatestOrFetch
     # (TODO): add more provider examples here
 
 status:

--- a/docs/snippets/full-secret-store.yaml
+++ b/docs/snippets/full-secret-store.yaml
@@ -128,6 +128,8 @@ spec:
             name: gcpsm-secret
             key: secret-access-credentials
       projectID: myproject
+      location: us-east1
+      getLatestEnabledSecret: false
     # (TODO): add more provider examples here
 
 status:

--- a/pkg/provider/gcp/secretmanager/client.go
+++ b/pkg/provider/gcp/secretmanager/client.go
@@ -505,7 +505,12 @@ func (c *Client) GetSecret(ctx context.Context, ref esv1.ExternalSecretDataRemot
 		ref.Version == "" && isErrSecretDestroyedOrDisabled(err) {
 		// if the secret is destroyed or disabled, and we are configured to get the latest enabled secret,
 		// we need to get the latest enabled secret
-		result, err = getLatestEnabledVersion(ctx, c.smClient, name)
+		// Extract the secret name from the version name for ListSecretVersions
+		secretName := fmt.Sprintf(globalSecretPath, c.store.ProjectID, ref.Key)
+		if c.store.Location != "" {
+			secretName = fmt.Sprintf(regionalSecretPath, c.store.ProjectID, c.store.Location, ref.Key)
+		}
+		result, err = getLatestEnabledVersion(ctx, c.smClient, secretName)
 	}
 	if err != nil {
 		metrics.ObserveAPICall(constants.ProviderGCPSM, constants.CallGCPSMAccessSecretVersion, err)

--- a/pkg/provider/gcp/secretmanager/client.go
+++ b/pkg/provider/gcp/secretmanager/client.go
@@ -502,7 +502,7 @@ func (c *Client) GetSecret(ctx context.Context, ref esv1.ExternalSecretDataRemot
 	}
 	result, err := c.smClient.AccessSecretVersion(ctx, req)
 	if err != nil {
-		if version == defaultVersion {
+		if c.store.GetLatestEnabledSecret && ref.Version == "" {
 			if isErrSecretDestroyedOrDisabled(err) {
 				result, err = getLatestEnabledVersion(ctx, c.smClient, name)
 				if err != nil {
@@ -706,7 +706,7 @@ func getLatestEnabledVersion(ctx context.Context, client GoogleSecretManagerClie
 	latestVersion := &secretmanagerpb.SecretVersion{}
 	for {
 		version, err := iter.Next()
-		if err == iterator.Done {
+		if errors.Is(err, iterator.Done) {
 			break
 		}
 		if version.CreateTime.AsTime().After(latestCreateTime) {

--- a/pkg/provider/gcp/secretmanager/client.go
+++ b/pkg/provider/gcp/secretmanager/client.go
@@ -501,7 +501,7 @@ func (c *Client) GetSecret(ctx context.Context, ref esv1.ExternalSecretDataRemot
 		Name: name,
 	}
 	result, err := c.smClient.AccessSecretVersion(ctx, req)
-	if err != nil && c.store.GetLatestEnabledSecret &&
+	if err != nil && c.store.SecretVersionSelectionPolicy == esv1.SecretVersionSelectionPolicyLatestOrFetch &&
 		ref.Version == "" && isErrSecretDestroyedOrDisabled(err) {
 		// if the secret is destroyed or disabled, and we are configured to get the latest enabled secret,
 		// we need to get the latest enabled secret

--- a/pkg/provider/gcp/secretmanager/client.go
+++ b/pkg/provider/gcp/secretmanager/client.go
@@ -501,6 +501,7 @@ func (c *Client) GetSecret(ctx context.Context, ref esv1.ExternalSecretDataRemot
 		Name: name,
 	}
 	result, err := c.smClient.AccessSecretVersion(ctx, req)
+	metrics.ObserveAPICall(constants.ProviderGCPSM, constants.CallGCPSMAccessSecretVersion, err)
 	if err != nil && c.store.SecretVersionSelectionPolicy == esv1.SecretVersionSelectionPolicyLatestOrFetch &&
 		ref.Version == "" && isErrSecretDestroyedOrDisabled(err) {
 		// if the secret is destroyed or disabled, and we are configured to get the latest enabled secret,
@@ -513,7 +514,6 @@ func (c *Client) GetSecret(ctx context.Context, ref esv1.ExternalSecretDataRemot
 		result, err = getLatestEnabledVersion(ctx, c.smClient, secretName)
 	}
 	if err != nil {
-		metrics.ObserveAPICall(constants.ProviderGCPSM, constants.CallGCPSMAccessSecretVersion, err)
 		err = parseError(err)
 		return nil, fmt.Errorf(errClientGetSecretAccess, err)
 	}

--- a/pkg/provider/gcp/secretmanager/fake/fake.go
+++ b/pkg/provider/gcp/secretmanager/fake/fake.go
@@ -40,6 +40,7 @@ type MockSMClient struct {
 	closeFn                 func() error
 	GetSecretFn             func(ctx context.Context, req *secretmanagerpb.GetSecretRequest, opts ...gax.CallOption) (*secretmanagerpb.Secret, error)
 	DeleteSecretFn          func(ctx context.Context, req *secretmanagerpb.DeleteSecretRequest, opts ...gax.CallOption) error
+	ListSecretVersionsFn    func(ctx context.Context, req *secretmanagerpb.ListSecretVersionsRequest, opts ...gax.CallOption) *secretmanager.SecretVersionIterator
 }
 
 func (mc *MockSMClient) Cleanup() {
@@ -200,6 +201,10 @@ func (mc *MockSMClient) NewUpdateSecretFn(mock SecretMockReturn) {
 	mc.updateSecretFn = func(_ context.Context, _ *secretmanagerpb.UpdateSecretRequest, _ ...gax.CallOption) (*secretmanagerpb.Secret, error) {
 		return mock.Secret, mock.Err
 	}
+}
+
+func (mc *MockSMClient) ListSecretVersions(ctx context.Context, req *secretmanagerpb.ListSecretVersionsRequest, _ ...gax.CallOption) *secretmanager.SecretVersionIterator {
+	return mc.ListSecretVersionsFn(ctx, req)
 }
 
 func (mc *MockSMClient) WithValue(_ context.Context, req *secretmanagerpb.AccessSecretVersionRequest, val *secretmanagerpb.AccessSecretVersionResponse, err error) {


### PR DESCRIPTION
## Problem Statement
When using External Secrets Operator (ESO) with Google Secret Manager (GSM), fetching a secret fails if the secret has multiple versions where the latest version is destroyed but an older version is still enabled.
Example: a secret has versions 1 (enabled) and 2 (destroyed). ESO appears to check both versions/latest and the latest active version; the call against versions/latest fails because that points to the destroyed v2, causing the whole fetch to fail even though v1 is valid.


## Related Issue
Fixes #5129 

## Proposed Changes
Implement [`GetSecret`](https://github.com/itaispiegel/external-secrets/blob/a2f3ac985192bc9795f7cd709368d26f2b1118e7/pkg/provider/gcp/secretmanager/client.go#L481) to fetch latest enabled secret, if the latest is destroyed or disabled.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable` (wasn't able to run this on my setup 😢)
