### PR TITLE
feat: allow templating immutable secrets

### DIFF
--- a/apis/externalsecrets/v1/externalsecret_types.go
+++ b/apis/externalsecrets/v1/externalsecret_types.go
@@ -246,6 +246,11 @@ type ExternalSecretTarget struct {
 	// Immutable defines if the final secret will be immutable
 	// +optional
 	Immutable bool `json:"immutable,omitempty"`
+
+	// Runs the template even when the final secret will be immutable.
+	// Enabling this with stateless generators may lead into unexpected sync errors.
+	// +optional
+	TemplateImmutable bool `json:"templateImmutable,omitempty"`
 }
 
 // ExternalSecretData defines the connection between the Kubernetes Secret key (spec.data.<key>) and the Provider data.

--- a/config/crds/bases/external-secrets.io_clusterexternalsecrets.yaml
+++ b/config/crds/bases/external-secrets.io_clusterexternalsecrets.yaml
@@ -706,6 +706,11 @@ spec:
                           type:
                             type: string
                         type: object
+                      templateImmutable:
+                        description: |-
+                          Runs the template even when the final secret will be immutable.
+                          Enabling this with stateless generators may lead into unexpected sync errors.
+                        type: boolean
                     type: object
                 type: object
               namespaceSelector:

--- a/config/crds/bases/external-secrets.io_externalsecrets.yaml
+++ b/config/crds/bases/external-secrets.io_externalsecrets.yaml
@@ -682,6 +682,11 @@ spec:
                       type:
                         type: string
                     type: object
+                  templateImmutable:
+                    description: |-
+                      Runs the template even when the final secret will be immutable.
+                      Enabling this with stateless generators may lead into unexpected sync errors.
+                    type: boolean
                 type: object
             type: object
           status:

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -660,6 +660,11 @@ spec:
                             type:
                               type: string
                           type: object
+                        templateImmutable:
+                          description: |-
+                            Runs the template even when the final secret will be immutable.
+                            Enabling this with stateless generators may lead into unexpected sync errors.
+                          type: boolean
                       type: object
                   type: object
                 namespaceSelector:
@@ -12406,6 +12411,11 @@ spec:
                         type:
                           type: string
                       type: object
+                    templateImmutable:
+                      description: |-
+                        Runs the template even when the final secret will be immutable.
+                        Enabling this with stateless generators may lead into unexpected sync errors.
+                      type: boolean
                   type: object
               type: object
             status:

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -4822,6 +4822,19 @@ bool
 <p>Immutable defines if the final secret will be immutable</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>templateImmutable</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Runs the template even when the final secret will be immutable.
+Enabling this with stateless generators may lead into unexpected sync errors.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="external-secrets.io/v1.ExternalSecretTemplate">ExternalSecretTemplate

--- a/pkg/controllers/externalsecret/externalsecret_controller.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller.go
@@ -487,9 +487,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 			secret.Immutable = ptr.To(true)
 		}
 
-		// only apply the template if the secret is mutable or if the secret is new (has no UID)
+		// only apply the template if the secret is mutable or immutable template is allowed or
+		// if the secret is new (has no UID)
 		// otherwise we would mutate an object that is immutable and already exists
-		objectDoesNotExistOrCanBeMutated := secret.GetUID() == "" || !externalSecret.Spec.Target.Immutable
+		objectDoesNotExistOrCanBeMutated := secret.GetUID() == "" || !externalSecret.Spec.Target.Immutable || externalSecret.Spec.Target.TemplateImmutable
 
 		if objectDoesNotExistOrCanBeMutated {
 			// get the list of keys that are managed by this ExternalSecret


### PR DESCRIPTION
## Problem Statement

A previous change disallowed templating immutable secrets since this may fail unexpectedly with stateless generators.
However, in case of stateful generators, we may want to run the templates to verify if there's data mismatch.

## Related Issue

Fixes #...

## Proposed Changes

Adds a new templateImmutable which brings back the old value by allowing templating even if immutable is set.

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
