### PR TITLE
fix: cosign verify does not use signing config

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -158,7 +158,7 @@ jobs:
 
             artifact_digest_uri="${chart_registry}/${chart_name}@${digest}"
             cosign sign --yes --new-bundle-format=false --use-signing-config=false "$artifact_digest_uri"
-            cosign verify --new-bundle-format=false --use-signing-config=false "$artifact_digest_uri" \
+            cosign verify --new-bundle-format=false "$artifact_digest_uri" \
                 --certificate-identity-regexp "https://github.com/$GITHUB_REPOSITORY/.*" \
                 --certificate-oidc-issuer https://token.actions.githubusercontent.com
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

Removed the `--use-signing-config=false` flag from the `cosign verify` command in the `push_chart` step of the Helm workflow. The verification now respects the signing configuration instead of explicitly disabling it, while keeping the `--new-bundle-format=false` flag and certificate identity/OIDC issuer options intact.

**File affected:** `.github/workflows/helm.yml`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->