### PR TITLE
feat(charts): add cert-manager Issuer to helm chart

### DIFF
--- a/deploy/charts/external-secrets/templates/webhook-certificate.yaml
+++ b/deploy/charts/external-secrets/templates/webhook-certificate.yaml
@@ -19,7 +19,13 @@ spec:
     - {{ include "external-secrets.fullname" . }}-webhook.{{ template "external-secrets.namespace" . }}
     - {{ include "external-secrets.fullname" . }}-webhook.{{ template "external-secrets.namespace" . }}.svc
   issuerRef:
+  {{- if .Values.webhook.certManager.issuer.create }}
+    group: cert-manager.io
+    kind: "Issuer"
+    name: {{ .Values.webhook.certManager.issuer.name }}
+  {{- else }}
     {{- toYaml .Values.webhook.certManager.cert.issuerRef | nindent 4 }}
+  {{- end }}
   {{- with .Values.webhook.certManager.cert.duration }}
   duration: {{ . | quote }}
   {{- end }}

--- a/deploy/charts/external-secrets/templates/webhook-issuer.yaml
+++ b/deploy/charts/external-secrets/templates/webhook-issuer.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.webhook.create .Values.webhook.certManager.enabled .Values.webhook.certManager.cert.create .Values.webhook.certManager.cert.createIssuer }}
+{{- if and .Values.webhook.create .Values.webhook.certManager.enabled .Values.webhook.certManager.cert.create .Values.webhook.certManager.issuer.create }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer
@@ -23,6 +23,9 @@ spec:
   isCA: true
   commonName: 'ca.webhook.{{ include "external-secrets.name" . }}'
   secretName: '{{ include "external-secrets.name" . }}-root-cert'
+  privateKey:
+    algorithm: ECDSA
+    size: 256
   duration: "48300h0m0s"
   issuerRef:
     name: '{{ include "external-secrets.name" . }}-selfsigned-issuer'
@@ -30,9 +33,9 @@ spec:
     group: cert-manager.io
 ---
 apiVersion: cert-manager.io/v1
-kind: {{ .Values.webhook.certManager.cert.issuerRef.kind }}
+kind: Issuer
 metadata:
-  name: "{{ .Values.webhook.certManager.cert.issuerRef.name }}"
+  name: "{{ .Values.webhook.certManager.issuer.name }}"
   namespace: {{ template "external-secrets.namespace" . }}
   labels:
     {{- include "external-secrets-webhook.labels" . | nindent 4 }}

--- a/deploy/charts/external-secrets/templates/webhook-issuer.yaml
+++ b/deploy/charts/external-secrets/templates/webhook-issuer.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.webhook.create .Values.webhook.certManager.enabled .Values.webhook.certManager.cert.create .Values.webhook.certManager.cert.createIssuer }}
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: "{{ include 'external-secrets.fullname' . }}-selfsigned-issuer"
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: "{{ include 'external-secrets.fullname' . }}-root-cert"
+spec:
+  isCA: true
+  commonName: "ca.webhook.{{ include 'external-secrets.fullname' . }}"
+  secretName: "{{ include 'external-secrets.fullname' . }}-root-cert"
+  duration: "48300h0m0s"
+  issuerRef:
+    name: "{{ include 'external-secrets.fullname' . }}-selfsigned-issuer"
+    kind: Issuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: {{ .Values.webhook.certManager.cert.issuerRef.kind }}
+metadata:
+  name: "{{ .Values.webhook.certManager.cert.issuerRef.name }}"
+spec:
+  ca:
+    secretName: "{{ include 'external-secrets.fullname' . }}-root-cert"
+{{- end }}

--- a/deploy/charts/external-secrets/templates/webhook-issuer.yaml
+++ b/deploy/charts/external-secrets/templates/webhook-issuer.yaml
@@ -3,21 +3,29 @@
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: "{{ include 'external-secrets.fullname' . }}-selfsigned-issuer"
+  name: '{{ include "external-secrets.name" . }}-selfsigned-issuer'
+  namespace: {{ template "external-secrets.namespace" . }}
+  labels:
+    {{- include "external-secrets-webhook.labels" . | nindent 4 }}
+    external-secrets.io/component: webhook
 spec:
   selfSigned: {}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: "{{ include 'external-secrets.fullname' . }}-root-cert"
+  name: '{{ include "external-secrets.name" . }}-root-cert'
+  namespace: {{ template "external-secrets.namespace" . }}
+  labels:
+    {{- include "external-secrets-webhook.labels" . | nindent 4 }}
+    external-secrets.io/component: webhook
 spec:
   isCA: true
