### PR TITLE
chore: sec fix of unstructed client id from environment passed to azure client

### DIFF
--- a/providers/v1/azure/keyvault/keyvault.go
+++ b/providers/v1/azure/keyvault/keyvault.go
@@ -26,6 +26,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -1133,6 +1134,9 @@ func NewTokenProvider(ctx context.Context, token, clientID, tenantID, aadEndpoin
 		return token, nil
 	})
 
+	// Azure client uses clientID field as a query parameter eventually
+	// qv.Set(clientID, req.AuthParams.ClientID)
+	clientID = url.QueryEscape(clientID)
 	cClient, err := confidential.New(fmt.Sprintf("%s%s", aadEndpoint, tenantID), clientID, cred)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Security fix for Azure client ID parameter handling**

This PR addresses a security vulnerability where client IDs sourced from environment variables were passed unvalidated to the Azure SDK's confidential client constructor. The fix ensures proper encoding of the `clientID` parameter.

**Changes:**
- Added `net/url` import to `providers/v1/azure/keyvault/keyvault.go`
- Applied `url.QueryEscape(clientID)` in the `NewTokenProvider` function before passing it to `confidential.New()`, preventing potential injection issues since the Azure SDK uses this value as a query parameter
- Added explanatory comments referencing the internal query parameter usage

**Impact:**
- Minimal code change (4 lines added)
- No public API modifications
- Improves security when client IDs come from untrusted sources like environment variables

<!-- end of auto-generated comment: release notes by coderabbit.ai -->