### PR TITLE
chore(ci): fix sonarqube security warnings in helm.yml

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -105,8 +105,11 @@ jobs:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: |
-          echo "$GPG_PRIVATE_KEY" | gpg --dearmor --output keyring.gpg
-          echo -n "$GPG_PASSPHRASE" > passphrase-file.txt
+          gpg --dearmor --output keyring.gpg <(printf '%s' "$GPG_PRIVATE_KEY")
+          chmod 600 keyring.gpg
+
+          printf '%s' "$GPG_PASSPHRASE" > passphrase-file.txt
+          chmod 600 passphrase-file.txt
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -101,9 +101,12 @@ jobs:
         run: make helm.generate
 
       - name: Import GPG key
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: |
-          echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --dearmor --output keyring.gpg
-          echo -n "${{ secrets.GPG_PASSPHRASE }}" > passphrase-file.txt
+          echo "$GPG_PRIVATE_KEY" | gpg --dearmor --output keyring.gpg
+          echo -n "$GPG_PASSPHRASE" > passphrase-file.txt
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0


### PR DESCRIPTION
## Problem Statement

SonarQube analysis has been failing on main for a while with a low priority warning under security hotspots.
https://sonarcloud.io/project/security_hotspots?id=external-secrets_external-secrets


## Related Issue

N/A

## Proposed Changes

It's a pretty straightforward fix as proposed by both SonarQube and as reference in the documentation of how to use secrets in Github Actions, it explicitly mentions to to pass them directly to command line arguments.
https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
