### PR TITLE
fix(gcp): correct version name in LatestOrFetch fallback

### DIFF
--- a/providers/v1/gcp/secretmanager/client.go
+++ b/providers/v1/gcp/secretmanager/client.go
@@ -748,7 +748,7 @@ func getLatestEnabledVersion(ctx context.Context, client GoogleSecretManagerClie
 		}
 	}
 	req := &secretmanagerpb.AccessSecretVersionRequest{
-		Name: fmt.Sprintf("%s/versions/%s", name, latestVersion.Name),
+		Name: latestVersion.Name,
 	}
 	return client.AccessSecretVersion(ctx, req)
 }


### PR DESCRIPTION
## Problem Statement

When using `secretVersionSelectionPolicy = "LatestOrFetch"` on a GSM secret store 

If the latest secret is DESTROYED, the sync fails and you see this when running `kubectl describe es secret`

```
...
Events:
  Type     Reason        Age                From              Message
  ----     ------        ----               ----              -------
  FailedPrecondition desc = Secret Version [projects/225994000000/secrets/application-secrets/versions/17] is in DESTROYED state.
  Warning  UpdateFailed  16m (x4 over 22m)  external-secrets  error processing spec.dataFrom[1].extract, err: unable to access Secret from SecretManager Client: rpc error: code = InvalidArgument desc = The provided Secret ID [projects/gcp-project/secrets/application-secrets/versions/projects/225994000000/secrets/application-secrets/versions/15] does not match the expected format [projects/*/secrets/*/versions/*]
  
```


## Proposed Changes

* In `client.go`, the `AccessSecretVersionRequest` now uses `latestVersion.Name` directly for the `Name` field, instead of formatting the string manually.

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] All tests pass with `make test`
- [X] I ensured my PR is ready for review with `make reviewable`
