### PR TITLE
docs(templating): update rbac for generic targets

### DIFF
--- a/docs/guides/targeting-custom-resources.md
+++ b/docs/guides/targeting-custom-resources.md
@@ -76,13 +76,12 @@ The operator automatically adds the `externalsecrets.external-secrets.io/managed
 When using custom resource targets, ensure the External Secrets Operator has appropriate RBAC permissions to create and manage those resources. The Helm chart provides configuration options to enable these permissions:
 
 ```yaml
-nonSecretTargets:
+genericTargets:
   enabled: true
-  rbac:
-    configMaps: true
-    customResources:
-    - apiGroups: ["config.example.com"]
-      resources: ["appconfigs"]
+  resources:
+  - apiGroups: ["config.example.com"]
+    resources: ["appconfigs"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ```
 
 Without these permissions, the operator will not be able to create or update your target resources.


### PR DESCRIPTION
## Problem Statement

Doc for custom resources does not match helm chart.

## Proposed Changes

Use same struct for generic targets as what's defined in the helm chart.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Helm chart configuration schema for targeting custom resources. The `nonSecretTargets` section is now `genericTargets` with a new `resources` list format for specifying RBAC permissions via `apiGroups`, `resources`, and `verbs` arrays.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->