-  commonName: "ca.webhook.{{ include 'external-secrets.fullname' . }}"
-  secretName: "{{ include 'external-secrets.fullname' . }}-root-cert"
+  commonName: 'ca.webhook.{{ include "external-secrets.name" . }}'
+  secretName: '{{ include "external-secrets.name" . }}-root-cert'
   duration: "48300h0m0s"
   issuerRef:
-    name: "{{ include 'external-secrets.fullname' . }}-selfsigned-issuer"
+    name: '{{ include "external-secrets.name" . }}-selfsigned-issuer'
     kind: Issuer
     group: cert-manager.io
 ---
@@ -25,7 +33,11 @@ apiVersion: cert-manager.io/v1
 kind: {{ .Values.webhook.certManager.cert.issuerRef.kind }}
 metadata:
   name: "{{ .Values.webhook.certManager.cert.issuerRef.name }}"
+  namespace: {{ template "external-secrets.namespace" . }}
+  labels:
+    {{- include "external-secrets-webhook.labels" . | nindent 4 }}
+    external-secrets.io/component: webhook
 spec:
   ca:
-    secretName: "{{ include 'external-secrets.fullname' . }}-root-cert"
+    secretName: '{{ include "external-secrets.name" . }}-root-cert'
 {{- end }}

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -451,17 +451,22 @@ webhook:
     # enabled, this will automatically setup your webhook's CA to the one used
     # by cert-manager. See https://cert-manager.io/docs/concepts/ca-injector
     addInjectorAnnotations: true
+    # -- Create a self-signed CA Issuer resource within this chart. Overrides webhook.certManager.cert.issuerRef
+    # if enabled. See https://cert-manager.io/docs/configuration/selfsigned/#bootstrapping-ca-issuers
+    issuer:
+      create: false
+      name: "external-secrets-root-issuer"
     cert:
       # -- Create a certificate resource within this chart. See
       # https://cert-manager.io/docs/usage/certificate/
       create: true
-      # -- For the Certificate created by this chart, setup the issuer. See
+      # -- For the Certificate created by this chart, use an externally-managed Issuer.
+      # Ignored if webhook.certManager.issuer.create is true. See
       # https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.IssuerSpec
-      createIssuer: true
       issuerRef:
         group: cert-manager.io
         kind: "Issuer"
-        name: "external-secrets-root-issuer"
+        name: "my-issuer"
       # -- Set the requested duration (i.e. lifetime) of the Certificate. See
       # https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificateSpec
       # One year by default.

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -457,10 +457,11 @@ webhook:
       create: true
       # -- For the Certificate created by this chart, setup the issuer. See
       # https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.IssuerSpec
+      createIssuer: true
       issuerRef:
         group: cert-manager.io
         kind: "Issuer"
-        name: "my-issuer"
+        name: "external-secrets-root-issuer"
       # -- Set the requested duration (i.e. lifetime) of the Certificate. See
       # https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificateSpec
       # One year by default.


### PR DESCRIPTION
## Problem Statement

When installing the external-secrets operator with Cert Manager support enabled, the helm installation hangs because the Certificate resource cannot be issued due to no Issuer existing. This PR adds a self-signed CA issuer to the Helm chart when the .Values.webhook.certManager.cert.createIssuer flag is set to true.

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds optional bootstrapping of a cert-manager Issuer + CA for the webhook so Certificates can be issued when no external Issuer exists.

### Changes

- **New file: `deploy/charts/external-secrets/templates/webhook-issuer.yaml`**
  - Renders three cert-manager resources when enabled:
    - a self-signed Issuer named "<release>-selfsigned-issuer"
    - a long-lived CA Certificate stored in a secret "<release>-root-cert"
    - an Issuer that uses the CA secret with name from `.Values.webhook.certManager.issuer.name`
  - Resources are labeled and placed in the chart namespace.
  - Creation guarded by: `webhook.create && webhook.certManager.enabled && webhook.certManager.cert.create && webhook.certManager.issuer.create`.

- **Updated: `deploy/charts/external-secrets/templates/webhook-certificate.yaml`**
  - Conditionalized `issuerRef`: when `webhook.certManager.issuer.create` is true, `issuerRef` is set to the generated Issuer (group: cert-manager.io, kind: Issuer, name from values); otherwise existing `cert.issuerRef` is preserved.

- **Updated: `deploy/charts/external-secrets/values.yaml`**
  - Adds `webhook.certManager.issuer` block with:
    - `issuer.create` (default: false) — opt-in to bootstrap an Issuer
    - `issuer.name` (default: "external-secrets-root-issuer")
  - Documentation clarifies this flag is ignored if an external issuer is managed separately.

All changes are Helm template-only and ensure issuer creation is opt-in and consistent with existing cert-manager toggles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->