### PR TITLE
docs: Fix provider stability and support table

### DIFF
--- a/docs/introduction/stability-support.md
+++ b/docs/introduction/stability-support.md
@@ -40,8 +40,8 @@ As of version 0.14.x , this is the only kubernetes version that we will guarante
 
 The following table describes the stability level of each provider and who's responsible.
 
-| Provider | Stability | Maintainer |
-| -------- | --------: | ---------: |-------|--:--------------------------------------------------------------------------------------------------|
+| Provider | Stability | Maintainer                                                                                                                                                                                            |
+| -------- | --------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
 | [AWS Secrets Manager](https://external-secrets.io/latest/provider/aws-secrets-manager/)                    | stable    | [external-secrets](https://github.com/external-secrets)                                             |
 | [AWS Parameter Store](https://external-secrets.io/latest/provider/aws-parameter-store/)                    | stable    | [external-secrets](https://github.com/external-secrets)                                             |
 | [Hashicorp Vault](https://external-secrets.io/latest/provider/hashicorp-vault/)                            | stable    | [external-secrets](https://github.com/external-secrets)                                             |


### PR DESCRIPTION
## Problem Statement

While working on #5160 and adding a new provider, I noticed that the [Provider stability and Support Table](https://external-secrets.io/latest/introduction/stability-support/) doesn't render well:
<img width="1509" height="791" alt="image" src="https://github.com/user-attachments/assets/4b4af174-7497-4e58-a8d0-8345d422c4de" />


## Related Issue

N/A

## Proposed Changes

* Fixes the formatting on the header so the table renders correctly
<img width="908" height="837" alt="image" src="https://github.com/user-attachments/assets/9fdb8dd1-77c2-43ed-84e2-defbf15216de" />


## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
