### PR TITLE
docs: add TLS certificates authentication example for Vault

### DIFF
--- a/docs/provider/hashicorp-vault.md
+++ b/docs/provider/hashicorp-vault.md
@@ -378,7 +378,14 @@ set of AWS Programmatic access credentials stored in a `Kind=Secret` and referen
 
 #### TLS certificates authentication
 
-[TLS certificates auth method](https://developer.hashicorp.com/vault/docs/auth/cert)  allows authentication using SSL/TLS client certificates which are either signed by a CA or self-signed. SSL/TLS client certificates are defined as having an ExtKeyUsage extension with the usage set to either ClientAuth or Any.
+[TLS certificates auth method](https://developer.hashicorp.com/vault/docs/auth/cert) allows authentication using SSL/TLS client certificates which are either signed by a CA or self-signed. SSL/TLS client certificates are defined as having an ExtKeyUsage extension with the usage set to either ClientAuth or Any.
+
+The client certificate and private key should be stored in a Kubernetes secret (typically of type `kubernetes.io/tls`). Certificate chains can be included in the certificate file.
+
+```yaml
+{% include 'vault-cert-store.yaml' %}
+```
+**NOTE:** In case of a `ClusterSecretStore`, be sure to provide `namespace` in `clientCert` and `secretRef` with the namespace where the secret resides.
 
 ### Mutual authentication (mTLS)
 

--- a/docs/snippets/vault-cert-store.yaml
+++ b/docs/snippets/vault-cert-store.yaml
@@ -1,0 +1,40 @@
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: vault-backend
+  namespace: example
+spec:
+  provider:
+    vault:
+      server: "https://vault.acme.org"
+      path: "secret"
+      version: "v2"
+      auth:
+        # VaultCertAuth authenticates with Vault using TLS
+        # client certificates.
+        # https://developer.hashicorp.com/vault/docs/auth/cert
+        cert:
+          # Path where the Certificate auth method is mounted, e.g. "cert"
+          # Defaults to "cert" if not specified.
+          # path: "cert"
+          clientCert:
+            name: "vault-tls"
+            key: "tls.crt"
+          secretRef:
+            name: "vault-tls"
+            key: "tls.key"
+---
+# Example TLS secret (kubernetes.io/tls type)
+# The secret must contain tls.crt and tls.key keys.
+# Certificate chains can be included in tls.crt.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vault-tls
+  namespace: example
+type: kubernetes.io/tls
+data:
+  # Base64 encoded TLS certificate
+  tls.crt: LS0tLS1CRUdJTi...
+  # Base64 encoded TLS private key
+  tls.key: LS0tLS1CRUdJTi...


### PR DESCRIPTION
Fixes #5604

## Changes
- Add TLS certificates authentication example to Vault documentation
- Create vault-cert-store.yaml snippet with SecretStore and TLS secret example

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds TLS certificate (client cert) authentication documentation and examples for HashiCorp Vault to address issue #5604.

## Changes

- **docs/provider/hashicorp-vault.md**: Adds a TLS certificates authentication section showing how to store the client certificate and private key in a kubernetes.io/tls Secret (tls.crt may include certificate chains). Documents Vault provider fields (server, path, version, optional enterprise namespace) and caBundle/caProvider alternatives. Documents auth.cert usage including clientCert and secretRef entries with namespace, name, and key fields and explicitly notes that ClusterSecretStore requires the namespace be provided for locating the TLS secret.

- **docs/snippets/vault-cert-store.yaml**: New YAML snippet with a complete example SecretStore (apiVersion: external-secrets.io/v1) configured for Vault TLS client-certificate authentication and a kubernetes.io/tls Secret (vault-tls) containing base64-encoded tls.crt and tls.key. The SecretStore references the TLS secret for clientCert and secretRef as shown.

## Impact

Provides a concrete, copy-paste example and clarifies fields (including namespace and caBundle/caProvider) to reduce trial-and-error when configuring (Cluster)SecretStore resources for certificate/TLS auth with Vault.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->