### PR TITLE
docs: issue-5350: Updates CRD and docs with write-only limitation for github provider

### DIFF
--- a/apis/externalsecrets/v1/secretstore_types.go
+++ b/apis/externalsecrets/v1/secretstore_types.go
@@ -107,7 +107,8 @@ type SecretStoreProvider struct {
 	// +optional
 	YandexLockbox *YandexLockboxProvider `json:"yandexlockbox,omitempty"`
 
-	// Github configures this store to push Github Action secrets using Github API provider
+	// Github configures this store to push GitHub Action secrets using GitHub API provider.
+	// Note: This provider only supports write operations (PushSecret) and cannot fetch secrets from GitHub
 	// +optional
 	Github *GithubProvider `json:"github,omitempty"`
 

--- a/config/crds/bases/external-secrets.io_clustersecretstores.yaml
+++ b/config/crds/bases/external-secrets.io_clustersecretstores.yaml
@@ -2074,8 +2074,9 @@ spec:
                         type: string
                     type: object
                   github:
-                    description: Github configures this store to push Github Action
-                      secrets using Github API provider
+                    description: |-
+                      Github configures this store to push GitHub Action secrets using GitHub API provider.
+                      Note: This provider only supports write operations (PushSecret) and cannot fetch secrets from GitHub
                     properties:
                       appID:
                         description: appID specifies the Github APP that will be used

--- a/config/crds/bases/external-secrets.io_secretstores.yaml
+++ b/config/crds/bases/external-secrets.io_secretstores.yaml
@@ -2074,8 +2074,9 @@ spec:
                         type: string
                     type: object
                   github:
-                    description: Github configures this store to push Github Action
-                      secrets using Github API provider
+                    description: |-
+                      Github configures this store to push GitHub Action secrets using GitHub API provider.
+                      Note: This provider only supports write operations (PushSecret) and cannot fetch secrets from GitHub
                     properties:
                       appID:
                         description: appID specifies the Github APP that will be used

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -3951,7 +3951,9 @@ spec:
                           type: string
                       type: object
                     github:
-                      description: Github configures this store to push Github Action secrets using Github API provider
+                      description: |-
+                        Github configures this store to push GitHub Action secrets using GitHub API provider.
+                        Note: This provider only supports write operations (PushSecret) and cannot fetch secrets from GitHub
                       properties:
                         appID:
                           description: appID specifies the Github APP that will be used to authenticate the client
@@ -15068,7 +15070,9 @@ spec:
                           type: string
                       type: object
                     github:
-                      description: Github configures this store to push Github Action secrets using Github API provider
+                      description: |-
+                        Github configures this store to push GitHub Action secrets using GitHub API provider.
+                        Note: This provider only supports write operations (PushSecret) and cannot fetch secrets from GitHub
                       properties:
                         appID:
                           description: appID specifies the Github APP that will be used to authenticate the client

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -8475,7 +8475,8 @@ GithubProvider
 </td>
 <td>
 <em>(Optional)</em>
-<p>Github configures this store to push Github Action secrets using Github API provider</p>
+<p>Github configures this store to push GitHub Action secrets using GitHub API provider.
+Note: This provider only supports write operations (PushSecret) and cannot fetch secrets from GitHub</p>
 </td>
 </tr>
 <tr>

--- a/docs/provider/github.md
+++ b/docs/provider/github.md
@@ -2,9 +2,14 @@
 
 External Secrets Operator integrates with GitHub to sync Kubernetes secrets with [GitHub Actions secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions).
 
+### Limitations
+
+The GitHub provider is **write-only**, designed specifically to **create and update** GitHub Actions secrets using the
+[GitHub REST API](https://docs.github.com/en/rest/actions/secrets), and does not support **fetching the secret values**.
+
 ### Configuring Github provider
 
-The GitHub API requires to install the ESO app to your GitHub organisation in order to use the Github provider features.
+The GitHub API requires to install the ESO app to your GitHub organisation in order to use the GitHub provider features.
 
 ### Configuring the secret store
 


### PR DESCRIPTION
## Problem Statement

GitHub Provider when used as SecretStore or ClusterSecret supports PushSecret only or in an essentially one-way / write-only behavior. However, the documentation doesn't mention it and could lead to confusion.

## Related Issue

Fixes #5350

## Proposed Changes

Updates the github provider API description and the provider documentation with the limitation.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`