### PR TITLE
docs: Fix example in GCP documentation

### DIFF
--- a/docs/provider/google-secrets-manager.md
+++ b/docs/provider/google-secrets-manager.md
@@ -323,7 +323,7 @@ spec:
           remoteKey: my-secret
       metadata:
         apiVersion: kubernetes.external-secrets.io/v1alpha1
-        kind: PushSecretMetadata`
+        kind: PushSecretMetadata
         spec:
           replicationLocation: "us-east1"
 ```


### PR DESCRIPTION
Remove trailing "`" character from example YAML code.

## Problem Statement

I stumbled across an issue with the example code, because a trailing "`" character somehow made it into the YAML code. external-secrets will complain about unparsable JSON which is resolved by removing the superflous character.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a formatting error in the provider documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->