### PR TITLE
fix: issue-5388: Fixes GCP Workload Identity Federation auth issue

### DIFF
--- a/pkg/provider/gcp/secretmanager/workload_identity_federation.go
+++ b/pkg/provider/gcp/secretmanager/workload_identity_federation.go
@@ -295,7 +295,7 @@ func (w *workloadIdentityFederation) updateExternalAccountConfigWithSubjectToken
 		ns = *w.config.ServiceAccountRef.Namespace
 	}
 	config.SubjectTokenSupplier = &k8sSATokenReader{
-		audience:         config.Audience,
+		audience:         w.config.Audience,
 		subjectTokenType: workloadIdentitySubjectTokenType,
 		saTokenGenerator: w.saTokenGenerator,
 		saAudience:       w.config.ServiceAccountRef.Audiences,


### PR DESCRIPTION
## Problem Statement

GCP Workload Identity Federation authentication fails when `serviceAccountRef` is specified.

## Related Issue

Fixes #5388 

## Proposed Changes

The issue is caused due to the incorrect initialization of the WIF audience.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
