### PR TITLE
feat: add path to cloud.ru provider

### DIFF
--- a/docs/provider/cloudru.md
+++ b/docs/provider/cloudru.md
@@ -191,3 +191,83 @@ curl --location 'https://secretmanager.api.cloud.ru/v1/secrets' \
             name:
               regexp: "my.*secret"
     ```
+  * Search the secrets by path:
+    ```yaml
+    apiVersion: external-secrets.io/v1
+    kind: ExternalSecret
+    metadata:
+      name: csm-ext-secret
+    spec:
+      refreshInterval: 10s
+      secretStoreRef:
+        name: csm
+        kind: SecretStore
+      target:
+        name: my-awesome-secret
+        creationPolicy: Owner
+      dataFrom:
+        - find: # Get all secrets from the specified path
+            path: "oss/snmp-auths"
+    ```
+  * Search the secrets by path with name filter:
+    ```yaml
+    apiVersion: external-secrets.io/v1
+    kind: ExternalSecret
+    metadata:
+      name: csm-ext-secret
+    spec:
+      refreshInterval: 10s
+      secretStoreRef:
+        name: csm
+        kind: SecretStore
+      target:
+        name: my-awesome-secret
+        creationPolicy: Owner
+      dataFrom:
+        - find: # Get secrets from path matching the name pattern
+            path: "oss/snmp-auths"
+            name:
+              regexp: ".*"
+    ```
+  * Search the secrets by path with tags:
+    ```yaml
+    apiVersion: external-secrets.io/v1
+    kind: ExternalSecret
+    metadata:
+      name: csm-ext-secret
+    spec:
+      refreshInterval: 10s
+      secretStoreRef:
+        name: csm
+        kind: SecretStore
+      target:
+        name: my-awesome-secret
+        creationPolicy: Owner
+      dataFrom:
+        - find: # Get secrets from path with specific tags
+            path: "oss/snmp-auths"
+            tags:
+              env: production
+    ```
+  * Search the secrets by path with name and tags:
+    ```yaml
+    apiVersion: external-secrets.io/v1
+    kind: ExternalSecret
+    metadata:
+      name: csm-ext-secret
+    spec:
+      refreshInterval: 10s
+      secretStoreRef:
+        name: csm
+        kind: SecretStore
+      target:
+        name: my-awesome-secret
+        creationPolicy: Owner
+      dataFrom:
+        - find: # Get secrets from path matching name pattern and tags
+            path: "oss/snmp-auths"
+            name:
+              regexp: "auth.*"
+            tags:
+              env: production
+    ```

--- a/providers/v1/cloudru/secretmanager/adapter/csm_client.go
+++ b/providers/v1/cloudru/secretmanager/adapter/csm_client.go
@@ -60,6 +60,7 @@ type ListSecretsRequest struct {
 	Labels    map[string]string
 	NameExact string
 	NameRegex string
+	Path      string
 }
 
 // Credentials holds the keyID and secret for the CSM client.
@@ -98,6 +99,9 @@ func (c *APIClient) ListSecrets(ctx context.Context, req *ListSecretsRequest) ([
 		searchReq.Name = &smsV2.SearchSecretRequest_Exact{Exact: req.NameExact}
 	case req.NameRegex != "":
 		searchReq.Name = &smsV2.SearchSecretRequest_Regex{Regex: req.NameRegex}
+	}
+	if req.Path != "" {
+		searchReq.Path = req.Path
 	}
 
 	var err error

--- a/providers/v1/cloudru/secretmanager/client.go
+++ b/providers/v1/cloudru/secretmanager/client.go
@@ -107,10 +107,10 @@ func (c *Client) GetSecretMap(ctx context.Context, ref esv1.ExternalSecretDataRe
 	return out, nil
 }
 
-// GetAllSecrets gets all secrets by the remote reference.
+// GetAllSecrets returns all secrets matching the find criteria (path, name, tags).
 func (c *Client) GetAllSecrets(ctx context.Context, ref esv1.ExternalSecretFind) (map[string][]byte, error) {
-	if len(ref.Tags) == 0 && ref.Name == nil {
-		return nil, fmt.Errorf("at least one of the following fields must be set: tags, name")
+	if len(ref.Tags) == 0 && ref.Name == nil && ref.Path == nil {
+		return nil, fmt.Errorf("at least one of the following fields must be set: tags, name, path")
 	}
 
 	var nameFilter string
@@ -122,6 +122,9 @@ func (c *Client) GetAllSecrets(ctx context.Context, ref esv1.ExternalSecretFind)
 		ProjectID: c.projectID,
 		Labels:    ref.Tags,
 		NameRegex: nameFilter,
+	}
+	if ref.Path != nil {
+		searchReq.Path = *ref.Path
 	}
 	secrets, err := c.apiClient.ListSecrets(ctx, searchReq)
 	if err != nil {

--- a/providers/v1/cloudru/secretmanager/client_test.go
+++ b/providers/v1/cloudru/secretmanager/client_test.go
@@ -298,10 +298,29 @@ func TestClientGetAllSecrets(t *testing.T) {
 			wantErr: nil,
 		},
 		{
+			name: "success_path_only",
+			ref: esv1.ExternalSecretFind{
+				Path: func() *string {
+					s := "oss/snmp-auths"
+					return &s
+				}(),
+			},
+			setup: func(mock *fake.MockSecretProvider) {
+				mock.MockListSecrets([]*smsV2.Secret{
+					{Id: keyID, Name: "secret1", Path: "oss/snmp-auths/secret1"},
+				}, nil)
+				mock.MockAccessSecretVersion([]byte(`value1`), nil)
+			},
+			wantPayload: map[string][]byte{
+				"oss/snmp-auths/secret1": []byte(`value1`),
+			},
+			wantErr: nil,
+		},
+		{
 			name:        "error_no_filters",
 			ref:         esv1.ExternalSecretFind{},
 			wantPayload: nil,
-			wantErr:     errors.New("at least one of the following fields must be set: tags, name"),
+			wantErr:     errors.New("at least one of the following fields must be set: tags, name, path"),
 		},
 		{
 			name: "error_list_secrets",


### PR DESCRIPTION
## Problem Statement

This PR adds ability to get secret by path from cloud.ru provider

## Related Issue

Fixes #5953

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
Adds path-based secret retrieval to the Cloud.ru provider so secrets can be searched by path in addition to name and tags. Fixes #5953.

## Changes

**Documentation**
- docs/provider/cloudru.md: Added four path-based examples for dataFrom.find (path-only, path + name.regexp, path + tags, path + name.regexp + tags).

**Implementation**
- providers/v1/cloudru/secretmanager/client.go
  - GetAllSecrets now accepts and forwards Path from ExternalSecretFind into the search request.
  - Validation updated to require at least one of tags, name, or path.
- providers/v1/cloudru/secretmanager/adapter/csm_client.go
  - Added Path string to ListSecretsRequest and propagate it into the SearchSecretRequest/ListSecrets call.

**Tests**
- providers/v1/cloudru/secretmanager/client_test.go
  - ExternalSecretFind now includes Path.
  - Added path-only success test and updated the missing-filter error test to include path as a required filter.

## Notes
- No changes to exported API surface beyond added Path fields on request/test types; documentation, implementation, and tests wired Path through listing and retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->