### PR TITLE
chore(testing): Add licence.check make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ FAIL	= (echo ${TIME} ${RED}[FAIL]${CNone} && false)
 # ====================================================================================
 # Conformance
 
-reviewable: generate docs manifests helm.generate helm.schema.update helm.docs lint ## Ensure a PR is ready for review.
+reviewable: generate docs manifests helm.generate helm.schema.update helm.docs lint license.check ## Ensure a PR is ready for review.
 	@go mod tidy
 	@cd e2e/ && go mod tidy
 
@@ -86,6 +86,10 @@ update-deps:
 	cd e2e && go get -u
 	@go mod tidy
 	@cd e2e/ && go mod tidy
+
+.PHONY: license.check
+license.check:
+	$(DOCKER) run --rm -u $(shell id -u) -v $(shell pwd):/github/workspace apache/skywalking-eyes:0.6.0 header check
 
 # ====================================================================================
 # Golang


### PR DESCRIPTION


## Problem Statement

There is a now a License header check that runs in CI

https://github.com/external-secrets/external-secrets/blob/db201ddb6a4ac7ad934e9b3e6675f2005afbe15c/.github/workflows/ci.yml#L73-L88

This check will fail if you don't have the correct License headers. It would be nice to be able to validate this locally when running `make reviewable` to make sure the PR is in the best shape possible.

## Related Issue

Related to #5290 

## Proposed Changes

* Adds a make target `license.check`
* Adds `license.check` as a dependency for `reviewable` target

Since we are already depending on docker locally for building the image, this seemed like a simple solution.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
