### PR TITLE
docs: extend bitwarden example and integration to accomodate the ssh key feature

### DIFF
--- a/docs/examples/bitwarden.md
+++ b/docs/examples/bitwarden.md
@@ -84,7 +84,7 @@ bw serve --hostname 0.0.0.0 #--disable-origin-protection
 
 ## Deploy (Cluster)SecretStores
 
-There are four possible (Cluster)SecretStores to deploy, each can access different types of fields from an item in the Bitwarden vault. It is not required to deploy them all.
+There are five possible (Cluster)SecretStores to deploy, each can access different types of fields from an item in the Bitwarden vault. It is not required to deploy them all.
 
 ```yaml
 {% include 'bitwarden-secret-store.yaml' %}
@@ -98,6 +98,7 @@ There are four possible (Cluster)SecretStores to deploy, each can access differe
 * `bitwarden-fields`: Use to get custom fields
 * `bitwarden-notes`: Use to get notes
 * `bitwarden-attachments`: Use to get attachments
+* `bitwarden-ssh`: Use to get ssh key stored in `privateKey` (other possible fields are `publicKey` and `keyFingerprint`)
 
 remoteRef:
 
@@ -109,6 +110,7 @@ remoteRef:
     * `password` for the password of a secret (`bitwarden-login` SecretStore)
     * `name_of_the_custom_field` for any custom field (`bitwarden-fields` SecretStore)
     * `id_or_name_of_the_attachment` for any attachment (`bitwarden-attachment`, SecretStore)
+    * `name_of_the_ssh_field` for any ssh field (`bitwarden-ssh` SecretStore) possible fields are `publicKey`, `privateKey` and `keyFingerprint`
 
 ```yaml
 {% include 'bitwarden-secret.yaml' %}

--- a/docs/snippets/bitwarden-secret-store.yaml
+++ b/docs/snippets/bitwarden-secret-store.yaml
@@ -44,4 +44,17 @@ spec:
     webhook:
       url: "http://bitwarden-cli:8087/object/attachment/{{ .remoteRef.property }}?itemid={{ .remoteRef.key }}"
       result: {}
+---
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: bitwarden-ssh
+spec:
+  provider:
+    webhook:
+      url: "http://bitwarden-cli:8087/object/item/{{ .remoteRef.key }}"
+      headers:
+        Content-Type: application/json
+      result:
+        jsonPath: "$.data.sshKey.{{ .remoteRef.property }}"
 {% endraw %}

--- a/docs/snippets/bitwarden-secret.yaml
+++ b/docs/snippets/bitwarden-secret.yaml
@@ -73,4 +73,25 @@ spec:
       remoteRef:
         key: aaaabbbb-cccc-dddd-eeee-000011112222
         property: id_rsa.pub
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: my-secrets-ssh
+  namespace: default
+spec:
+  target:
+    template:
+      type: kubernetes.io/ssh-auth
+      data:
+        ssh-privatekey: "{{ .privateKey | toString }}"
+  data:
+    - secretKey: privateKey
+      sourceRef:
+        storeRef:
+          name: bitwarden-ssh
+          kind: ClusterSecretStore  # or SecretStore
+      remoteRef:
+        key: aaaabbbb-cccc-dddd-eeee-000011112222
+        property: privateKey
 {% endraw %}


### PR DESCRIPTION
Extending documentation

## Problem Statement

I created a SSH Key in Bitwarden Password Manager.
<img width="135" height="324" alt="Screenshot from 2025-10-05 13-12-33" src="https://github.com/user-attachments/assets/acceec2d-a913-482d-9a4e-73a20d4cf357" />
Then, I failed to be able to deploy my ssh private key with the 4 example (Cluster)SecretStore on this [guide](https://external-secrets.io/latest/examples/bitwarden/).
The values for the ssh key generated are under `$.data.sshKey.privateKey`, `$.data.sshKey.publicKey` and `$.data.sshKey.keyFingerprint`

## Related Issue

None.

## Proposed Changes

This PR proposes to add a new (Cluster)SecretStore named `bitwarden-ssh` in the documentation guide related to Bitwarden Password Manager, and includes a secret example as well.

## Format

git commit is `docs: extend bitwarden example and integration to accomodate the ssh key feature`

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] ~~My changes have reasonable test coverage~~ => no code change, only documentation
- [ ] ~~All tests pass with `make test`~~ => no code change, only documentation
- [x] I ensured my PR is ready for review with `make reviewable`
