### PR TITLE
fix(charts): exclude 'address' key from livenessProbe definition

### DIFF
--- a/deploy/charts/external-secrets/templates/deployment.yaml
+++ b/deploy/charts/external-secrets/templates/deployment.yaml
@@ -120,7 +120,7 @@ spec:
               name: metrics
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
-          {{- toYaml .Values.livenessProbe.spec | nindent 12 }}
+          {{- toYaml (omit .Values.livenessProbe.spec "address") | nindent 12 }}
           {{- end }}
           {{- with .Values.extraEnv }}
           env:


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?

`address` is not part of the allowed fields of the livenessProbe section (`kubectl explain Pod.spec.containers.livenessProbe`)

## Proposed Changes

We now exclude the `address` field from the dict.

Another option if you prefer would be to move the `address` key one level above (`.livenessProbe` instead of `.livenessProbe.spec`) so we can keep templating the full `.livenessProbe.spec`.

## Format

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
