### PR TITLE
chore: remove the 20 default for the linter and update it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   # Common versions
-  GOLANGCI_VERSION: 'v2.4.0'
+  GOLANGCI_VERSION: 'v2.11.3'
   KUBERNETES_VERSION: '1.33.x'
 
   # Sonar

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ lint: golangci-lint ## Run golangci-lint (set LINT_TARGET to run on specific mod
 		$(OK) Finished linting $(LINT_TARGET); \
 	else \
 		$(INFO) Running golangci-lint on all modules in parallel; \
-		JOBS=$${LINT_JOBS:-20}; \
+		JOBS=$${LINT_JOBS:-1}; \
 		TMPDIR=$$(mktemp -d); \
 		GOLANGCI=$(GOLANGCI_LINT); \
 		trap "rm -rf $$TMPDIR" EXIT; \
@@ -428,7 +428,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 LINT_TARGET ?= ""
 ## Tool Versions
-GOLANGCI_VERSION := 2.4.0
+GOLANGCI_VERSION := 2.11.3
 KUBERNETES_VERSION := 1.33.x
 TILT_VERSION := 0.33.21
 CTY_VERSION := 1.1.3

--- a/apis/externalsecrets/v1/clusterexternalsecret_types.go
+++ b/apis/externalsecrets/v1/clusterexternalsecret_types.go
@@ -39,6 +39,7 @@ type ClusterExternalSecretSpec struct {
 	ExternalSecretMetadata ExternalSecretMetadata `json:"externalSecretMetadata,omitempty"`
 
 	// The labels to select by to find the Namespaces to create the ExternalSecrets in.
+	//
 	// Deprecated: Use NamespaceSelectors instead.
 	// +optional
 	NamespaceSelector *metav1.LabelSelector `json:"namespaceSelector,omitempty"`
@@ -48,6 +49,7 @@ type ClusterExternalSecretSpec struct {
 	NamespaceSelectors []*metav1.LabelSelector `json:"namespaceSelectors,omitempty"`
 
 	// Choose namespaces by name. This field is ORed with anything that NamespaceSelectors ends up choosing.
+	//
 	// Deprecated: Use NamespaceSelectors instead.
 	// +optional
 	// +kubebuilder:validation:items:MinLength:=1

--- a/apis/externalsecrets/v1/secretstore_vault_types.go
+++ b/apis/externalsecrets/v1/secretstore_vault_types.go
@@ -289,6 +289,7 @@ type VaultKubernetesServiceAccountTokenAuth struct {
 	// Optional audiences field that will be used to request a temporary Kubernetes service
 	// account token for the service account referenced by `serviceAccountRef`.
 	// Defaults to a single audience `vault` it not specified.
+	//
 	// Deprecated: use serviceAccountRef.Audiences instead
 	// +optional
 	Audiences *[]string `json:"audiences,omitempty"`
@@ -296,6 +297,7 @@ type VaultKubernetesServiceAccountTokenAuth struct {
 	// Optional expiration time in seconds that will be used to request a temporary
 	// Kubernetes service account token for the service account referenced by
 	// `serviceAccountRef`.
+	//
 	// Deprecated: this will be removed in the future.
 	// Defaults to 10 minutes.
 	// +optional

--- a/apis/externalsecrets/v1beta1/clusterexternalsecret_types.go
+++ b/apis/externalsecrets/v1beta1/clusterexternalsecret_types.go
@@ -46,6 +46,7 @@ type ClusterExternalSecretSpec struct {
 	NamespaceSelectors []*metav1.LabelSelector `json:"namespaceSelectors,omitempty"`
 
 	// Choose namespaces by name. This field is ORed with anything that NamespaceSelectors ends up choosing.
+	//
 	// Deprecated: Use NamespaceSelectors instead.
 	// +optional
 	// +kubebuilder:validation:items:MinLength:=1

--- a/apis/externalsecrets/v1beta1/secretstore_vault_types.go
+++ b/apis/externalsecrets/v1beta1/secretstore_vault_types.go
@@ -278,6 +278,7 @@ type VaultKubernetesServiceAccountTokenAuth struct {
 	// Optional audiences field that will be used to request a temporary Kubernetes service
 	// account token for the service account referenced by `serviceAccountRef`.
 	// Defaults to a single audience `vault` it not specified.
+	//
 	// Deprecated: use serviceAccountRef.Audiences instead
 	// +optional
 	Audiences *[]string `json:"audiences,omitempty"`
@@ -285,6 +286,7 @@ type VaultKubernetesServiceAccountTokenAuth struct {
 	// Optional expiration time in seconds that will be used to request a temporary
 	// Kubernetes service account token for the service account referenced by
 	// `serviceAccountRef`.
+	//
 	// Deprecated: this will be removed in the future.
 	// Defaults to 10 minutes.
 	// +optional

--- a/cmd/controller/certcontroller.go
+++ b/cmd/controller/certcontroller.go
@@ -53,7 +53,7 @@ var certcontrollerCmd = &cobra.Command{
 
 		// completely disable caching of Secrets and ConfigMaps to save memory
 		// see: https://github.com/external-secrets/external-secrets/issues/721
-		clientCacheDisableFor := make([]client.Object, 0)
+		clientCacheDisableFor := make([]client.Object, 0, 2)
 		clientCacheDisableFor = append(clientCacheDisableFor, &v1.Secret{}, &v1.ConfigMap{})
 
 		// in large clusters, the CRDs and ValidatingWebhookConfigurations can take up a lot of memory

--- a/cmd/esoctl/generator/bootstrap.go
+++ b/cmd/esoctl/generator/bootstrap.go
@@ -223,7 +223,7 @@ func updateRegisterFile(rootDir string, cfg Config) error {
 		return fmt.Errorf("failed to add import or register call to %s", registerFile)
 	}
 
-	if err := os.WriteFile(filepath.Clean(registerFile), []byte(strings.Join(newLines, "\n")), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Clean(registerFile), []byte(strings.Join(newLines, "\n")), 0o600); err != nil { //nolint:gosec // paths are constructed internally, not from user input
 		return err
 	}
 
@@ -307,7 +307,7 @@ func updateTypesClusterFile(rootDir string, cfg Config) error {
 				cfg.GeneratorName, cfg.GeneratorName, strings.ToLower(cfg.GeneratorName))
 		}
 	} else {
-		if err := os.WriteFile(filepath.Clean(typesClusterFile), []byte(strings.Join(newLines, "\n")), 0o600); err != nil {
+		if err := os.WriteFile(filepath.Clean(typesClusterFile), []byte(strings.Join(newLines, "\n")), 0o600); err != nil { //nolint:gosec // paths are constructed internally
 			return err
 		}
 		fmt.Printf("✓ Updated types_cluster.go\n")
@@ -370,7 +370,7 @@ func updateMainGoMod(rootDir string, cfg Config) error {
 		return fmt.Errorf("could not find appropriate position to insert replace directive")
 	}
 
-	if err := os.WriteFile(filepath.Clean(goModFile), []byte(strings.Join(newLines, "\n")), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Clean(goModFile), []byte(strings.Join(newLines, "\n")), 0o600); err != nil { //nolint:gosec // paths are constructed internally
 		return err
 	}
 
@@ -445,7 +445,7 @@ func updateResolverFile(rootDir string, cfg Config) error {
 		return fmt.Errorf("could not find default case in resolver file")
 	}
 
-	if err := os.WriteFile(filepath.Clean(resolverFile), []byte(strings.Join(newLines, "\n")), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Clean(resolverFile), []byte(strings.Join(newLines, "\n")), 0o600); err != nil { //nolint:gosec // paths are constructed internally
 		return err
 	}
 
@@ -511,7 +511,7 @@ func updateRegisterKindFile(rootDir string, cfg Config) error {
 			fmt.Printf("   2. Add SchemeBuilder registration: SchemeBuilder.Register(&%s{}, &%sList{})\n", cfg.GeneratorName, cfg.GeneratorName)
 		}
 	} else {
-		if err := os.WriteFile(filepath.Clean(registerFile), []byte(strings.Join(newLines, "\n")), 0o600); err != nil {
+		if err := os.WriteFile(filepath.Clean(registerFile), []byte(strings.Join(newLines, "\n")), 0o600); err != nil { //nolint:gosec // paths are constructed internally
 			return err
 		}
 		fmt.Printf("✓ Updated register.go\n")
@@ -563,7 +563,7 @@ func updateExternalSecretGeneratorRef(rootDir string, cfg Config) error {
 		return nil
 	}
 
-	if err := os.WriteFile(filepath.Clean(externalSecretFile), []byte(strings.Join(newLines, "\n")), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Clean(externalSecretFile), []byte(strings.Join(newLines, "\n")), 0o600); err != nil { //nolint:gosec // paths are constructed internally
 		return fmt.Errorf("failed to write v1 externalsecret_types.go: %w", err)
 	}
 

--- a/config/crds/bases/external-secrets.io_clusterexternalsecrets.yaml
+++ b/config/crds/bases/external-secrets.io_clusterexternalsecrets.yaml
@@ -711,6 +711,7 @@ spec:
               namespaceSelector:
                 description: |-
                   The labels to select by to find the Namespaces to create the ExternalSecrets in.
+
                   Deprecated: Use NamespaceSelectors instead.
                 properties:
                   matchExpressions:
@@ -812,6 +813,7 @@ spec:
               namespaces:
                 description: |-
                   Choose namespaces by name. This field is ORed with anything that NamespaceSelectors ends up choosing.
+
                   Deprecated: Use NamespaceSelectors instead.
                 items:
                   maxLength: 63
@@ -1604,6 +1606,7 @@ spec:
               namespaces:
                 description: |-
                   Choose namespaces by name. This field is ORed with anything that NamespaceSelectors ends up choosing.
+
                   Deprecated: Use NamespaceSelectors instead.
                 items:
                   maxLength: 63

--- a/config/crds/bases/external-secrets.io_clustersecretstores.yaml
+++ b/config/crds/bases/external-secrets.io_clustersecretstores.yaml
@@ -5125,6 +5125,7 @@ spec:
                                       Optional audiences field that will be used to request a temporary Kubernetes service
                                       account token for the service account referenced by `serviceAccountRef`.
                                       Defaults to a single audience `vault` it not specified.
+
                                       Deprecated: use serviceAccountRef.Audiences instead
                                     items:
                                       type: string
@@ -5134,6 +5135,7 @@ spec:
                                       Optional expiration time in seconds that will be used to request a temporary
                                       Kubernetes service account token for the service account referenced by
                                       `serviceAccountRef`.
+
                                       Deprecated: this will be removed in the future.
                                       Defaults to 10 minutes.
                                     format: int64
@@ -9812,6 +9814,7 @@ spec:
                                       Optional audiences field that will be used to request a temporary Kubernetes service
                                       account token for the service account referenced by `serviceAccountRef`.
                                       Defaults to a single audience `vault` it not specified.
+
                                       Deprecated: use serviceAccountRef.Audiences instead
                                     items:
                                       type: string
@@ -9821,6 +9824,7 @@ spec:
                                       Optional expiration time in seconds that will be used to request a temporary
                                       Kubernetes service account token for the service account referenced by
                                       `serviceAccountRef`.
+
                                       Deprecated: this will be removed in the future.
                                       Defaults to 10 minutes.
                                     format: int64

--- a/config/crds/bases/external-secrets.io_secretstores.yaml
+++ b/config/crds/bases/external-secrets.io_secretstores.yaml
@@ -5125,6 +5125,7 @@ spec:
                                       Optional audiences field that will be used to request a temporary Kubernetes service
                                       account token for the service account referenced by `serviceAccountRef`.
                                       Defaults to a single audience `vault` it not specified.
+
                                       Deprecated: use serviceAccountRef.Audiences instead
                                     items:
                                       type: string
@@ -5134,6 +5135,7 @@ spec:
                                       Optional expiration time in seconds that will be used to request a temporary
                                       Kubernetes service account token for the service account referenced by
                                       `serviceAccountRef`.
+
                                       Deprecated: this will be removed in the future.
                                       Defaults to 10 minutes.
                                     format: int64
@@ -9812,6 +9814,7 @@ spec:
                                       Optional audiences field that will be used to request a temporary Kubernetes service
                                       account token for the service account referenced by `serviceAccountRef`.
                                       Defaults to a single audience `vault` it not specified.
+
                                       Deprecated: use serviceAccountRef.Audiences instead
                                     items:
                                       type: string
@@ -9821,6 +9824,7 @@ spec:
                                       Optional expiration time in seconds that will be used to request a temporary
                                       Kubernetes service account token for the service account referenced by
                                       `serviceAccountRef`.
+
                                       Deprecated: this will be removed in the future.
                                       Defaults to 10 minutes.
                                     format: int64

--- a/config/crds/bases/generators.external-secrets.io_clustergenerators.yaml
+++ b/config/crds/bases/generators.external-secrets.io_clustergenerators.yaml
@@ -1658,6 +1658,7 @@ spec:
                                           Optional audiences field that will be used to request a temporary Kubernetes service
                                           account token for the service account referenced by `serviceAccountRef`.
                                           Defaults to a single audience `vault` it not specified.
+
                                           Deprecated: use serviceAccountRef.Audiences instead
                                         items:
                                           type: string
@@ -1667,6 +1668,7 @@ spec:
                                           Optional expiration time in seconds that will be used to request a temporary
                                           Kubernetes service account token for the service account referenced by
                                           `serviceAccountRef`.
+
                                           Deprecated: this will be removed in the future.
                                           Defaults to 10 minutes.
                                         format: int64

--- a/config/crds/bases/generators.external-secrets.io_vaultdynamicsecrets.yaml
+++ b/config/crds/bases/generators.external-secrets.io_vaultdynamicsecrets.yaml
@@ -529,6 +529,7 @@ spec:
                                   Optional audiences field that will be used to request a temporary Kubernetes service
                                   account token for the service account referenced by `serviceAccountRef`.
                                   Defaults to a single audience `vault` it not specified.
+
                                   Deprecated: use serviceAccountRef.Audiences instead
                                 items:
                                   type: string
@@ -538,6 +539,7 @@ spec:
                                   Optional expiration time in seconds that will be used to request a temporary
                                   Kubernetes service account token for the service account referenced by
                                   `serviceAccountRef`.
+
                                   Deprecated: this will be removed in the future.
                                   Defaults to 10 minutes.
                                 format: int64

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -665,6 +665,7 @@ spec:
                 namespaceSelector:
                   description: |-
                     The labels to select by to find the Namespaces to create the ExternalSecrets in.
+
                     Deprecated: Use NamespaceSelectors instead.
                   properties:
                     matchExpressions:
@@ -761,6 +762,7 @@ spec:
                 namespaces:
                   description: |-
                     Choose namespaces by name. This field is ORed with anything that NamespaceSelectors ends up choosing.
+
                     Deprecated: Use NamespaceSelectors instead.
                   items:
                     maxLength: 63
@@ -1494,6 +1496,7 @@ spec:
                 namespaces:
                   description: |-
                     Choose namespaces by name. This field is ORed with anything that NamespaceSelectors ends up choosing.
+
                     Deprecated: Use NamespaceSelectors instead.
                   items:
                     maxLength: 63
@@ -6858,6 +6861,7 @@ spec:
                                         Optional audiences field that will be used to request a temporary Kubernetes service
                                         account token for the service account referenced by `serviceAccountRef`.
                                         Defaults to a single audience `vault` it not specified.
+
                                         Deprecated: use serviceAccountRef.Audiences instead
                                       items:
                                         type: string
@@ -6867,6 +6871,7 @@ spec:
                                         Optional expiration time in seconds that will be used to request a temporary
                                         Kubernetes service account token for the service account referenced by
                                         `serviceAccountRef`.
+
                                         Deprecated: this will be removed in the future.
                                         Defaults to 10 minutes.
                                       format: int64
@@ -11202,6 +11207,7 @@ spec:
                                         Optional audiences field that will be used to request a temporary Kubernetes service
                                         account token for the service account referenced by `serviceAccountRef`.
                                         Defaults to a single audience `vault` it not specified.
+
                                         Deprecated: use serviceAccountRef.Audiences instead
                                       items:
                                         type: string
@@ -11211,6 +11217,7 @@ spec:
                                         Optional expiration time in seconds that will be used to request a temporary
                                         Kubernetes service account token for the service account referenced by
                                         `serviceAccountRef`.
+
                                         Deprecated: this will be removed in the future.
                                         Defaults to 10 minutes.
                                       format: int64
@@ -18613,6 +18620,7 @@ spec:
                                         Optional audiences field that will be used to request a temporary Kubernetes service
                                         account token for the service account referenced by `serviceAccountRef`.
                                         Defaults to a single audience `vault` it not specified.
+
                                         Deprecated: use serviceAccountRef.Audiences instead
                                       items:
                                         type: string
@@ -18622,6 +18630,7 @@ spec:
                                         Optional expiration time in seconds that will be used to request a temporary
                                         Kubernetes service account token for the service account referenced by
                                         `serviceAccountRef`.
+
                                         Deprecated: this will be removed in the future.
                                         Defaults to 10 minutes.
                                       format: int64
@@ -22957,6 +22966,7 @@ spec:
                                         Optional audiences field that will be used to request a temporary Kubernetes service
                                         account token for the service account referenced by `serviceAccountRef`.
                                         Defaults to a single audience `vault` it not specified.
+
                                         Deprecated: use serviceAccountRef.Audiences instead
                                       items:
                                         type: string
@@ -22966,6 +22976,7 @@ spec:
                                         Optional expiration time in seconds that will be used to request a temporary
                                         Kubernetes service account token for the service account referenced by
                                         `serviceAccountRef`.
+
                                         Deprecated: this will be removed in the future.
                                         Defaults to 10 minutes.
                                       format: int64
@@ -25634,6 +25645,7 @@ spec:
                                             Optional audiences field that will be used to request a temporary Kubernetes service
                                             account token for the service account referenced by `serviceAccountRef`.
                                             Defaults to a single audience `vault` it not specified.
+
                                             Deprecated: use serviceAccountRef.Audiences instead
                                           items:
                                             type: string
@@ -25643,6 +25655,7 @@ spec:
                                             Optional expiration time in seconds that will be used to request a temporary
                                             Kubernetes service account token for the service account referenced by
                                             `serviceAccountRef`.
+
                                             Deprecated: this will be removed in the future.
                                             Defaults to 10 minutes.
                                           format: int64
@@ -28319,6 +28332,7 @@ spec:
                                     Optional audiences field that will be used to request a temporary Kubernetes service
                                     account token for the service account referenced by `serviceAccountRef`.
                                     Defaults to a single audience `vault` it not specified.
+
                                     Deprecated: use serviceAccountRef.Audiences instead
                                   items:
                                     type: string
@@ -28328,6 +28342,7 @@ spec:
                                     Optional expiration time in seconds that will be used to request a temporary
                                     Kubernetes service account token for the service account referenced by
                                     `serviceAccountRef`.
+
                                     Deprecated: this will be removed in the future.
                                     Defaults to 10 minutes.
                                   format: int64

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -2280,8 +2280,8 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <em>(Optional)</em>
-<p>The labels to select by to find the Namespaces to create the ExternalSecrets in.
-Deprecated: Use NamespaceSelectors instead.</p>
+<p>The labels to select by to find the Namespaces to create the ExternalSecrets in.</p>
+<p>Deprecated: Use NamespaceSelectors instead.</p>
 </td>
 </tr>
 <tr>
@@ -2307,8 +2307,8 @@ Deprecated: Use NamespaceSelectors instead.</p>
 </td>
 <td>
 <em>(Optional)</em>
-<p>Choose namespaces by name. This field is ORed with anything that NamespaceSelectors ends up choosing.
-Deprecated: Use NamespaceSelectors instead.</p>
+<p>Choose namespaces by name. This field is ORed with anything that NamespaceSelectors ends up choosing.</p>
+<p>Deprecated: Use NamespaceSelectors instead.</p>
 </td>
 </tr>
 <tr>
@@ -2472,8 +2472,8 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <em>(Optional)</em>
-<p>The labels to select by to find the Namespaces to create the ExternalSecrets in.
-Deprecated: Use NamespaceSelectors instead.</p>
+<p>The labels to select by to find the Namespaces to create the ExternalSecrets in.</p>
+<p>Deprecated: Use NamespaceSelectors instead.</p>
 </td>
 </tr>
 <tr>
@@ -2499,8 +2499,8 @@ Deprecated: Use NamespaceSelectors instead.</p>
 </td>
 <td>
 <em>(Optional)</em>
-<p>Choose namespaces by name. This field is ORed with anything that NamespaceSelectors ends up choosing.
-Deprecated: Use NamespaceSelectors instead.</p>
+<p>Choose namespaces by name. This field is ORed with anything that NamespaceSelectors ends up choosing.</p>
+<p>Deprecated: Use NamespaceSelectors instead.</p>
 </td>
 </tr>
 <tr>
@@ -11640,8 +11640,8 @@ External Secrets meta/v1.ServiceAccountSelector
 <em>(Optional)</em>
 <p>Optional audiences field that will be used to request a temporary Kubernetes service
 account token for the service account referenced by <code>serviceAccountRef</code>.
-Defaults to a single audience <code>vault</code> it not specified.
-Deprecated: use serviceAccountRef.Audiences instead</p>
+Defaults to a single audience <code>vault</code> it not specified.</p>
+<p>Deprecated: use serviceAccountRef.Audiences instead</p>
 </td>
 </tr>
 <tr>
@@ -11655,8 +11655,8 @@ int64
 <em>(Optional)</em>
 <p>Optional expiration time in seconds that will be used to request a temporary
 Kubernetes service account token for the service account referenced by
-<code>serviceAccountRef</code>.
-Deprecated: this will be removed in the future.
+<code>serviceAccountRef</code>.</p>
+<p>Deprecated: this will be removed in the future.
 Defaults to 10 minutes.</p>
 </td>
 </tr>
@@ -15843,8 +15843,8 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <em>(Optional)</em>
-<p>Choose namespaces by name. This field is ORed with anything that NamespaceSelectors ends up choosing.
-Deprecated: Use NamespaceSelectors instead.</p>
+<p>Choose namespaces by name. This field is ORed with anything that NamespaceSelectors ends up choosing.</p>
+<p>Deprecated: Use NamespaceSelectors instead.</p>
 </td>
 </tr>
 <tr>
@@ -16033,8 +16033,8 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <em>(Optional)</em>
-<p>Choose namespaces by name. This field is ORed with anything that NamespaceSelectors ends up choosing.
-Deprecated: Use NamespaceSelectors instead.</p>
+<p>Choose namespaces by name. This field is ORed with anything that NamespaceSelectors ends up choosing.</p>
+<p>Deprecated: Use NamespaceSelectors instead.</p>
 </td>
 </tr>
 <tr>
@@ -23304,8 +23304,8 @@ External Secrets meta/v1.ServiceAccountSelector
 <em>(Optional)</em>
 <p>Optional audiences field that will be used to request a temporary Kubernetes service
 account token for the service account referenced by <code>serviceAccountRef</code>.
-Defaults to a single audience <code>vault</code> it not specified.
-Deprecated: use serviceAccountRef.Audiences instead</p>
+Defaults to a single audience <code>vault</code> it not specified.</p>
+<p>Deprecated: use serviceAccountRef.Audiences instead</p>
 </td>
 </tr>
 <tr>
@@ -23319,8 +23319,8 @@ int64
 <em>(Optional)</em>
 <p>Optional expiration time in seconds that will be used to request a temporary
 Kubernetes service account token for the service account referenced by
-<code>serviceAccountRef</code>.
-Deprecated: this will be removed in the future.
+<code>serviceAccountRef</code>.</p>
+<p>Deprecated: this will be removed in the future.
 Defaults to 10 minutes.</p>
 </td>
 </tr>

--- a/generators/v1/vault/vault.go
+++ b/generators/v1/vault/vault.go
@@ -140,7 +140,7 @@ func (g *Generator) prepareResponse(res *genv1alpha1.VaultDynamicSecret, result 
 	data := make(map[string]any)
 	response := make(map[string][]byte)
 	if res.Spec.ResultType == genv1alpha1.VaultDynamicSecretResultTypeAuth {
-		authJSON, err := json.Marshal(result.Auth)
+		authJSON, err := json.Marshal(result.Auth) //nolint:gosec // G117: ClientToken is not a secret leak, it's intentional auth response data
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/controllers/clusterexternalsecret/clusterexternalsecret_controller.go
+++ b/pkg/controllers/clusterexternalsecret/clusterexternalsecret_controller.go
@@ -201,7 +201,7 @@ func (r *Reconciler) gatherProvisionedNamespaces(
 	esName string,
 	failedNamespaces map[string]error,
 ) []string {
-	var provisionedNamespaces []string //nolint:prealloc // we don't know the size
+	var provisionedNamespaces []string
 	for _, namespace := range namespaces {
 		// If namespace is being deleted, remove our finalizer to allow deletion to proceed
 		if namespace.DeletionTimestamp != nil {

--- a/pkg/controllers/clusterexternalsecret/clusterexternalsecret_controller_test.go
+++ b/pkg/controllers/clusterexternalsecret/clusterexternalsecret_controller_test.go
@@ -96,7 +96,7 @@ var _ = Describe("ClusterExternalSecret controller", func() {
 		func(tc testCase) {
 			ctx := context.Background()
 			By("creating namespaces")
-			var namespaces []v1.Namespace
+			namespaces := make([]v1.Namespace, 0, len(tc.namespaces))
 			for _, ns := range tc.namespaces {
 				err := k8sClient.Create(ctx, &ns)
 				Expect(err).ShouldNot(HaveOccurred())
@@ -139,7 +139,7 @@ var _ = Describe("ClusterExternalSecret controller", func() {
 			expectedESs := tc.expectedExternalSecrets(namespaces, ces)
 
 			Eventually(func(g Gomega) {
-				var gotESs []esv1.ExternalSecret
+				var gotESs []esv1.ExternalSecret //nolint:prealloc // size unknown before loop
 				for _, ns := range namespaces {
 					var externalSecrets esv1.ExternalSecretList
 					err := k8sClient.List(ctx, &externalSecrets, crclient.InNamespace(ns.Name))

--- a/pkg/controllers/clusterpushsecret/clusterpushsecret_controller.go
+++ b/pkg/controllers/clusterpushsecret/clusterpushsecret_controller.go
@@ -135,7 +135,7 @@ func (r *Reconciler) updateProvisionedNamespaces(
 	failedNamespaces map[string]error,
 	cps *v1alpha1.ClusterPushSecret,
 ) []string {
-	var provisionedNamespaces []string //nolint:prealloc // I have no idea what the size will be.
+	var provisionedNamespaces []string
 	for _, namespace := range namespaces {
 		var pushSecret v1alpha1.PushSecret
 		err := r.Get(ctx, types.NamespacedName{

--- a/pkg/controllers/clusterpushsecret/clusterpushsecret_controller_test.go
+++ b/pkg/controllers/clusterpushsecret/clusterpushsecret_controller_test.go
@@ -107,7 +107,7 @@ var _ = Describe("ClusterPushSecret controller", func() {
 	}
 
 	defaultSourceSecret := func(namespaces []v1.Namespace) []v1.Secret {
-		var result []v1.Secret
+		result := make([]v1.Secret, 0, len(namespaces))
 		for _, s := range namespaces {
 			result = append(result, v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -127,7 +127,7 @@ var _ = Describe("ClusterPushSecret controller", func() {
 		func(tc clusterPushSecretTestCase) {
 			ctx := context.Background()
 			By("creating namespaces")
-			var namespaces []v1.Namespace
+			namespaces := make([]v1.Namespace, 0, len(tc.namespaces))
 			for _, ns := range tc.namespaces {
 				err := k8sClient.Create(ctx, &ns)
 				Expect(err).ShouldNot(HaveOccurred())
@@ -176,7 +176,7 @@ var _ = Describe("ClusterPushSecret controller", func() {
 			expectedPSs := tc.expectedPushSecrets(namespaces, pes)
 
 			Eventually(func(g Gomega) {
-				var gotESs []v1alpha1.PushSecret
+				var gotESs []v1alpha1.PushSecret //nolint:prealloc // size unknown before loop
 				for _, ns := range namespaces {
 					var pushSecrets v1alpha1.PushSecretList
 					err := k8sClient.List(ctx, &pushSecrets, crclient.InNamespace(ns.Name))

--- a/providers/v1/cloudru/secretmanager/endpoints.go
+++ b/providers/v1/cloudru/secretmanager/endpoints.go
@@ -44,12 +44,12 @@ func GetEndpoints(url string) (*EndpointsResponse, error) {
 		return nil, fmt.Errorf("invalid endpoints URL: expected %s, got %s", EndpointsURI, url)
 	}
 
-	req, err := http.NewRequest(http.MethodGet, url, http.NoBody)
+	req, err := http.NewRequest(http.MethodGet, url, http.NoBody) //nolint:gosec // URL is validated against EndpointsURI above
 	if err != nil {
 		return nil, fmt.Errorf("construct HTTP request for cloud.ru endpoints: %w", err)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := http.DefaultClient.Do(req) //nolint:gosec // URL is validated against EndpointsURI above
 	if err != nil {
 		return nil, fmt.Errorf("get cloud.ru endpoints: %w", err)
 	}

--- a/providers/v1/conjur/fake/fake.go
+++ b/providers/v1/conjur/fake/fake.go
@@ -57,7 +57,7 @@ func (mc *ConjurMockClient) Resources(filter *conjurapi.ResourceFilter) (resourc
 	policyID := "conjur:policy:root"
 	if filter.Offset == 0 {
 		// First "page" of secrets: 2 static ones and 98 random ones
-		secrets := []map[string]interface{}{
+		secrets := []map[string]interface{}{ //nolint:prealloc // static init + dynamic append
 			{
 				"id": "conjur:variable:secret1",
 				"annotations": []interface{}{

--- a/providers/v1/infisical/api/api_test.go
+++ b/providers/v1/infisical/api/api_test.go
@@ -157,7 +157,7 @@ func TestGetSecretsV3(t *testing.T) {
 			Secrets: secrets,
 		})
 
-		var sdkFormattedSecrets []infisical.Secret
+		sdkFormattedSecrets := make([]infisical.Secret, 0, len(secrets))
 
 		for _, secret := range secrets {
 			sdkFormattedSecrets = append(sdkFormattedSecrets, infisical.Secret{
@@ -190,7 +190,7 @@ func TestGetSecretsV3(t *testing.T) {
 		})
 		defer closeFunc()
 
-		var sdkFormattedSecrets []infisical.Secret
+		sdkFormattedSecrets := make([]infisical.Secret, 0, len(secrets))
 
 		for _, secret := range secrets {
 			sdkFormattedSecrets = append(sdkFormattedSecrets, infisical.Secret{

--- a/providers/v1/nebius/mysterybox/validation_test.go
+++ b/providers/v1/nebius/mysterybox/validation_test.go
@@ -304,7 +304,7 @@ func TestValidateStore_APIDomainCases(t *testing.T) {
 		nm.Auth.Token = esmeta.SecretKeySelector{Name: "tok", Key: "k"}
 		return st
 	}
-	cases := []struct {
+	cases := []struct { //nolint:prealloc // struct literal with dynamic appends below
 		name   string
 		domain string
 		valid  bool

--- a/providers/v1/onepassword/onepassword.go
+++ b/providers/v1/onepassword/onepassword.go
@@ -791,7 +791,7 @@ func sortVaults(vaults map[string]int) []string {
 		index++
 	}
 	sort.Sort(list)
-	sortedVaults := []string{}
+	sortedVaults := make([]string, 0, len(list))
 	for _, item := range list {
 		sortedVaults = append(sortedVaults, item.Name)
 	}

--- a/providers/v1/previder/client_test.go
+++ b/providers/v1/previder/client_test.go
@@ -40,7 +40,7 @@ func (v *PreviderVaultFakeClient) DecryptSecret(id string) (*model.SecretDecrypt
 }
 
 func (v *PreviderVaultFakeClient) GetSecrets() ([]model.Secret, error) {
-	secretList := make([]model.Secret, 0)
+	secretList := make([]model.Secret, 0, len(secrets))
 	for k := range secrets {
 		secretList = append(secretList, model.Secret{Description: k})
 	}

--- a/providers/v1/scaleway/client.go
+++ b/providers/v1/scaleway/client.go
@@ -377,7 +377,7 @@ func (c *client) safeConvertInt32(page *int32) uint64 {
 		return 0
 	}
 
-	return uint64(*page - 1) //nolint:gosec // already checked above
+	return uint64(*page - 1)
 }
 
 func (c *client) Close(context.Context) error {

--- a/providers/v1/secretserver/client_test.go
+++ b/providers/v1/secretserver/client_test.go
@@ -159,7 +159,7 @@ func createEmptyFieldsSecret(id int) *server.Secret {
 
 func newTestClient(t *testing.T) esv1.SecretsClient {
 	// Build secrets list while handling any errors from createSecret
-	var secrets []*server.Secret
+	var secrets []*server.Secret //nolint:prealloc // populated incrementally
 
 	s, err := createSecret(1000, "{ \"user\": \"robertOppenheimer\", \"password\": \"badPassword\",\"server\":\"192.168.1.50\"}")
 	require.NoError(t, err)

--- a/providers/v1/vault/client_get.go
+++ b/providers/v1/vault/client_get.go
@@ -298,7 +298,8 @@ func (c *client) buildPath(path string) string {
 	}
 	if !strings.Contains(out, "/data/") && c.store.Version == esv1.VaultKVStoreV2 {
 		buildPath := strings.Split(out, "/")
-		buildMount := []string{buildPath[0], "data"}
+		buildMount := make([]string, 0, 1+len(buildPath))
+		buildMount = append(buildMount, buildPath[0], "data")
 		buildMount = append(buildMount, buildPath[1:]...)
 		out = strings.Join(buildMount, "/")
 		return out


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR updates linter defaults and the golangci-lint version, and includes small lint-suppression and preallocation/cosmetic edits across the repo.

## Key Changes

- Makefile: LINT_JOBS default changed from 20 to 1.
- CI: GOLANGCI_VERSION updated from v2.4.0 to v2.11.3 (.github/workflows/ci.yml).
- Added inline //nolint:gosec comments on a few file/HTTP/write sites.
- Removed some //nolint:prealloc directives and added explicit slice preallocation in several tests and implementations.
- Added deprecation notes and minor comment/formatting tweaks in CRDs and API type docs.

## Impact

Non-functional changes only: linter configuration/version bump, lint-suppression annotations, small memory-allocation optimizations, and documentation/comment edits. No changes to public APIs or runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->