### PR TITLE
Add Roche to official ADOPTERS

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -30,6 +30,7 @@
 - [Polarpoint](https://www.polarpoint.io/)
 - [Radio France](https://www.radiofrance.fr/)
 - [Red Hat OpenShift](https://www.redhat.com/en/technologies/cloud-computing/openshift)
+- [Roche](https://www.roche.com/)
 - [SAP](https://www.sap.com/)
 - [Skeeled](https://www.skeeled.com/)
 - [Topicus.Education](https://topicus.nl/en/sectors/education)


### PR DESCRIPTION
Without this, there is no way to know Roche is using, caring, and involved in External-Secrets!

## Problem Statement

What is the problem you're trying to solve?

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Added Roche to the official ADOPTERS list in ADOPTERS.md, maintaining alphabetical order between Red Hat OpenShift and SAP.

**Changes:**
- Added one entry: `[Roche](https://www.roche.com/)`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->