### PR TITLE
feat(aws): reconcile metadata update

### DIFF
--- a/docs/provider/aws-secrets-manager.md
+++ b/docs/provider/aws-secrets-manager.md
@@ -61,7 +61,9 @@ If you're planning to use `PushSecret`, ensure you also have the following permi
   "Action": [
     "secretsmanager:CreateSecret",
     "secretsmanager:PutSecretValue",
+    "secretsmanager:UpdateSecret",
     "secretsmanager:TagResource",
+    "secretsmanager:UntagResource",
     "secretsmanager:DeleteSecret",
     "secretsmanager:GetResourcePolicy",
     "secretsmanager:PutResourcePolicy",
@@ -75,6 +77,7 @@ If you're planning to use `PushSecret`, ensure you also have the following permi
 }
 ```
 
+**Note:** `UpdateSecret` is required to update a secret's `description` or `kmsKeyID` when the secret value itself has not changed.
 **Note:** The resource policy permissions (`GetResourcePolicy`, `PutResourcePolicy`, `DeleteResourcePolicy`) are only required if you're using the `resourcePolicy` metadata option to manage resource-based policies on secrets.
 **Note:** The replication permissions (`ReplicateSecretToRegions`, `RemoveRegionsFromReplication`) are only required if you're using the `replicationLocations` metadata option to manage secret replication across multiple regions.
 
@@ -89,7 +92,9 @@ Here's a more restrictive version of the IAM policy:
       "Action": [
         "secretsmanager:CreateSecret",
         "secretsmanager:PutSecretValue",
+        "secretsmanager:UpdateSecret",
         "secretsmanager:TagResource",
+        "secretsmanager:UntagResource",
         "secretsmanager:GetResourcePolicy",
         "secretsmanager:PutResourcePolicy",
         "secretsmanager:DeleteResourcePolicy",

--- a/providers/v1/aws/parameterstore/parameterstore.go
+++ b/providers/v1/aws/parameterstore/parameterstore.go
@@ -318,7 +318,10 @@ func (pm *ParameterStore) setExisting(ctx context.Context, existing *ssm.GetPara
 	if paramMeta != nil &&
 		paramMeta.Tier == ssmTypes.ParameterTierAdvanced &&
 		secretRequest.Tier != ssmTypes.ParameterTierAdvanced {
-		return fmt.Errorf("cannot downgrade parameter %q from Advanced to Standard tier: AWS does not support this operation; set tier.type to Advanced in PushSecret metadata to continue managing this parameter", secretName)
+		return fmt.Errorf(
+			"cannot downgrade parameter %q from Advanced to Standard tier: AWS does not support this operation; set tier.type to Advanced in PushSecret metadata to continue managing this parameter",
+			secretName,
+		)
 	}
 
 	if existing.Parameter.Value != nil && *existing.Parameter.Value == string(value) {

--- a/providers/v1/aws/parameterstore/parameterstore.go
+++ b/providers/v1/aws/parameterstore/parameterstore.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -301,8 +302,29 @@ func (pm *ParameterStore) setExisting(ctx context.Context, existing *ssm.GetPara
 		return errors.New("unable to compare 'sensitive' result, ensure to request a decrypted value")
 	}
 
+	// Fetch current parameter metadata unconditionally so the tier downgrade guard
+	// can run before any write, regardless of whether the value has changed.
+	// Best-effort: a lookup failure is logged and treated as unknown (update proceeds).
+	paramMeta, err := pm.fetchParameterMetadata(ctx, secretName)
+	if err != nil {
+		logger.Info("could not fetch parameter metadata, proceeding with update", "parameter", secretName, "err", err)
+		paramMeta = nil
+	}
+
+	// Guard against Advanced - Standard tier downgrade. AWS does not support this
+	// operation and will reject it; blocking it here prevents a partial update where
+	// the value is written but the tier change is then rejected by the API.
+	// Users should keep tier.type: Advanced in their PushSecret metadata.
+	if paramMeta != nil &&
+		paramMeta.Tier == ssmTypes.ParameterTierAdvanced &&
+		secretRequest.Tier != ssmTypes.ParameterTierAdvanced {
+		return fmt.Errorf("cannot downgrade parameter %q from Advanced to Standard tier: AWS does not support this operation; set tier.type to Advanced in PushSecret metadata to continue managing this parameter", secretName)
+	}
+
 	if existing.Parameter.Value != nil && *existing.Parameter.Value == string(value) {
-		return nil
+		if paramMeta != nil && !hasParameterMetadataChanged(paramMeta, &secretRequest) {
+			return nil
+		}
 	}
 
 	err = pm.setManagedRemoteParameter(ctx, secretRequest, []ssmTypes.Tag{}, false)
@@ -310,9 +332,15 @@ func (pm *ParameterStore) setExisting(ctx context.Context, existing *ssm.GetPara
 		return err
 	}
 
-	tagKeysToRemove := awsutil.FindTagKeysToRemove(tags, metaTags)
+	return pm.reconcileParameterTags(ctx, existing, tags, metaTags)
+}
+
+// reconcileParameterTags syncs the parameter's tags with the desired metadata
+// tags, removing keys that are no longer present and adding/updating the rest.
+func (pm *ParameterStore) reconcileParameterTags(ctx context.Context, existing *ssm.GetParameterOutput, currentTags, metaTags map[string]string) error {
+	tagKeysToRemove := awsutil.FindTagKeysToRemove(currentTags, metaTags)
 	if len(tagKeysToRemove) > 0 {
-		_, err = pm.client.RemoveTagsFromResource(ctx, &ssm.RemoveTagsFromResourceInput{
+		_, err := pm.client.RemoveTagsFromResource(ctx, &ssm.RemoveTagsFromResourceInput{
 			ResourceId:   existing.Parameter.Name,
 			ResourceType: ssmTypes.ResourceTypeForTaggingParameter,
 			TagKeys:      tagKeysToRemove,
@@ -323,9 +351,9 @@ func (pm *ParameterStore) setExisting(ctx context.Context, existing *ssm.GetPara
 		}
 	}
 
-	tagsToUpdate, isModified := computeTagsToUpdate(tags, metaTags)
+	tagsToUpdate, isModified := computeTagsToUpdate(currentTags, metaTags)
 	if isModified {
-		_, err = pm.client.AddTagsToResource(ctx, &ssm.AddTagsToResourceInput{
+		_, err := pm.client.AddTagsToResource(ctx, &ssm.AddTagsToResourceInput{
 			ResourceId:   existing.Parameter.Name,
 			ResourceType: ssmTypes.ResourceTypeForTaggingParameter,
 			Tags:         tagsToUpdate,
@@ -341,6 +369,76 @@ func (pm *ParameterStore) setExisting(ctx context.Context, existing *ssm.GetPara
 
 func isManagedByESO(tags map[string]string) bool {
 	return tags[managedBy] == externalSecrets
+}
+
+// fetchParameterMetadata retrieves the ParameterMetadata for a single parameter by name.
+// Returns nil, nil when no matching parameter is found.
+func (pm *ParameterStore) fetchParameterMetadata(ctx context.Context, name string) (*ssmTypes.ParameterMetadata, error) {
+	out, err := pm.client.DescribeParameters(ctx, &ssm.DescribeParametersInput{
+		ParameterFilters: []ssmTypes.ParameterStringFilter{
+			{
+				Key:    aws.String("Name"),
+				Option: aws.String("Equals"),
+				Values: []string{name},
+			},
+		},
+	})
+	metrics.ObserveAPICall(constants.ProviderAWSPS, constants.CallAWSPSDescribeParameter, err)
+	if err != nil {
+		return nil, err
+	}
+	if len(out.Parameters) == 0 {
+		return nil, nil
+	}
+	return &out.Parameters[0], nil
+}
+
+// hasParameterMetadataChanged returns true if the desired PutParameterInput differs from
+// the current ParameterMetadata in any mutable metadata field (Type, Description, Tier, KeyId, Policies).
+func hasParameterMetadataChanged(meta *ssmTypes.ParameterMetadata, req *ssm.PutParameterInput) bool {
+	if meta.Type != req.Type {
+		return true
+	}
+	if aws.ToString(meta.Description) != aws.ToString(req.Description) {
+		return true
+	}
+	if req.Tier != "" && meta.Tier != req.Tier {
+		return true
+	}
+	if req.Type == ssmTypes.ParameterTypeSecureString {
+		if aws.ToString(meta.KeyId) != aws.ToString(req.KeyId) {
+			return true
+		}
+	}
+	if aws.ToString(req.Policies) != "" {
+		if policiesChanged(aws.ToString(req.Policies), meta.Policies) {
+			return true
+		}
+	}
+	return false
+}
+
+// policiesChanged reports whether the desired policies (a JSON array string) differ from
+// the current inline policies returned by DescribeParameters.
+// Comparison is JSON-normalized and order-sensitive; parse errors are treated as changed.
+func policiesChanged(desired string, current []ssmTypes.ParameterInlinePolicy) bool {
+	var desiredPolicies []map[string]any
+	if err := json.Unmarshal([]byte(desired), &desiredPolicies); err != nil {
+		return true
+	}
+	if len(desiredPolicies) != len(current) {
+		return true
+	}
+	for i, p := range current {
+		var currentPolicy map[string]any
+		if err := json.Unmarshal([]byte(aws.ToString(p.PolicyText)), &currentPolicy); err != nil {
+			return true
+		}
+		if !reflect.DeepEqual(desiredPolicies[i], currentPolicy) {
+			return true
+		}
+	}
+	return false
 }
 
 func (pm *ParameterStore) setManagedRemoteParameter(ctx context.Context, secretRequest ssm.PutParameterInput, tags []ssmTypes.Tag, createManagedByTags bool) error {

--- a/providers/v1/aws/parameterstore/parameterstore.go
+++ b/providers/v1/aws/parameterstore/parameterstore.go
@@ -302,30 +302,13 @@ func (pm *ParameterStore) setExisting(ctx context.Context, existing *ssm.GetPara
 		return errors.New("unable to compare 'sensitive' result, ensure to request a decrypted value")
 	}
 
-	// Fetch current parameter metadata unconditionally so the tier downgrade guard
-	// can run before any write, regardless of whether the value has changed.
-	// Best-effort: a lookup failure is logged and treated as unknown (update proceeds).
-	paramMeta, err := pm.fetchParameterMetadata(ctx, secretName)
-	if err != nil {
-		logger.Info("could not fetch parameter metadata, proceeding with update", "parameter", secretName, "err", err)
-		paramMeta = nil
-	}
-
-	// Guard against Advanced - Standard tier downgrade. AWS does not support this
-	// operation and will reject it; blocking it here prevents a partial update where
-	// the value is written but the tier change is then rejected by the API.
-	// Users should keep tier.type: Advanced in their PushSecret metadata.
-	if paramMeta != nil &&
-		paramMeta.Tier == ssmTypes.ParameterTierAdvanced &&
-		secretRequest.Tier != ssmTypes.ParameterTierAdvanced {
-		return fmt.Errorf(
-			"cannot downgrade parameter %q from Advanced to Standard tier: AWS does not support this operation; set tier.type to Advanced in PushSecret metadata to continue managing this parameter",
-			secretName,
-		)
-	}
-
 	if existing.Parameter.Value != nil && *existing.Parameter.Value == string(value) {
-		if paramMeta != nil && !hasParameterMetadataChanged(paramMeta, &secretRequest) {
+		// Best-effort metadata comparison: only skip the update when metadata is
+		// present and unchanged. A lookup failure is logged and the update proceeds.
+		paramMeta, err := pm.fetchParameterMetadata(ctx, secretName)
+		if err != nil {
+			logger.Info("could not fetch parameter metadata, proceeding with update", "parameter", secretName, "err", err)
+		} else if paramMeta != nil && !hasParameterMetadataChanged(paramMeta, &secretRequest) {
 			return nil
 		}
 	}

--- a/providers/v1/aws/parameterstore/parameterstore_test.go
+++ b/providers/v1/aws/parameterstore/parameterstore_test.go
@@ -769,7 +769,16 @@ func TestPushSecretCalledOnlyOnce(t *testing.T) {
 			Value: &fakeValue,
 		},
 	}
-	describeParameterOutput := &ssm.DescribeParametersOutput{}
+	defaultDescription := "secret 'managed-by:external-secrets'"
+	describeParameterOutput := &ssm.DescribeParametersOutput{
+		Parameters: []ssmtypes.ParameterMetadata{
+			{
+				Type:        ssmtypes.ParameterTypeString,
+				Description: aws.String(defaultDescription),
+				Tier:        ssmtypes.ParameterTierStandard,
+			},
+		},
+	}
 	validListTagsForResourceOutput := &ssm.ListTagsForResourceOutput{
 		TagList: []ssmtypes.Tag{managedByESO},
 	}
@@ -789,6 +798,405 @@ func TestPushSecretCalledOnlyOnce(t *testing.T) {
 	require.NoError(t, ps.PushSecret(context.TODO(), fakeSecret, psd))
 
 	assert.Equal(t, 0, client.PutParameterCalledN)
+}
+
+// TestPushSecretMetadataChange tests that PutParameter is (or is not) called when the
+// secret value is unchanged but metadata fields differ.
+func TestPushSecretMetadataChange(t *testing.T) {
+	defaultDescription := "secret 'managed-by:external-secrets'"
+	managedByESO := ssmtypes.Tag{Key: &managedBy, Value: &externalSecrets}
+
+	fakeSecret := &corev1.Secret{
+		Data: map[string][]byte{fakeSecretKey: []byte(fakeValue)},
+	}
+	validGetParameterOutput := &ssm.GetParameterOutput{
+		Parameter: &ssmtypes.Parameter{Value: &fakeValue},
+	}
+	validListTagsForResourceOutput := &ssm.ListTagsForResourceOutput{
+		TagList: []ssmtypes.Tag{managedByESO},
+	}
+
+	type testCase struct {
+		reason             string
+		describeOutput     *ssm.DescribeParametersOutput
+		describeErr        error
+		metadata           *apiextensionsv1.JSON
+		wantErr            string
+		wantPutParameterN  int
+	}
+
+	tests := map[string]testCase{
+		"SetSecretSameValueMetadataUnchanged": {
+			reason: "no PutParameter when value and metadata are unchanged",
+			describeOutput: &ssm.DescribeParametersOutput{
+				Parameters: []ssmtypes.ParameterMetadata{
+					{
+						Type:        ssmtypes.ParameterTypeString,
+						Description: aws.String(defaultDescription),
+						Tier:        ssmtypes.ParameterTierStandard,
+					},
+				},
+			},
+			wantPutParameterN: 0,
+		},
+		"SetSecretSameValueTypeChanged": {
+			reason: "PutParameter called when Type changes from String to SecureString",
+			describeOutput: &ssm.DescribeParametersOutput{
+				Parameters: []ssmtypes.ParameterMetadata{
+					{
+						Type:        ssmtypes.ParameterTypeSecureString,
+						Description: aws.String(defaultDescription),
+						Tier:        ssmtypes.ParameterTierStandard,
+					},
+				},
+			},
+			wantPutParameterN: 1,
+		},
+		"SetSecretSameValueKMSKeyChanged": {
+			reason: "PutParameter called when KMS key changes",
+			describeOutput: &ssm.DescribeParametersOutput{
+				Parameters: []ssmtypes.ParameterMetadata{
+					{
+						Type:        ssmtypes.ParameterTypeSecureString,
+						Description: aws.String(defaultDescription),
+						Tier:        ssmtypes.ParameterTierStandard,
+						KeyId:       aws.String("old-key"),
+					},
+				},
+			},
+			metadata: &apiextensionsv1.JSON{Raw: []byte(`{
+				"apiVersion": "kubernetes.external-secrets.io/v1alpha1",
+				"kind": "PushSecretMetadata",
+				"spec": {
+					"secretType": "SecureString",
+					"kmsKeyID": "new-key-arn"
+				}
+			}`)},
+			wantPutParameterN: 1,
+		},
+		"SetSecretSameValueDescriptionChanged": {
+			reason: "PutParameter called when description changes",
+			describeOutput: &ssm.DescribeParametersOutput{
+				Parameters: []ssmtypes.ParameterMetadata{
+					{
+						Type:        ssmtypes.ParameterTypeString,
+						Description: aws.String("old description"),
+						Tier:        ssmtypes.ParameterTierStandard,
+					},
+				},
+			},
+			wantPutParameterN: 1,
+		},
+		"SetSecretSameValueTierChanged": {
+			reason: "PutParameter called when tier changes to Advanced",
+			describeOutput: &ssm.DescribeParametersOutput{
+				Parameters: []ssmtypes.ParameterMetadata{
+					{
+						Type:        ssmtypes.ParameterTypeString,
+						Description: aws.String(defaultDescription),
+						Tier:        ssmtypes.ParameterTierStandard,
+					},
+				},
+			},
+			metadata: &apiextensionsv1.JSON{Raw: []byte(`{
+				"apiVersion": "kubernetes.external-secrets.io/v1alpha1",
+				"kind": "PushSecretMetadata",
+				"spec": {
+					"tier": {"type": "Advanced"}
+				}
+			}`)},
+			wantPutParameterN: 1,
+		},
+		"SetSecretSameValuePoliciesChanged": {
+			reason: "PutParameter called when tier policies change while value stays the same",
+			describeOutput: &ssm.DescribeParametersOutput{
+				Parameters: []ssmtypes.ParameterMetadata{
+					{
+						Type:        ssmtypes.ParameterTypeString,
+						Description: aws.String(defaultDescription),
+						Tier:        ssmtypes.ParameterTierAdvanced,
+						Policies: []ssmtypes.ParameterInlinePolicy{
+							{PolicyText: aws.String(`{"Type":"Expiration","Version":"1.0","Attributes":{"Timestamp":"2024-01-01T00:00:00.000Z"}}`)},
+						},
+					},
+				},
+			},
+			metadata: &apiextensionsv1.JSON{Raw: []byte(`{
+				"apiVersion": "kubernetes.external-secrets.io/v1alpha1",
+				"kind": "PushSecretMetadata",
+				"spec": {
+					"tier": {
+						"type": "Advanced",
+						"policies": [{"Type":"Expiration","Version":"1.0","Attributes":{"Timestamp":"2025-06-01T00:00:00.000Z"}}]
+					}
+				}
+			}`)},
+			wantPutParameterN: 1,
+		},
+		"SetSecretSameValuePoliciesUnchanged": {
+			reason: "PutParameter not called when tier policies are the same",
+			describeOutput: &ssm.DescribeParametersOutput{
+				Parameters: []ssmtypes.ParameterMetadata{
+					{
+						Type:        ssmtypes.ParameterTypeString,
+						Description: aws.String(defaultDescription),
+						Tier:        ssmtypes.ParameterTierAdvanced,
+						Policies: []ssmtypes.ParameterInlinePolicy{
+							{PolicyText: aws.String(`{"Type":"Expiration","Version":"1.0","Attributes":{"Timestamp":"2025-06-01T00:00:00.000Z"}}`)},
+						},
+					},
+				},
+			},
+			metadata: &apiextensionsv1.JSON{Raw: []byte(`{
+				"apiVersion": "kubernetes.external-secrets.io/v1alpha1",
+				"kind": "PushSecretMetadata",
+				"spec": {
+					"tier": {
+						"type": "Advanced",
+						"policies": [{"Type":"Expiration","Version":"1.0","Attributes":{"Timestamp":"2025-06-01T00:00:00.000Z"}}]
+					}
+				}
+			}`)},
+			wantPutParameterN: 0,
+		},
+		"SetSecretSameValueDescribeError": {
+			reason:            "PutParameter still called when DescribeParameters fails (best-effort)",
+			describeErr:       errors.New("describe error"),
+			describeOutput:    &ssm.DescribeParametersOutput{},
+			wantErr:           "",
+			wantPutParameterN: 1,
+		},
+		"SetSecretSameValueMetadataNotFound": {
+			reason:            "PutParameter still called when DescribeParameters returns no results",
+			describeOutput:    &ssm.DescribeParametersOutput{},
+			wantErr:           "",
+			wantPutParameterN: 1,
+		},
+		"SetSecretTierDowngradeAdvancedToStandard": {
+			reason: "error returned and no PutParameter when trying to downgrade from Advanced to Standard tier",
+			describeOutput: &ssm.DescribeParametersOutput{
+				Parameters: []ssmtypes.ParameterMetadata{
+					{
+						Type:        ssmtypes.ParameterTypeString,
+						Description: aws.String(defaultDescription),
+						Tier:        ssmtypes.ParameterTierAdvanced,
+					},
+				},
+			},
+			// No metadata - defaults to Standard tier, triggering the downgrade guard.
+			wantErr:           "cannot downgrade",
+			wantPutParameterN: 0,
+		},
+		"SetSecretTierKeepAdvanced": {
+			reason: "no PutParameter when current and desired tier are both Advanced and metadata is unchanged",
+			describeOutput: &ssm.DescribeParametersOutput{
+				Parameters: []ssmtypes.ParameterMetadata{
+					{
+						Type:        ssmtypes.ParameterTypeString,
+						Description: aws.String(defaultDescription),
+						Tier:        ssmtypes.ParameterTierAdvanced,
+					},
+				},
+			},
+			metadata: &apiextensionsv1.JSON{Raw: []byte(`{
+				"apiVersion": "kubernetes.external-secrets.io/v1alpha1",
+				"kind": "PushSecretMetadata",
+				"spec": {
+					"tier": {"type": "Advanced"}
+				}
+			}`)},
+			wantPutParameterN: 0,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			client := fakeps.Client{
+				PutParameterFn:        fakeps.NewPutParameterFn(&ssm.PutParameterOutput{}, nil),
+				GetParameterFn:        fakeps.NewGetParameterFn(validGetParameterOutput, nil),
+				DescribeParametersFn:  fakeps.NewDescribeParametersFn(tc.describeOutput, tc.describeErr),
+				ListTagsForResourceFn: fakeps.NewListTagsForResourceFn(validListTagsForResourceOutput, nil),
+				RemoveTagsFromResourceFn: fakeps.NewRemoveTagsFromResourceFn(&ssm.RemoveTagsFromResourceOutput{}, nil),
+				AddTagsToResourceFn:      fakeps.NewAddTagsToResourceFn(&ssm.AddTagsToResourceOutput{}, nil),
+			}
+			psd := fake.PushSecretData{SecretKey: fakeSecretKey, RemoteKey: remoteKey}
+			if tc.metadata != nil {
+				psd.Metadata = tc.metadata
+			}
+			ps := ParameterStore{client: &client}
+
+			err := ps.PushSecret(context.TODO(), fakeSecret, psd)
+
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr, tc.reason)
+			} else {
+				require.NoError(t, err, tc.reason)
+			}
+			assert.Equal(t, tc.wantPutParameterN, client.PutParameterCalledN, tc.reason)
+		})
+	}
+}
+
+func TestHasParameterMetadataChanged(t *testing.T) {
+	defaultDescription := "secret 'managed-by:external-secrets'"
+
+	tests := map[string]struct {
+		meta *ssmtypes.ParameterMetadata
+		req  *ssm.PutParameterInput
+		want bool
+	}{
+		"NothingChanged": {
+			meta: &ssmtypes.ParameterMetadata{
+				Type:        ssmtypes.ParameterTypeString,
+				Description: aws.String(defaultDescription),
+				Tier:        ssmtypes.ParameterTierStandard,
+			},
+			req: &ssm.PutParameterInput{
+				Type:        ssmtypes.ParameterTypeString,
+				Description: aws.String(defaultDescription),
+			},
+			want: false,
+		},
+		"TypeChanged": {
+			meta: &ssmtypes.ParameterMetadata{
+				Type: ssmtypes.ParameterTypeSecureString,
+			},
+			req: &ssm.PutParameterInput{
+				Type: ssmtypes.ParameterTypeString,
+			},
+			want: true,
+		},
+		"DescriptionChanged": {
+			meta: &ssmtypes.ParameterMetadata{
+				Type:        ssmtypes.ParameterTypeString,
+				Description: aws.String("old"),
+			},
+			req: &ssm.PutParameterInput{
+				Type:        ssmtypes.ParameterTypeString,
+				Description: aws.String("new"),
+			},
+			want: true,
+		},
+		"TierChangedToAdvanced": {
+			meta: &ssmtypes.ParameterMetadata{
+				Type: ssmtypes.ParameterTypeString,
+				Tier: ssmtypes.ParameterTierStandard,
+			},
+			req: &ssm.PutParameterInput{
+				Type: ssmtypes.ParameterTypeString,
+				Tier: ssmtypes.ParameterTierAdvanced,
+			},
+			want: true,
+		},
+		"TierEmptyInReqIgnored": {
+			meta: &ssmtypes.ParameterMetadata{
+				Type: ssmtypes.ParameterTypeString,
+				Tier: ssmtypes.ParameterTierStandard,
+			},
+			req: &ssm.PutParameterInput{
+				Type: ssmtypes.ParameterTypeString,
+				Tier: "",
+			},
+			want: false,
+		},
+		"KMSKeyChangedForSecureString": {
+			meta: &ssmtypes.ParameterMetadata{
+				Type:  ssmtypes.ParameterTypeSecureString,
+				KeyId: aws.String("old-key"),
+			},
+			req: &ssm.PutParameterInput{
+				Type:  ssmtypes.ParameterTypeSecureString,
+				KeyId: aws.String("new-key"),
+			},
+			want: true,
+		},
+		"KMSKeyIgnoredForStringType": {
+			meta: &ssmtypes.ParameterMetadata{
+				Type:  ssmtypes.ParameterTypeString,
+				KeyId: aws.String("some-key"),
+			},
+			req: &ssm.PutParameterInput{
+				Type:  ssmtypes.ParameterTypeString,
+				KeyId: aws.String("different-key"),
+			},
+			want: false,
+		},
+		"PoliciesChanged": {
+			meta: &ssmtypes.ParameterMetadata{
+				Type: ssmtypes.ParameterTypeString,
+				Tier: ssmtypes.ParameterTierAdvanced,
+				Policies: []ssmtypes.ParameterInlinePolicy{
+					{PolicyText: aws.String(`{"Type":"Expiration","Version":"1.0","Attributes":{"Timestamp":"2024-01-01T00:00:00.000Z"}}`)},
+				},
+			},
+			req: &ssm.PutParameterInput{
+				Type:     ssmtypes.ParameterTypeString,
+				Tier:     ssmtypes.ParameterTierAdvanced,
+				Policies: aws.String(`[{"Type":"Expiration","Version":"1.0","Attributes":{"Timestamp":"2025-06-01T00:00:00.000Z"}}]`),
+			},
+			want: true,
+		},
+		"PoliciesUnchanged": {
+			meta: &ssmtypes.ParameterMetadata{
+				Type: ssmtypes.ParameterTypeString,
+				Tier: ssmtypes.ParameterTierAdvanced,
+				Policies: []ssmtypes.ParameterInlinePolicy{
+					{PolicyText: aws.String(`{"Type":"Expiration","Version":"1.0","Attributes":{"Timestamp":"2025-06-01T00:00:00.000Z"}}`)},
+				},
+			},
+			req: &ssm.PutParameterInput{
+				Type:     ssmtypes.ParameterTypeString,
+				Tier:     ssmtypes.ParameterTierAdvanced,
+				Policies: aws.String(`[{"Type":"Expiration","Version":"1.0","Attributes":{"Timestamp":"2025-06-01T00:00:00.000Z"}}]`),
+			},
+			want: false,
+		},
+		"PoliciesAddedToEmpty": {
+			meta: &ssmtypes.ParameterMetadata{
+				Type:     ssmtypes.ParameterTypeString,
+				Tier:     ssmtypes.ParameterTierAdvanced,
+				Policies: []ssmtypes.ParameterInlinePolicy{},
+			},
+			req: &ssm.PutParameterInput{
+				Type:     ssmtypes.ParameterTypeString,
+				Tier:     ssmtypes.ParameterTierAdvanced,
+				Policies: aws.String(`[{"Type":"Expiration","Version":"1.0","Attributes":{"Timestamp":"2025-06-01T00:00:00.000Z"}}]`),
+			},
+			want: true,
+		},
+		"NoPoliciesInReqIgnoresCurrentPolicies": {
+			meta: &ssmtypes.ParameterMetadata{
+				Type: ssmtypes.ParameterTypeString,
+				Tier: ssmtypes.ParameterTierAdvanced,
+				Policies: []ssmtypes.ParameterInlinePolicy{
+					{PolicyText: aws.String(`{"Type":"Expiration","Version":"1.0","Attributes":{"Timestamp":"2025-06-01T00:00:00.000Z"}}`)},
+				},
+			},
+			req: &ssm.PutParameterInput{
+				Type: ssmtypes.ParameterTypeString,
+				Tier: ssmtypes.ParameterTierAdvanced,
+			},
+			want: false,
+		},
+		"PoliciesInvalidJSONTreatedAsChanged": {
+			meta: &ssmtypes.ParameterMetadata{
+				Type:     ssmtypes.ParameterTypeString,
+				Policies: []ssmtypes.ParameterInlinePolicy{},
+			},
+			req: &ssm.PutParameterInput{
+				Type:     ssmtypes.ParameterTypeString,
+				Policies: aws.String(`not-valid-json`),
+			},
+			want: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := hasParameterMetadataChanged(tc.meta, tc.req)
+			assert.Equal(t, tc.want, got)
+		})
+	}
 }
 
 // test the ssm<->aws interface

--- a/providers/v1/aws/parameterstore/parameterstore_test.go
+++ b/providers/v1/aws/parameterstore/parameterstore_test.go
@@ -40,8 +40,9 @@ import (
 )
 
 const (
-	errInvalidProperty = "key INVALPROP does not exist in secret"
-	invalidProp        = "INVALPROP"
+	errInvalidProperty        = "key INVALPROP does not exist in secret"
+	invalidProp               = "INVALPROP"
+	defaultManagedDescription = "secret 'managed-by:external-secrets'"
 )
 
 var (
@@ -769,7 +770,7 @@ func TestPushSecretCalledOnlyOnce(t *testing.T) {
 			Value: &fakeValue,
 		},
 	}
-	defaultDescription := "secret 'managed-by:external-secrets'"
+	defaultDescription := defaultManagedDescription
 	describeParameterOutput := &ssm.DescribeParametersOutput{
 		Parameters: []ssmtypes.ParameterMetadata{
 			{
@@ -803,7 +804,7 @@ func TestPushSecretCalledOnlyOnce(t *testing.T) {
 // TestPushSecretMetadataChange tests that PutParameter is (or is not) called when the
 // secret value is unchanged but metadata fields differ.
 func TestPushSecretMetadataChange(t *testing.T) {
-	defaultDescription := "secret 'managed-by:external-secrets'"
+	defaultDescription := defaultManagedDescription
 	managedByESO := ssmtypes.Tag{Key: &managedBy, Value: &externalSecrets}
 
 	fakeSecret := &corev1.Secret{
@@ -817,12 +818,12 @@ func TestPushSecretMetadataChange(t *testing.T) {
 	}
 
 	type testCase struct {
-		reason             string
-		describeOutput     *ssm.DescribeParametersOutput
-		describeErr        error
-		metadata           *apiextensionsv1.JSON
-		wantErr            string
-		wantPutParameterN  int
+		reason            string
+		describeOutput    *ssm.DescribeParametersOutput
+		describeErr       error
+		metadata          *apiextensionsv1.JSON
+		wantErr           string
+		wantPutParameterN int
 	}
 
 	tests := map[string]testCase{
@@ -1012,10 +1013,10 @@ func TestPushSecretMetadataChange(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			client := fakeps.Client{
-				PutParameterFn:        fakeps.NewPutParameterFn(&ssm.PutParameterOutput{}, nil),
-				GetParameterFn:        fakeps.NewGetParameterFn(validGetParameterOutput, nil),
-				DescribeParametersFn:  fakeps.NewDescribeParametersFn(tc.describeOutput, tc.describeErr),
-				ListTagsForResourceFn: fakeps.NewListTagsForResourceFn(validListTagsForResourceOutput, nil),
+				PutParameterFn:           fakeps.NewPutParameterFn(&ssm.PutParameterOutput{}, nil),
+				GetParameterFn:           fakeps.NewGetParameterFn(validGetParameterOutput, nil),
+				DescribeParametersFn:     fakeps.NewDescribeParametersFn(tc.describeOutput, tc.describeErr),
+				ListTagsForResourceFn:    fakeps.NewListTagsForResourceFn(validListTagsForResourceOutput, nil),
 				RemoveTagsFromResourceFn: fakeps.NewRemoveTagsFromResourceFn(&ssm.RemoveTagsFromResourceOutput{}, nil),
 				AddTagsToResourceFn:      fakeps.NewAddTagsToResourceFn(&ssm.AddTagsToResourceOutput{}, nil),
 			}
@@ -1038,7 +1039,7 @@ func TestPushSecretMetadataChange(t *testing.T) {
 }
 
 func TestHasParameterMetadataChanged(t *testing.T) {
-	defaultDescription := "secret 'managed-by:external-secrets'"
+	defaultDescription := defaultManagedDescription
 
 	tests := map[string]struct {
 		meta *ssmtypes.ParameterMetadata
@@ -1561,7 +1562,7 @@ func TestConstructMetadataWithDefaults(t *testing.T) {
 			input: nil,
 			expected: &metadata.PushSecretMetadata[PushSecretMetadataSpec]{
 				Spec: PushSecretMetadataSpec{
-					Description: "secret 'managed-by:external-secrets'",
+					Description: defaultManagedDescription,
 					Tier: Tier{
 						Type: "Standard",
 					},

--- a/providers/v1/aws/parameterstore/parameterstore_test.go
+++ b/providers/v1/aws/parameterstore/parameterstore_test.go
@@ -973,21 +973,6 @@ func TestPushSecretMetadataChange(t *testing.T) {
 			wantErr:           "",
 			wantPutParameterN: 1,
 		},
-		"SetSecretTierDowngradeAdvancedToStandard": {
-			reason: "error returned and no PutParameter when trying to downgrade from Advanced to Standard tier",
-			describeOutput: &ssm.DescribeParametersOutput{
-				Parameters: []ssmtypes.ParameterMetadata{
-					{
-						Type:        ssmtypes.ParameterTypeString,
-						Description: aws.String(defaultDescription),
-						Tier:        ssmtypes.ParameterTierAdvanced,
-					},
-				},
-			},
-			// No metadata - defaults to Standard tier, triggering the downgrade guard.
-			wantErr:           "cannot downgrade",
-			wantPutParameterN: 0,
-		},
 		"SetSecretTierKeepAdvanced": {
 			reason: "no PutParameter when current and desired tier are both Advanced and metadata is unchanged",
 			describeOutput: &ssm.DescribeParametersOutput{

--- a/providers/v1/aws/secretsmanager/fake/fake.go
+++ b/providers/v1/aws/secretsmanager/fake/fake.go
@@ -48,6 +48,9 @@ type Client struct {
 	DeleteResourcePolicyFn         DeleteResourcePolicyFn
 	ReplicateSecretToRegionsFn     ReplicateSecretToRegionsFn
 	RemoveRegionsFromReplicationFn RemoveRegionsFromReplicationFn
+	UpdateSecretFn                 UpdateSecretFn
+	UpdateSecretCalledN            int
+	UpdateSecretFnCalledWith       [][]*awssm.UpdateSecretInput
 }
 type (
 	CreateSecretFn        func(context.Context, *awssm.CreateSecretInput, ...func(*awssm.Options)) (*awssm.CreateSecretOutput, error)
@@ -71,6 +74,8 @@ type (
 	ReplicateSecretToRegionsFn     func(context.Context, *awssm.ReplicateSecretToRegionsInput, ...func(*awssm.Options)) (*awssm.ReplicateSecretToRegionsOutput, error)
 	RemoveRegionsFromReplicationFn func(context.Context, *awssm.RemoveRegionsFromReplicationInput, ...func(*awssm.Options)) (*awssm.RemoveRegionsFromReplicationOutput, error)
 )
+
+type UpdateSecretFn func(context.Context, *awssm.UpdateSecretInput, ...func(*awssm.Options)) (*awssm.UpdateSecretOutput, error)
 
 func (sm *Client) CreateSecret(ctx context.Context, input *awssm.CreateSecretInput, options ...func(*awssm.Options)) (*awssm.CreateSecretOutput, error) {
 	return sm.CreateSecretFn(ctx, input, options...)
@@ -310,4 +315,16 @@ func (sm *Client) RemoveRegionsFromReplication(
 	optFns ...func(*awssm.Options),
 ) (*awssm.RemoveRegionsFromReplicationOutput, error) {
 	return sm.RemoveRegionsFromReplicationFn(ctx, params, optFns...)
+}
+
+func (sm *Client) UpdateSecret(ctx context.Context, input *awssm.UpdateSecretInput, opts ...func(*awssm.Options)) (*awssm.UpdateSecretOutput, error) {
+	sm.UpdateSecretCalledN++
+	sm.UpdateSecretFnCalledWith = append(sm.UpdateSecretFnCalledWith, []*awssm.UpdateSecretInput{input})
+	return sm.UpdateSecretFn(ctx, input, opts...)
+}
+
+func NewUpdateSecretFn(output *awssm.UpdateSecretOutput, err error) UpdateSecretFn {
+	return func(_ context.Context, _ *awssm.UpdateSecretInput, _ ...func(*awssm.Options)) (*awssm.UpdateSecretOutput, error) {
+		return output, err
+	}
 }

--- a/providers/v1/aws/secretsmanager/secretsmanager.go
+++ b/providers/v1/aws/secretsmanager/secretsmanager.go
@@ -724,7 +724,7 @@ func (sm *SecretsManager) reconcileTags(ctx context.Context, secretArn string, p
 // isDefaultKMSKey reports whether kmsKeyID represents the AWS-managed default
 // KMS key for Secrets Manager. Per the DescribeSecret API, the KmsKeyId field
 // is omitted (empty) when the default key is in use. The alias short-form and
-// its full ARN are also recognised for completeness.
+// its full ARN are also recognized for completeness.
 func isDefaultKMSKey(kmsKeyID string) bool {
 	switch {
 	case kmsKeyID == "":

--- a/providers/v1/aws/secretsmanager/secretsmanager.go
+++ b/providers/v1/aws/secretsmanager/secretsmanager.go
@@ -114,13 +114,16 @@ type SMInterface interface {
 	DeleteResourcePolicy(ctx context.Context, params *awssm.DeleteResourcePolicyInput, optFuncs ...func(*awssm.Options)) (*awssm.DeleteResourcePolicyOutput, error)
 	ReplicateSecretToRegions(ctx context.Context, params *awssm.ReplicateSecretToRegionsInput, optFuncs ...func(*awssm.Options)) (*awssm.ReplicateSecretToRegionsOutput, error)
 	RemoveRegionsFromReplication(ctx context.Context, params *awssm.RemoveRegionsFromReplicationInput, optFuncs ...func(*awssm.Options)) (*awssm.RemoveRegionsFromReplicationOutput, error)
+	UpdateSecret(ctx context.Context, params *awssm.UpdateSecretInput, optFuncs ...func(*awssm.Options)) (*awssm.UpdateSecretOutput, error)
 }
 
 const (
 	errUnexpectedFindOperator = "unexpected find operator"
+	errFailedToParseMetadata  = "failed to parse metadata: %w"
 	managedBy                 = "managed-by"
 	externalSecrets           = "external-secrets"
 	initialVersion            = "00000000-0000-0000-0000-000000000001"
+	defaultKMSKeyID           = "alias/aws/secretsmanager"
 )
 
 var log = ctrl.Log.WithName("provider").WithName("aws").WithName("secretsmanager")
@@ -630,11 +633,23 @@ func (sm *SecretsManager) putSecretValueWithContext(
 	value []byte,
 	describeSecret *awssm.DescribeSecretOutput,
 ) error {
-	currentTags := make(map[string]string, len(describeSecret.Tags))
-	for _, tag := range describeSecret.Tags {
-		currentTags[*tag.Key] = *tag.Value
+	valueUnchanged := awsSecret != nil && (bytes.Equal(awsSecret.SecretBinary, value) ||
+		esutils.CompareStringAndByteSlices(awsSecret.SecretString, value))
+
+	var err error
+	if valueUnchanged {
+		// Value is the same — reconcile Description / KMSKeyID if they changed.
+		err = sm.reconcileSecretMetadata(ctx, secretArn, psd, describeSecret)
+	} else {
+		err = sm.pushSecretValue(ctx, secretArn, awsSecret, psd, value)
 	}
-	if err := sm.patchTags(ctx, psd.GetMetadata(), &secretArn, currentTags); err != nil {
+	if err != nil {
+		return err
+	}
+
+	// Reconcile tags, resource policy, and region replication on every push,
+	// regardless of whether the secret value changed.
+	if err := sm.reconcileTags(ctx, secretArn, psd, describeSecret); err != nil {
 		return err
 	}
 
@@ -642,14 +657,11 @@ func (sm *SecretsManager) putSecretValueWithContext(
 		return err
 	}
 
-	if err := sm.manageRegionReplication(ctx, psd.GetMetadata(), &secretArn, describeSecret.KmsKeyId, describeSecret.ReplicationStatus); err != nil {
-		return err
-	}
+	return sm.manageRegionReplication(ctx, psd.GetMetadata(), &secretArn, describeSecret.KmsKeyId, describeSecret.ReplicationStatus)
+}
 
-	if awsSecret != nil && (bytes.Equal(awsSecret.SecretBinary, value) || esutils.CompareStringAndByteSlices(awsSecret.SecretString, value)) {
-		return nil
-	}
-
+// pushSecretValue writes a new version of the secret value.
+func (sm *SecretsManager) pushSecretValue(ctx context.Context, secretArn string, awsSecret *awssm.GetSecretValueOutput, psd esv1.PushSecretData, value []byte) error {
 	newVersionNumber := initialVersion
 	if awsSecret != nil {
 		if sm.newUUID == nil {
@@ -665,7 +677,7 @@ func (sm *SecretsManager) putSecretValueWithContext(
 	}
 	secretPushFormat, err := esutils.FetchValueFromMetadata(SecretPushFormatKey, psd.GetMetadata(), SecretPushFormatBinary)
 	if err != nil {
-		return fmt.Errorf("failed to parse metadata: %w", err)
+		return fmt.Errorf(errFailedToParseMetadata, err)
 	}
 	if secretPushFormat == SecretPushFormatString {
 		input.SecretBinary = nil
@@ -675,6 +687,80 @@ func (sm *SecretsManager) putSecretValueWithContext(
 	_, err = sm.client.PutSecretValue(ctx, input)
 	metrics.ObserveAPICall(constants.ProviderAWSSM, constants.CallAWSSMPutSecretValue, err)
 	return err
+}
+
+// reconcileSecretMetadata updates the secret's Description or KMSKeyID when the
+// value is unchanged but the desired metadata differs from the current state.
+func (sm *SecretsManager) reconcileSecretMetadata(ctx context.Context, secretArn string, psd esv1.PushSecretData, describeSecret *awssm.DescribeSecretOutput) error {
+	meta, err := sm.constructMetadataWithDefaults(psd.GetMetadata())
+	if err != nil {
+		return fmt.Errorf(errFailedToParseMetadata, err)
+	}
+	if describeSecret == nil || !hasSecretMetadataChanged(describeSecret, meta.Spec.Description, meta.Spec.KMSKeyID) {
+		return nil
+	}
+
+	_, err = sm.client.UpdateSecret(ctx, &awssm.UpdateSecretInput{
+		SecretId:    &secretArn,
+		Description: aws.String(meta.Spec.Description),
+		KmsKeyId:    aws.String(meta.Spec.KMSKeyID),
+	})
+	metrics.ObserveAPICall(constants.ProviderAWSSM, constants.CallAWSSMUpdateSecret, err)
+	if err != nil {
+		return fmt.Errorf("error updating metadata for secret %v: %w", secretArn, err)
+	}
+	return nil
+}
+
+// reconcileTags syncs the secret's tags with the desired metadata state.
+func (sm *SecretsManager) reconcileTags(ctx context.Context, secretArn string, psd esv1.PushSecretData, describeSecret *awssm.DescribeSecretOutput) error {
+	currentTags := make(map[string]string, len(describeSecret.Tags))
+	for _, tag := range describeSecret.Tags {
+		currentTags[*tag.Key] = *tag.Value
+	}
+	return sm.patchTags(ctx, psd.GetMetadata(), &secretArn, currentTags)
+}
+
+// isDefaultKMSKey reports whether kmsKeyID represents the AWS-managed default
+// KMS key for Secrets Manager. Per the DescribeSecret API, the KmsKeyId field
+// is omitted (empty) when the default key is in use. The alias short-form and
+// its full ARN are also recognised for completeness.
+func isDefaultKMSKey(kmsKeyID string) bool {
+	switch {
+	case kmsKeyID == "":
+		// AWS omits the field when the default key is in use.
+		return true
+	case kmsKeyID == defaultKMSKeyID: // "alias/aws/secretsmanager"
+		return true
+	case kmsKeyID == "aws/secretsmanager":
+		return true
+	case strings.HasSuffix(kmsKeyID, ":alias/aws/secretsmanager"):
+		// Full ARN form: "arn:aws:kms:<region>:<account>:alias/aws/secretsmanager"
+		return true
+	default:
+		return false
+	}
+}
+
+// hasSecretMetadataChanged reports whether Description or KMSKeyID differ from the
+// current secret state captured in describe.
+func hasSecretMetadataChanged(describe *awssm.DescribeSecretOutput, desiredDescription, desiredKMSKeyID string) bool {
+	if aws.ToString(describe.Description) != desiredDescription {
+		return true
+	}
+	currentKMSKeyID := aws.ToString(describe.KmsKeyId)
+	if desiredKMSKeyID == defaultKMSKeyID {
+		// Transitioning to (or staying at) the default key: trigger an update
+		// only when the current key is not already the default.
+		if !isDefaultKMSKey(currentKMSKeyID) {
+			return true
+		}
+	} else {
+		if currentKMSKeyID != desiredKMSKeyID {
+			return true
+		}
+	}
+	return false
 }
 
 func (sm *SecretsManager) patchTags(ctx context.Context, rawMetadata *apiextensionsv1.JSON, secretID *string, tags map[string]string) error {
@@ -820,7 +906,7 @@ func (sm *SecretsManager) constructMetadataWithDefaults(data *apiextensionsv1.JS
 
 	meta, err = metadata.ParseMetadataParameters[PushSecretMetadataSpec](data)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse metadata: %w", err)
+		return nil, fmt.Errorf(errFailedToParseMetadata, err)
 	}
 
 	if meta == nil {
@@ -838,7 +924,7 @@ func (sm *SecretsManager) constructMetadataWithDefaults(data *apiextensionsv1.JS
 	}
 
 	if meta.Spec.KMSKeyID == "" {
-		meta.Spec.KMSKeyID = "alias/aws/secretsmanager"
+		meta.Spec.KMSKeyID = defaultKMSKeyID
 	}
 
 	if len(meta.Spec.Tags) > 0 {

--- a/providers/v1/aws/secretsmanager/secretsmanager_test.go
+++ b/providers/v1/aws/secretsmanager/secretsmanager_test.go
@@ -487,8 +487,9 @@ func TestSetSecret(t *testing.T) {
 	defaultVersion := testDefaultVersion
 
 	tagSecretOutput := &awssm.DescribeSecretOutput{
-		ARN:  &arn,
-		Tags: externalSecretsTag,
+		ARN:         &arn,
+		Tags:        externalSecretsTag,
+		Description: aws.String("secret 'managed-by:external-secrets'"),
 		VersionIdsToStages: map[string][]string{
 			defaultVersion: {"AWSCURRENT"},
 		},
@@ -1490,6 +1491,7 @@ func TestPushSecretTagsUpdatedWhenValueUnchanged(t *testing.T) {
 			capturedTagInput = input
 		}),
 		UntagResourceFn:        fakesm.NewUntagResourceFn(&awssm.UntagResourceOutput{}, nil),
+		UpdateSecretFn:         fakesm.NewUpdateSecretFn(&awssm.UpdateSecretOutput{}, nil),
 		DeleteResourcePolicyFn: fakesm.NewDeleteResourcePolicyFn(&awssm.DeleteResourcePolicyOutput{}, nil),
 	}
 
@@ -1562,6 +1564,7 @@ func TestPushSecretResourcePolicyUpdatedWhenValueUnchanged(t *testing.T) {
 		},
 		TagResourceFn:          fakesm.NewTagResourceFn(&awssm.TagResourceOutput{}, nil),
 		UntagResourceFn:        fakesm.NewUntagResourceFn(&awssm.UntagResourceOutput{}, nil),
+		UpdateSecretFn:         fakesm.NewUpdateSecretFn(&awssm.UpdateSecretOutput{}, nil),
 		DeleteResourcePolicyFn: fakesm.NewDeleteResourcePolicyFn(&awssm.DeleteResourcePolicyOutput{}, nil),
 		GetResourcePolicyFn: fakesm.NewGetResourcePolicyFn(&awssm.GetResourcePolicyOutput{
 			ResourcePolicy: &existingPolicy,
@@ -1652,6 +1655,7 @@ func TestPushSecretEmptyExistingResourcePolicy(t *testing.T) {
 		PutSecretValueFn:    fakesm.NewPutSecretValueFn(&awssm.PutSecretValueOutput{}, nil),
 		TagResourceFn:       fakesm.NewTagResourceFn(&awssm.TagResourceOutput{}, nil),
 		UntagResourceFn:     fakesm.NewUntagResourceFn(&awssm.UntagResourceOutput{}, nil),
+		UpdateSecretFn:      fakesm.NewUpdateSecretFn(&awssm.UpdateSecretOutput{}, nil),
 		GetResourcePolicyFn: fakesm.NewGetResourcePolicyFn(&awssm.GetResourcePolicyOutput{}, nil),
 		PutResourcePolicyFn: fakesm.NewPutResourcePolicyFn(&awssm.PutResourcePolicyOutput{}, nil, func(input *awssm.PutResourcePolicyInput) {
 			putResourcePolicyCalled = true
@@ -1968,6 +1972,256 @@ func TestDeleteSecret(t *testing.T) {
 		})
 	}
 }
+func TestSetSecretMetadataChange(t *testing.T) {
+	ctx := context.Background()
+	arn := "arn:aws:secretsmanager:us-east-1:702902267788:secret:test-metadata"
+	secretValue := []byte("same-value")
+
+	managedByKey := managedBy
+	externalSecretsVal := externalSecrets
+	defaultDescription := fmt.Sprintf("secret '%s:%s'", managedBy, externalSecrets)
+
+	externalSecretsTag := []types.Tag{
+		{Key: &managedByKey, Value: &externalSecretsVal},
+	}
+
+	// Existing secret with the same binary value — triggers the valueUnchanged path.
+	existingSecret := &awssm.GetSecretValueOutput{
+		ARN:          &arn,
+		SecretBinary: secretValue,
+	}
+
+	psd := fake.PushSecretData{
+		SecretKey: "secret-key",
+		RemoteKey: "test-metadata",
+	}
+
+	fakeSecret := &corev1.Secret{
+		Data: map[string][]byte{
+			"secret-key": secretValue,
+		},
+	}
+
+	tests := map[string]struct {
+		describe            *awssm.DescribeSecretOutput
+		metadata            *apiextensionsv1.JSON
+		setupClient         func(*fakesm.Client)
+		expectUpdateCalledN int
+		wantErr             string
+	}{
+		"SameValueMetadataUnchanged": {
+			describe: &awssm.DescribeSecretOutput{
+				ARN:         &arn,
+				Tags:        externalSecretsTag,
+				Description: aws.String(defaultDescription),
+				VersionIdsToStages: map[string][]string{
+					"version1": {"AWSCURRENT"},
+				},
+			},
+			setupClient: func(c *fakesm.Client) {
+				c.DeleteResourcePolicyFn = fakesm.NewDeleteResourcePolicyFn(&awssm.DeleteResourcePolicyOutput{}, nil)
+			},
+			expectUpdateCalledN: 0,
+		},
+		"SameValueDescriptionChanged": {
+			describe: &awssm.DescribeSecretOutput{
+				ARN:         &arn,
+				Tags:        externalSecretsTag,
+				Description: aws.String("old description"),
+				VersionIdsToStages: map[string][]string{
+					"version1": {"AWSCURRENT"},
+				},
+			},
+			setupClient: func(c *fakesm.Client) {
+				c.UpdateSecretFn = fakesm.NewUpdateSecretFn(&awssm.UpdateSecretOutput{ARN: &arn}, nil)
+				c.DeleteResourcePolicyFn = fakesm.NewDeleteResourcePolicyFn(&awssm.DeleteResourcePolicyOutput{}, nil)
+			},
+			expectUpdateCalledN: 1,
+		},
+		"SameValueKMSKeyChanged": {
+			describe: &awssm.DescribeSecretOutput{
+				ARN:         &arn,
+				Tags:        externalSecretsTag,
+				Description: aws.String(defaultDescription),
+				KmsKeyId:    aws.String("old-key"),
+				VersionIdsToStages: map[string][]string{
+					"version1": {"AWSCURRENT"},
+				},
+			},
+			metadata: &apiextensionsv1.JSON{
+				Raw: []byte(`{
+					"apiVersion": "kubernetes.external-secrets.io/v1alpha1",
+					"kind": "PushSecretMetadata",
+					"spec": {
+						"kmsKeyId": "new-key-arn"
+					}
+				}`),
+			},
+			setupClient: func(c *fakesm.Client) {
+				c.UpdateSecretFn = fakesm.NewUpdateSecretFn(&awssm.UpdateSecretOutput{ARN: &arn}, nil)
+				c.DeleteResourcePolicyFn = fakesm.NewDeleteResourcePolicyFn(&awssm.DeleteResourcePolicyOutput{}, nil)
+			},
+			expectUpdateCalledN: 1,
+		},
+		"SameValueTagsChanged": {
+			describe: &awssm.DescribeSecretOutput{
+				ARN:         &arn,
+				Tags:        externalSecretsTag,
+				Description: aws.String(defaultDescription),
+				VersionIdsToStages: map[string][]string{
+					"version1": {"AWSCURRENT"},
+				},
+			},
+			metadata: &apiextensionsv1.JSON{
+				Raw: []byte(`{
+					"apiVersion": "kubernetes.external-secrets.io/v1alpha1",
+					"kind": "PushSecretMetadata",
+					"spec": {
+						"tags": {"new-tag": "new-value"}
+					}
+				}`),
+			},
+			setupClient: func(c *fakesm.Client) {
+				c.TagResourceFn = fakesm.NewTagResourceFn(&awssm.TagResourceOutput{}, nil)
+				c.DeleteResourcePolicyFn = fakesm.NewDeleteResourcePolicyFn(&awssm.DeleteResourcePolicyOutput{}, nil)
+			},
+			expectUpdateCalledN: 0,
+		},
+		"SameValueUpdateSecretError": {
+			describe: &awssm.DescribeSecretOutput{
+				ARN:         &arn,
+				Tags:        externalSecretsTag,
+				Description: aws.String("old description"),
+				VersionIdsToStages: map[string][]string{
+					"version1": {"AWSCURRENT"},
+				},
+			},
+			setupClient: func(c *fakesm.Client) {
+				c.UpdateSecretFn = fakesm.NewUpdateSecretFn(nil, errors.New("update failed"))
+			},
+			expectUpdateCalledN: 1,
+			wantErr:             "update failed",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			client := &fakesm.Client{}
+			tc.setupClient(client)
+
+			sm := &SecretsManager{
+				client: client,
+			}
+
+			psdCopy := psd
+			if tc.metadata != nil {
+				psdCopy.Metadata = tc.metadata
+			}
+
+			// Call PushSecret rather than the unexported function so we exercise
+			// the full path including DescribeSecret / GetSecretValue.
+			client.DescribeSecretFn = fakesm.NewDescribeSecretFn(tc.describe, nil)
+			client.GetSecretValueFn = fakesm.NewGetSecretValueFn(existingSecret, nil)
+
+			err := sm.PushSecret(ctx, fakeSecret, psdCopy)
+
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tc.expectUpdateCalledN, client.UpdateSecretCalledN,
+				"UpdateSecret call count mismatch for test %s", name)
+		})
+	}
+}
+
+func TestHasSecretMetadataChanged(t *testing.T) {
+	defaultDescription := fmt.Sprintf("secret '%s:%s'", managedBy, externalSecrets)
+
+	tests := map[string]struct {
+		describe           *awssm.DescribeSecretOutput
+		desiredDescription string
+		desiredKMSKeyID    string
+		want               bool
+	}{
+		"NothingChanged": {
+			describe: &awssm.DescribeSecretOutput{
+				Description: aws.String(defaultDescription),
+				KmsKeyId:    nil,
+			},
+			desiredDescription: defaultDescription,
+			desiredKMSKeyID:    defaultKMSKeyID,
+			want:               false,
+		},
+		"DescriptionChanged": {
+			describe: &awssm.DescribeSecretOutput{
+				Description: aws.String("old description"),
+			},
+			desiredDescription: defaultDescription,
+			desiredKMSKeyID:    defaultKMSKeyID,
+			want:               true,
+		},
+		"DefaultKMSKeyOmittedByAWS": {
+			describe: &awssm.DescribeSecretOutput{
+				Description: aws.String(defaultDescription),
+				// Per the DescribeSecret API, KmsKeyId is omitted when the default key is in use.
+				KmsKeyId: nil,
+			},
+			desiredDescription: defaultDescription,
+			desiredKMSKeyID:    defaultKMSKeyID,
+			want:               false,
+		},
+		"DefaultKMSKeyAliasARNReturnedByAWS": {
+			describe: &awssm.DescribeSecretOutput{
+				Description: aws.String(defaultDescription),
+				// Full ARN form of the default alias — still the default key, no update needed.
+				KmsKeyId: aws.String("arn:aws:kms:us-east-1:123456789012:alias/aws/secretsmanager"),
+			},
+			desiredDescription: defaultDescription,
+			desiredKMSKeyID:    defaultKMSKeyID,
+			want:               false,
+		},
+		"CustomKeyToDefault": {
+			describe: &awssm.DescribeSecretOutput{
+				Description: aws.String(defaultDescription),
+				// Secret was previously configured with a custom key.
+				KmsKeyId: aws.String("arn:aws:kms:us-east-1:123456789012:key/custom-key"),
+			},
+			desiredDescription: defaultDescription,
+			desiredKMSKeyID:    defaultKMSKeyID,
+			// Removing the custom key (reverting to default) must trigger UpdateSecret.
+			want: true,
+		},
+		"NonDefaultKMSKeyChanged": {
+			describe: &awssm.DescribeSecretOutput{
+				Description: aws.String(defaultDescription),
+				KmsKeyId:    aws.String("old-key-arn"),
+			},
+			desiredDescription: defaultDescription,
+			desiredKMSKeyID:    "new-key-arn",
+			want:               true,
+		},
+		"NonDefaultKMSKeySame": {
+			describe: &awssm.DescribeSecretOutput{
+				Description: aws.String(defaultDescription),
+				KmsKeyId:    aws.String("my-custom-key"),
+			},
+			desiredDescription: defaultDescription,
+			desiredKMSKeyID:    "my-custom-key",
+			want:               false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := hasSecretMetadataChanged(tc.describe, tc.desiredDescription, tc.desiredKMSKeyID)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func makeValidSecretStore() *esv1.SecretStore {
 	return &esv1.SecretStore{
 		ObjectMeta: metav1.ObjectMeta{

--- a/runtime/constants/constants.go
+++ b/runtime/constants/constants.go
@@ -35,6 +35,7 @@ const (
 	CallAWSSMDeleteResourcePolicy         = "DeleteResourcePolicy"
 	CallAWSSMReplicateSecretToRegions     = "ReplicateSecretToRegions"
 	CallAWSSMRemoveRegionsFromReplication = "RemoveRegionsFromReplication"
+	CallAWSSMUpdateSecret                 = "UpdateSecret"
 	ProviderAWSPS                         = "AWS/ParameterStore"
 
 	CallAWSPSGetParameter        = "GetParameter"


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?

https://github.com/external-secrets/external-secrets/issues/5302

## Related Issue

Fixes # https://github.com/external-secrets/external-secrets/issues/5302

## Proposed Changes

How do you like to solve the issue and why?

Check metadata for potential updates.

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds metadata-aware reconciliation for AWS Parameter Store and Secrets Manager to avoid unnecessary Put/Update calls when only metadata differs; implements metadata fetching, comparison, and update paths. Expands fakes, constants, docs, and tests to cover metadata-driven behavior. Fixes #5302.

## Changes

providers/v1/aws/parameterstore/parameterstore.go
- When an existing parameter's value matches the desired value, fetches ParameterMetadata (DescribeParameters) and compares it to the desired PutParameterInput; skips PutParameter if metadata is unchanged.
- Added helpers: fetchParameterMetadata(ctx, name), hasParameterMetadataChanged(meta, req), and policiesChanged(desired, current).

providers/v1/aws/parameterstore/parameterstore_test.go
- Added TestPushSecretMetadataChange and TestHasParameterMetadataChanged; test scaffolding updated to use DescribeParameters outputs and cover metadata/no-op and error scenarios.

providers/v1/aws/secretsmanager/secretsmanager.go
- Added SMInterface.UpdateSecret and logic to call UpdateSecret when secret metadata (Description, KMSKeyID, tags) changes while the secret value is unchanged.
- Refactored push flow to accept DescribeSecretOutput for metadata comparisons; added hasSecretMetadataChanged and default KMS key handling.

providers/v1/aws/secretsmanager/fake/fake.go
- Added UpdateSecretFn, call counters, and argument capture to the fake Secrets Manager client to support testing UpdateSecret invocations.

providers/v1/aws/secretsmanager/secretsmanager_test.go
- Added TestSetSecretMetadataChange and TestHasSecretMetadataChanged; tests cover description, KMS key defaulting, tags, policy handling, and related update flows. Extended test fakes for UntagResource and DeleteResourcePolicy.

runtime/constants/constants.go
- Added CallAWSSMUpdateSecret = "UpdateSecret" constant.

docs/provider/aws-secrets-manager.md
- Updated IAM policy examples and note to include secretsmanager:UpdateSecret and secretsmanager:UntagResource (required to update Description/KMSKeyID or untag) in PushSecret permissions.

Tests
- New and updated tests exercise metadata comparison and update behavior for both Parameter Store and Secrets Manager.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->