### PR TITLE
fix(ci): listing required roles should NOT mention/tag the roles, just name them.

### DIFF
--- a/.github/workflows/lgtm.yml
+++ b/.github/workflows/lgtm.yml
@@ -187,7 +187,7 @@ jobs:
 
           // Check if user has any required reviewer role
           if (commenterReviewerRoles.size === 0) {
-            const rolesList = Array.from(requiredReviewerRoles).join(', ');
+            const rolesList = Array.from(requiredReviewerRoles).map(role => role.replace(`@${organization}/`, '')).join(', ');
             await github.rest.issues.createComment({
               owner, repo, issue_number: prNumber,
               body: `@${commenter} You must be a member of one of the required reviewer roles to use /lgtm.\n\nRequired roles for this PR: ${rolesList}`


### PR DESCRIPTION
## Problem Statement

We don't actually want to mention/notify the required roles in this message, the goal is only to inform the commenter what roles are necessary. We do this the same way in other areas of this workflow.

## Related Issue

Fixes #...

## Proposed Changes

Trim off the organisazation and only use the name of the role, so maintainer, not @external-secrets/maintainer

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
