### PR TITLE
feat: make the serving of the old beta version configurable for a period of time

### DIFF
--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -98,6 +98,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | crds.createClusterSecretStore | bool | `true` | If true, create CRDs for Cluster Secret Store. If set to false you must also set processClusterStore: false. |
 | crds.createPushSecret | bool | `true` | If true, create CRDs for Push Secret. If set to false you must also set processPushSecret: false. |
 | crds.createSecretStore | bool | `true` | If true, create CRDs for Secret Store. If set to false you must also set processSecretStore: false. |
+| crds.unsafeServeV1Beta1 | bool | `false` | If true, enable v1beta1 API version serving for ExternalSecret, ClusterExternalSecret, SecretStore, and ClusterSecretStore CRDs. v1beta1 is deprecated. Only enable this for backward compatibility if you have existing v1beta1 resources. Warning: This flag will be removed on 2026.05.01. |
 | createOperator | bool | `true` | Specifies whether an external secret operator deployment be created. |
 | deploymentAnnotations | object | `{}` | Annotations to add to Deployment |
 | dnsConfig | object | `{}` | Specifies `dnsOptions` to deployment |

--- a/deploy/charts/external-secrets/values.schema.json
+++ b/deploy/charts/external-secrets/values.schema.json
@@ -296,6 +296,9 @@
                 },
                 "createSecretStore": {
                     "type": "boolean"
+                },
+                "unsafeServeV1Beta1": {
+                    "type": "boolean"
                 }
             }
         },

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -71,6 +71,10 @@ crds:
   conversion:
     # -- Conversion is disabled by default as we stopped supporting v1alpha1.
     enabled: false
+  # -- If true, enable v1beta1 API version serving for ExternalSecret, ClusterExternalSecret, SecretStore, and ClusterSecretStore CRDs.
+  # v1beta1 is deprecated. Only enable this for backward compatibility if you have existing v1beta1 resources.
+  # Warning: This flag will be removed on 2026.05.01.
+  unsafeServeV1Beta1: false
 
 imagePullSecrets: []
 nameOverride: ""

--- a/hack/helm.generate.sh
+++ b/hack/helm.generate.sh
@@ -24,6 +24,8 @@ for i in "${HELM_DIR}"/templates/crds/*.yml; do
     $SEDPRG -i '/- |-/d' "$i.bkp"
     # Indent the remaining additionalPrinterColumn property right
     $SEDPRG -i 's/       additionalPrinterColumns:/    - additionalPrinterColumns:/' "$i.bkp"
+    # Replace served: false with templated value for v1beta1
+    $SEDPRG -i '/name: v1beta1/,/served: false/{s/served: false/served: {{ .Values.crds.unsafeServeV1Beta1 }}/}' "$i.bkp"
   fi
 
   if [[ "${CRDS_FLAG_NAME}" == *"Cluster"* ]]; then


### PR DESCRIPTION


## Problem Statement

What is the problem you're trying to solve?

## Related Issue

Fixes https://github.com/external-secrets/external-secrets/pull/5805

## Proposed Changes

How do you like to solve the issue and why?

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Introduces a new Helm configuration flag crds.serveV1Beta1 to make serving of the v1beta1 API versions for ExternalSecret, ClusterExternalSecret, SecretStore, and ClusterSecretStore CRDs configurable (default: false). 

Changes:
- deploy/charts/external-secrets/values.yaml: add crds.serveV1Beta1 (bool, false) with deprecation warning (to be removed 2026-05-01).
- deploy/charts/external-secrets/values.schema.json: add serveV1Beta1 boolean property under crds.
- deploy/charts/external-secrets/README.md: document the new crds.serveV1Beta1 values entry.
- hack/helm.generate.sh: modify CRD YAML generation to replace the static served: false for v1beta1 with the Helm template value {{ .Values.crds.serveV1Beta1 }} so serving can be toggled via the new flag.

Notes:
- No public code signatures changed.
- PR body lacks implementation details and tests; contribution checklist items remain unmarked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->