### PR TITLE
fix: tilt build was failing to rebuild

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -19,34 +19,47 @@ settings.update(read_yaml(
     tilt_file,
     default = {},
 ))
+
 # set up the development environment
 
-# Update the root security group. Tilt requires root access to update the
-# running process.
+# Split the YAML into CRDs and other resources
 objects = decode_yaml_stream(read_file('bin/deploy/manifests/external-secrets.yaml'))
+
+crds = []
+other_resources = []
+
 for o in objects:
+    if o.get('kind') == 'CustomResourceDefinition':
+        crds.append(o)
+    else:
+        other_resources.append(o)
+
+# Process deployments for development
+for o in other_resources:
     if o.get('kind') == 'Deployment' and o.get('metadata').get('name') in ['external-secrets-cert-controller', 'external-secrets', 'external-secrets-webhook']:
         o['spec']['template']['spec']['containers'][0]['securityContext'] = {'runAsNonRoot': False, 'readOnlyRootFilesystem': False}
         o['spec']['template']['spec']['containers'][0]['imagePullPolicy'] = 'Always'
         if settings.get('debug').get('enabled') and o.get('metadata').get('name') == 'external-secrets':
             o['spec']['template']['spec']['containers'][0]['ports'] = [{'containerPort': 30000}]
 
-
-updated_install = encode_yaml_stream(objects)
-
-# Apply the updated yaml to the cluster.
-# Create the directory and write the file
+# Create the directory
 local('mkdir -p .tilt-tmp')
-local('cat > .tilt-tmp/external-secrets-modified.yaml', stdin=updated_install)
 
-# Now use k8s_custom_deploy to apply it
-k8s_custom_deploy(
-    'external-secrets',
-    apply_cmd='kubectl apply --server-side -f .tilt-tmp/external-secrets-modified.yaml -o yaml',
-    delete_cmd='kubectl delete --ignore-not-found -f .tilt-tmp/external-secrets-modified.yaml',
-    deps=['bin/deploy/manifests/external-secrets.yaml'],
-    image_deps=['oci.external-secrets.io/external-secrets/external-secrets']
-)
+# Apply CRDs with server-side apply (handles large CRDs)
+if crds:
+    crd_yaml = encode_yaml_stream(crds)
+    local('cat > .tilt-tmp/external-secrets-crds.yaml', stdin=crd_yaml)
+    local_resource(
+        'apply-crds',
+        'kubectl apply --server-side -f .tilt-tmp/external-secrets-crds.yaml',
+        deps=['bin/deploy/manifests/external-secrets.yaml']
+    )
+
+# Use regular k8s_yaml for deployments (Tilt will handle image substitution)
+if other_resources:
+    deployments_yaml = encode_yaml_stream(other_resources)
+    local('cat > .tilt-tmp/external-secrets-deployments.yaml', stdin=deployments_yaml)
+    k8s_yaml('.tilt-tmp/external-secrets-deployments.yaml')
 
 load('ext://restart_process', 'docker_build_with_restart')
 
@@ -73,7 +86,6 @@ local_resource(
     ],
 )
 
-
 # Build the docker image for our controller. We use a specific Dockerfile
 # since tilt can't run on a scratch container.
 # `only` here is important, otherwise, the container will get updated
@@ -88,7 +100,6 @@ if settings.get('debug').get('enabled'):
     ])
     entrypoint = ['/dlv', '--listen=:30000', '--api-version=2', '--continue=true', '--accept-multiclient=true', '--headless=true', 'exec', '/external-secrets', '--']
     dockerfile = 'tilt.debug.dockerfile'
-
 
 docker_build_with_restart(
     'oci.external-secrets.io/external-secrets/external-secrets',


### PR DESCRIPTION
## Problem Statement

tilt build was failing to rebuild because after server-side apply the image targets weren't re-written. So now, we server-side apply the CRDs and THEN we normal apply the rest of the controllers which correctly updates the images being used.

<img width="1464" height="892" alt="Screenshot 2025-08-29 at 14 22 30" src="https://github.com/user-attachments/assets/fa2a01ff-1f32-4c85-9b15-76aeea632162" />


## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
