### PR TITLE
feat(doppler): add ETag-based caching

### DIFF
--- a/providers/v1/doppler/cache.go
+++ b/providers/v1/doppler/cache.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2025 ESO Maintainer Team
+Copyright © The ESO Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ func newSecretsCache(size int) *secretsCache {
 		cache: cache.Must(size, func(_ *cacheEntry) {
 			// No cleanup needed on eviction — entries are plain data with no external resources.
 		}),
-		keys:  make(map[string]map[cache.Key]struct{}),
+		keys: make(map[string]map[cache.Key]struct{}),
 	}
 }
 

--- a/providers/v1/doppler/cache.go
+++ b/providers/v1/doppler/cache.go
@@ -1,0 +1,128 @@
+/*
+Copyright © 2025 ESO Maintainer Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package doppler
+
+import (
+	"sync"
+
+	dclient "github.com/external-secrets/external-secrets/providers/v1/doppler/client"
+	"github.com/external-secrets/external-secrets/runtime/cache"
+)
+
+type cacheEntry struct {
+	etag    string
+	secrets dclient.Secrets
+	body    []byte
+}
+
+// Constant version because entries are invalidated explicitly on mutations.
+const etagCacheVersion = ""
+
+type secretsCache struct {
+	cache  *cache.Cache[*cacheEntry]
+	keys   map[string]map[cache.Key]struct{}
+	keysMu sync.RWMutex
+}
+
+func newSecretsCache(size int) *secretsCache {
+	if size <= 0 {
+		return nil
+	}
+	return &secretsCache{
+		cache: cache.Must(size, func(_ *cacheEntry) {
+			// No cleanup needed on eviction — entries are plain data with no external resources.
+		}),
+		keys:  make(map[string]map[cache.Key]struct{}),
+	}
+}
+
+type storeIdentity struct {
+	namespace string
+	name      string
+	kind      string
+}
+
+func cacheKey(store storeIdentity, secretName string) cache.Key {
+	name := store.name
+	if secretName != "" {
+		name = store.name + "|" + secretName
+	}
+	return cache.Key{
+		Name:      name,
+		Namespace: store.namespace,
+		Kind:      store.kind,
+	}
+}
+
+func storeKey(store storeIdentity) string {
+	return store.namespace + "|" + store.name + "|" + store.kind
+}
+
+func (c *secretsCache) get(store storeIdentity, secretName string) (*cacheEntry, bool) {
+	if c == nil || c.cache == nil {
+		return nil, false
+	}
+	key := cacheKey(store, secretName)
+	return c.cache.Get(etagCacheVersion, key)
+}
+
+func (c *secretsCache) set(store storeIdentity, secretName string, entry *cacheEntry) {
+	if c == nil || c.cache == nil {
+		return
+	}
+	key := cacheKey(store, secretName)
+
+	c.keysMu.Lock()
+	c.cache.Add(etagCacheVersion, key, entry)
+	prefix := storeKey(store)
+	if c.keys[prefix] == nil {
+		c.keys[prefix] = make(map[cache.Key]struct{})
+	}
+	// Prune keys that have been evicted from the underlying cache to prevent unbounded growth.
+	for k := range c.keys[prefix] {
+		if !c.cache.Contains(k) {
+			delete(c.keys[prefix], k)
+		}
+	}
+	c.keys[prefix][key] = struct{}{}
+	c.keysMu.Unlock()
+}
+
+func (c *secretsCache) invalidate(store storeIdentity) {
+	if c == nil || c.cache == nil {
+		return
+	}
+
+	c.keysMu.Lock()
+	defer c.keysMu.Unlock()
+
+	prefix := storeKey(store)
+	keys, exists := c.keys[prefix]
+	if !exists {
+		return
+	}
+
+	for key := range keys {
+		if c.cache.Contains(key) {
+			c.cache.Get("__invalidate__", key) // wrong version triggers eviction
+		}
+	}
+
+	delete(c.keys, prefix)
+}
+
+var etagCache *secretsCache

--- a/providers/v1/doppler/cache_test.go
+++ b/providers/v1/doppler/cache_test.go
@@ -1,0 +1,577 @@
+/*
+Copyright © 2025 ESO Maintainer Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package doppler
+
+import (
+	"bytes"
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+
+	esv1alpha1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
+	"github.com/external-secrets/external-secrets/providers/v1/doppler/client"
+	"github.com/external-secrets/external-secrets/providers/v1/doppler/fake"
+	"github.com/external-secrets/external-secrets/runtime/cache"
+)
+
+const testETagValue = "etag-123"
+
+// testCacheSize is used in tests to create caches with sufficient capacity.
+const testCacheSize = 100
+
+const testAPIKeyValue = "secret-value"
+const testDBPassValue = "password"
+
+// testStore is a default store identity used in tests.
+var testStore = storeIdentity{
+	namespace: "test-namespace",
+	name:      "test-store",
+	kind:      "SecretStore",
+}
+
+func TestCacheKey(t *testing.T) {
+	store := storeIdentity{namespace: "ns", name: "store", kind: "SecretStore"}
+
+	tests := []struct {
+		store      storeIdentity
+		secretName string
+		expected   cache.Key
+	}{
+		{store, "", cache.Key{Name: "store", Namespace: "ns", Kind: "SecretStore"}},
+		{store, "API_KEY", cache.Key{Name: "store|API_KEY", Namespace: "ns", Kind: "SecretStore"}},
+		{store, "DB_PASS", cache.Key{Name: "store|DB_PASS", Namespace: "ns", Kind: "SecretStore"}},
+	}
+
+	for _, tt := range tests {
+		result := cacheKey(tt.store, tt.secretName)
+		if result != tt.expected {
+			t.Errorf("cacheKey(%v, %q) = %v, want %v", tt.store, tt.secretName, result, tt.expected)
+		}
+	}
+}
+
+func TestSecretsCacheGetSet(t *testing.T) {
+	c := newSecretsCache(testCacheSize)
+
+	entry, found := c.get(testStore, "")
+	if found || entry != nil {
+		t.Error("expected empty cache to return nil, false")
+	}
+
+	testEntry := &cacheEntry{
+		etag:    "test-etag",
+		secrets: client.Secrets{"KEY": "value"},
+		body:    []byte("test body"),
+	}
+	c.set(testStore, "", testEntry)
+
+	entry, found = c.get(testStore, "")
+	if !found {
+		t.Error("expected cache hit after set")
+	}
+	if entry.etag != testEntry.etag {
+		t.Errorf("expected etag %q, got %q", testEntry.etag, entry.etag)
+	}
+	if !cmp.Equal(entry.secrets, testEntry.secrets) {
+		t.Errorf("expected secrets %v, got %v", testEntry.secrets, entry.secrets)
+	}
+
+	// Different secret name should miss
+	entry, found = c.get(testStore, "API_KEY")
+	if found || entry != nil {
+		t.Error("expected cache miss for different secret name")
+	}
+
+	// Different store should not see the entry
+	otherStore := storeIdentity{namespace: "other-ns", name: "other-store", kind: "SecretStore"}
+	entry, found = c.get(otherStore, "")
+	if found || entry != nil {
+		t.Error("expected cache miss for different store")
+	}
+}
+
+func TestSecretsCacheInvalidate(t *testing.T) {
+	c := newSecretsCache(testCacheSize)
+
+	testEntry := &cacheEntry{
+		etag:    "test-etag",
+		secrets: client.Secrets{"KEY": "value"},
+	}
+	c.set(testStore, "", testEntry)
+	c.set(testStore, "API_KEY", testEntry)
+	c.set(testStore, "DB_PASS", testEntry)
+
+	_, found := c.get(testStore, "")
+	if !found {
+		t.Error("expected cache hit before invalidate")
+	}
+	_, found = c.get(testStore, "API_KEY")
+	if !found {
+		t.Error("expected cache hit for API_KEY before invalidate")
+	}
+
+	c.invalidate(testStore)
+
+	_, found = c.get(testStore, "")
+	if found {
+		t.Error("expected cache miss after invalidate")
+	}
+	_, found = c.get(testStore, "API_KEY")
+	if found {
+		t.Error("expected cache miss for API_KEY after invalidate")
+	}
+	_, found = c.get(testStore, "DB_PASS")
+	if found {
+		t.Error("expected cache miss for DB_PASS after invalidate")
+	}
+}
+
+func TestSecretsCacheConcurrency(t *testing.T) {
+	c := newSecretsCache(testCacheSize)
+	const numGoroutines = 100
+	const numIterations = 100
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	for i := range numGoroutines {
+		go func(id int) {
+			defer wg.Done()
+			for j := range numIterations {
+				entry := &cacheEntry{
+					etag:    "etag",
+					secrets: client.Secrets{"KEY": "value"},
+				}
+				c.set(testStore, "", entry)
+				c.get(testStore, "")
+				if j%10 == 0 {
+					c.invalidate(testStore)
+				}
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+func TestGetAllSecretsUsesCache(t *testing.T) {
+	etagCache = newSecretsCache(testCacheSize)
+
+	fakeClient := &fake.DopplerClient{}
+
+	var callCount atomic.Int32
+	testSecrets := client.Secrets{"API_KEY": testAPIKeyValue, "DB_PASS": testDBPassValue}
+	testETag := testETagValue
+
+	fakeClient.WithSecretsFunc(func(request client.SecretsRequest) (*client.SecretsResponse, error) {
+		count := callCount.Add(1)
+
+		if request.ETag == "" {
+			return &client.SecretsResponse{
+				Modified: true,
+				Secrets:  testSecrets,
+				ETag:     testETag,
+			}, nil
+		}
+
+		if request.ETag == testETag {
+			return &client.SecretsResponse{
+				Modified: false,
+				Secrets:  nil,
+				ETag:     testETag,
+			}, nil
+		}
+
+		t.Errorf("unexpected call %d with ETag %q", count, request.ETag)
+		return nil, nil
+	})
+
+	c := &Client{
+		doppler:   fakeClient,
+		project:   "test-project",
+		config:    "test-config",
+		namespace: "test-namespace",
+		storeName: "test-store",
+		storeKind: "SecretStore",
+	}
+
+	secrets, err := c.secrets(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(secrets) != 2 {
+		t.Errorf("expected 2 secrets, got %d", len(secrets))
+	}
+	if string(secrets["API_KEY"]) != testAPIKeyValue {
+		t.Errorf("expected API_KEY=%s, got %s", testAPIKeyValue, secrets["API_KEY"])
+	}
+
+	secrets, err = c.secrets(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error on second call: %v", err)
+	}
+	if len(secrets) != 2 {
+		t.Errorf("expected 2 secrets on second call, got %d", len(secrets))
+	}
+
+	if callCount.Load() != 2 {
+		t.Errorf("expected 2 API calls, got %d", callCount.Load())
+	}
+}
+
+func TestCacheInvalidationOnPushSecret(t *testing.T) {
+	etagCache = newSecretsCache(testCacheSize)
+
+	fakeClient := &fake.DopplerClient{}
+
+	var secretsCallCount atomic.Int32
+	testSecrets := client.Secrets{"API_KEY": "original-value"}
+	updatedSecrets := client.Secrets{"API_KEY": "updated-value"}
+	testETag := testETagValue
+	newETag := "etag-456"
+
+	fakeClient.WithSecretsFunc(func(request client.SecretsRequest) (*client.SecretsResponse, error) {
+		count := secretsCallCount.Add(1)
+
+		switch count {
+		case 1:
+			return &client.SecretsResponse{
+				Modified: true,
+				Secrets:  testSecrets,
+				ETag:     testETag,
+			}, nil
+		case 2:
+			if request.ETag != "" {
+				t.Errorf("expected no ETag after cache invalidation, got %q", request.ETag)
+			}
+			return &client.SecretsResponse{
+				Modified: true,
+				Secrets:  updatedSecrets,
+				ETag:     newETag,
+			}, nil
+		default:
+			t.Errorf("unexpected call %d", count)
+			return nil, nil
+		}
+	})
+
+	fakeClient.WithUpdateValue(client.UpdateSecretsRequest{
+		Secrets: client.Secrets{validRemoteKey: validSecretValue},
+		Project: "test-project",
+		Config:  "test-config",
+	}, nil)
+
+	c := &Client{
+		doppler:   fakeClient,
+		project:   "test-project",
+		config:    "test-config",
+		namespace: "test-namespace",
+		storeName: "test-store",
+		storeKind: "SecretStore",
+	}
+
+	_, err := c.secrets(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	storeID := c.storeIdentity()
+	entry, found := etagCache.get(storeID, "")
+	if !found {
+		t.Error("expected cache to be populated after first call")
+	}
+	if entry.etag != testETag {
+		t.Errorf("expected ETag %q, got %q", testETag, entry.etag)
+	}
+
+	secret := &corev1.Secret{
+		Data: map[string][]byte{
+			validSecretName: []byte(validSecretValue),
+		},
+	}
+	secretData := esv1alpha1.PushSecretData{
+		Match: esv1alpha1.PushSecretMatch{
+			SecretKey: validSecretName,
+			RemoteRef: esv1alpha1.PushSecretRemoteRef{
+				RemoteKey: validRemoteKey,
+			},
+		},
+	}
+	err = c.PushSecret(context.Background(), secret, secretData)
+	if err != nil {
+		t.Fatalf("unexpected error pushing secret: %v", err)
+	}
+
+	_, found = etagCache.get(storeID, "")
+	if found {
+		t.Error("expected cache to be invalidated after push")
+	}
+
+	_, err = c.secrets(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error after push: %v", err)
+	}
+
+	if secretsCallCount.Load() != 2 {
+		t.Errorf("expected 2 secrets API calls, got %d", secretsCallCount.Load())
+	}
+}
+
+func TestCacheInvalidationOnDeleteSecret(t *testing.T) {
+	etagCache = newSecretsCache(testCacheSize)
+
+	fakeClient := &fake.DopplerClient{}
+
+	testSecrets := client.Secrets{"API_KEY": "value"}
+	testETag := testETagValue
+
+	fakeClient.WithSecretsFunc(func(_ client.SecretsRequest) (*client.SecretsResponse, error) {
+		return &client.SecretsResponse{
+			Modified: true,
+			Secrets:  testSecrets,
+			ETag:     testETag,
+		}, nil
+	})
+
+	fakeClient.WithUpdateValue(client.UpdateSecretsRequest{
+		ChangeRequests: []client.Change{
+			{
+				Name:         validRemoteKey,
+				OriginalName: validRemoteKey,
+				ShouldDelete: true,
+			},
+		},
+		Project: "test-project",
+		Config:  "test-config",
+	}, nil)
+
+	c := &Client{
+		doppler:   fakeClient,
+		project:   "test-project",
+		config:    "test-config",
+		namespace: "test-namespace",
+		storeName: "test-store",
+		storeKind: "SecretStore",
+	}
+
+	_, err := c.secrets(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	storeID := c.storeIdentity()
+	_, found := etagCache.get(storeID, "")
+	if !found {
+		t.Error("expected cache to be populated")
+	}
+
+	remoteRef := &esv1alpha1.PushSecretRemoteRef{RemoteKey: validRemoteKey}
+	err = c.DeleteSecret(context.Background(), remoteRef)
+	if err != nil {
+		t.Fatalf("unexpected error deleting secret: %v", err)
+	}
+
+	_, found = etagCache.get(storeID, "")
+	if found {
+		t.Error("expected cache to be invalidated after delete")
+	}
+}
+
+func TestCacheWithFormat(t *testing.T) {
+	etagCache = newSecretsCache(testCacheSize)
+
+	fakeClient := &fake.DopplerClient{}
+
+	var callCount atomic.Int32
+	testBody := []byte("KEY=value\nDB_PASS=password")
+	testETag := "etag-format-123"
+
+	fakeClient.WithSecretsFunc(func(request client.SecretsRequest) (*client.SecretsResponse, error) {
+		count := callCount.Add(1)
+
+		if request.ETag == "" {
+			return &client.SecretsResponse{
+				Modified: true,
+				Body:     testBody,
+				ETag:     testETag,
+			}, nil
+		}
+
+		if request.ETag == testETag {
+			return &client.SecretsResponse{
+				Modified: false,
+				Body:     nil,
+				ETag:     testETag,
+			}, nil
+		}
+
+		t.Errorf("unexpected call %d with ETag %q", count, request.ETag)
+		return nil, nil
+	})
+
+	c := &Client{
+		doppler:   fakeClient,
+		project:   "test-project",
+		config:    "test-config",
+		format:    "env",
+		namespace: "test-namespace",
+		storeName: "test-store",
+		storeKind: "SecretStore",
+	}
+
+	secrets, err := c.secrets(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(secrets["DOPPLER_SECRETS_FILE"], testBody) {
+		t.Errorf("expected body %q, got %q", testBody, secrets["DOPPLER_SECRETS_FILE"])
+	}
+
+	secrets, err = c.secrets(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error on second call: %v", err)
+	}
+	if !bytes.Equal(secrets["DOPPLER_SECRETS_FILE"], testBody) {
+		t.Errorf("expected cached body %q, got %q", testBody, secrets["DOPPLER_SECRETS_FILE"])
+	}
+
+	if callCount.Load() != 2 {
+		t.Errorf("expected 2 API calls, got %d", callCount.Load())
+	}
+}
+
+func TestSecretsCacheDisabled(t *testing.T) {
+	// When cache size is 0, caching should be disabled
+	c := newSecretsCache(0)
+	if c != nil {
+		t.Error("expected nil cache when size is 0")
+	}
+
+	// Operations on nil cache should be no-ops (not panic)
+	var nilCache *secretsCache
+	entry, found := nilCache.get(testStore, "")
+	if found || entry != nil {
+		t.Error("expected nil cache get to return nil, false")
+	}
+
+	// set should be a no-op
+	nilCache.set(testStore, "", &cacheEntry{etag: "test"})
+
+	// invalidate should be a no-op
+	nilCache.invalidate(testStore)
+}
+
+func TestDisabledCacheDoesNotCacheSecrets(t *testing.T) {
+	// Test that when cache is disabled, secrets are fetched on every call
+	etagCache = nil // Disabled cache
+
+	fakeClient := &fake.DopplerClient{}
+
+	var callCount atomic.Int32
+	testSecrets := client.Secrets{"API_KEY": testAPIKeyValue}
+
+	fakeClient.WithSecretsFunc(func(_ client.SecretsRequest) (*client.SecretsResponse, error) {
+		callCount.Add(1)
+		return &client.SecretsResponse{
+			Modified: true,
+			Secrets:  testSecrets,
+			ETag:     "etag-123",
+		}, nil
+	})
+
+	c := &Client{
+		doppler:   fakeClient,
+		project:   "test-project",
+		config:    "test-config",
+		namespace: "test-namespace",
+		storeName: "test-store",
+		storeKind: "SecretStore",
+	}
+
+	// First call
+	_, err := c.secrets(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Second call - should still fetch because cache is disabled
+	_, err = c.secrets(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Third call
+	_, err = c.secrets(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// All three calls should have been made to the API
+	if callCount.Load() != 3 {
+		t.Errorf("expected 3 API calls with disabled cache, got %d", callCount.Load())
+	}
+}
+
+func TestCacheIsolationBetweenStores(t *testing.T) {
+	// Test that different stores don't share cache entries even with same project/config
+	c := newSecretsCache(testCacheSize)
+
+	storeA := storeIdentity{namespace: "ns-a", name: "store-a", kind: "SecretStore"}
+	storeB := storeIdentity{namespace: "ns-b", name: "store-b", kind: "SecretStore"}
+
+	entryA := &cacheEntry{etag: "etag-a", secrets: client.Secrets{"KEY": "value-a"}}
+	entryB := &cacheEntry{etag: "etag-b", secrets: client.Secrets{"KEY": "value-b"}}
+
+	// Both stores use same project/config but should have separate cache entries
+	c.set(storeA, "", entryA)
+	c.set(storeB, "", entryB)
+
+	// Each store should get its own entry
+	gotA, foundA := c.get(storeA, "")
+	gotB, foundB := c.get(storeB, "")
+
+	if !foundA {
+		t.Error("expected cache hit for store A")
+	}
+	if !foundB {
+		t.Error("expected cache hit for store B")
+	}
+
+	if gotA.etag != "etag-a" {
+		t.Errorf("store A got wrong etag: %q, want %q", gotA.etag, "etag-a")
+	}
+	if gotB.etag != "etag-b" {
+		t.Errorf("store B got wrong etag: %q, want %q", gotB.etag, "etag-b")
+	}
+
+	// Invalidating store A should not affect store B
+	c.invalidate(storeA)
+
+	_, foundA = c.get(storeA, "")
+	_, foundB = c.get(storeB, "")
+
+	if foundA {
+		t.Error("expected cache miss for store A after invalidation")
+	}
+	if !foundB {
+		t.Error("expected cache hit for store B after store A invalidation")
+	}
+}

--- a/providers/v1/doppler/cache_test.go
+++ b/providers/v1/doppler/cache_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2025 ESO Maintainer Team
+Copyright © The ESO Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/providers/v1/doppler/client/client.go
+++ b/providers/v1/doppler/client/client.go
@@ -84,7 +84,7 @@ type SecretsRequest struct {
 	Config          string
 	NameTransformer string
 	Format          string
-	ETag            string // Specifying an ETag implies that the caller has implemented response caching
+	ETag            string
 }
 
 // UpdateSecretsRequest represents a request to update secrets in Doppler.

--- a/providers/v1/doppler/doppler_test.go
+++ b/providers/v1/doppler/doppler_test.go
@@ -164,7 +164,19 @@ func makeValidDopplerTestCaseCustom(tweaks ...func(pstc *dopplerTestCase)) *dopp
 	for _, fn := range tweaks {
 		fn(pstc)
 	}
-	pstc.fakeClient.WithValue(pstc.request, pstc.response, pstc.apiErr)
+	pstc.fakeClient.WithSecretFunc(func(req client.SecretRequest) (*client.SecretResponse, error) {
+		if pstc.apiErr != nil {
+			return nil, pstc.apiErr
+		}
+		if pstc.response == nil {
+			return nil, &client.APIError{Message: "secret not found"}
+		}
+		return &client.SecretResponse{
+			Name:     pstc.response.Name,
+			Value:    pstc.response.Value,
+			Modified: true,
+		}, nil
+	})
 	return pstc
 }
 

--- a/providers/v1/doppler/fake/fake.go
+++ b/providers/v1/doppler/fake/fake.go
@@ -91,3 +91,8 @@ func (dc *DopplerClient) WithSecretsFunc(fn func(request client.SecretsRequest) 
 	}
 }
 
+func (dc *DopplerClient) WithSecretFunc(fn func(request client.SecretRequest) (*client.SecretResponse, error)) {
+	if dc != nil {
+		dc.getSecret = fn
+	}
+}

--- a/providers/v1/doppler/provider.go
+++ b/providers/v1/doppler/provider.go
@@ -50,9 +50,9 @@ var _ esv1.SecretsClient = &Client{}
 var _ esv1.Provider = &Provider{}
 
 var (
-	enableCache      bool
-	oidcClientCache  *cache.Cache[esv1.SecretsClient]
-	defaultCacheSize = 2 << 17
+	enableCache          bool
+	oidcClientCache      *cache.Cache[esv1.SecretsClient]
+	defaultOIDCCacheSize = 2 << 17
 )
 
 func init() {
@@ -67,17 +67,17 @@ func init() {
 	fs.IntVar(
 		&dopplerOIDCCacheSize,
 		"experimental-doppler-oidc-cache-size",
-		defaultCacheSize,
+		defaultOIDCCacheSize,
 		"Maximum size of Doppler OIDC provider cache. Set to 0 to disable caching. Only used if --experimental-enable-doppler-oidc-cache is set.")
 
 	feature.Register(feature.Feature{
 		Flags:      fs,
-		Initialize: func() { initCache(dopplerOIDCCacheSize) },
+		Initialize: func() { initOIDCCache(dopplerOIDCCacheSize) },
 	})
 }
 
 // Gating on enableCache to not enable cache out of the blue for new releases.
-func initCache(cacheSize int) {
+func initOIDCCache(cacheSize int) {
 	if oidcClientCache == nil && cacheSize > 0 && enableCache {
 		oidcClientCache = cache.Must(cacheSize, func(_ esv1.SecretsClient) {
 			// No cleanup is needed when evicting OIDC clients from cache


### PR DESCRIPTION
## Problem Statement

The Doppler provider makes a full API request on every reconciliation loop, even when secrets haven't changed. Doppler's API already supports ETag-based conditional requests, but the provider doesn't take advantage of this. This results in unnecessary data transfer on almost every reconciliation cycle.

## Related Issue

Fixes #5855

## Proposed Changes

Implement HTTP ETag-based conditional request caching for the Doppler provider. Doppler's API natively supports ETag headers, making this a zero-config improvement for operators.

Specifically, this PR:

- Adds to the Doppler provider a `secretsCache` (backed by `runtime/cache.Cache`) stores ETags alongside cached secret data, keyed by SecretStore identity (namespace/name/kind) and secret name.
- Updates `GetAllSecrets`/`GetSecretMap` so they now send `If-None-Match` headers on subsequent calls. On 304 Not Modified, cached data is returned without re-downloading.
- Updates `GetSecret` to use the same ETag mechanism via the `/v3/configs/config/secrets/download` endpoint with a `secrets` query parameter, enabling per-key caching.
- Makes `PushSecret` and `DeleteSecret` invalidate all cached entries for the affected store to ensure mutations are never served stale.
- Adds a `--doppler-etag-cache-size` flag which can be set to 0 to disable caching entirely. Defaults to 16384.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ETag-based Caching for Doppler Provider

### Overview
Adds HTTP ETag-based conditional request caching for the Doppler provider to avoid redundant API calls when secrets haven't changed.

### Key Changes
- New unexported in-memory `secretsCache` (backed by runtime/cache.Cache) storing ETags, raw response bodies and parsed secrets keyed by SecretStore identity (namespace/name/kind) and secret name.
- `GetAllSecrets` / `GetSecretMap` and `GetSecret` send If-None-Match headers and handle 304 Not Modified by returning cached data. `GetSecret` now uses the /v3/configs/config/secrets/download endpoint for per-key ETag support.
- `PushSecret` and `DeleteSecret` invalidate all cache entries for the affected store to avoid stale responses after mutations.
- Provider wiring: new `--doppler-etag-cache-size` flag (default 16384; 0 disables the cache) and separate ETag cache initialization alongside the existing OIDC cache.
- Tests and fakes updated: comprehensive cache unit and integration tests, fake client hooks adjusted to support the new request/response shapes and ETag behaviors.

### Modified Files (high level)
- providers/v1/doppler/cache.go, cache_test.go
- providers/v1/doppler/client.go and client/client.go
- providers/v1/doppler/provider.go
- providers/v1/doppler/fake/fake.go
- providers/v1/doppler/doppler_test.go

### Impact
Reduces Doppler API traffic and unnecessary data transfer by leveraging ETag conditional requests and preserving ETag state across reconciliations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->