### PR TITLE
chore(previder): Update Previder Provider dependency and fix ReadOnly token

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -109,7 +109,7 @@ require (
 	github.com/lestrrat-go/jwx/v2 v2.1.6
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.11.3
 	github.com/passbolt/go-passbolt v0.7.2
-	github.com/previder/vault-cli v0.1.2
+	github.com/previder/vault-cli v0.1.3
 	github.com/pulumi/esc-sdk/sdk v0.12.1
 	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.34
 	github.com/sethvargo/go-password v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -803,8 +803,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
 github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
-github.com/previder/vault-cli v0.1.2 h1:aui5v+L243JGbRaJ65z5XsuItjyCtoBND32v1XU3gd4=
-github.com/previder/vault-cli v0.1.2/go.mod h1:u9JDPB5/Em/Czjb/yIwfTODr31kKmeSO3JGrheLMaP8=
+github.com/previder/vault-cli v0.1.3 h1:NZ10yzJpqIcV6TJWONMIzYnPsXJAZrOICBnHTdNJ58I=
+github.com/previder/vault-cli v0.1.3/go.mod h1:EdtgLE+TpL1+noRf8A7Y1Y3M9urIkKqSFCkYhNzdlmc=
 github.com/prometheus/client_golang v1.23.0 h1:ust4zpdl9r4trLY/gSjlm07PuiBq2ynaXXlptpfy8Uc=
 github.com/prometheus/client_golang v1.23.0/go.mod h1:i/o0R9ByOnHX0McrTMTyhYvKE4haaf2mW08I+jGAjEE=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/pkg/provider/previder/client_test.go
+++ b/pkg/provider/previder/client_test.go
@@ -46,3 +46,9 @@ func (v *PreviderVaultFakeClient) GetSecrets() ([]model.Secret, error) {
 	}
 	return secretList, nil
 }
+
+func (v *PreviderVaultFakeClient) GetTokenInfo() (*model.Token, error) {
+	token := new(model.Token)
+	token.TokenType = "ReadOnly"
+	return token, nil
+}

--- a/pkg/provider/previder/provider.go
+++ b/pkg/provider/previder/provider.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-
 	previderclient "github.com/previder/vault-cli/pkg"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -37,6 +36,7 @@ var _ esv1.Provider = &SecretManager{}
 
 type SecretManager struct {
 	VaultClient previderclient.PreviderVaultClient
+	TokenType   string
 }
 
 func init() {
@@ -111,11 +111,11 @@ func (s *SecretManager) SecretExists(ctx context.Context, remoteRef esv1.PushSec
 }
 
 func (s *SecretManager) Validate() (esv1.ValidationResult, error) {
-	_, err := s.VaultClient.GetSecrets()
+	tokenInfo, err := s.VaultClient.GetTokenInfo()
 	if err != nil {
 		return esv1.ValidationResultError, err
 	}
-
+	s.TokenType = tokenInfo.TokenType
 	return esv1.ValidationResultReady, nil
 }
 


### PR DESCRIPTION
## Problem Statement

When using a ReadOnly type token, the pod crashes because of a log failure in de vault-cli. 
Also when validating the store, the Provider always tried to get the list of secrets which is not allowed with a ReadOnly token. This will now get the token info endpoint and save the type of token for future reference when we're implementing writing and creating secrets also.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
