### PR TITLE
feat(security): Add NetworkPolicy resources for controller, webhook, and cert-controller [WIP]

### DIFF
--- a/deploy/charts/external-secrets/templates/cert-controller-networkpolicy.yaml
+++ b/deploy/charts/external-secrets/templates/cert-controller-networkpolicy.yaml
@@ -1,0 +1,78 @@
+{{- if and .Values.certController.create .Values.networkPolicy.enabled (not .Values.webhook.certManager.enabled) }}
+{{- $isOpenShift := include "external-secrets.isOpenShift" . | trim }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "external-secrets.fullname" . }}-cert-controller
+  namespace: {{ template "external-secrets.namespace" . }}
+  labels:
+    {{- include "external-secrets-cert-controller.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "external-secrets-cert-controller.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow Prometheus to scrape metrics
+    - ports:
+        - port: {{ .Values.certController.metrics.listen.port }}
+          protocol: TCP
+      {{- if and .Values.networkPolicy.certController (hasKey .Values.networkPolicy.certController "ingressFrom") }}
+      {{- with .Values.networkPolicy.certController.ingressFrom }}
+      from:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- end }}
+    # Allow readiness probes from kubelet
+    - ports:
+        - port: {{ .Values.certController.readinessProbe.port }}
+          protocol: TCP
+      from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+  egress:
+    # Note: DNS access is configured in a separate NetworkPolicy resource:
+    # - {{ include "external-secrets.fullname" . }}-allow-dns
+    
+    # Allow access to Kubernetes API server
+    {{- if eq $isOpenShift "true" }}
+    # OpenShift API server configuration
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-apiserver
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-kube-apiserver
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: default
+    {{- else }}
+    # Standard Kubernetes API server configuration
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - namespaceSelector: {}
+    {{- end }}
+    {{- if and .Values.networkPolicy.certController (hasKey .Values.networkPolicy.certController "egressTo") }}
+    {{- with .Values.networkPolicy.certController.egressTo }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- end }}
+{{- end }}
+

--- a/deploy/charts/external-secrets/templates/networkpolicy-dns.yaml
+++ b/deploy/charts/external-secrets/templates/networkpolicy-dns.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.networkPolicy.enabled }}
+{{- $isOpenShift := include "external-secrets.isOpenShift" . | trim }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "external-secrets.fullname" . }}-allow-dns
+  namespace: {{ template "external-secrets.namespace" . }}
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+    app.kubernetes.io/component: network-policy
+spec:
+  podSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: In
+        values:
+          - {{ include "external-secrets.name" . }}
+          - {{ include "external-secrets.name" . }}-webhook
+          - {{ include "external-secrets.name" . }}-cert-controller
+          {{- if index .Values "bitwarden-sdk-server" "enabled" }}
+          - bitwarden-sdk-server
+          {{- end }}
+  policyTypes:
+    - Egress
+  egress:
+    {{- if eq $isOpenShift "true" }}
+    # OpenShift DNS configuration
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+          podSelector:
+            matchLabels:
+              dns.operator.openshift.io/daemonset-dns: default
+      ports:
+        - protocol: TCP
+          port: 5353
+        - protocol: UDP
+          port: 5353
+        - protocol: TCP
+          port: 53
+        - protocol: UDP
+          port: 53
+    {{- else }}
+    # Standard Kubernetes DNS configuration
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: TCP
+          port: 53
+        - protocol: UDP
+          port: 53
+    {{- end }}
+{{- end }}
+

--- a/deploy/charts/external-secrets/templates/networkpolicy.yaml
+++ b/deploy/charts/external-secrets/templates/networkpolicy.yaml
@@ -1,0 +1,69 @@
+{{- if and .Values.createOperator .Values.networkPolicy.enabled }}
+{{- $isOpenShift := include "external-secrets.isOpenShift" . | trim }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "external-secrets.fullname" . }}
+  namespace: {{ template "external-secrets.namespace" . }}
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "external-secrets.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow Prometheus to scrape metrics
+    - ports:
+        - port: {{ .Values.metrics.listen.port }}
+          protocol: TCP
+      {{- with .Values.networkPolicy.controller.ingressFrom }}
+      from:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  egress:
+    # Note: DNS access is configured in a separate NetworkPolicy resource:
+    # - {{ include "external-secrets.fullname" . }}-allow-dns
+    
+    # Allow access to Kubernetes API server
+    {{- if eq $isOpenShift "true" }}
+    # OpenShift API server configuration
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-apiserver
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-kube-apiserver
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: default
+    {{- else }}
+    # Standard Kubernetes API server configuration
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - namespaceSelector: {}
+    {{- end }}
+    
+    # Allow access to external secret providers (cloud APIs, vault, etc.)
+    # Note: Users must explicitly configure provider access via networkPolicy.controller.egressTo
+    {{- if .Values.networkPolicy.controller.egressTo }}
+    {{- toYaml .Values.networkPolicy.controller.egressTo | nindent 4 }}
+    {{- end }}
+{{- end }}
+

