### PR TITLE
docs(apis): fix inaccurate SecretStore comments (v1 + v1beta1)

### DIFF
--- a/apis/externalsecrets/v1/secretstore_types.go
+++ b/apis/externalsecrets/v1/secretstore_types.go
@@ -31,7 +31,7 @@ type SecretStoreSpec struct {
 	// Used to configure the provider. Only one provider may be set
 	Provider *SecretStoreProvider `json:"provider"`
 
-	// Used to configure http retries if failed
+	// Used to configure HTTP retries on failures.
 	// +optional
 	RetrySettings *SecretStoreRetrySettings `json:"retrySettings,omitempty"`
 
@@ -39,7 +39,7 @@ type SecretStoreSpec struct {
 	// +optional
 	RefreshInterval int `json:"refreshInterval,omitempty"`
 
-	// Used to constraint a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore
+	// Used to constrain a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore.
 	// +optional
 	Conditions []ClusterSecretStoreCondition `json:"conditions,omitempty"`
 }
@@ -83,7 +83,7 @@ type SecretStoreProvider struct {
 	// +optional
 	BitwardenSecretsManager *BitwardenSecretsManagerProvider `json:"bitwardensecretsmanager,omitempty"`
 
-	// Vault configures this store to sync secrets using Hashi provider
+	// Vault configures this store to sync secrets using the HashiCorp Vault provider.
 	// +optional
 	Vault *VaultProvider `json:"vault,omitempty"`
 
@@ -107,7 +107,7 @@ type SecretStoreProvider struct {
 	// +optional
 	YandexLockbox *YandexLockboxProvider `json:"yandexlockbox,omitempty"`
 
-	// Github configures this store to push GitHub Action secrets using GitHub API provider.
+	// Github configures this store to push GitHub Actions secrets using the GitHub API provider.
 	// Note: This provider only supports write operations (PushSecret) and cannot fetch secrets from GitHub
 	// +optional
 	Github *GithubProvider `json:"github,omitempty"`
@@ -144,7 +144,7 @@ type SecretStoreProvider struct {
 	// +optional
 	Senhasegura *SenhaseguraProvider `json:"senhasegura,omitempty"`
 
-	// Scaleway
+	// Scaleway configures this store to sync secrets using the Scaleway provider.
 	// +optional
 	Scaleway *ScalewayProvider `json:"scaleway,omitempty"`
 

--- a/apis/externalsecrets/v1beta1/secretstore_types.go
+++ b/apis/externalsecrets/v1beta1/secretstore_types.go
@@ -31,7 +31,7 @@ type SecretStoreSpec struct {
 	// Used to configure the provider. Only one provider may be set
 	Provider *SecretStoreProvider `json:"provider"`
 
-	// Used to configure http retries if failed
+	// Used to configure HTTP retries on failures.
 	// +optional
 	RetrySettings *SecretStoreRetrySettings `json:"retrySettings,omitempty"`
 
@@ -39,7 +39,7 @@ type SecretStoreSpec struct {
 	// +optional
 	RefreshInterval int `json:"refreshInterval,omitempty"`
 
-	// Used to constraint a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore
+	// Used to constrain a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore.
 	// +optional
 	Conditions []ClusterSecretStoreCondition `json:"conditions,omitempty"`
 }
@@ -83,7 +83,7 @@ type SecretStoreProvider struct {
 	// +optional
 	BitwardenSecretsManager *BitwardenSecretsManagerProvider `json:"bitwardensecretsmanager,omitempty"`
 
-	// Vault configures this store to sync secrets using Hashi provider
+	// Vault configures this store to sync secrets using the HashiCorp Vault provider.
 	// +optional
 	Vault *VaultProvider `json:"vault,omitempty"`
 
@@ -107,7 +107,7 @@ type SecretStoreProvider struct {
 	// +optional
 	YandexLockbox *YandexLockboxProvider `json:"yandexlockbox,omitempty"`
 
-	// Github configures this store to push Github Action secrets using Github API provider
+	// Github configures this store to push GitHub Actions secrets using the GitHub API provider.
 	// +optional
 	Github *GithubProvider `json:"github,omitempty"`
 
@@ -139,7 +139,7 @@ type SecretStoreProvider struct {
 	// +optional
 	Senhasegura *SenhaseguraProvider `json:"senhasegura,omitempty"`
 
-	// Scaleway
+	// Scaleway configures this store to sync secrets using the Scaleway provider.
 	// +optional
 	Scaleway *ScalewayProvider `json:"scaleway,omitempty"`
 

--- a/config/crds/bases/external-secrets.io_clustersecretstores.yaml
+++ b/config/crds/bases/external-secrets.io_clustersecretstores.yaml
@@ -59,8 +59,8 @@ spec:
             description: SecretStoreSpec defines the desired state of SecretStore.
             properties:
               conditions:
-                description: Used to constraint a ClusterSecretStore to specific namespaces.
-                  Relevant only to ClusterSecretStore
+                description: Used to constrain a ClusterSecretStore to specific namespaces.
+                  Relevant only to ClusterSecretStore.
                 items:
                   description: |-
                     ClusterSecretStoreCondition describes a condition by which to choose namespaces to process ExternalSecrets in
@@ -2254,7 +2254,7 @@ spec:
                     type: object
                   github:
                     description: |-
-                      Github configures this store to push GitHub Action secrets using GitHub API provider.
+                      Github configures this store to push GitHub Actions secrets using the GitHub API provider.
                       Note: This provider only supports write operations (PushSecret) and cannot fetch secrets from GitHub
                     properties:
                       appID:
@@ -4277,7 +4277,8 @@ spec:
                     - project
                     type: object
                   scaleway:
-                    description: Scaleway
+                    description: Scaleway configures this store to sync secrets using
+                      the Scaleway provider.
                     properties:
                       accessKey:
                         description: AccessKey is the non-secret part of the api key.
@@ -4563,7 +4564,7 @@ spec:
                     type: object
                   vault:
                     description: Vault configures this store to sync secrets using
-                      Hashi provider
+                      the HashiCorp Vault provider.
                     properties:
                       auth:
                         description: Auth configures how secret-manager authenticates
@@ -6021,7 +6022,7 @@ spec:
                   Empty or 0 will default to the controller config.
                 type: integer
               retrySettings:
-                description: Used to configure http retries if failed
+                description: Used to configure HTTP retries on failures.
                 properties:
                   maxRetries:
                     format: int32
@@ -6109,8 +6110,8 @@ spec:
             description: SecretStoreSpec defines the desired state of SecretStore.
             properties:
               conditions:
-                description: Used to constraint a ClusterSecretStore to specific namespaces.
-                  Relevant only to ClusterSecretStore
+                description: Used to constrain a ClusterSecretStore to specific namespaces.
+                  Relevant only to ClusterSecretStore.
                 items:
                   description: |-
                     ClusterSecretStoreCondition describes a condition by which to choose namespaces to process ExternalSecrets in
@@ -7981,8 +7982,8 @@ spec:
                         type: string
                     type: object
                   github:
-                    description: Github configures this store to push Github Action
-                      secrets using Github API provider
+                    description: Github configures this store to push GitHub Actions
+                      secrets using the GitHub API provider.
                     properties:
                       appID:
                         description: appID specifies the Github APP that will be used
@@ -9149,7 +9150,8 @@ spec:
                     - project
                     type: object
                   scaleway:
-                    description: Scaleway
+                    description: Scaleway configures this store to sync secrets using
+                      the Scaleway provider.
                     properties:
                       accessKey:
                         description: AccessKey is the non-secret part of the api key.
@@ -9388,7 +9390,7 @@ spec:
                     type: object
                   vault:
                     description: Vault configures this store to sync secrets using
-                      Hashi provider
+                      the HashiCorp Vault provider.
                     properties:
                       auth:
                         description: Auth configures how secret-manager authenticates
@@ -10531,7 +10533,7 @@ spec:
                   Empty or 0 will default to the controller config.
                 type: integer
               retrySettings:
-                description: Used to configure http retries if failed
+                description: Used to configure HTTP retries on failures.
                 properties:
                   maxRetries:
                     description: MaxRetries is the maximum number of retry attempts.

--- a/config/crds/bases/external-secrets.io_secretstores.yaml
+++ b/config/crds/bases/external-secrets.io_secretstores.yaml
@@ -59,8 +59,8 @@ spec:
             description: SecretStoreSpec defines the desired state of SecretStore.
             properties:
               conditions:
-                description: Used to constraint a ClusterSecretStore to specific namespaces.
-                  Relevant only to ClusterSecretStore
+                description: Used to constrain a ClusterSecretStore to specific namespaces.
+                  Relevant only to ClusterSecretStore.
                 items:
                   description: |-
                     ClusterSecretStoreCondition describes a condition by which to choose namespaces to process ExternalSecrets in
@@ -2254,7 +2254,7 @@ spec:
                     type: object
                   github:
                     description: |-
-                      Github configures this store to push GitHub Action secrets using GitHub API provider.
+                      Github configures this store to push GitHub Actions secrets using the GitHub API provider.
                       Note: This provider only supports write operations (PushSecret) and cannot fetch secrets from GitHub
                     properties:
                       appID:
@@ -4277,7 +4277,8 @@ spec:
                     - project
                     type: object
                   scaleway:
-                    description: Scaleway
+                    description: Scaleway configures this store to sync secrets using
+                      the Scaleway provider.
                     properties:
                       accessKey:
                         description: AccessKey is the non-secret part of the api key.
@@ -4563,7 +4564,7 @@ spec:
                     type: object
                   vault:
                     description: Vault configures this store to sync secrets using
-                      Hashi provider
+                      the HashiCorp Vault provider.
                     properties:
                       auth:
                         description: Auth configures how secret-manager authenticates
@@ -6021,7 +6022,7 @@ spec:
                   Empty or 0 will default to the controller config.
                 type: integer
               retrySettings:
-                description: Used to configure http retries if failed
+                description: Used to configure HTTP retries on failures.
                 properties:
                   maxRetries:
                     format: int32
@@ -6109,8 +6110,8 @@ spec:
             description: SecretStoreSpec defines the desired state of SecretStore.
             properties:
               conditions:
-                description: Used to constraint a ClusterSecretStore to specific namespaces.
-                  Relevant only to ClusterSecretStore
+                description: Used to constrain a ClusterSecretStore to specific namespaces.
+                  Relevant only to ClusterSecretStore.
                 items:
                   description: |-
                     ClusterSecretStoreCondition describes a condition by which to choose namespaces to process ExternalSecrets in
@@ -7981,8 +7982,8 @@ spec:
                         type: string
                     type: object
                   github:
-                    description: Github configures this store to push Github Action
-                      secrets using Github API provider
+                    description: Github configures this store to push GitHub Actions
+                      secrets using the GitHub API provider.
                     properties:
                       appID:
                         description: appID specifies the Github APP that will be used
@@ -9149,7 +9150,8 @@ spec:
                     - project
                     type: object
                   scaleway:
-                    description: Scaleway
+                    description: Scaleway configures this store to sync secrets using
+                      the Scaleway provider.
                     properties:
                       accessKey:
                         description: AccessKey is the non-secret part of the api key.
@@ -9388,7 +9390,7 @@ spec:
                     type: object
                   vault:
                     description: Vault configures this store to sync secrets using
-                      Hashi provider
+                      the HashiCorp Vault provider.
                     properties:
                       auth:
                         description: Auth configures how secret-manager authenticates
@@ -10531,7 +10533,7 @@ spec:
                   Empty or 0 will default to the controller config.
                 type: integer
               retrySettings:
-                description: Used to configure http retries if failed
+                description: Used to configure HTTP retries on failures.
                 properties:
                   maxRetries:
                     description: MaxRetries is the maximum number of retry attempts.

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -2155,7 +2155,7 @@ spec:
               description: SecretStoreSpec defines the desired state of SecretStore.
               properties:
                 conditions:
-                  description: Used to constraint a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore
+                  description: Used to constrain a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore.
                   items:
                     description: |-
                       ClusterSecretStoreCondition describes a condition by which to choose namespaces to process ExternalSecrets in
@@ -4188,7 +4188,7 @@ spec:
                       type: object
                     github:
                       description: |-
-                        Github configures this store to push GitHub Action secrets using GitHub API provider.
+                        Github configures this store to push GitHub Actions secrets using the GitHub API provider.
                         Note: This provider only supports write operations (PushSecret) and cannot fetch secrets from GitHub
                       properties:
                         appID:
@@ -6071,7 +6071,7 @@ spec:
                         - project
                       type: object
                     scaleway:
-                      description: Scaleway
+                      description: Scaleway configures this store to sync secrets using the Scaleway provider.
                       properties:
                         accessKey:
                           description: AccessKey is the non-secret part of the api key.
@@ -6334,7 +6334,7 @@ spec:
                         - url
                       type: object
                     vault:
-                      description: Vault configures this store to sync secrets using Hashi provider
+                      description: Vault configures this store to sync secrets using the HashiCorp Vault provider.
                       properties:
                         auth:
                           description: Auth configures how secret-manager authenticates with the Vault server.
@@ -7703,7 +7703,7 @@ spec:
                   description: Used to configure store refresh interval in seconds. Empty or 0 will default to the controller config.
                   type: integer
                 retrySettings:
-                  description: Used to configure http retries if failed
+                  description: Used to configure HTTP retries on failures.
                   properties:
                     maxRetries:
                       format: int32
@@ -7787,7 +7787,7 @@ spec:
               description: SecretStoreSpec defines the desired state of SecretStore.
               properties:
                 conditions:
-                  description: Used to constraint a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore
+                  description: Used to constrain a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore.
                   items:
                     description: |-
                       ClusterSecretStoreCondition describes a condition by which to choose namespaces to process ExternalSecrets in
@@ -9520,7 +9520,7 @@ spec:
                           type: string
                       type: object
                     github:
-                      description: Github configures this store to push Github Action secrets using Github API provider
+                      description: Github configures this store to push GitHub Actions secrets using the GitHub API provider.
                       properties:
                         appID:
                           description: appID specifies the Github APP that will be used to authenticate the client
@@ -10588,7 +10588,7 @@ spec:
                         - project
                       type: object
                     scaleway:
-                      description: Scaleway
+                      description: Scaleway configures this store to sync secrets using the Scaleway provider.
                       properties:
                         accessKey:
                           description: AccessKey is the non-secret part of the api key.
@@ -10808,7 +10808,7 @@ spec:
                         - url
                       type: object
                     vault:
-                      description: Vault configures this store to sync secrets using Hashi provider
+                      description: Vault configures this store to sync secrets using the HashiCorp Vault provider.
                       properties:
                         auth:
                           description: Auth configures how secret-manager authenticates with the Vault server.
@@ -11894,7 +11894,7 @@ spec:
                   description: Used to configure store refresh interval in seconds. Empty or 0 will default to the controller config.
                   type: integer
                 retrySettings:
-                  description: Used to configure http retries if failed
+                  description: Used to configure HTTP retries on failures.
                   properties:
                     maxRetries:
                       description: MaxRetries is the maximum number of retry attempts.
@@ -13821,7 +13821,7 @@ spec:
               description: SecretStoreSpec defines the desired state of SecretStore.
               properties:
                 conditions:
-                  description: Used to constraint a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore
+                  description: Used to constrain a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore.
                   items:
                     description: |-
                       ClusterSecretStoreCondition describes a condition by which to choose namespaces to process ExternalSecrets in
@@ -15854,7 +15854,7 @@ spec:
                       type: object
                     github:
                       description: |-
-                        Github configures this store to push GitHub Action secrets using GitHub API provider.
+                        Github configures this store to push GitHub Actions secrets using the GitHub API provider.
                         Note: This provider only supports write operations (PushSecret) and cannot fetch secrets from GitHub
                       properties:
                         appID:
@@ -17737,7 +17737,7 @@ spec:
                         - project
                       type: object
                     scaleway:
-                      description: Scaleway
+                      description: Scaleway configures this store to sync secrets using the Scaleway provider.
                       properties:
                         accessKey:
                           description: AccessKey is the non-secret part of the api key.
@@ -18000,7 +18000,7 @@ spec:
                         - url
                       type: object
                     vault:
-                      description: Vault configures this store to sync secrets using Hashi provider
+                      description: Vault configures this store to sync secrets using the HashiCorp Vault provider.
                       properties:
                         auth:
                           description: Auth configures how secret-manager authenticates with the Vault server.
@@ -19369,7 +19369,7 @@ spec:
                   description: Used to configure store refresh interval in seconds. Empty or 0 will default to the controller config.
                   type: integer
                 retrySettings:
-                  description: Used to configure http retries if failed
+                  description: Used to configure HTTP retries on failures.
                   properties:
                     maxRetries:
                       format: int32
@@ -19453,7 +19453,7 @@ spec:
               description: SecretStoreSpec defines the desired state of SecretStore.
               properties:
                 conditions:
-                  description: Used to constraint a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore
+                  description: Used to constrain a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore.
                   items:
                     description: |-
                       ClusterSecretStoreCondition describes a condition by which to choose namespaces to process ExternalSecrets in
@@ -21186,7 +21186,7 @@ spec:
                           type: string
                       type: object
                     github:
-                      description: Github configures this store to push Github Action secrets using Github API provider
+                      description: Github configures this store to push GitHub Actions secrets using the GitHub API provider.
                       properties:
                         appID:
                           description: appID specifies the Github APP that will be used to authenticate the client
@@ -22254,7 +22254,7 @@ spec:
                         - project
                       type: object
                     scaleway:
-                      description: Scaleway
+                      description: Scaleway configures this store to sync secrets using the Scaleway provider.
                       properties:
                         accessKey:
                           description: AccessKey is the non-secret part of the api key.
@@ -22474,7 +22474,7 @@ spec:
                         - url
                       type: object
                     vault:
-                      description: Vault configures this store to sync secrets using Hashi provider
+                      description: Vault configures this store to sync secrets using the HashiCorp Vault provider.
                       properties:
                         auth:
                           description: Auth configures how secret-manager authenticates with the Vault server.
@@ -23560,7 +23560,7 @@ spec:
                   description: Used to configure store refresh interval in seconds. Empty or 0 will default to the controller config.
                   type: integer
                 retrySettings:
-                  description: Used to configure http retries if failed
+                  description: Used to configure HTTP retries on failures.
                   properties:
                     maxRetries:
                       description: MaxRetries is the maximum number of retry attempts.

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -2850,7 +2850,7 @@ SecretStoreRetrySettings
 </td>
 <td>
 <em>(Optional)</em>
-<p>Used to configure http retries if failed</p>
+<p>Used to configure HTTP retries on failures.</p>
 </td>
 </tr>
 <tr>
@@ -2876,7 +2876,7 @@ int
 </td>
 <td>
 <em>(Optional)</em>
-<p>Used to constraint a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore</p>
+<p>Used to constrain a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore.</p>
 </td>
 </tr>
 </table>
@@ -8934,7 +8934,7 @@ SecretStoreRetrySettings
 </td>
 <td>
 <em>(Optional)</em>
-<p>Used to configure http retries if failed</p>
+<p>Used to configure HTTP retries on failures.</p>
 </td>
 </tr>
 <tr>
@@ -8960,7 +8960,7 @@ int
 </td>
 <td>
 <em>(Optional)</em>
-<p>Used to constraint a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore</p>
+<p>Used to constrain a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore.</p>
 </td>
 </tr>
 </table>
@@ -9112,7 +9112,7 @@ VaultProvider
 </td>
 <td>
 <em>(Optional)</em>
-<p>Vault configures this store to sync secrets using Hashi provider</p>
+<p>Vault configures this store to sync secrets using the HashiCorp Vault provider.</p>
 </td>
 </tr>
 <tr>
@@ -9196,7 +9196,7 @@ GithubProvider
 </td>
 <td>
 <em>(Optional)</em>
-<p>Github configures this store to push GitHub Action secrets using GitHub API provider.
+<p>Github configures this store to push GitHub Actions secrets using the GitHub API provider.
 Note: This provider only supports write operations (PushSecret) and cannot fetch secrets from GitHub</p>
 </td>
 </tr>
@@ -9323,7 +9323,7 @@ ScalewayProvider
 </td>
 <td>
 <em>(Optional)</em>
-<p>Scaleway</p>
+<p>Scaleway configures this store to sync secrets using the Scaleway provider.</p>
 </td>
 </tr>
 <tr>
@@ -9734,7 +9734,7 @@ SecretStoreRetrySettings
 </td>
 <td>
 <em>(Optional)</em>
-<p>Used to configure http retries if failed</p>
+<p>Used to configure HTTP retries on failures.</p>
 </td>
 </tr>
 <tr>
@@ -9760,7 +9760,7 @@ int
 </td>
 <td>
 <em>(Optional)</em>
-<p>Used to constraint a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore</p>
+<p>Used to constrain a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore.</p>
 </td>
 </tr>
 </tbody>
@@ -16175,7 +16175,7 @@ SecretStoreRetrySettings
 </td>
 <td>
 <em>(Optional)</em>
-<p>Used to configure http retries if failed</p>
+<p>Used to configure HTTP retries on failures.</p>
 </td>
 </tr>
 <tr>
@@ -16201,7 +16201,7 @@ int
 </td>
 <td>
 <em>(Optional)</em>
-<p>Used to constraint a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore</p>
+<p>Used to constrain a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore.</p>
 </td>
 </tr>
 </table>
@@ -20844,7 +20844,7 @@ SecretStoreRetrySettings
 </td>
 <td>
 <em>(Optional)</em>
-<p>Used to configure http retries if failed</p>
+<p>Used to configure HTTP retries on failures.</p>
 </td>
 </tr>
 <tr>
@@ -20870,7 +20870,7 @@ int
 </td>
 <td>
 <em>(Optional)</em>
-<p>Used to constraint a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore</p>
+<p>Used to constrain a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore.</p>
 </td>
 </tr>
 </table>
@@ -21022,7 +21022,7 @@ VaultProvider
 </td>
 <td>
 <em>(Optional)</em>
-<p>Vault configures this store to sync secrets using Hashi provider</p>
+<p>Vault configures this store to sync secrets using the HashiCorp Vault provider.</p>
 </td>
 </tr>
 <tr>
@@ -21106,7 +21106,7 @@ GithubProvider
 </td>
 <td>
 <em>(Optional)</em>
-<p>Github configures this store to push Github Action secrets using Github API provider</p>
+<p>Github configures this store to push GitHub Actions secrets using the GitHub API provider.</p>
 </td>
 </tr>
 <tr>
@@ -21218,7 +21218,7 @@ ScalewayProvider
 </td>
 <td>
 <em>(Optional)</em>
-<p>Scaleway</p>
+<p>Scaleway configures this store to sync secrets using the Scaleway provider.</p>
 </td>
 </tr>
 <tr>
@@ -21588,7 +21588,7 @@ SecretStoreRetrySettings
 </td>
 <td>
 <em>(Optional)</em>
-<p>Used to configure http retries if failed</p>
+<p>Used to configure HTTP retries on failures.</p>
 </td>
 </tr>
 <tr>
@@ -21614,7 +21614,7 @@ int
 </td>
 <td>
 <em>(Optional)</em>
-<p>Used to constraint a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore</p>
+<p>Used to constrain a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore.</p>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
### Summary
This PR fixes a handful of clearly incorrect/incomplete Go doc comments in the SecretStore API types for both `v1` and `v1beta1`.

### Changes
- Fix “http” -> “HTTP” and clarify wording around retries.
- Fix grammar: “constraint” -> “constrain”.
- Correct provider naming:
  - HashiCorp Vault (was “Hashi provider”)
  - GitHub Actions / GitHub API wording
- Replace placeholder comment for Scaleway with an accurate provider description.
- Mirror the same comment-only fixes in `v1beta1` to keep generated docs/CRDs consistent.

### Notes
- Comment-only changes; no API shape/behavior changes.

### Files touched
- `apis/externalsecrets/v1/secretstore_types.go`
- `apis/externalsecrets/v1beta1/secretstore_types.go`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Documentation fixes for SecretStore API comments

This PR updates Go doc comments for SecretStore types in both `apis/externalsecrets/v1` and `apis/externalsecrets/v1beta1`. Changes are comment-only and do not alter API shapes, behavior, or validation.

Key edits:
- Standardized "http" → "HTTP" and clarified retry wording ("Used to configure HTTP retries on failures").
- Fixed grammar (e.g., "constraint" → "constrain").
- Corrected provider naming and phrasing (e.g., "Hashi provider" → "the HashiCorp Vault provider"; "Github/Github Action" → "GitHub/GitHub Actions").
- Replaced Scaleway placeholder with an accurate provider description.
- Mirrored the same comment updates in v1beta1 to keep generated docs/CRDs consistent.

Files modified:
- apis/externalsecrets/v1/secretstore_types.go
- apis/externalsecrets/v1beta1/secretstore_types.go
- (Related CRD and docs description strings updated accordingly in CRD and docs files.)

Note: These are documentation/text-only changes. Reviewer requested running `make check-diff` and committing any generated diff.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->