### PR TITLE
fix: onepasswordsdk shared tenant by altering the provider in the client cache

### DIFF
--- a/providers/v1/onepasswordsdk/provider.go
+++ b/providers/v1/onepasswordsdk/provider.go
@@ -84,14 +84,16 @@ func (p *Provider) NewClient(ctx context.Context, store esv1.GenericStore, kube 
 		return nil, err
 	}
 
-	p.client = c
-	p.vaultPrefix = "op://" + config.Vault + "/"
+	provider := &Provider{
+		client:      c,
+		vaultPrefix: "op://" + config.Vault + "/",
+	}
 
-	vaultID, err := p.GetVault(ctx, config.Vault)
+	vaultID, err := provider.GetVault(ctx, config.Vault)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get store ID: %w", err)
 	}
-	p.vaultID = vaultID
+	provider.vaultID = vaultID
 
 	if config.Cache != nil {
 		ttl := 5 * time.Minute
@@ -104,10 +106,10 @@ func (p *Provider) NewClient(ctx context.Context, store esv1.GenericStore, kube 
 			maxSize = config.Cache.MaxSize
 		}
 
-		p.cache = expirable.NewLRU[string, []byte](maxSize, nil, ttl)
+		provider.cache = expirable.NewLRU[string, []byte](maxSize, nil, ttl)
 	}
 
-	return p, nil
+	return provider, nil
 }
 
 // ValidateStore validates the 1Password SDK SecretStore resource configuration.


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?

## Related Issue

Fixes https://github.com/external-secrets/external-secrets/issues/5920.

## Proposed Changes

How do you like to solve the issue and why?

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes an issue where 1Password SDK Provider instances could share vault/tenant state across SecretStore requests, causing secrets from one vault to appear in another namespace.

### Root cause
NewClient() mutated the receiver (`p *Provider`) (vault ID, prefix, cache), so reused Provider instances could mix vault-specific state.

### Fix
NewClient() now allocates a new Provider instance populated with a new 1Password client, the request-specific vault prefix/ID, and a dedicated cache when configured, and returns that new instance instead of mutating and returning the receiver.

### Changes
- providers/v1/onepasswordsdk/provider.go: NewClient() creates and returns a new Provider rather than mutating the receiver (net +8/-6).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->