### PR TITLE
fix: put back the expires into the github generator

### DIFF
--- a/pkg/generator/github/github.go
+++ b/pkg/generator/github/github.go
@@ -195,8 +195,9 @@ func newGHClient(ctx context.Context, k client.Client, n string, hc *http.Client
 // GetInstallationToken generates a GitHub installation token using the provided private key and app ID.
 func GetInstallationToken(key *rsa.PrivateKey, aid string) (string, error) {
 	claims := jwt.RegisteredClaims{
-		Issuer:   aid,
-		IssuedAt: jwt.NewNumericDate(time.Now().Add(-time.Second * 10)),
+		Issuer:    aid,
+		IssuedAt:  jwt.NewNumericDate(time.Now().Add(-time.Second * 10)),
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Second * 300)),
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?

## Related Issue

Fixes https://github.com/external-secrets/external-secrets/issues/5471

## Proposed Changes

How do you like to solve the issue and why?

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
