### PR TITLE
feat: add contributor ladder

### DIFF
--- a/CODEOWNERS.md
+++ b/CODEOWNERS.md
@@ -1,0 +1,64 @@
+# External Secrets CODEOWNERS
+# This file maps repository paths to GitHub teams for review.
+# Syntax: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# --- CI / Infrastructure ---
+.github/                     @external-secrets/ci-approvers @external-secrets/ci-reviewers
+scripts/                     @external-secrets/ci-approvers @external-secrets/ci-reviewers
+build/                       @external-secrets/ci-approvers @external-secrets/ci-reviewers
+hack/                        @external-secrets/ci-approvers @external-secrets/ci-reviewers
+
+# --- Testing ---
+test/                        @external-secrets/testing-approvers @external-secrets/testing-reviewers
+e2e/                         @external-secrets/testing-approvers @external-secrets/testing-reviewers
+tests/                       @external-secrets/testing-approvers @external-secrets/testing-reviewers
+hack/                        @external-secrets/testing-approvers @external-secrets/testing-reviewers
+
+# --- Core Controllers ---
+apis/                        @external-secrets/core-approvers @external-secrets/core-reviewers
+pkg/controllers/             @external-secrets/core-approvers @external-secrets/core-reviewers
+
+# --- Providers ---
+pkg/provider/                @external-secrets/providers-approvers @external-secrets/providers-reviewers
+pkg/provider/akeyless/       @external-secrets/provider-akeyless-approvers @external-secrets/provider-akeyless-reviewers
+pkg/provider/alibaba/        @external-secrets/provider-alibaba-approvers @external-secrets/provider-alibaba-reviewers
+pkg/provider/aws/            @external-secrets/provider-aws-approvers @external-secrets/provider-aws-reviewers
+pkg/provider/azure/          @external-secrets/provider-azure-approvers @external-secrets/provider-azure-reviewers
+pkg/provider/beyondtrust/    @external-secrets/provider-beyondtrust-approvers @external-secrets/provider-beyondtrust-reviewers
+pkg/provider/bitwarden/      @external-secrets/provider-bitwarden-approvers @external-secrets/provider-bitwarden-reviewers
+pkg/provider/chef/           @external-secrets/provider-chef-approvers @external-secrets/provider-chef-reviewers
+pkg/provider/cloudru/        @external-secrets/provider-cloudru-approvers @external-secrets/provider-cloudru-reviewers
+pkg/provider/conjur/         @external-secrets/provider-conjur-approvers @external-secrets/provider-conjur-reviewers
+pkg/provider/delinea/        @external-secrets/provider-delinea-approvers @external-secrets/provider-delinea-reviewers
+pkg/provider/device42/       @external-secrets/provider-device42-approvers @external-secrets/provider-device42-reviewers
+pkg/provider/doppler/        @external-secrets/provider-doppler-approvers @external-secrets/provider-doppler-reviewers
+pkg/provider/fake/           @external-secrets/provider-fake-approvers @external-secrets/provider-fake-reviewers
+pkg/provider/fortanix/       @external-secrets/provider-fortanix-approvers @external-secrets/provider-fortanix-reviewers
+pkg/provider/gcp/            @external-secrets/provider-gcp-approvers @external-secrets/provider-gcp-reviewers
+pkg/provider/github/         @external-secrets/provider-github-approvers @external-secrets/provider-github-reviewers
+pkg/provider/gitlab/         @external-secrets/provider-gitlab-approvers @external-secrets/provider-gitlab-reviewers
+pkg/provider/ibm/            @external-secrets/provider-ibm-approvers @external-secrets/provider-ibm-reviewers
+pkg/provider/infisical/      @external-secrets/provider-infisical-approvers @external-secrets/provider-infisical-reviewers
+pkg/provider/keepersecurity/ @external-secrets/provider-keepersecurity-approvers @external-secrets/provider-keepersecurity-reviewers
+pkg/provider/kubernetes/     @external-secrets/provider-kubernetes-approvers @external-secrets/provider-kubernetes-reviewers
+pkg/provider/onboardbase/    @external-secrets/provider-onboardbase-approvers @external-secrets/provider-onboardbase-reviewers
+pkg/provider/onepassword/    @external-secrets/provider-onepassword-approvers @external-secrets/provider-onepassword-reviewers
+pkg/provider/onepasswordsdk/ @external-secrets/provider-onepasswordsdk-approvers @external-secrets/provider-onepasswordsdk-reviewers
+pkg/provider/oracle/         @external-secrets/provider-oracle-approvers @external-secrets/provider-oracle-reviewers
+pkg/provider/passbolt/       @external-secrets/provider-passbolt-approvers @external-secrets/provider-passbolt-reviewers
+pkg/provider/passworddepot/  @external-secrets/provider-passworddepot-approvers @external-secrets/provider-passworddepot-reviewers
+pkg/provider/previder/       @external-secrets/provider-previder-approvers @external-secrets/provider-previder-reviewers
+pkg/provider/pulumi/         @external-secrets/provider-pulumi-approvers @external-secrets/provider-pulumi-reviewers
+pkg/provider/scaleway/       @external-secrets/provider-scaleway-approvers @external-secrets/provider-scaleway-reviewers
+pkg/provider/secretserver/   @external-secrets/provider-secretserver-approvers @external-secrets/provider-secretserver-reviewers
+pkg/provider/senhasegura/    @external-secrets/provider-senhasegura-approvers @external-secrets/provider-senhasegura-reviewers
+pkg/provider/vault/          @external-secrets/provider-vault-approvers @external-secrets/provider-vault-reviewers
+pkg/provider/webhook/        @external-secrets/provider-webhook-approvers @external-secrets/provider-webhook-reviewers
+pkg/provider/yandex/         @external-secrets/provider-yandex-approvers @external-secrets/provider-yandex-reviewers
+
+# --- Security ---
+security/                    @external-secrets/security-approvers @external-secrets/security-reviewers
+docs/security/               @external-secrets/security-approvers @external-secrets/security-reviewers
+
+# --- Maintainers (project-wide) ---
+*                            @external-secrets/maintainers

