### PR TITLE
fix: liveness probe would include invalid value `enable`

### DIFF
--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -128,15 +128,16 @@ The command removes all the Kubernetes components associated with the chart and 
 | imagePullSecrets | list | `[]` |  |
 | installCRDs | bool | `true` | If set, install and upgrade CRDs through helm chart. |
 | leaderElect | bool | `false` | If true, external-secrets will perform leader election between instances to ensure no more than one instance of external-secrets operates at a time. |
-| livenessProbe.address | string | `""` | Address for liveness probe. |
 | livenessProbe.enabled | bool | `false` | Enabled determines if the liveness probe should be used or not. By default it's disabled. |
-| livenessProbe.failureThreshold | int | `5` | Number of consecutive probe failures that should occur before considering the probe as failed. |
-| livenessProbe.httpGet | object | `{"path":"/healthz","port":"8082"}` | Handler for liveness probe. |
-| livenessProbe.httpGet.port | string | `"8082"` | Set this value to 8082 to active liveness probes. |
-| livenessProbe.initialDelaySeconds | int | `10` | Delay in seconds for the container to start before performing the initial probe. |
-| livenessProbe.periodSeconds | int | `10` | Period in seconds for K8s to start performing probes. |
-| livenessProbe.successThreshold | int | `1` | Number of successful probes to mark probe successful. |
-| livenessProbe.timeoutSeconds | int | `5` | Specify the maximum amount of time to wait for a probe to respond before considering it fails. |
+| livenessProbe.spec | object | `{"address":"","failureThreshold":5,"httpGet":{"path":"/healthz","port":"8082"},"initialDelaySeconds":10,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5}` | The body of the liveness probe settings. |
+| livenessProbe.spec.address | string | `""` | Address for liveness probe. |
+| livenessProbe.spec.failureThreshold | int | `5` | Number of consecutive probe failures that should occur before considering the probe as failed. |
+| livenessProbe.spec.httpGet | object | `{"path":"/healthz","port":"8082"}` | Handler for liveness probe. |
+| livenessProbe.spec.httpGet.port | string | `"8082"` | Set this value to 8082 to active liveness probes. |
+| livenessProbe.spec.initialDelaySeconds | int | `10` | Delay in seconds for the container to start before performing the initial probe. |
+| livenessProbe.spec.periodSeconds | int | `10` | Period in seconds for K8s to start performing probes. |
+| livenessProbe.spec.successThreshold | int | `1` | Number of successful probes to mark probe successful. |
+| livenessProbe.spec.timeoutSeconds | int | `5` | Specify the maximum amount of time to wait for a probe to respond before considering it fails. |
 | log | object | `{"level":"info","timeEncoding":"epoch"}` | Specifies Log Params to the External Secrets Operator |
 | metrics.listen.port | int | `8080` |  |
 | metrics.listen.secure.certDir | string | `"/etc/tls"` | TLS cert directory path |

--- a/deploy/charts/external-secrets/templates/deployment.yaml
+++ b/deploy/charts/external-secrets/templates/deployment.yaml
@@ -106,7 +106,7 @@ spec:
           - --loglevel={{ .Values.log.level }}
           - --zap-time-encoding={{ .Values.log.timeEncoding }}
           {{- if .Values.livenessProbe.enabled }}
-          - --live-addr={{ .Values.livenessProbe.address }}:{{ .Values.livenessProbe.httpGet.port }}
+          - --live-addr={{ .Values.livenessProbe.spec.address }}:{{ .Values.livenessProbe.spec.httpGet.port }}
           {{- end }}
           {{- if .Values.metrics.listen.secure.enabled }}
           - --metrics-secure=true
@@ -120,7 +120,7 @@ spec:
               name: metrics
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
-          {{- toYaml .Values.livenessProbe | nindent 12 }}
+          {{- toYaml .Values.livenessProbe.spec | nindent 12 }}
           {{- end }}
           {{- with .Values.extraEnv }}
           env:

--- a/deploy/charts/external-secrets/tests/controller_test.yaml
+++ b/deploy/charts/external-secrets/tests/controller_test.yaml
@@ -104,15 +104,16 @@ tests:
     set:
       livenessProbe:
         enabled: true
