### PR TITLE
chore: bump golang to 1.25.7 because of cve

### DIFF
--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -1,6 +1,6 @@
 # This version of Dockerfile is for building without external dependencies.
 # Build a multi-platform image e.g. `docker buildx build --push --platform linux/arm64,linux/amd64 --tag external-secrets:dev --file Dockerfile.standalone .`
-FROM golang:1.25.6-alpine@sha256:98e6cffc31ccc44c7c15d83df1d69891efee8115a5bb7ede2bf30a38af3e3c92 AS builder
+FROM golang:1.25.7-alpine@sha256:20c8a94b529a9a127b6990c5e03537bd71ce3ebfdd744741e96168ac338bd862 AS builder
 # Add metadata
 LABEL maintainer="cncf-externalsecretsop-maintainers@lists.cncf.io" \
       description="External Secrets Operator is a Kubernetes operator that integrates external secret management systems"

--- a/apis/go.mod
+++ b/apis/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/apis
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.6-bookworm@sha256:2f768d462dbffbb0f0b3a5171009f162945b086f326e0b2a8fd5d29c3219ff14 AS builder
+FROM golang:1.25.7-bookworm@sha256:38342f3e7a504bf1efad858c18e771f84b66dc0b363add7a57c9a0bbb6cf7b12 AS builder
 RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.6
 
 FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets-e2e
 
-go 1.25.6
+go 1.25.7
 
 replace github.com/external-secrets/external-secrets => ../
 

--- a/generators/v1/acr/go.mod
+++ b/generators/v1/acr/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/acr
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.1

--- a/generators/v1/cloudsmith/go.mod
+++ b/generators/v1/cloudsmith/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/cloudsmith
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/ecr/go.mod
+++ b/generators/v1/ecr/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/ecr
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.39.6

--- a/generators/v1/fake/go.mod
+++ b/generators/v1/fake/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/fake
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/gcr/go.mod
+++ b/generators/v1/gcr/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/gcr
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/github/go.mod
+++ b/generators/v1/github/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/github
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/grafana/go.mod
+++ b/generators/v1/grafana/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/grafana
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/mfa/go.mod
+++ b/generators/v1/mfa/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/mfa
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/password/go.mod
+++ b/generators/v1/password/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/password
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/quay/go.mod
+++ b/generators/v1/quay/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/quay
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/sshkey/go.mod
+++ b/generators/v1/sshkey/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/sshkey
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/sts/go.mod
+++ b/generators/v1/sts/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/sts
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.39.6

--- a/generators/v1/uuid/go.mod
+++ b/generators/v1/uuid/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/uuid
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/vault/go.mod
+++ b/generators/v1/vault/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/vault
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/webhook/go.mod
+++ b/generators/v1/webhook/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/webhook
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets
 
