### PR TITLE
feat(security): Allow system trust store for certificate validation

### DIFF
--- a/docs/provider/kubernetes.md
+++ b/docs/provider/kubernetes.md
@@ -82,11 +82,15 @@ spec:
 
 ### Target API-Server Configuration
 
-The servers `url` can be omitted and defaults to `kubernetes.default`. You **have to** provide a CA certificate in order to connect to the API Server securely.
-For your convenience, each namespace has a ConfigMap `kube-root-ca.crt` that contains the CA certificate of the internal API Server (see `RootCAConfigMap` [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/)).
-Use that if you want to connect to the same API server.
-If you want to connect to a remote API Server you need to fetch it and store it inside the cluster as ConfigMap or Secret.
-You may also define it inline as base64 encoded value using the `caBundle` property.
+The servers `url` can be omitted and defaults to `kubernetes.default`.
+
+TLS verification behavior:
+- If neither `caBundle` nor `caProvider` is specified, the provider uses the system trust store (same behavior as `kubectl`). This is suitable for API servers that present publicly trusted certificates (for example, via Let's Encrypt).
+- If the API server uses a private/internal CA, provide a custom CA via `caBundle` or `caProvider` so the connection can be verified against that CA.
+
+For your convenience, each namespace has a ConfigMap `kube-root-ca.crt` that contains the CA certificate of the internal API Server (see `RootCAConfigMap` [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/)). Use that if you want to connect to the same API server.
+
+If you want to connect to a remote API Server that does not use a publicly trusted CA, fetch its CA certificate and store it inside the cluster as a ConfigMap or Secret. You may also define it inline as a base64-encoded value using the `caBundle` property.
 
 ```yaml
 apiVersion: external-secrets.io/v1

--- a/pkg/provider/kubernetes/auth.go
+++ b/pkg/provider/kubernetes/auth.go
@@ -71,9 +71,15 @@ func (c *Client) getAuth(ctx context.Context) (*rest.Config, error) {
 		return nil, err
 	}
 
+	// Configure TLS client config
 	cfg.TLSClientConfig = rest.TLSClientConfig{
 		Insecure: false,
-		CAData:   ca,
+	}
+	
+	// Only set CAData if we have a custom CA bundle
+	// If ca is nil, the Kubernetes client will use the system trust store
+	if ca != nil {
+		cfg.TLSClientConfig.CAData = ca
 	}
 
 	switch {

--- a/pkg/provider/kubernetes/validate.go
+++ b/pkg/provider/kubernetes/validate.go
@@ -36,8 +36,10 @@ import (
 func (p *Provider) ValidateStore(store esv1.GenericStore) (admission.Warnings, error) {
 	storeSpec := store.GetSpec()
 	k8sSpec := storeSpec.Provider.Kubernetes
+	// Allow system trust store when neither caBundle nor caProvider is provided
+	// This matches kubectl behavior where system roots are used when no certificate-authority is specified
 	if k8sSpec.AuthRef == nil && k8sSpec.Server.CABundle == nil && k8sSpec.Server.CAProvider == nil {
-		return nil, errors.New("a CABundle or CAProvider is required")
+		// System trust store will be used - this is valid
 	}
 	if store.GetObjectKind().GroupVersionKind().Kind == esv1.ClusterSecretStoreKind &&
 		k8sSpec.Server.CAProvider != nil &&

--- a/pkg/provider/kubernetes/validate_test.go
+++ b/pkg/provider/kubernetes/validate_test.go
@@ -66,15 +66,27 @@ func TestValidateStore(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "empty ca",
+			name: "empty ca - system trust store allowed",
 			store: &esv1.SecretStore{
 				Spec: esv1.SecretStoreSpec{
 					Provider: &esv1.SecretStoreProvider{
-						Kubernetes: &esv1.KubernetesProvider{},
+						Kubernetes: &esv1.KubernetesProvider{
+							Server: esv1.KubernetesServer{
+								URL: "https://demo.gardener.cloud",
+							},
+							Auth: &esv1.KubernetesAuth{
+								Token: &esv1.TokenAuth{
+									BearerToken: v1.SecretKeySelector{
+										Name: "token-secret",
+										Key:  "token",
+									},
+								},
+							},
+						},
 					},
 				},
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "invalid client cert name",


### PR DESCRIPTION
## Problem Statement

- Currently requires users to explicitly specify a certificate authority (CA) using either caBundle or caProvider to establish a secure connection with a Kubernetes API serve which might be the problem for publicly trusted and automatically rotated certificates.

## Related Issue

Fixes #5393

## Proposed Changes

- Allow system trust store for certificate validation in the absence of caBundle or caProvider
## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
