### PR TITLE
fix(onepassword): Reduce API usage

### DIFF
--- a/providers/v1/onepasswordsdk/client.go
+++ b/providers/v1/onepasswordsdk/client.go
@@ -380,12 +380,9 @@ func (p *Provider) SecretExists(_ context.Context, _ esv1.PushSecretRemoteRef) (
 	return false, fmt.Errorf("not implemented")
 }
 
-// Checks that the client was initialized correctly.
-// We don't make calls the the API, as the rate-limit of the 1password SDK is quite restrictive.
+// Validate does nothing here. It would be possible to ping the SDK to prove we're healthy, but
+// since the 1password SDK rate-limit is pretty aggressive, we prefer to do nothing.
 func (p *Provider) Validate() (esv1.ValidationResult, error) {
-	if p.client == nil || p.vaultID == "" {
-		return esv1.ValidationResultError, fmt.Errorf("client not properly initialized")
-	}
 	return esv1.ValidationResultReady, nil
 }
 

--- a/providers/v1/onepasswordsdk/client_test.go
+++ b/providers/v1/onepasswordsdk/client_test.go
@@ -310,43 +310,6 @@ func TestProviderValidate(t *testing.T) {
 			},
 			vaultPrefix: "op://vault/",
 		},
-		{
-			name: "validate error",
-			client: func() *onepassword.Client {
-				fc := &fakeClient{
-					listAllResult: []onepassword.VaultOverview{},
-					listAllError:  errors.New("no vaults found when listing"),
-				}
-
-				return &onepassword.Client{
-					SecretsAPI: fc,
-					VaultsAPI:  fc,
-				}
-			},
-			want: v1.ValidationResultError,
-			assertError: func(t *testing.T, err error) {
-				require.ErrorContains(t, err, "no vaults found when listing")
-			},
-			vaultPrefix: "op://vault/",
-		},
-		{
-			name: "validate error missing vault prefix",
-			client: func() *onepassword.Client {
-				fc := &fakeClient{
-					listAllResult: []onepassword.VaultOverview{},
-					listAllError:  errors.New("no vaults found when listing"),
-				}
-
-				return &onepassword.Client{
-					SecretsAPI: fc,
-					VaultsAPI:  fc,
-				}
-			},
-			want: v1.ValidationResultError,
-			assertError: func(t *testing.T, err error) {
-				require.ErrorContains(t, err, "no vaults found when listing")
-			},
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Problem Statement

Users (including me) seem to run into the 1password SDK rate limit (1000 calls per day).

## Related Issue

https://github.com/external-secrets/external-secrets/issues/4925

## Proposed Changes

Dropping the list-vault operation seems like it should help reduce our usage. I'm not 100% sure this is OK, but would love to discuss it.

As a follow-up, perhaps we could add a short TTL cache for `findItem`?

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
