### PR TITLE
feat(kubernetes): add insecure TLS option for API server connections

### DIFF
--- a/apis/externalsecrets/v1/secretstore_kubernetes_types.go
+++ b/apis/externalsecrets/v1/secretstore_kubernetes_types.go
@@ -34,6 +34,13 @@ type KubernetesServer struct {
 	// see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider
 	// +optional
 	CAProvider *CAProvider `json:"caProvider,omitempty"`
+
+	// Insecure skips TLS certificate verification when connecting to the Kubernetes API server.
+	// This is useful when the server uses a certificate signed by a CA that is not in the
+	// system trust store (e.g., when accessing through a proxy with its own certificates).
+	// This is NOT RECOMMENDED for production use.
+	// +optional
+	Insecure bool `json:"insecure,omitempty"`
 }
 
 // KubernetesProvider configures a store to sync secrets with a Kubernetes instance.

--- a/apis/externalsecrets/v1beta1/secretstore_kubernetes_types.go
+++ b/apis/externalsecrets/v1beta1/secretstore_kubernetes_types.go
@@ -35,6 +35,13 @@ type KubernetesServer struct {
 	// see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider
 	// +optional
 	CAProvider *CAProvider `json:"caProvider,omitempty"`
+
+	// Insecure skips TLS certificate verification when connecting to the Kubernetes API server.
+	// This is useful when the server uses a certificate signed by a CA that is not in the
+	// system trust store (e.g., when accessing through a proxy with its own certificates).
+	// This is NOT RECOMMENDED for production use.
+	// +optional
+	Insecure bool `json:"insecure,omitempty"`
 }
 
 // KubernetesProvider configures a store to sync secrets with a Kubernetes instance.