--- a/deploy/charts/external-secrets/templates/webhook-networkpolicy.yaml
+++ b/deploy/charts/external-secrets/templates/webhook-networkpolicy.yaml
@@ -1,0 +1,86 @@
+{{- if and .Values.webhook.create .Values.networkPolicy.enabled }}
+{{- $isOpenShift := include "external-secrets.isOpenShift" . | trim }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "external-secrets.fullname" . }}-webhook
+  namespace: {{ template "external-secrets.namespace" . }}
+  labels:
+    {{- include "external-secrets-webhook.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "external-secrets-webhook.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow Kubernetes API server to call webhook
+    - ports:
+        - port: {{ .Values.webhook.port }}
+          protocol: TCP
+      from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+    # Allow Prometheus to scrape metrics
+    - ports:
+        - port: {{ .Values.webhook.metrics.listen.port }}
+          protocol: TCP
+      {{- if and .Values.networkPolicy.webhook (hasKey .Values.networkPolicy.webhook "ingressFrom") }}
+      {{- with .Values.networkPolicy.webhook.ingressFrom }}
+      from:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- end }}
+    # Allow readiness probes from kubelet
+    - ports:
+        - port: {{ .Values.webhook.readinessProbe.port }}
+          protocol: TCP
+      from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+  egress:
+    # Note: DNS access is configured in a separate NetworkPolicy resource:
+    # - {{ include "external-secrets.fullname" . }}-allow-dns
+    
+    # Allow access to Kubernetes API server
+    {{- if eq $isOpenShift "true" }}
+    # OpenShift API server configuration
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-apiserver
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-kube-apiserver
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: default
+    {{- else }}
+    # Standard Kubernetes API server configuration
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - namespaceSelector: {}
+    {{- end }}
+    {{- if and .Values.networkPolicy.webhook (hasKey .Values.networkPolicy.webhook "egressTo") }}
+    {{- with .Values.networkPolicy.webhook.egressTo }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- end }}
+{{- end }}
+

--- a/deploy/charts/external-secrets/values.schema.json
+++ b/deploy/charts/external-secrets/values.schema.json
@@ -534,6 +534,22 @@
         "namespaceOverride": {
             "type": "string"
         },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "controller": {
+                    "type": "object",
+                    "properties": {
+                        "egressTo": {
+                            "type": "array"
+                        }
+                    }
+                },
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
         "nodeSelector": {
             "type": "object"
         },

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -357,6 +357,32 @@ podDisruptionBudget:
 # -- Run the controller on the host network
 hostNetwork: false
 
+# -- Network policy configuration for all components
+networkPolicy:
+  # -- Specifies whether network policies should be created
+  enabled: false
+
+  # -- Controller network policy settings
+  controller:
+    # -- Egress rules for external secret providers (AWS, GCP, Azure, Vault, etc.)
+    # REQUIRED: You must configure access to your secret providers
+    # Examples:
+
+    # egressTo:
+    #   - to:
+    #       - namespaceSelector:
+    #           matchLabels:
+    #             name: vault
+    #         podSelector:
+    #           matchLabels:
+    #             app: vault
+    #     ports:
+    #       - port: 8200
+    #         protocol: TCP
+    #
+    # Note: DNS and API server access are handled automatically
+    egressTo: []
+
 webhook:
   # -- Annotations to place on validating webhook configuration.
   annotations: {}


### PR DESCRIPTION
## Problem Statement

External Secrets Operator currently lacks native NetworkPolicy support, making it difficult for users to implement network segmentation and follow security best practices in restricted environments. This is particularly challenging for:

1. **Enterprise/regulated environments** that require network policies for compliance
2. **Multi-tenant clusters** where network isolation is mandatory
3. **Security-conscious organizations** following principle of least privilege
4. **Users** who need to explicitly control which external secret providers the operator can access

## Related Issue

Fixes [#5606 ](https://github.com/external-secrets/external-secrets/issues/5606)

## Proposed Changes

How do you like to solve the issue and why?
This PR adds comprehensive NetworkPolicy support to the Helm chart for all the controllers(controller, webhook, cert-controller)

### Key Features
- **Opt-in via single flag**: `networkPolicy.enabled: true`

*1. Modular Architecture**

- **Shared DNS Policy** (`networkpolicy-dns.yaml`)
  - Applies to all components using matchExpressions pattern
  - Handles platform-specific DNS configuration
  - Includes bitwarden-sdk-server when enabled

- **Component-Specific Policies**
  - Controller: metrics ingress, API server egress, provider access (user-configured)
  - Webhook: webhook/metrics/readiness ingress, API server egress
  - Cert Controller: metrics/readiness ingress, API server egress

**2. Security-First Design**

- No default egress for external providers - users must explicitly configure access
- Follows principle of least privilege
- Only port 443 for API server access (no port 6443)

**3. Platform Support**

- Works on standard Kubernetes and OpenShift
- Platform detection handles namespace and port differences automatically
- Uses existing `external-secrets.isOpenShift` helper

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
