### PR TITLE
feat(chart): use ghcr.io instead of our own domain

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -102,7 +102,7 @@ if settings.get('debug').get('enabled'):
     dockerfile = 'tilt.debug.dockerfile'
 
 docker_build_with_restart(
-    'oci.external-secrets.io/external-secrets/external-secrets',
+    'ghcr.io/external-secrets/external-secrets',
     '.',
     dockerfile = dockerfile,
     entrypoint = entrypoint,

--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -48,7 +48,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | certController.hostNetwork | bool | `false` | Run the certController on the host network |
 | certController.image.flavour | string | `""` |  |
 | certController.image.pullPolicy | string | `"IfNotPresent"` |  |
-| certController.image.repository | string | `"oci.external-secrets.io/external-secrets/external-secrets"` |  |
+| certController.image.repository | string | `"ghcr.io/external-secrets/external-secrets"` |  |
 | certController.image.tag | string | `""` |  |
 | certController.imagePullSecrets | list | `[]` |  |
 | certController.log | object | `{"level":"info","timeEncoding":"epoch"}` | Specifies Log Params to the Certificate Controller |
@@ -127,7 +127,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | hostNetwork | bool | `false` | Run the controller on the host network |
 | image.flavour | string | `""` | The flavour of tag you want to use There are different image flavours available, like distroless and ubi. Please see GitHub release notes for image tags for these flavors. By default, the distroless image is used. |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"oci.external-secrets.io/external-secrets/external-secrets"` |  |
+| image.repository | string | `"ghcr.io/external-secrets/external-secrets"` |  |
 | image.tag | string | `""` | The image tag to use. The default is the chart appVersion. |
 | imagePullSecrets | list | `[]` |  |
 | installCRDs | bool | `true` | If set, install and upgrade CRDs through helm chart. |
@@ -226,7 +226,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | webhook.hostNetwork | bool | `false` | Specifies if webhook pod should use hostNetwork or not. |
 | webhook.image.flavour | string | `""` | The flavour of tag you want to use |
 | webhook.image.pullPolicy | string | `"IfNotPresent"` |  |
-| webhook.image.repository | string | `"oci.external-secrets.io/external-secrets/external-secrets"` |  |
+| webhook.image.repository | string | `"ghcr.io/external-secrets/external-secrets"` |  |
 | webhook.image.tag | string | `""` | The image tag to use. The default is the chart appVersion. |
 | webhook.imagePullSecrets | list | `[]` |  |
 | webhook.log | object | `{"level":"info","timeEncoding":"epoch"}` | Specifies Log Params to the Webhook |

--- a/deploy/charts/external-secrets/tests/__snapshot__/cert_controller_test.yaml.snap
+++ b/deploy/charts/external-secrets/tests/__snapshot__/cert_controller_test.yaml.snap
@@ -41,7 +41,7 @@ should match snapshot of default values:
                 - --loglevel=info
                 - --zap-time-encoding=epoch
                 - --enable-partial-cache=true
-              image: oci.external-secrets.io/external-secrets/external-secrets:v0.20.2
+              image: ghcr.io/external-secrets/external-secrets:v0.20.2
               imagePullPolicy: IfNotPresent
               name: cert-controller
               ports:

--- a/deploy/charts/external-secrets/tests/__snapshot__/controller_test.yaml.snap
+++ b/deploy/charts/external-secrets/tests/__snapshot__/controller_test.yaml.snap
@@ -34,7 +34,7 @@ should match snapshot of default values:
                 - --metrics-addr=:8080
                 - --loglevel=info
                 - --zap-time-encoding=epoch
-              image: oci.external-secrets.io/external-secrets/external-secrets:v0.20.2
+              image: ghcr.io/external-secrets/external-secrets:v0.20.2
               imagePullPolicy: IfNotPresent
               name: external-secrets
               ports:

--- a/deploy/charts/external-secrets/tests/__snapshot__/webhook_test.yaml.snap
+++ b/deploy/charts/external-secrets/tests/__snapshot__/webhook_test.yaml.snap
@@ -39,7 +39,7 @@ should match snapshot of default values:
                 - --healthz-addr=:8081
                 - --loglevel=info
                 - --zap-time-encoding=epoch
-              image: oci.external-secrets.io/external-secrets/external-secrets:v0.20.2
+              image: ghcr.io/external-secrets/external-secrets:v0.20.2
               imagePullPolicy: IfNotPresent
               name: webhook
               ports:

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -22,7 +22,7 @@ bitwarden-sdk-server:
 revisionHistoryLimit: 10
 
 image:
-  repository: oci.external-secrets.io/external-secrets/external-secrets
+  repository: ghcr.io/external-secrets/external-secrets
   pullPolicy: IfNotPresent
   # -- The image tag to use. The default is the chart appVersion.
   tag: ""
@@ -380,7 +380,7 @@ webhook:
   # -- Specifies if webhook pod should use hostNetwork or not.
   hostNetwork: false
   image:
-    repository: oci.external-secrets.io/external-secrets/external-secrets
+    repository: ghcr.io/external-secrets/external-secrets
     pullPolicy: IfNotPresent
     # -- The image tag to use. The default is the chart appVersion.
     tag: ""
@@ -558,7 +558,7 @@ certController:
   revisionHistoryLimit: 10
 
   image:
-    repository: oci.external-secrets.io/external-secrets/external-secrets
+    repository: ghcr.io/external-secrets/external-secrets
     pullPolicy: IfNotPresent
     tag: ""
     flavour: ""

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -9,7 +9,7 @@ export E2E_IMAGE_NAME ?= ghcr.io/external-secrets/external-secrets-e2e
 export GINKGO_LABELS ?= !managed
 export TEST_SUITES ?= provider generator flux argocd
 
-export OCI_IMAGE_NAME = oci.external-secrets.io/external-secrets/external-secrets
+export OCI_IMAGE_NAME = ghcr.io/external-secrets/external-secrets
 
 start-kind: ## Start kind cluster
 	kind create cluster \


### PR DESCRIPTION
Without this, we use our own domain, for statistics purposes.

This is a problem, as:

- Someone need to pay the provider (scarf currently) for this and we do not have the budget for it
- We need to maintain an account for it
- It is a long term effort to migrate to another provider and we are not certain as a community it is worth it.
- We can still adapt later

This fixes it by using ghcr.io, which already builds our images and stores them. We are only cutting the middleman.

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
