### PR TITLE
feat: add externalsecret namespace for webhook provider

### DIFF
--- a/pkg/common/webhook/webhook.go
+++ b/pkg/common/webhook/webhook.go
@@ -140,8 +140,6 @@ func (w *Webhook) GetTemplateData(ctx context.Context, ref *esv1.ExternalSecretD
 	if err := w.getTemplatedSecrets(ctx, secrets, data); err != nil {
 		return nil, err
 	}
-	fmt.Print("---------->")
-	fmt.Print(data)
 	return data, nil
 }
 

--- a/pkg/common/webhook/webhook.go
+++ b/pkg/common/webhook/webhook.go
@@ -122,15 +122,17 @@ func (w *Webhook) GetTemplateData(ctx context.Context, ref *esv1.ExternalSecretD
 	if ref != nil {
 		if urlEncode {
 			data["remoteRef"] = map[string]string{
-				"key":      url.QueryEscape(ref.Key),
-				"version":  url.QueryEscape(ref.Version),
-				"property": url.QueryEscape(ref.Property),
+				"key":       url.QueryEscape(ref.Key),
+				"version":   url.QueryEscape(ref.Version),
+				"property":  url.QueryEscape(ref.Property),
+				"namespace": w.Namespace,
 			}
 		} else {
 			data["remoteRef"] = map[string]string{
-				"key":      ref.Key,
-				"version":  ref.Version,
-				"property": ref.Property,
+				"key":       ref.Key,
+				"version":   ref.Version,
+				"property":  ref.Property,
+				"namespace": w.Namespace,
 			}
 		}
 	}
@@ -138,7 +140,8 @@ func (w *Webhook) GetTemplateData(ctx context.Context, ref *esv1.ExternalSecretD
 	if err := w.getTemplatedSecrets(ctx, secrets, data); err != nil {
 		return nil, err
 	}
-
+	fmt.Print("---------->")
+	fmt.Print(data)
 	return data, nil
 }
 

--- a/pkg/provider/webhook/webhook_test.go
+++ b/pkg/provider/webhook/webhook_test.go
@@ -375,6 +375,26 @@ args:
 want:
   path: /api/getsecrets?folder=%2Fmyapp%2Fsecrets
   body: '{"folder": "/myapp/secrets"}'
+---
+case: namespace template in headers
+args:
+  url: /api/getsecret?id={{ .remoteRef.key }}
+  key: testkey
+  response: secret-value
+want:
+  path: /api/getsecret?id=testkey
+  err: ''
+  result: secret-value
+---
+case: namespace template in url
+args:
+  url: /api/getsecret?id={{ .remoteRef.key }}&namespace={{ .remoteRef.namespace }}
+  key: testkey
+  response: secret-value
+want:
+  path: /api/getsecret?id=testkey&namespace=testnamespace
+  err: ''
+  result: secret-value
 `
 
 func TestWebhookGetSecret(t *testing.T) {
@@ -669,8 +689,9 @@ func makeClusterSecretStore(url string, args args) *esv1.ClusterSecretStore {
 					URL:  url + args.URL,
 					Body: args.Body,
 					Headers: map[string]string{
-						"Content-Type": "application.json",
-						"X-SecretKey":  "{{ .remoteRef.key }}",
+						"Content-Type":           "application.json",
+						"X-SecretKey":            "{{ .remoteRef.key }}",
+						"X-Kubernetes-Namespace": "{{ .remoteRef.namespace }}",
 					},
 					Result: esv1.WebhookResult{
 						JSONPath: args.JSONPath,


### PR DESCRIPTION
## Problem Statement
Update the possibility of using the namespace where the external secret was deployed is being added to the webhook provider template: `{{ .remoteRef.namespace }}`.

## Related Issue

Fixes #4207

## Proposed Changes
Add the proposed externalsecret namespace field

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
