### PR TITLE
fix: Dockerfile standalone

### DIFF
--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -8,12 +8,9 @@ ARG TARGETOS
 ARG TARGETARCH
 ENV CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH}
 WORKDIR /app
-# Avoid invalidating the `go mod download` cache when only code has changed.
-COPY go.mod go.sum /app/
-RUN go mod download
 COPY . /app/
+RUN go mod download
 RUN go build -o external-secrets main.go
-
 
 FROM gcr.io/distroless/static@sha256:4b2a093ef4649bccd586625090a3c668b254cfe180dee54f4c94f3e9bd7e381e AS app
 COPY --from=builder /app/external-secrets /bin/external-secrets


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Dockerfile.standalone Changes

Modified the builder stage's dependency handling:
- Removed the comment about preserving go mod download cache
- Removed the selective COPY of `go.mod` and `go.sum` before dependency download
- Changed to copy the entire application context first (`COPY . /app/`), then execute `RUN go mod download`
- Removed extra whitespace for tighter formatting

This simplifies the build process but removes a caching optimization that previously prevented cache invalidation when only source code changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->