### PR TITLE
fix: the ubi breaking build

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -16,15 +16,19 @@ RUN mkdir /image && \
 	ln -s usr/lib /image/lib && \
 	mkdir -p /image/{usr/bin,usr/lib64,usr/lib,root,home,proc,etc,sys,var,dev}
 
-COPY ubi-build-files-${TARGETARCH}.txt /tmp
 # Copy all the required files from the base UBI image into the image directory
 # As the go binary is not statically compiled this includes everything needed for CGO to work, cacerts, tzdata and RH release files
-RUN tar cf /tmp/files.tar -T /tmp/ubi-build-files-${TARGETARCH}.txt && tar xf /tmp/files.tar -C /image/ \
+COPY ubi-build-files-${TARGETARCH}.txt /tmp/file-list.txt
+RUN mkdir -p /image/etc/pki/tls/certs /image/etc/pki/ca-trust/extracted/openssl /image/etc/pki/ca-trust/extracted/pem /image/usr/share \
+  && while IFS= read -r file; do \
+       [ -z "$file" ] && continue; \
+       mkdir -p "/image/$(dirname "$file")" 2>/dev/null || true; \
+       cp -a "/$file" "/image/$file" 2>/dev/null || true; \
+     done < /tmp/file-list.txt \
   && rpm --root /image --initdb \
-  && PACKAGES=$(rpm -qf $(cat /tmp/ubi-build-files-${TARGETARCH}.txt) | grep -v "is not owned by any package" | sort -u) \
-  && echo dnf install -y 'dnf-command(download)' \
+  && PACKAGES=$(while IFS= read -r file; do [ -n "$file" ] && echo "/$file"; done < /tmp/file-list.txt | xargs rpm -qf 2>/dev/null | grep -v "is not owned by any package" | sort -u) \
   && dnf download --destdir / ${PACKAGES} \
-  && rpm --root /image -ivh --justdb --nodeps `for i in ${PACKAGES}; do echo $i.rpm; done`
+  && rpm --root /image -ivh --justdb --nodeps /*.rpm
 
 FROM scratch
 # Copy all required files + rpm database so the image is scannable

--- a/ubi-build-files-amd64.txt
+++ b/ubi-build-files-amd64.txt
@@ -1,4 +1,3 @@
-
 etc/redhat-release
 usr/share/zoneinfo
 usr/lib64/ld-linux-x86-64.so.2
@@ -6,8 +5,8 @@ usr/lib64/libc.so.6
 usr/lib64/libdl.so.2
 usr/lib64/libpthread.so.0
 usr/lib64/libm.so.6
-/etc/pki/tls/cert.pem
-/etc/pki/tls/certs/ca-bundle.crt
-/etc/pki/tls/certs/ca-bundle.trust.crt
-/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt
-/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+etc/pki/tls/cert.pem
+etc/pki/tls/certs/ca-bundle.crt
+etc/pki/tls/certs/ca-bundle.trust.crt
+etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt
+etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem

--- a/ubi-build-files-arm64.txt
+++ b/ubi-build-files-arm64.txt
@@ -1,4 +1,3 @@
-
 etc/redhat-release
 usr/share/zoneinfo
 usr/lib/ld-linux-aarch64.so.1
@@ -6,8 +5,8 @@ usr/lib64/libc.so.6
 usr/lib64/libdl.so.2
 usr/lib64/libpthread.so.0
 usr/lib64/libm.so.6
-/etc/pki/tls/cert.pem
-/etc/pki/tls/certs/ca-bundle.crt
-/etc/pki/tls/certs/ca-bundle.trust.crt
-/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt
-/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+etc/pki/tls/cert.pem
+etc/pki/tls/certs/ca-bundle.crt
+etc/pki/tls/certs/ca-bundle.trust.crt
+etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt
+etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem

--- a/ubi-build-files-ppc64le.txt
+++ b/ubi-build-files-ppc64le.txt
@@ -1,4 +1,3 @@
-
 etc/redhat-release
 usr/share/zoneinfo
 usr/lib64/ld64.so.2
@@ -6,8 +5,8 @@ usr/lib64/libc.so.6
 usr/lib64/libdl.so.2
 usr/lib64/libpthread.so.0
 usr/lib64/libm.so.6
-/etc/pki/tls/cert.pem
-/etc/pki/tls/certs/ca-bundle.crt
-/etc/pki/tls/certs/ca-bundle.trust.crt
-/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt
-/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+etc/pki/tls/cert.pem
+etc/pki/tls/certs/ca-bundle.crt
+etc/pki/tls/certs/ca-bundle.trust.crt
+etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt
+etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem

--- a/ubi-build-files-s390x.txt
+++ b/ubi-build-files-s390x.txt
@@ -1,4 +1,3 @@
-
 etc/redhat-release
 usr/share/zoneinfo
 usr/lib/ld64.so.1
@@ -6,8 +5,8 @@ usr/lib64/libc.so.6
 usr/lib64/libdl.so.2
 usr/lib64/libpthread.so.0
 usr/lib64/libm.so.6
-/etc/pki/tls/cert.pem
-/etc/pki/tls/certs/ca-bundle.crt
-/etc/pki/tls/certs/ca-bundle.trust.crt
-/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt
-/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+etc/pki/tls/cert.pem
+etc/pki/tls/certs/ca-bundle.crt
+etc/pki/tls/certs/ca-bundle.trust.crt
+etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt
+etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Summary**

Fixes the UBI (Universal Base Image) build by refactoring the build process to dynamically discover and install packages instead of using static configurations.

**Key Changes**

- **Dockerfile.ubi**: Replaces tar-based extraction and static package installation with a dynamic approach that reads packages from `/tmp/file-list.txt`, determines which RPM packages own the required files, and installs them accordingly.

- **ubi-build-files-*.txt files** (amd64, arm64, ppc64le, s390x): Converts absolute TLS certificate paths (e.g., `/etc/pki/tls/cert.pem`) to relative paths (e.g., `etc/pki/tls/cert.pem`) to support the new per-file copy mechanism.

These changes make the UBI build process more flexible by removing hardcoded package names and instead dynamically determining which packages are needed based on the files required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->