### PR TITLE
fix(akeyless): distinguish access denied from item not found errors

### DIFF
--- a/providers/v1/akeyless/akeyless_api.go
+++ b/providers/v1/akeyless/akeyless_api.go
@@ -183,7 +183,7 @@ func (a *akeylessBase) DescribeItem(ctx context.Context, itemName string) (*akey
 		errBody := string(apiErr.Body())
 		if isAccessDeniedError(errBody) {
 			return nil, fmt.Errorf("access denied for item %v: the authenticated identity does not have permission to access this secret. "+
-				"Verify that the role permissions and any namespace-based sub-claims are configured correctly. API response: %v", itemName, errBody)
+				"Verify that the role permissions and any namespace-based sub-claims are configured correctly. API response: %v: %w", itemName, errBody, ErrAccessDenied)
 		}
 		return nil, fmt.Errorf("can't describe item: %v, error: %v", itemName, errBody)
 	}

--- a/providers/v1/akeyless/akeyless_test.go
+++ b/providers/v1/akeyless/akeyless_test.go
@@ -487,6 +487,41 @@ func TestIsAccessDeniedError(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "access_denied underscore variant",
+			errBody:  `{"error":"access_denied"}`,
+			expected: true,
+		},
+		{
+			name:     "not_allowed underscore variant",
+			errBody:  `{"error":"operation not_allowed"}`,
+			expected: true,
+		},
+		{
+			name:     "permission_denied underscore variant",
+			errBody:  `{"error":"permission_denied"}`,
+			expected: true,
+		},
+		{
+			name:     "no access response",
+			errBody:  `{"error":"no access to resource"}`,
+			expected: true,
+		},
+		{
+			name:     "not authorized response",
+			errBody:  `{"error":"not authorized"}`,
+			expected: true,
+		},
+		{
+			name:     "authorization failed response",
+			errBody:  `{"error":"authorization failed"}`,
+			expected: true,
+		},
+		{
+			name:     "you don't have permission response",
+			errBody:  `{"error":"you don't have permission to perform this action"}`,
+			expected: true,
+		},
+		{
 			name:     "item not found is not access denied",
 			errBody:  `{"error":"item not found"}`,
 			expected: false,


### PR DESCRIPTION
## Description

When using the Akeyless provider with namespace-based sub-claims, if a secret is accessed from a namespace not permitted by the sub-claim, the error message misleadingly says `item does not exist` instead of indicating an authorization failure.

### Root Cause

In `DescribeItem`, when the Akeyless API returns an error, the code attempted to unmarshal the error response body as an `Item` struct. If the JSON unmarshal succeeded (producing a mostly-empty Item), the original API error was silently set to `nil`. The caller then checked `GetItemNameOk()`, which returned false for the empty item, resulting in `ErrItemNotExists` — masking the real authorization error.

### Changes

- **Removed error-swallowing logic** in `DescribeItem`: API errors are now always propagated instead of being silently unmarshalled away
- **Added `isAccessDeniedError` helper**: detects common authorization failure patterns (unauthorized, forbidden, permission denied, etc.) in the Akeyless API response body
- **Improved error messages**: when access is denied, the error now clearly states it and suggests checking role permissions and namespace sub-claims
- **Added unit tests** for the `isAccessDeniedError` helper covering various response patterns

### Testing

All existing Akeyless provider tests pass. Added 8 new test cases for the access denied detection logic.

Fixes #5394

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Fixes misleading error handling in the Akeyless provider where authorization failures (e.g., namespace-based sub-claim restrictions) were incorrectly reported as "item does not exist".

## Changes

- Removed error-swallowing logic: DescribeItem no longer clears API errors during unmarshal attempts, allowing authorization errors to propagate properly.
- Added access-denied detection: New isAccessDeniedError() helper identifies authorization failure patterns in Akeyless API responses (unauthorized, forbidden, permission denied, not allowed, etc.).
- Added new error value: ErrAccessDenied for clearer error signaling (wrapped with %w where returned).
- Improved error messaging: DescribeItem returns a dedicated access-denied message that guides users to check role permissions and namespace sub-claims and includes the API response.
- Added tests: New TestIsAccessDeniedError covering multiple positive and negative scenarios for access-denied detection.

## Files Changed

- providers/v1/akeyless/akeyless_api.go: +36/-4 lines
- providers/v1/akeyless/akeyless_test.go: +91/-0 lines

Fixes issue #5394.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->