### PR TITLE
fix: remove release- branch automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - release-*
   pull_request: {}
 
 env:

--- a/.github/workflows/crds.yml
+++ b/.github/workflows/crds.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - release-*
     paths:
       - 'apis/**'
   pull_request:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - release-*
 
 permissions:
   contents: read

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - release-*
     paths:
       - 'deploy/charts/**'
       - 'deploy/crds/**'
@@ -70,7 +69,7 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: make helm.test
   release:
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-')
+    if: github.ref == 'refs/heads/main'
     permissions:
       contents: write  # for helm/chart-releaser-action to push chart release and create a release
       packages: write  # to push OCI chart package to GitHub Registry

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -104,8 +104,8 @@ jobs:
           # rebuild-image
           if [ "${{ inputs.image-tag }}" != "" ]; then
             TAG="${{ inputs.image-tag }}${{ inputs.tag-suffix }}"
-          # main / release-x.y
-          elif [[ "$GITHUB_REF" == "refs/heads/main" || "$GITHUB_REF" =~ refs/heads/release-.*  ]]; then
+          # main
+          elif [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
             TAG=${GITHUB_REF#refs/heads/}${{ inputs.tag-suffix }}
           # Pull Request
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
         required: true
         default: 'v0.1.0'
       source_ref:
-        description: 'source ref to publish from. E.g.: main or release-x.y'
+        description: 'source ref to publish from. E.g.: main'
         required: true
         default: 'main'
 

--- a/.github/workflows/release_esoctl.yml
+++ b/.github/workflows/release_esoctl.yml
@@ -8,7 +8,7 @@ on:
         required: true
         default: 'v0.1.0-esoctl'
       source_ref:
-        description: 'source ref to publish from. E.g.: main or release-x.y'
+        description: 'source ref to publish from. E.g.: main'
         required: true
         default: 'main'
 

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -29,9 +29,7 @@ jobs:
           ref: ${{ github.event.inputs.ref }}
       - name: set branches output
         id: branches
-        # outputs the second to most recent `release-x.y` branches plus `main` as JSON
-        run: |
-          echo "branches=$(git branch -a | grep -E "remotes/origin/(main|release-)" | sed 's/  remotes\/origin\///' | sort -V | tail -2 | head -1 | jq -R -s -c 'split("\n") | map(select(length > 0)) | . + ["main"]')" >> $GITHUB_OUTPUT
+        run: echo "branches=[\"main\"]" >> $GITHUB_OUTPUT
 
   update-dependencies:
     permissions:

--- a/docs/contributing/release.md
+++ b/docs/contributing/release.md
@@ -10,10 +10,10 @@ When doing a release it's best to start with  with the ["Create Release" issue t
 Otherwise the `latest` documentation will point to the older version. Also avoid to release both versions at the same time to avoid race conditions in the CI pipeline (updating docs, GitHub Release, helm chart release).
 
 1. Run `Create Release` Action to create a new release, pass in the desired version number to release.
-    1. choose the right `branch` to execute the action: use `main` when creating a new release. Use `release-x.y` when you want to bump a LTS release.
-    1. ⚠️ make sure that CI on the relevant branch has completed the docker build/push jobs. Otherwise an old image will be promoted.
-1. GitHub Release, Changelog will be created by the `release.yml` workflow which also promotes the container image.
-1. update Helm Chart, see below
+    1. choose the right `branch` to execute the action: use `main` when creating a new release.
+    2. ⚠️ make sure that CI on the relevant branch has completed the docker build/push jobs. Otherwise an old image will be promoted.
+2. GitHub Release, Changelog will be created by the `release.yml` workflow which also promotes the container image.
+3. update Helm Chart, see below
 
 ## Release Helm Chart
 
@@ -22,6 +22,3 @@ Otherwise the `latest` documentation will point to the older version. Also avoid
 1. run `/ok-to-test-managed` commands for all cloud providers
 1. merge PR if everything is green
 1. CI picks up the new chart version and creates a new GitHub Release for it
-1. create/merge into release branch
-    1. on a `minor` release: create a new branch `release-x.y`
-    1. on a `patch` release: merge main into `release-x.y`


### PR DESCRIPTION
LTS releases are no more #4417, #4480. This removes the automation for bumping dependencies and triggering releases from release branches.
