### PR TITLE
feat: Add reconciliationPolicy to PushSecret data object

### DIFF
--- a/apis/externalsecrets/v1/pushsecret_interfaces.go
+++ b/apis/externalsecrets/v1/pushsecret_interfaces.go
@@ -18,6 +18,18 @@ package v1
 
 import apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
+// PushSecretReconciliationPolicy defines how the target secret data is handled.
+// +kubebuilder:validation:Enum=Merge;Replace
+type PushSecretDataReconciliationPolicy string
+
+const (
+	// PushSecretReconciliationPolicyMerge merges existing secret data with new templated data, keeping old keys behind.
+	PushSecretReconciliationPolicyMerge PushSecretDataReconciliationPolicy = "Merge"
+
+	// PushSecretReconciliationPolicyReplace replaces existing secret data with new templated data.
+	PushSecretReconciliationPolicyReplace PushSecretDataReconciliationPolicy = "Replace"
+)
+
 // +kubebuilder:object:root=false
 // +kubebuilder:object:generate:false
 // +k8s:deepcopy-gen:interfaces=nil
@@ -29,6 +41,7 @@ type PushSecretData interface {
 	GetSecretKey() string
 	GetRemoteKey() string
 	GetProperty() string
+	GetReconciliationPolicy() PushSecretDataReconciliationPolicy
 }
 
 // +kubebuilder:object:root=false

--- a/apis/externalsecrets/v1alpha1/pushsecret_types.go
+++ b/apis/externalsecrets/v1alpha1/pushsecret_types.go
@@ -183,6 +183,11 @@ type PushSecretData struct {
 	// Used to define a conversion Strategy for the secret keys
 	// +kubebuilder:default="None"
 	ConversionStrategy PushSecretConversionStrategy `json:"conversionStrategy,omitempty"`
+
+	// ReconciliationPolicy to handle whether the secret gets replaced or merged in the provider.
+	// +kubebuilder:default="Merge"
+	// +optional
+	ReconciliationPolicy esv1.PushSecretDataReconciliationPolicy `json:"reconciliationPolicy,omitempty"`
 }
 
 // GetMetadata returns the metadata of the PushSecretData.