--- a/docs/provider/kubernetes.md
+++ b/docs/provider/kubernetes.md
@@ -106,6 +106,37 @@ spec:
           key: ca.crt
 ```
 
+#### Insecure TLS (Skip Certificate Verification)
+
+In some scenarios, you may need to connect to a Kubernetes API server without verifying its TLS certificate. This is useful when:
+
+- Accessing a cluster through a proxy that uses its own TLS certificates (e.g., Tailscale API server proxy)
+- The API server uses a certificate signed by a CA that is not in the system trust store
+- Testing or development environments with self-signed certificates
+
+!!! warning "Security Notice"
+    Setting `insecure: true` disables TLS certificate verification, which makes the connection vulnerable to man-in-the-middle attacks. **This is NOT RECOMMENDED for production use.** Always prefer providing a proper CA certificate when possible.
+
+```yaml
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: k8s-store-insecure
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: default
+      server:
+        url: "https://my-cluster-proxy.example.com"
+        # Skip TLS certificate verification
+        insecure: true
+      auth:
+        serviceAccount:
+          name: "my-service-account"
+```
+
+When `insecure: true` is set, you do not need to provide a `caBundle` or `caProvider`.
+
 ### Authentication
 
 It's possible to authenticate against the Kubernetes API using client certificates, a bearer token or service account. The operator enforces that exactly one authentication method is used. You can not use the service account that is mounted inside the operator, this is by design to avoid reading secrets across namespaces.

--- a/providers/v1/kubernetes/validate.go
+++ b/providers/v1/kubernetes/validate.go
@@ -36,8 +36,9 @@ import (
 func (p *Provider) ValidateStore(store esv1.GenericStore) (admission.Warnings, error) {
 	storeSpec := store.GetSpec()
 	k8sSpec := storeSpec.Provider.Kubernetes
-	if k8sSpec.AuthRef == nil && k8sSpec.Server.CABundle == nil && k8sSpec.Server.CAProvider == nil {
-		return nil, errors.New("a CABundle or CAProvider is required")
+	// CA is required unless Insecure is set or AuthRef is used (which has its own config)
+	if k8sSpec.AuthRef == nil && !k8sSpec.Server.Insecure && k8sSpec.Server.CABundle == nil && k8sSpec.Server.CAProvider == nil {
+		return nil, errors.New("a CABundle or CAProvider is required (or set insecure: true to skip TLS verification)")
 	}
 	if store.GetObjectKind().GroupVersionKind().Kind == esv1.ClusterSecretStoreKind &&
 		k8sSpec.Server.CAProvider != nil &&

--- a/providers/v1/kubernetes/validate_test.go
+++ b/providers/v1/kubernetes/validate_test.go
@@ -77,6 +77,27 @@ func TestValidateStore(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "insecure mode without ca is valid",
+			store: &esv1.SecretStore{
+				Spec: esv1.SecretStoreSpec{
+					Provider: &esv1.SecretStoreProvider{
+						Kubernetes: &esv1.KubernetesProvider{
+							Server: esv1.KubernetesServer{
+								URL:      "https://my-cluster.example.com",
+								Insecure: true,
+							},
+							Auth: &esv1.KubernetesAuth{
+								ServiceAccount: &v1.ServiceAccountSelector{
+									Name: "foobar",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "invalid client cert name",
 			store: &esv1.SecretStore{
 				Spec: esv1.SecretStoreSpec{


### PR DESCRIPTION
## Summary

Add an `insecure` field to the Kubernetes provider's `KubernetesServer` configuration that allows skipping TLS certificate verification when connecting to Kubernetes API servers.

Closes #5904

## Changes

- **API Types (v1 & v1beta1)**: Added `Insecure bool` field to `KubernetesServer` struct
- **Provider Auth**: Updated `auth.go` to use `c.store.Server.Insecure` instead of hardcoded `false`
- **Validation**: Modified `validate.go` to allow `insecure: true` without requiring CA
- **Tests**: Added test case for insecure mode validation
- **Documentation**: Added usage examples with security warnings

## Use Case

When accessing Kubernetes clusters through API proxies like **Tailscale's Kubernetes API server proxy**, the proxy terminates TLS and presents its own certificate (typically Let's Encrypt for `*.ts.net` domains). These certificates are trusted by system CA roots, but external-secrets currently requires an explicit `caBundle` or `caProvider`.

This creates friction because other K8s tools (kubectl, Headlamp, etc.) work seamlessly since Go's `client-go` uses system CA roots by default.

## Usage

```yaml
apiVersion: external-secrets.io/v1
kind: ClusterSecretStore
spec:
  provider:
    kubernetes:
      server:
        url: "https://my-cluster-proxy.example.com"
        insecure: true  # Skips TLS verification
      auth:
        serviceAccount:
          name: "my-sa"
```

## Security Notice

The documentation clearly warns that:
- This disables TLS certificate verification
- This is NOT recommended for production use
- Users should prefer proper CA certificates when possible

This follows the pattern of `--insecure-skip-tls-verify` in kubectl and other tools.

## Testing

```
=== RUN   TestValidateStore/insecure_mode_without_ca_is_valid
--- PASS: TestValidateStore/insecure_mode_without_ca_is_valid (0.00s)
```

All existing tests continue to pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds support for skipping TLS certificate verification when connecting to Kubernetes API servers via a new Insecure field on the KubernetesServer struct.

### Changes
- API types: Add `Insecure bool` to `KubernetesServer` in both apis/externalsecrets/v1 and v1beta1.
- Auth logic (providers/v1/kubernetes/auth.go): Only fetch CA data when `Server.Insecure` is false; `TLSClientConfig.Insecure` now reflects the server's `Insecure` setting instead of being hard-coded false.
- Validation (providers/v1/kubernetes/validate.go): Allow `Insecure: true` without requiring `caBundle` or `caProvider`; updated error message to reference the new option.
- Tests (providers/v1/kubernetes/validate_test.go): Add test `insecure mode without ca is valid`; existing tests continue to pass.
- Docs (docs/provider/kubernetes.md): Add "Insecure TLS (Skip Certificate Verification)" section with usage example and explicit security warnings.

Use case: Reduces friction for connections via API proxies or setups where system CA roots already trust the proxy cert (aligns behavior with kubectl). 

Security note: Disabling TLS verification is unsafe for production; prefer supplying proper CA certificates where possible.

Closes #5904.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->