-go 1.25.6
+go 1.25.7
 
 replace (
 	github.com/external-secrets/external-secrets/apis => ./apis

--- a/providers/v1/akeyless/go.mod
+++ b/providers/v1/akeyless/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/akeyless
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/akeylesslabs/akeyless-go-cloud-id v0.3.5

--- a/providers/v1/aws/go.mod
+++ b/providers/v1/aws/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/aws
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.39.6

--- a/providers/v1/azure/go.mod
+++ b/providers/v1/azure/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/azure
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible

--- a/providers/v1/barbican/go.mod
+++ b/providers/v1/barbican/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/barbican
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/beyondtrust/go.mod
+++ b/providers/v1/beyondtrust/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/beyondtrust
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/BeyondTrust/go-client-library-passwordsafe v1.0.0

--- a/providers/v1/bitwarden/go.mod
+++ b/providers/v1/bitwarden/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/bitwarden
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/chef/go.mod
+++ b/providers/v1/chef/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/chef
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/cloudru/go.mod
+++ b/providers/v1/cloudru/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/cloudru
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/cloudru-tech/iam-sdk v1.0.4

--- a/providers/v1/conjur/go.mod
+++ b/providers/v1/conjur/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/conjur
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/cyberark/conjur-api-go v0.13.8

--- a/providers/v1/delinea/go.mod
+++ b/providers/v1/delinea/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/delinea
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/DelineaXPM/dsv-sdk-go/v2 v2.2.0

--- a/providers/v1/doppler/go.mod
+++ b/providers/v1/doppler/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/doppler
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/dvls/go.mod
+++ b/providers/v1/dvls/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/dvls
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/Devolutions/go-dvls v0.15.0

--- a/providers/v1/fake/go.mod
+++ b/providers/v1/fake/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/fake
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/fortanix/go.mod
+++ b/providers/v1/fortanix/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/fortanix
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.1

--- a/providers/v1/gcp/go.mod
+++ b/providers/v1/gcp/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/gcp
 
-go 1.25.6
+go 1.25.7
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0

--- a/providers/v1/github/go.mod
+++ b/providers/v1/github/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/github
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.17.0

--- a/providers/v1/gitlab/go.mod
+++ b/providers/v1/gitlab/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/gitlab
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/ibm/go.mod
+++ b/providers/v1/ibm/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/ibm
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/IBM/go-sdk-core/v5 v5.21.0

--- a/providers/v1/infisical/go.mod
+++ b/providers/v1/infisical/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/infisical
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/keepersecurity/go.mod
+++ b/providers/v1/keepersecurity/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/keepersecurity
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/kubernetes/go.mod
+++ b/providers/v1/kubernetes/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/kubernetes
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/ngrok/go.mod
+++ b/providers/v1/ngrok/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/ngrok
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/onboardbase/go.mod
+++ b/providers/v1/onboardbase/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/onboardbase
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/Onboardbase/go-cryptojs-aes-decrypt v0.0.0-20230430095000-27c0d3a9016d

--- a/providers/v1/onepassword/go.mod
+++ b/providers/v1/onepassword/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/onepassword
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/1Password/connect-sdk-go v1.5.3

--- a/providers/v1/onepasswordsdk/go.mod
+++ b/providers/v1/onepasswordsdk/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/onepasswordsdk
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/1password/onepassword-sdk-go v0.3.1

--- a/providers/v1/oracle/go.mod
+++ b/providers/v1/oracle/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/oracle
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/passbolt/go.mod
+++ b/providers/v1/passbolt/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/passbolt
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/passworddepot/go.mod
+++ b/providers/v1/passworddepot/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/passworddepot
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/previder/go.mod
+++ b/providers/v1/previder/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/previder
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/pulumi/go.mod
+++ b/providers/v1/pulumi/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/pulumi
 
-go 1.25.6
+go 1.25.7
 
 require (
 	dario.cat/mergo v1.0.2

--- a/providers/v1/scaleway/go.mod
+++ b/providers/v1/scaleway/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/scaleway
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/secretserver/go.mod
+++ b/providers/v1/secretserver/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/secretserver
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/DelineaXPM/tss-sdk-go/v3 v3.0.1

--- a/providers/v1/senhasegura/go.mod
+++ b/providers/v1/senhasegura/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/senhasegura
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/vault/go.mod
+++ b/providers/v1/vault/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/vault
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.39.6

--- a/providers/v1/volcengine/go.mod
+++ b/providers/v1/volcengine/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/volcengine
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/webhook/go.mod
+++ b/providers/v1/webhook/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/webhook
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358

--- a/providers/v1/yandex/go.mod
+++ b/providers/v1/yandex/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/yandex
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/runtime/go.mod
+++ b/runtime/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/runtime
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0

--- a/tilt.debug.dockerfile
+++ b/tilt.debug.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.6@sha256:ce63a16e0f7063787ebb4eb28e72d477b00b4726f79874b3205a965ffd797ab2
+FROM golang:1.25.7@sha256:cc737435e2742bd6da3b7d575623968683609a3d2e0695f9d85bee84071c08e6
 WORKDIR /
 COPY ./bin/external-secrets /external-secrets
 


### PR DESCRIPTION
## Problem Statement

[There is a CVE in 1.25.6](https://github.com/external-secrets/external-secrets/actions/runs/21794993546/job/62880949775?pr=5931)

```

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬──────────────────────────────┬────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │        Fixed Version         │                           Title                            │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼──────────────────────────────┼────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2025-68121 │ HIGH     │ fixed  │ v1.25.6           │ 1.24.13, 1.25.7, 1.26.0-rc.3 │ During session resumption in crypto/tls, if the underlying │
│         │                │          │        │                   │                              │ Config has ......                                          │
│         │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2025-68121                 │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴──────────────────────────────┴────────────────────────────────────────────────────────────┘
```

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Go Version Bump to 1.25.7 for CVE Mitigation

This PR bumps the Go toolchain version from 1.25.6 to 1.25.7 across the repository due to a CVE.

**Changes:**
- Updated all `go.mod` files (apis, e2e, generators, providers, runtime) from `go 1.25.6` to `go 1.25.7`
- Updated Dockerfile base images from `golang:1.25.6` to `golang:1.25.7`:
  - `Dockerfile.standalone`
  - `e2e/Dockerfile`
  - `tilt.debug.dockerfile`

**Impact:**
- No functional code changes; purely a tooling/build dependency version update
- ~57 files modified, each with minimal changes (+1/-1 lines)
- All changes are consistent version increments with updated image digests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->