### PR TITLE
fix: lets not use the docker buildx cache

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -120,6 +120,7 @@ jobs:
           IMAGE_TAG: ${{ steps.container_info.outputs.image-tag }}
           BUILD_ARGS: ${{ inputs.build-args }}
           DOCKER_BUILD_ARGS: >-
+            --no-cache
             --push
             --platform ${{ inputs.build-platform }}
         run: make docker.build
@@ -130,7 +131,7 @@ jobs:
         env:
           IMAGE_TAG: ${{ steps.container_info.outputs.image-tag }}
           BUILD_ARGS: ${{ inputs.build-args }}
-          DOCKER_BUILD_ARGS: --load
+          DOCKER_BUILD_ARGS: --no-cache --load
         run: make docker.build
       # images are large to the point trivy fails due to no space on disk left
       # This is a silly attempt to clean up space for trivy to run more

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -19,7 +19,7 @@ RUN mkdir /image && \
 COPY ubi-build-files-${TARGETARCH}.txt /tmp
 # Copy all the required files from the base UBI image into the image directory
 # As the go binary is not statically compiled this includes everything needed for CGO to work, cacerts, tzdata and RH release files
-RUN tar cf /tmp/files.tar -T /tmp/ubi-build-files-${TARGETARCH}.txt && tar xf /tmp/files.tar -C /image/ \
+RUN tar chf /tmp/files.tar -T /tmp/ubi-build-files-${TARGETARCH}.txt && tar xf /tmp/files.tar -C /image/ \
   && rpm --root /image --initdb \
   && PACKAGES=$(rpm -qf $(cat /tmp/ubi-build-files-${TARGETARCH}.txt) | grep -v "is not owned by any package" | sort -u) \
   && echo dnf install -y 'dnf-command(download)' \


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Disables Docker buildx cache to ensure clean builds.

**Changes:**
- `.github/workflows/publish.yml`: Adds `--no-cache` flag to Docker build arguments in both fork and non-fork publishing paths
- `Dockerfile.ubi`: Changes tar invocation from `-cf` to `-chf` to follow symlinks when archiving files

These modifications prevent cached Docker layers from being reused during builds and ensure symlinks are resolved in the archive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->