### PR TITLE
Fix yaml codeblock for oracle-vault provider docs

### DIFF
--- a/docs/provider/oracle-vault.md
+++ b/docs/provider/oracle-vault.md
@@ -13,7 +13,9 @@ External Secrets Operator may authenticate to OCI Vault using User Principal, [I
 
 To specify the authenticating principal in a secret store, set the `spec.provider.oracle.principalType` value. Note that the value of `principalType` defaults `InstancePrincipal` if not set.
 
+```yaml
 {% include 'oracle-principal-type.yaml' %}
+```
 
 ### User Principal Authentication
 


### PR DESCRIPTION
I noticed that the `SecretStore` yaml block in the docs is not properly formatted, so i added the missing yaml tag.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