@@ -203,6 +208,10 @@ func (d PushSecretData) GetRemoteKey() string {
 // GetProperty returns the property from the PushSecretData match.
 func (d PushSecretData) GetProperty() string {
 	return d.Match.RemoteRef.Property
+}
+
+func (d PushSecretData) GetReconciliationPolicy() esv1.PushSecretDataReconciliationPolicy {
+	return d.ReconciliationPolicy
 }
 
 // PushSecretConditionType indicates the condition of the PushSecret.

--- a/config/crds/bases/external-secrets.io_clusterpushsecrets.yaml
+++ b/config/crds/bases/external-secrets.io_clusterpushsecrets.yaml
@@ -170,6 +170,14 @@ spec:
                             Metadata is metadata attached to the secret.
                             The structure of metadata is provider specific, please look it up in the provider documentation.
                           x-kubernetes-preserve-unknown-fields: true
+                        reconciliationPolicy:
+                          default: Merge
+                          description: ReconciliationPolicy to handle whether the
+                            secret gets replaced or merged in the provider.
+                          enum:
+                          - Merge
+                          - Replace
+                          type: string
                       required:
                       - match
                       type: object

--- a/config/crds/bases/external-secrets.io_pushsecrets.yaml
+++ b/config/crds/bases/external-secrets.io_pushsecrets.yaml
@@ -92,6 +92,14 @@ spec:
                         Metadata is metadata attached to the secret.
                         The structure of metadata is provider specific, please look it up in the provider documentation.
                       x-kubernetes-preserve-unknown-fields: true
+                    reconciliationPolicy:
+                      default: Merge
+                      description: ReconciliationPolicy to handle whether the secret
+                        gets replaced or merged in the provider.
+                      enum:
+                      - Merge
+                      - Replace
+                      type: string
                   required:
                   - match
                   type: object
@@ -505,6 +513,14 @@ spec:
                           Metadata is metadata attached to the secret.
                           The structure of metadata is provider specific, please look it up in the provider documentation.
                         x-kubernetes-preserve-unknown-fields: true
+                      reconciliationPolicy:
+                        default: Merge
+                        description: ReconciliationPolicy to handle whether the secret
+                          gets replaced or merged in the provider.
+                        enum:
+                        - Merge
+                        - Replace
+                        type: string
                     required:
                     - match
                     type: object

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -1718,6 +1718,13 @@ spec:
                               Metadata is metadata attached to the secret.
                               The structure of metadata is provider specific, please look it up in the provider documentation.
                             x-kubernetes-preserve-unknown-fields: true
+                          reconciliationPolicy:
+                            default: Merge
+                            description: ReconciliationPolicy to handle whether the secret gets replaced or merged in the provider.
+                            enum:
+                              - Merge
+                              - Replace
+                            type: string
                         required:
                           - match
                         type: object
@@ -13174,6 +13181,13 @@ spec:
                           Metadata is metadata attached to the secret.
                           The structure of metadata is provider specific, please look it up in the provider documentation.
                         x-kubernetes-preserve-unknown-fields: true
+                      reconciliationPolicy:
+                        default: Merge
+                        description: ReconciliationPolicy to handle whether the secret gets replaced or merged in the provider.
+                        enum:
+                          - Merge
+                          - Replace
+                        type: string
                     required:
                       - match
                     type: object
@@ -13561,6 +13575,13 @@ spec:
                             Metadata is metadata attached to the secret.
                             The structure of metadata is provider specific, please look it up in the provider documentation.
                           x-kubernetes-preserve-unknown-fields: true
+                        reconciliationPolicy:
+                          default: Merge
+                          description: ReconciliationPolicy to handle whether the secret gets replaced or merged in the provider.
+                          enum:
+                            - Merge
+                            - Replace
+                          type: string
                       required:
                         - match
                       type: object

--- a/pkg/controllers/pushsecret/pushsecret_controller.go
+++ b/pkg/controllers/pushsecret/pushsecret_controller.go
@@ -44,7 +44,7 @@ import (
 	ctrlmetrics "github.com/external-secrets/external-secrets/pkg/controllers/metrics"
 	"github.com/external-secrets/external-secrets/pkg/controllers/pushsecret/psmetrics"
 	"github.com/external-secrets/external-secrets/pkg/controllers/secretstore"
-	"github.com/external-secrets/external-secrets/pkg/controllers/util"
+	ctrlutil "github.com/external-secrets/external-secrets/pkg/controllers/util"
 	"github.com/external-secrets/external-secrets/runtime/esutils"
 	"github.com/external-secrets/external-secrets/runtime/esutils/resolvers"
 	"github.com/external-secrets/external-secrets/runtime/statemanager"

--- a/providers/v1/kubernetes/client.go
+++ b/providers/v1/kubernetes/client.go
@@ -163,6 +163,10 @@ func (c *Client) mergePushSecretData(remoteRef esv1.PushSecretData, remoteSecret
 
 	// case 1: push the whole secret
 	if remoteRef.GetProperty() == "" {
+		if remoteRef.GetReconciliationPolicy() == esv1.PushSecretReconciliationPolicyReplace { // if we want to replace the whole data, create new map
+			remoteSecret.Data = make(map[string][]byte)
+		}
+
 		for k, v := range localSecret.Data {
 			remoteSecret.Data[k] = v
 		}


### PR DESCRIPTION
## Problem Statement

The option to replace target secret's data rather than just add new/replace existing keys. The original code leaves behind old and dead keys which can cause pollution in the target secret, when it is used "as a whole" as a filesystem mount.

## Related Issue

Fixes #5639 

## Proposed Changes

Add `.spec.data[].reconciliationPolicy {Merge, Replace}` where `Merge` keeps the current way (and is the default)

## Format
Sorry not sure what `scope` this would belong to? Release? Templating?

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## Checklist

I will add the tests once you approve that this is the correct way :)

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