--- a/CONTRIBUTOR_LADDER.md
+++ b/CONTRIBUTOR_LADDER.md
@@ -1,0 +1,207 @@
+# External Secrets Contributor Ladder
+
+This document defines the roles, responsibilities, advancement criteria, inactivity process, and interim role policies for ESO contributors.
+It extends the standard Kubernetes-style ladder with **specialty tracks** so contributors can grow within their focus areas.
+
+---
+
+## Roles
+
+### 1) Contributor
+Anyone making contributions of any kind (code, docs, tests, CI configs, security reports, reviews, triage, discussions).
+
+**Requirements**
+- Sign the CNCF CLA.
+- Follow the ESO Code of Conduct.
+
+**Privileges**
+- Recognized as an active community member.
+- Eligible for nomination to **Member**.
+
+---
+
+### 2) Member
+Regular contributors engaged with the project for at least **3 months**.
+
+**Requirements**
+- Nominated by a **Member** or above.
+- Sponsored by **two Maintainers**.
+- ~**8+** substantive contributions (code, docs, tests, reviews, triage) in the last 3 months.
+
+**Privileges**
+- Added to the GitHub `members` team.
+- Can be assigned issues and PRs.
+- Eligible for **Reviewer** nomination.
+
+---
+
+### 3) Reviewer (per Specialty)
+Experienced contributors who review changes in **one or more specialties**.
+
+**Requirements**
+- Member for at least **3 months**.
+- Regular, high-quality reviews in the specialty.
+- ~**20+** meaningful PR reviews over the last 3 months (or equivalent specialty output).
+
+**Privileges**
+- Listed as `reviewer` in the relevant `OWNERS` files.
+- May use `/lgtm` on PRs within the specialty.
+- Eligible for **Approver** nomination.
+
+---
+
+### 4) Approver (per Specialty)
+Trusted contributors with **merge/approve authority** in their specialty.
+
+**Requirements**
+- Reviewer for at least **3 months**.
+- Multiple significant approvals/landed changes in the specialty.
+- Demonstrated understanding of project-wide implications.
+
+**Privileges**
+- Listed as `approver` in relevant `OWNERS` files.
+- Can approve and merge PRs within the specialty.
+- Eligible for **Maintainer** nomination.
+
+---
+
+### 5) Maintainer (Project-Wide)
+Project leaders with governance, release, and cross-specialty responsibility.
+
+**Requirements**
+- Approver for at least **6 months** in one or more specialties.
+- Demonstrated leadership, reliability, and constructive collaboration.
+- Nominated and approved by a **supermajority** of Maintainers.
+
+**Privileges**
+- GitHub admin rights as needed.
+- Release management authority.
+- Representation in CNCF processes.
+
+> A contributor may hold different roles across specialties (e.g., **Approver** in Providers and **Reviewer** in CI).
+
+---
+
+## Specialty Tracks
+
+Specialties define scope for `reviewer`/`approver` permissions and expectations. Ownership is documented in `OWNERS` files.
+
+### CI / Infrastructure
+Focus: GitHub Actions, build/test pipelines, images, release automation.
+- **Reviewer**: Reviews CI changes, enforces reproducibility, flags flaky tests.
+- **Approver**: Owns pipeline stability, approves release workflow changes.
+
+### Testing
+Focus: Unit/integration/E2E tests, frameworks, fixtures, test data.
+- **Reviewer**: Ensures adequate coverage and quality in PRs, promotes testability.
+- **Approver**: Sets testing strategy, guards test harness stability and performance.
+
+### Core Controllers
+Focus: CRDs, reconciliation logic, API evolution, performance.
+- **Reviewer**: Reviews controller/CRD changes, ensures API consistency and backward compatibility.
+- **Approver**: Owns core designs affecting controller behavior and APIs.
+
+### Providers
+Focus: Provider integrations (AWS, Vault, GCP, Azure, CyberArk, etc.).
+- **Reviewer**: Reviews provider-specific code and conformance to provider guidelines.
+- **Approver**: Owns lifecycle and quality of one or more providers; coordinates breaking changes.
+
+### Security
+Focus: Vulnerability handling, dependency hygiene, threat modeling, secure coding.
+- **Reviewer**: Reviews PRs for security impact; flags risky patterns.
+- **Approver**: Leads security releases and coordinates disclosure/patch processes.
+
+---
+
+## Interim Roles
+
+In some cases, Maintainers may create **interim roles** for **Member** or **Reviewer** positions in a given specialty.  
+These are **temporary training-oriented roles** designed to help contributors gain the experience needed to meet the full role requirements.
+
+### Purpose
+- Provide **on-the-job training** and mentorship.
+- Allow contributors to participate with limited privileges while building their track record.
+- Reduce barriers for new contributors to join governance roles.
+
+### Scope
+- Available only for **Member** and **Reviewer** levels (including per-specialty Reviewers).
+- Limited to a **maximum of three (3) months**.
+- Specialty and scope are explicitly documented in `OWNERS` files and/or a public tracking issue.
+- Interim roles per specialty can accumulate (e.g. a contributor can be an interim reviewer on CI and on Providers at the same time). This is to allow a fast path to upskill future project-wide maintainers.
+
+#### Approver exclusion
+
+Approvers on any specialty may never be interim. This is to prevent abuse of the interim role system, and to consolidate the needed trust between the other maintainers & approvers for the different elements of the codebase.
+
+### Limits
+- There can only be a maximum of two interim roles per specialty (two CI members; two CI reviewers; two CI interim approvers; two provider Members; two provider Reviewers; two provider interim Approvers).
+
+### Examples
+- **Interim Member**: Has fewer than 8 substantive contributions but commits to achieve them within 3 months.
+- **Interim Reviewer**: Has not yet reviewed 20+ PRs but is actively being mentored to do so.
+
+### Process
+1. Maintainers discuss and vote on the need for an interim role (lazy consensus).
+2. Scope and duration are defined clearly (specialty, responsibilities, expected milestones).
+3. Nomination of interim roles is done by lazy consensus.
+4. Interim roles are granted for a maximum of three months.
+5. Interim status is reviewed at the end of the period:
+   - If requirements are met → promotion to the permanent role.
+   - If not met → revert to previous role; contributor may try again later.
+
+### Handling abuse
+
+Interim roles are not a substitute for permanent roles. If a contributor is abusing the interim role system, they may be demoted to their previous role.
+
+---
+
+## Advancement Process
+
+1. **Nomination** by an eligible community member (Member+).
+2. **Sponsorship** by two role holders at the **target level or higher** (within the specialty where applicable).
+3. **Review** of activity and behavior (quality, reliability, collaboration, responsiveness).
+4. **Decision** by lazy consensus of the relevant group (or **supermajority** if contested).
+
+---
+
+## Inactivity
+
+A role holder may be considered inactive if they have not actively contributed in their specialty or general project responsibilities for **six (6) consecutive months**.
+
+### Measurement Sources
+- GitHub activity: merged PRs, PR reviews, issue triage/comments.
+- Participation in community calls or asynchronous design discussions.
+- Specialty-specific metrics (e.g., CI job maintenance, provider updates, security disclosures).
+
+### Triggering Process
+1. **Detection**  
+   - Activity is reviewed at least quarterly by Maintainers or via automation.  
+   - Any Maintainer may propose an inactivity review for a role holder.
+2. **Notification**  
+   - A public issue is opened in a `community`/`governance` space (or email if sensitive).  
+   - The individual is tagged/emailed and given **30 days** to respond.
+3. **Grace Period**  
+   - If the contributor indicates intent to return, no change is made.  
+   - If there is no response or no significant activity within the grace period, proceed.
+4. **Decision**  
+   - Demotion is decided by **lazy consensus** of Maintainers, or **supermajority** if contested.
+5. **Documentation**  
+   - Update `OWNERS`, GitHub teams, and governance records.  
+   - Former Maintainers are listed as **Emeritus**.
+
+### Reinstatement
+A contributor can be reinstated at their previous level via the standard advancement process. Prior history is considered favorably.
+
+---
+
+## Conduct & CLA
+
+All contributors must follow the CNCF Code of Conduct and sign the CNCF CLA (where applicable) before contributions are merged.
+
+---
+
+## Cross-References
+
+- Project governance and decision-making: see [`GOVERNANCE.md`](./GOVERNANCE.md)
+- Proposal process and template: `design/000-template.md`
+- Specialty ownership: `OWNERS` files per directory

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -16,128 +16,116 @@ Secret](https://kubernetes.io/docs/concepts/configuration/secret/).
 
 ## Community Roles
 
-* **Users:** Members that engage with the ESO community via any medium (Slack, WeChat, GitHub, mailing lists, etc.).
-* **Contributors:** Regular contributions to projects (documentation, code reviews, responding to issues, participation in proposal discussions, contributing code, etc.).
-* **Maintainers**: The ESO project leaders. They are responsible for the overall health and direction of the project; final reviewers of PRs and responsible for releases. Some Maintainers are responsible for one or more components within a project, acting as technical leads for that component. Maintainers are expected to contribute code and documentation, review PRs including ensuring quality of code, triage issues, proactively fix bugs, and perform maintenance tasks for these components.
+- **Users**: People who use ESO and engage via GitHub, Slack, or mailing lists.
+- **Contributors**: Anyone who makes contributions (code, docs, tests, reviews, triage, discussions).
+- **Reviewers / Approvers / Maintainers**: Governance roles with defined responsibilities, privileges, and promotion
+  processes described in the [Contributor Ladder](CONTRIBUTOR_LADDER.md).
 
-### Maintainers
-Maintainers have the ability to merge code into the project. Anyone can become an External Secrets maintainer (see "Becoming a maintainer" below.)
+Maintainers are project leaders responsible for overall health, technical direction, and release management.
 
+---
 
-#### Expectations
+## Maintainers
+
+### Expectations
 Maintainers are expected to:
+- Review pull requests, triage issues, and fix bugs in their areas of expertise.
+- Monitor community channels and help users and contributors.
+- Respond rapidly to time-sensitive security issues.
+- Participate in ESO community meetings and asynchronous design/review discussions.
+- Follow the decision-making processes described in this document and in the Contributor Ladder.
 
-* Review pull requests, triage issues, and fix bugs in their areas of expertise, ensuring that all changes go through the project's code review and integration processes.
-* Monitor cncf-* emails and community channels, and help out when possible.
-* Rapidly respond to any time-sensitive security release processes.
-* Attend meetings with the ESO Community Meetings.
-* If a maintainer is no longer interested in or cannot perform the duties listed above, they should move themselves to emeritus status. If necessary, this can also occur through the decision-making process outlined below.
+If a maintainer cannot fulfill these duties, they should move to **Emeritus** status. Maintainers may also be moved to
+Emeritus via the decision-making process.
 
+### Adding or Removing Maintainers
+- **Addition**: A candidate is nominated by an existing maintainer and elected by a **supermajority** of current maintainers.
+- **Removal**: Removal requires a **supermajority** of current maintainers.
+- **Company voting**: Votes to nominate maintainers by contributors belonging to the same employer count as **one** collective vote. If they cannot reach internal consensus, that employer’s vote is recorded as **abstain**.
 
-New maintainers must be nominated by an existing maintainer(e.g. via [PR](https://github.com/external-secrets/external-secrets/pull/1591)) and must be elected by a supermajority of existing maintainers. Likewise, maintainers can be removed by a supermajority of the existing maintainers or can resign by notifying one of the maintainers.
+---
 
+## Voting Eligibility
 
-### Becoming a maintainer
-Anyone can become an External Secrets maintainer. Maintainers should be extremely proficient in Go; have relevant domain expertise; have the time and ability to meet the maintainer expectations above; and demonstrate the ability to work with the existing maintainers and project processes.
+Voting rights vary by decision type:
 
-To become a maintainer, start by expressing interest to existing maintainers. Existing maintainers will then ask you to demonstrate the qualifications above by contributing PRs, doing code reviews, and other such tasks under their guidance. After several months of working together, maintainers will decide whether to grant maintainer status.
+| Decision Type                                  | Eligible Voters                              |
+|------------------------------------------------|----------------------------------------------|
+| **Governance changes**                         | All Maintainers                              |
+| **Adding/removing Maintainers**                | All Maintainers                              |
+| **Technical decisions within a specialty**     | Approvers and Maintainers for that specialty |
+| **Project-wide technical direction**           | All Maintainers                              |
+| **Security incident decisions**                | Security Approvers and Maintainers           |
+| **Interim role appointments (Member/Reviewer)**| Maintainers                                  |
 
-### Supermajority
+**Notes:**
+- Interim role holders do **not** vote in role promotions/demotions.
+- Company voting limits apply: maintainers/approvers from the same declared employer have **two** combined votes - regardless if they contribute individually or representing their employer. An exception to this rule is for voting to add/remove maintainers. In this case, a company voting limit is of **one** vote.
+- If more than two maintainers/approvers from the same declared employer cannot reach consensus for their vote (e.g. 3 in favour, 2 against), both the employer's votes are recorded as **abstain**.
 
-A supermajority is defined as two-thirds of members in the group.
-A supermajority of [Maintainers](#maintainers) is required for certain
-decisions as outlined above. Voting on decisions can happen on the mailing list, GitHub, Slack, email, or via a voting service, when appropriate. Maintainers can either vote "agree, yes, +1", "disagree, no, -1", or "abstain". A vote passes when supermajority is met. An abstain vote equals not voting at all.
+---
 
-### Decision Making
+## Decision Making
 
-Ideally, all project decisions are resolved by consensus. If impossible, any
-maintainer may call a vote. Unless otherwise specified in this document, any
-vote will be decided by a supermajority of maintainers.
+ESO strives for **consensus** via open discussion. When consensus cannot be reached, any eligible voter may call a vote.
 
-Votes by maintainers belonging to the same company
-will count as one vote; e.g., 4 maintainers employed by fictional company **ESOtum** will
-only have **one** combined vote. If voting members from a given company do not
-agree, the company's vote is determined by a supermajority of voters from that
-company. If no supermajority is achieved, the company is considered to have
-abstained.
+- **Supermajority**: Two-thirds (⅔) of eligible voters in the group.
+- **Venues**: Votes may occur on GitHub, email, Slack, community meetings, or a suitable voting service.
+- **Ballots**: “Agree/+1”, “Disagree/-1”, or “Abstain” (counts as no vote).
+
+---
 
 ## Proposal Process
 
-One of the most important aspects in any open source community is the concept
-of proposals. Large changes to the codebase and / or new features should be
-preceded by a proposal in our community repo. This process allows for all
-members of the community to weigh in on the concept (including the technical
-details), share their comments and ideas, and offer to help. It also ensures
-that members are not duplicating work or inadvertently stepping on toes by
-making large conflicting changes.
+Large or impactful changes should begin as proposals under the repository’s `design/` directory.
 
-The project roadmap is defined by accepted proposals.
+**Proposal requirements**
+- Objectives, use cases, and high-level technical approach.
+- Open discussion prior to implementation.
+- Use the proposal template at `design/000-template.md`.
 
-Proposals should cover the high-level objectives, use cases, and technical
-recommendations on how to implement. In general, the community member(s)
-interested in implementing the proposal should be either deeply engaged in the
-proposal process or be an author of the proposal.
+**Lifecycle labels**
+- **New** → **Reviewing** → **Accepted** or **Rejected**.
 
-The proposal should be documented as a separated markdown file pushed to the
-`design` folder in the [external-secrets repository](https://github.com/external-secrets/external-secrets/tree/main/design)
-repository via PR. The name of the file should follow the name pattern `<NUMBER-
-meaningful words joined by '-'>.md`, e.g:
-`000-clear-old-tags-with-policies.md`.
+The project roadmap is shaped by **Accepted** proposals.
 
-Use the [Proposal Template](design/000-template.md) as a starting point.
-
-### Proposal Lifecycle
-
-The proposal PR can be marked with different status labels to represent the
-status of the proposal:
-
-* **New**: Proposal is just created.
-* **Reviewing**: Proposal is under review and discussion.
-* **Accepted**: Proposal is reviewed and accepted (either by consensus or vote).
-* **Rejected**: Proposal is reviewed and rejected (either by consensus or vote).
+---
 
 ## Lazy Consensus
 
-The concept of [Lazy Consensus](http://en.osswiki.info/concepts/lazy_consensus) is practiced. Ideas
-and / or proposals should be shared by maintainers via
-GitHub with the appropriate maintainer groups (e.g.,
-`@external-secrets/maintainers`) tagged. Out of respect for other contributors,
-major changes should also be accompanied by a ping on Slack or a note on the
-ESO dev mailing list as appropriate. Author(s) of proposal, Pull Requests,
-issues, etc.  will give a time period of no less than five (5) working days for
-comment and remain cognizant of popular observed world holidays.
+ESO uses [Lazy Consensus](http://en.osswiki.info/concepts/lazy_consensus) for most decisions.
 
-Other maintainers may chime in and request additional time for review, but
-should remain cognizant of blocking progress and abstain from delaying
-progress unless absolutely needed. The expectation is that blocking progress
-is accompanied by a guarantee to review and respond to the relevant action(s)
-(proposals, PRs, issues, etc.) in short order.
+- PRs and proposals should allow **at least five (5) working days** for comments and consider global holidays.
+- Other maintainers may request additional time when justified and commit to a timely review.
 
+**Exclusions** (lazy consensus does **not** apply):
+- Removal of maintainers.
+- Any substantive governance changes.
 
-Lazy consensus does _not_ apply to the process of:
-
-* Removal of maintainers from ESO.
+---
 
 ## Updating Governance
 
-All substantive changes in Governance require a supermajority agreement by all maintainers.
+Substantive changes to this document require a **supermajority** of maintainers.
 
-## Example of Governance Process being enforced
+---
 
-### Case @shuheiktgw
+## Contributor Pathways & Specialties
 
-The PR linking to acceptance of new maintainer member Shuhei Kitagawa. Consensus was achieved. Kitagawa was accepted as
-a maintainer and added to the relevant Organization.
+Advancement pathways, responsibilities, privileges, and specialty areas (CI/Infra, Testing, Core Controllers, Providers, Security)
+are defined in the [Contributor Ladder](CONTRIBUTOR_LADDER.md).
 
-On June 12th, 2024 Kitagawa stepped down as maintainer. https://github.com/external-secrets/external-secrets/pull/3573 was
-created to remove him from the Maintainers file.
+---
 
-### Case @Skarlso
+## Security
 
-Skarlso (Gergely Brautigam) was added as a maintainer and organization member on 23th or October 2023. The corresponding PR: https://github.com/external-secrets/external-secrets/pull/2823.
+ESO follows responsible disclosure practices. Security-impacting issues should be reported via the documented security
+contact channels (see `SECURITY.md` if present or repository Security tab). Security fixes may be handled privately until
+a coordinated disclosure and release are ready.
 
-Lazy consensus was applied first in [Slack discussion](https://kubernetes.slack.com/archives/C047LA9MUPJ/p1698667596168189) on the external-secrets-dev channel, then in PR.
+---
 
-## CNCF Governance
+## CNCF Alignment
 
-This project abides by the [CNCF Code Of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
+ESO governance aims for open, transparent, and vendor-neutral operation consistent with CNCF expectations. The
+[Contributor Ladder](CONTRIBUTOR_LADDER.md) provides clear pathways for community members to grow into leadership.

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,0 +1,54 @@
+# External Secrets Owners
+
+This document maps **specialty areas** to GitHub teams used for reviews and approvals.  
+It complements the automation in [`CODEOWNERS`](./CODEOWNERS) and the roles defined in
+[`CONTRIBUTOR_LADDER.md`](./CONTRIBUTOR_LADDER.md).
+
+- **Reviewer**: may review and `/lgtm` within their specialty.
+- **Approver**: may `/approve` and merge within their specialty.
+- **Maintainer**: project-wide governance and release authority.
+
+> Manage membership via GitHub Teams, not this file—keep teams stable and adjust members in org settings.
+
+---
+
+## Maintainers (project-wide)
+- Teams: **@external-secrets/maintainers**
+- Scope: entire repository; final escalation point.
+
+---
+
+## Specialties & Paths
+
+### 1) CI / Infrastructure
+- **Paths**: `.github/`, `scripts/`, `build/`
+- **Approvers**: `@external-secrets/ci-approvers`
+- **Reviewers**: `@external-secrets/ci-reviewers`
+
+### 2) Testing
+- **Paths**: `test/`, `tests/`, `hack/`
+- **Approvers**: `@external-secrets/testing-approvers`
+- **Reviewers**: `@external-secrets/testing-reviewers`
+
+### 3) Core Controllers
+- **Paths**: `apis/`, `pkg/controllers/`
+- **Approvers**: `@external-secrets/core-approvers`
+- **Reviewers**: `@external-secrets/core-reviewers`
+
+### 4) Providers
+- **Paths**: `pkg/provider/` (and subfolders like `aws/`, `gcp/`, `azure/`, `vault/`, `cyberark/`), and their respective API files.
+- **Approvers**: `@external-secrets/providers-approvers`
+- **Reviewers**: `@external-secrets/providers-reviewers`
+
+### 5) Security
+- **Paths**: `security/`, `docs/security/`
+- **Approvers**: `@external-secrets/security-approvers`
+- **Reviewers**: `@external-secrets/security-reviewers`
+
+---
+
+## Interim Role Holders
+If someone holds an **Interim Member** or **Interim Reviewer** role for a specialty, note it in a public tracking issue and (optionally) list here as informational, e.g.:
+- `@username` — Interim Reviewer, Providers (until YYYY-MM-DD)
+
+> Interim roles are time-boxed and governed by the policy in `CONTRIBUTOR_LADDER.md`.


### PR DESCRIPTION
Adding a contributor ladder so we have clear roles and responsibilities. This will help us onboard contributors to specific areas.