### PR TITLE
feat: migrate from tibdex to actions/create-github-app-token

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -102,10 +102,12 @@ jobs:
       uses: ./.github/actions/e2e
     - id: create_token
       if: always()
-      uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+      uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # v2.1.1
       with:
-        app_id: ${{ secrets.APP_ID }}
-        private_key: ${{ secrets.PRIVATE_KEY }}
+        app-id: ${{ secrets.APP_ID }}
+        private-key: ${{ secrets.PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+
     - name: Update on Succeess
       if: always() && steps.e2e.conclusion == 'success'
       uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0

--- a/.github/workflows/ok-to-test-managed.yml
+++ b/.github/workflows/ok-to-test-managed.yml
@@ -25,10 +25,11 @@ jobs:
         egress-policy: audit
     - name: Generate token
       id: generate_token
-      uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+      uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # v2.1.1
       with:
-        app_id: ${{ secrets.APP_ID }}
-        private_key: ${{ secrets.PRIVATE_KEY }}
+        app-id: ${{ secrets.APP_ID }}
+        private-key: ${{ secrets.PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
 
     - name: Slash Command Dispatch
       uses: peter-evans/slash-command-dispatch@13bc09769d122a64f75aa5037256f6f2d78be8c4 # v4.0.0

--- a/.github/workflows/ok-to-test.yml
+++ b/.github/workflows/ok-to-test.yml
@@ -25,10 +25,11 @@ jobs:
     # See app.yml for an example app manifest
     - name: Generate token
       id: generate_token
-      uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+      uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # v2.1.1
       with:
-        app_id: ${{ secrets.APP_ID }}
-        private_key: ${{ secrets.PRIVATE_KEY }}
+        app-id: ${{ secrets.APP_ID }}
+        private-key: ${{ secrets.PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
 
     - name: Slash Command Dispatch
       uses: peter-evans/slash-command-dispatch@13bc09769d122a64f75aa5037256f6f2d78be8c4 # v4.0.0

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -52,10 +52,12 @@ jobs:
       # from running: we can create a PR but the tests won't run :/
     - name: Generate token
       id: generate_token
-      uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+      uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # v2.1.1
       with:
-        app_id: ${{ secrets.APP_ID }}
-        private_key: ${{ secrets.PRIVATE_KEY }}
+        app-id: ${{ secrets.APP_ID }}
+        private-key: ${{ secrets.PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         token: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
Issue [5271](https://github.com/external-secrets/external-secrets/issues/5271)

This pull request updates the GitHub Actions workflows to use the official `actions/create-github-app-token` action instead of the previously used `tibdex/github-app-token`. The change improves supportability and future compatibility by switching to the recommended action, and also updates input parameter names to match the new action's requirements. The update is applied consistently across all relevant workflow files.

**GitHub Actions migration and input updates:**

* Replaced `tibdex/github-app-token` with `actions/create-github-app-token@v2.1.1` in `.github/workflows/e2e.yml`, `.github/workflows/ok-to-test-managed.yml`, `.github/workflows/ok-to-test.yml`, and `.github/workflows/update-deps.yml`. [[1]](diffhunk://#diff-3e103440521ada06efd263ae09b259e5507e4b8f7408308dc227621ad9efa31eL105-R110) [[2]](diffhunk://#diff-5b8e16f46e3d6a07b72f3369ff1d36167bf2c89f1b357bfa43f9383cc7797cb6L28-R32) [[3]](diffhunk://#diff-8b216a69b6cd9712230f9848bf7e76fa03ae117155d783c18e92128e2a71acc6L28-R32) [[4]](diffhunk://#diff-97fb4a2bc76ecb30a4c3461e49dfbf4fd8816a3c6a4e9c492432e554605aac6cL55-R60)
* Updated input parameter names from `app_id` and `private_key` to `app-id` and `private-key`, and added  `owner` input referencing to force **getTokenFromOwner** function`${{ github.repository_owner }}` in all affected workflow files. [[1]](diffhunk://#diff-3e103440521ada06efd263ae09b259e5507e4b8f7408308dc227621ad9efa31eL105-R110) [[2]](diffhunk://#diff-5b8e16f46e3d6a07b72f3369ff1d36167bf2c89f1b357bfa43f9383cc7797cb6L28-R32) [[3]](diffhunk://#diff-8b216a69b6cd9712230f9848bf7e76fa03ae117155d783c18e92128e2a71acc6L28-R32) [[4]](diffhunk://#diff-97fb4a2bc76ecb30a4c3461e49dfbf4fd8816a3c6a4e9c492432e554605aac6cL55-R60)