### PR TITLE
fix(release): Validate GCP GetSecret json format

### DIFF
--- a/pkg/provider/gcp/secretmanager/push_secret.go
+++ b/pkg/provider/gcp/secretmanager/push_secret.go
@@ -146,7 +146,7 @@ func (b *propertyPSBuilder) needUpdate(original []byte) bool {
 		return true
 	}
 
-	val := getDataByProperty(original, b.pushSecretData.GetProperty())
+	val, _ := getDataByProperty(original, b.pushSecretData.GetProperty())
 	return !val.Exists() || val.String() != string(b.payload)
 }
 


### PR DESCRIPTION
## Problem Statement

The current method allows user to use a GCP secret manager with a malformed json content. It happens because there's no validation and it can cause problems in the future.

## Related Issue

Fixes #4336 

## Proposed Changes

Add a json validation using the official lib `encoding/json` to GCP secrets. This change will prevent malformed stored json's to the secrets. 

## Checklist

- [ x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
