### PR TITLE
chore(release): add darwin_arm64 releases

### DIFF
--- a/cmd/esoctl/.goreleaser.yaml
+++ b/cmd/esoctl/.goreleaser.yaml
@@ -14,6 +14,10 @@ builds:
       - windows
     goarch:
       - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
 
 archives:
   - id: default


### PR DESCRIPTION
## Problem Statement

I attended the KubeCon NA 2025 ContribFest for external secrets, which involved running esoctl to create a secret generator. Unfortunately, no binary was available for MacBook laptops on Apple Silicon.

## Related Issue

Fixes #5581

## Proposed Changes

I added `arm64` builds to the goreleaser; future releases of `esoctl` will now include binaries available for Mac laptops on Apple Silicon.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
