### PR TITLE
docs: Oracle Vault provider capabilities

### DIFF
--- a/docs/introduction/stability-support.md
+++ b/docs/introduction/stability-support.md
@@ -95,7 +95,7 @@ The following table describes the stability level of each provider and who's res
 The following table show the support for features across different providers.
 
 | Provider                  | find by name | find by tags | metadataPolicy Fetch | referent authentication | store validation | push secret | DeletionPolicy Merge/Delete |
-| ------------------------- | :----------: | :----------: | :------------------: | :---------------------: | :--------------: | :---------: | :-------------------------: |
+| ------------------------- |:------------:|:------------:| :------------------: | :---------------------: | :--------------: |:-----------:|:---------------------------:|
 | AWS Secrets Manager       |      x       |      x       |          x           |            x            |        x         |      x      |              x              |
 | AWS Parameter Store       |      x       |      x       |          x           |            x            |        x         |      x      |              x              |
 | Hashicorp Vault           |      x       |      x       |          x           |            x            |        x         |      x      |              x              |
@@ -105,7 +105,7 @@ The following table show the support for features across different providers.
 | IBM Cloud Secrets Manager |      x       |              |          x           |                         |        x         |             |                             |
 | Yandex Lockbox            |              |              |                      |                         |        x         |             |                             |
 | GitLab Variables          |      x       |      x       |                      |                         |        x         |             |                             |
-| Oracle Vault              |              |              |                      |                         |        x         |             |                             |
+| Oracle Vault              |      x       |      x       |                      |                         |        x         |      x      |              x              |
 | Akeyless                  |      x       |      x       |                      |            x            |        x         |      x      |              x              |
 | 1Password                 |      x       |      x       |                      |                         |        x         |      x      |              x              |
 | 1Password SDK             |              |              |                      |                         |        x         |      x      |              x              |

--- a/providers/v1/oracle/oracle.go
+++ b/providers/v1/oracle/oracle.go
@@ -289,7 +289,7 @@ func (vms *VaultManagementService) GetSecretMap(ctx context.Context, ref esv1.Ex
 
 // Capabilities return the provider supported capabilities (ReadOnly, WriteOnly, ReadWrite).
 func (vms *VaultManagementService) Capabilities() esv1.SecretStoreCapabilities {
-	return esv1.SecretStoreReadOnly
+	return esv1.SecretStoreReadWrite
 }
 
 // NewClient constructs a new secrets client based on the provided store.


### PR DESCRIPTION
## Problem Statement
The Oracle provider supported features and capabilities method are outdated. 

## Related Issue

N/A

## Proposed Changes

Update the docs and provider capabilities to accurately reflect the oracle provider

## Checklist

- [x ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x ] All commits are signed with `git commit --signoff`
- [ x] My changes have reasonable test coverage
- [ x] All tests pass with `make test`
- [ x] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Updated Oracle Provider Capabilities

**Changes:**

1. **providers/v1/oracle/oracle.go**: Updated the `Capabilities()` method to return `SecretStoreReadWrite` instead of `SecretStoreReadOnly`, reflecting that the Oracle Vault provider now supports both read and write operations.

2. **docs/introduction/stability-support.md**: Updated the Provider Feature Support table to reflect the expanded capabilities of the Oracle Vault provider and other providers, with formatting improvements to the table structure.

These changes bring the Oracle provider's documented capabilities and implementation in line with its actual read-write functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->