### PR TITLE
chore(build): Update ubi Docker builds to UBI9

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi@sha256:2f698e145dd30ac9f611b8984b910640bc210fae476dc36aa9ba200fad2a30ed AS minimal-ubi
+FROM registry.access.redhat.com/ubi9/ubi@sha256:dec374e05cc13ebbc0975c9f521f3db6942d27f8ccdf06b180160490eef8bdbc AS minimal-ubi
 
 # Add metadata
 LABEL maintainer="cncf-externalsecretsop-maintainers@lists.cncf.io" \
@@ -20,7 +20,7 @@ COPY ubi-build-files-${TARGETARCH}.txt /tmp
 # Copy all the required files from the base UBI image into the image directory
 # As the go binary is not statically compiled this includes everything needed for CGO to work, cacerts, tzdata and RH release files
 RUN tar cf /tmp/files.tar -T /tmp/ubi-build-files-${TARGETARCH}.txt && tar xf /tmp/files.tar -C /image/ \
-  && strip --strip-unneeded /image/usr/lib64/*[0-9].so && rpm --root /image --initdb \
+  && rpm --root /image --initdb \
   && PACKAGES=$(rpm -qf $(cat /tmp/ubi-build-files-${TARGETARCH}.txt) | grep -v "is not owned by any package" | sort -u) \
   && echo dnf install -y 'dnf-command(download)' \
   && dnf download --destdir / ${PACKAGES} \

--- a/ubi-build-files-amd64.txt
+++ b/ubi-build-files-amd64.txt
@@ -2,13 +2,8 @@ etc/pki
 etc/ssl/certs
 etc/redhat-release
 usr/share/zoneinfo
-usr/lib64/ld-2.28.so
 usr/lib64/ld-linux-x86-64.so.2
-usr/lib64/libc-2.28.so
 usr/lib64/libc.so.6
-usr/lib64/libdl-2.28.so
 usr/lib64/libdl.so.2
-usr/lib64/libpthread-2.28.so
 usr/lib64/libpthread.so.0
-usr/lib64/libm-2.28.so
 usr/lib64/libm.so.6

--- a/ubi-build-files-arm64.txt
+++ b/ubi-build-files-arm64.txt
@@ -2,13 +2,8 @@ etc/pki
 etc/ssl/certs
 etc/redhat-release
 usr/share/zoneinfo
-usr/lib64/ld-2.28.so
-usr/lib64/ld-linux-aarch64.so.1
-usr/lib64/libc-2.28.so
+usr/lib/ld-linux-aarch64.so.1
 usr/lib64/libc.so.6
-usr/lib64/libdl-2.28.so
 usr/lib64/libdl.so.2
-usr/lib64/libpthread-2.28.so
 usr/lib64/libpthread.so.0
-usr/lib64/libm-2.28.so
 usr/lib64/libm.so.6

--- a/ubi-build-files-ppc64le.txt
+++ b/ubi-build-files-ppc64le.txt
@@ -2,12 +2,8 @@ etc/pki
 etc/ssl/certs
 etc/redhat-release
 usr/share/zoneinfo
-usr/lib64/ld-2.28.so
-usr/lib64/libc-2.28.so
+usr/lib64/ld64.so.2
 usr/lib64/libc.so.6
-usr/lib64/libdl-2.28.so
 usr/lib64/libdl.so.2
-usr/lib64/libpthread-2.28.so
 usr/lib64/libpthread.so.0
-usr/lib64/libm-2.28.so
 usr/lib64/libm.so.6

--- a/ubi-build-files-s390x.txt
+++ b/ubi-build-files-s390x.txt
@@ -2,12 +2,8 @@ etc/pki
 etc/ssl/certs
 etc/redhat-release
 usr/share/zoneinfo
-usr/lib64/ld-2.28.so
-usr/lib64/libc-2.28.so
+usr/lib/ld64.so.1
 usr/lib64/libc.so.6
-usr/lib64/libdl-2.28.so
 usr/lib64/libdl.so.2
-usr/lib64/libpthread-2.28.so
 usr/lib64/libpthread.so.0
-usr/lib64/libm-2.28.so
 usr/lib64/libm.so.6


### PR DESCRIPTION
## Problem Statement

Update UBI base images to UBI9. RHEL8 which UBI8 is based on has been in maintenance, rather than full support, for a while now so we update the bases to UBI9 which is fully supported. 

## Related Issue


## Proposed Changes

How do you like to solve the issue and why?

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
