### PR TITLE
fix: the api docs are not referencing sshkey generator

### DIFF
--- a/hack/api-docs/mkdocs.yml
+++ b/hack/api-docs/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
           - Github: api/generator/github.md
           - UUID: api/generator/uuid.md
           - MFA: api/generator/mfa.md
+          - SSHKey: api/generator/sshkey.md
       - Reference Docs:
           - API specification: api/spec.md
           - Controller Options: api/controller-options.md


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
