### PR TITLE
fix: minor typo in comment of KeeperSecurity example

### DIFF
--- a/docs/provider/keeper-security.md
+++ b/docs/provider/keeper-security.md
@@ -25,7 +25,7 @@ Once you have created your SMC, you will get a config.json file or a base64 json
 This base64 encoded jsong string will be required to create your secretStores
 
 ## Important note about this documentation
-_**The KepeerSecurity calls the entries in vaults 'Records'. These docs use the same term.**_
+_**The KeeperSecurity calls the entries in vaults 'Records'. These docs use the same term.**_
 
 ### Update secret store
 Be sure the `keepersecurity` provider is listed in the `Kind=SecretStore`
@@ -99,4 +99,4 @@ To create a Keeper Security record from kubernetes a `Kind=PushSecret` is needed
 
 ### Limitations
 * Only possible to push one key per secret at the moment
-* If the record with the selected name exists but the key does not exists the record can not be updated. See [Ability to add custom fields to existing secret #17](https://github.com/Keeper-Security/secrets-manager-go/issues/17)
+* If the record with the selected name exists but the key does not exist, the record cannot be updated. See [Ability to add custom fields to existing secret #17](https://github.com/Keeper-Security/secrets-manager-go/issues/17)

--- a/docs/snippets/keepersecurity-external-secret.yaml
+++ b/docs/snippets/keepersecurity-external-secret.yaml
@@ -4,7 +4,7 @@ kind: ExternalSecret
 metadata:
   name: example
 spec:
-  refreshInterval: 1h           # rate SecretManager pulls KeeperSrucity
+  refreshInterval: 1h           # rate SecretManager pulls KeeperSecurity
   secretStoreRef:
     kind: SecretStore
     name: example               # name of the SecretStore (or kind specified)
@@ -76,7 +76,7 @@ kind: ExternalSecret
 metadata:
   name: example
 spec:
-  refreshInterval: 1h           # rate SecretManager pulls KeeperSrucity
+  refreshInterval: 1h           # rate SecretManager pulls KeeperSecurity
   secretStoreRef:
     kind: SecretStore
     name: example               # name of the SecretStore (or kind specified)


### PR DESCRIPTION
## Problem Statement

Ran into some small typos while reading the docs on Keeper Security, figured I'd make this tiny PR to get rid of them.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
