### PR TITLE
docs: remove jwt token authentication option from STSSessionToken generator

### DIFF
--- a/docs/snippets/generator-sts.yaml
+++ b/docs/snippets/generator-sts.yaml
@@ -15,7 +15,7 @@ spec:
   # credentials from the environment of the controller.
   auth:
 
-    # 1: static credentials
+    # static credentials:
     # point to a secret that contains static credentials
     # like AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
     secretRef:
@@ -25,13 +25,6 @@ spec:
       secretAccessKeySecretRef:
         name: "my-aws-creds"
         key: "access-secret"
-
-    # option 2: IAM Roles for Service Accounts
-    # point to a service account that should be used
-    # that is configured for IAM Roles for Service Accounts (IRSA)
-    jwt:
-      serviceAccountRef:
-        name: "oci-token-sync"
 
   # optional request parameters for further fine-tuning the Token generation.
   requestParameters:


### PR DESCRIPTION
## Problem Statement

STSSessionToken generator code snippet is outdated, and confuses people

## Related Issue

https://github.com/external-secrets/external-secrets/pull/5026

## Proposed Changes

How do you like to solve the issue and why?

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