-        initialDelaySeconds: 10
-        periodSeconds: 10
-        timeoutSeconds: 10
-        failureThreshold: 10
-        successThreshold: 10
-        httpGet:
-          path: /healthz
-          port: "8080"
-          scheme: HTTP
+        spec:
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 10
+          failureThreshold: 10
+          successThreshold: 10
+          httpGet:
+            path: /healthz
+            port: "8080"
+            scheme: HTTP
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.port

--- a/deploy/charts/external-secrets/values.schema.json
+++ b/deploy/charts/external-secrets/values.schema.json
@@ -412,37 +412,42 @@
         "livenessProbe": {
             "type": "object",
             "properties": {
-                "address": {
-                    "type": "string"
-                },
                 "enabled": {
                     "type": "boolean"
                 },
-                "failureThreshold": {
-                    "type": "integer"
-                },
-                "httpGet": {
+                "spec": {
                     "type": "object",
                     "properties": {
-                        "path": {
+                        "address": {
                             "type": "string"
                         },
-                        "port": {
-                            "type": "string"
+                        "failureThreshold": {
+                            "type": "integer"
+                        },
+                        "httpGet": {
+                            "type": "object",
+                            "properties": {
+                                "path": {
+                                    "type": "string"
+                                },
+                                "port": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "initialDelaySeconds": {
+                            "type": "integer"
+                        },
+                        "periodSeconds": {
+                            "type": "integer"
+                        },
+                        "successThreshold": {
+                            "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                            "type": "integer"
                         }
                     }
-                },
-                "initialDelaySeconds": {
-                    "type": "integer"
-                },
-                "periodSeconds": {
-                    "type": "integer"
-                },
-                "successThreshold": {
-                    "type": "integer"
-                },
-                "timeoutSeconds": {
-                    "type": "integer"
                 }
             }
         },

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -298,23 +298,25 @@ grafanaDashboard:
 livenessProbe:
   # -- Enabled determines if the liveness probe should be used or not. By default it's disabled.
   enabled: false
-  # -- Address for liveness probe.
-  address: ""
-  # -- Specify the maximum amount of time to wait for a probe to respond before considering it fails.
-  timeoutSeconds: 5
-  # -- Number of consecutive probe failures that should occur before considering the probe as failed.
-  failureThreshold: 5
-  # -- Period in seconds for K8s to start performing probes.
-  periodSeconds: 10
-  # -- Number of successful probes to mark probe successful.
-  successThreshold: 1
-  # -- Delay in seconds for the container to start before performing the initial probe.
-  initialDelaySeconds: 10
-  # -- Handler for liveness probe.
-  httpGet:
-    # -- Set this value to 8082 to active liveness probes.
-    port: "8082"
-    path: /healthz
+  # -- The body of the liveness probe settings.
+  spec:
+    # -- Address for liveness probe.
+    address: ""
+    # -- Specify the maximum amount of time to wait for a probe to respond before considering it fails.
+    timeoutSeconds: 5
+    # -- Number of consecutive probe failures that should occur before considering the probe as failed.
+    failureThreshold: 5
+    # -- Period in seconds for K8s to start performing probes.
+    periodSeconds: 10
+    # -- Number of successful probes to mark probe successful.
+    successThreshold: 1
+    # -- Delay in seconds for the container to start before performing the initial probe.
+    initialDelaySeconds: 10
+    # -- Handler for liveness probe.
+    httpGet:
+      # -- Set this value to 8082 to active liveness probes.
+      port: "8082"
+      path: /healthz
 
 nodeSelector: {}
 


### PR DESCRIPTION
## Problem Statement

Since it's including the entire body `enabled` would have been part of the rendered thing in Kubernetes manifest leading to a potential failure:

```yaml
        enabled: true
        initialDelaySeconds: 10
        periodSeconds: 10
        timeoutSeconds: 10
        failureThreshold: 10
        successThreshold: 10
        httpGet:
          path: /healthz
          port: "8080"
          scheme: HTTP
```

`enabled: true` here is invalid. We need an internal field that can be used for entire field parsing here:

```yaml
          {{- if .Values.livenessProbe.enabled }}
          livenessProbe:
          {{- toYaml .Values.livenessProbe.spec | nindent 12 }}
          {{- end }}
```

Note that `spec.template.spec.containers[0].livenessProbe.httpGet.port` should still be the path and not `spec.template.spec.containers[0].livenessProbe.spec.httpGet.port`. Because that would mean it includes `spec`.

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
