### PR TITLE
feat: fail fast if LGTM label does not exist in repository

### DIFF
--- a/.github/scripts/lgtm-processor-test.js
+++ b/.github/scripts/lgtm-processor-test.js
@@ -144,4 +144,72 @@ assert.equal(fileMatchesPattern('pkg/provider/aws-extra/file.go', 'pkg/provider/
   assert.ok(roles.has('@external-secrets/gcp-team'));
 }
 
+// ---------------------------------------------------------------------------
+// lgtmProcessor integration tests (mocked GitHub API)
+// ---------------------------------------------------------------------------
+
+import { describe, it } from 'node:test';
+import run from './lgtm-processor.js';
+
+function makeMockContext() {
+  return {
+    repo: { owner: 'external-secrets', repo: 'external-secrets' },
+    payload: {
+      comment: { user: { login: 'testuser' } },
+      issue: { number: 42 }
+    }
+  };
+}
+
+// label existence check: fails fast when lgtm label is missing
+await describe('lgtmProcessor label existence check', async () => {
+  await it('should call core.setFailed when lgtm label does not exist', async () => {
+    let failedMessage = null;
+    const core = {
+      setFailed: (msg) => { failedMessage = msg; }
+    };
+    const github = {
+      paginate: async () => [{ name: 'bug' }, { name: 'enhancement' }],
+      rest: {
+        issues: {
+          listLabelsForRepo: () => {}
+        }
+      }
+    };
+    const context = makeMockContext();
+    const fs = { readFileSync: () => '* @external-secrets/maintainers\n' };
+
+    await run({ core, github, context, fs });
+
+    assert.ok(failedMessage !== null, 'core.setFailed should have been called');
+    assert.ok(failedMessage.includes('does not exist'), `Expected message about missing label, got: ${failedMessage}`);
+  });
+
+  await it('should not call core.setFailed when lgtm label exists', async () => {
+    let failedMessage = null;
+    const core = {
+      setFailed: (msg) => { failedMessage = msg; }
+    };
+
+    // The function will proceed past the label check and try to read CODEOWNERS.
+    // We let readFileSync throw to stop execution early (the point is that setFailed was NOT called).
+    const github = {
+      paginate: async () => [{ name: 'bug' }, { name: 'lgtm' }],
+      rest: {
+        issues: {
+          listLabelsForRepo: () => {}
+        }
+      }
+    };
+    const context = makeMockContext();
+    const fs = {
+      readFileSync: () => { throw new Error('stop here'); }
+    };
+
+    await run({ core, github, context, fs });
+
+    assert.equal(failedMessage, null, 'core.setFailed should not have been called when lgtm label exists');
+  });
+});
+
 console.log('All tests passed.');

--- a/.github/scripts/lgtm-processor.js
+++ b/.github/scripts/lgtm-processor.js
@@ -15,10 +15,20 @@ export default async function run({ core, github, context, fs }) {
   const organization = 'external-secrets';
   const lgtmLabelName = 'lgtm';
 
-  const commenter = context.payload.comment.user.login;
-  const prNumber = context.payload.issue.number;
   const owner = context.repo.owner;
   const repo = context.repo.repo;
+
+  // Fail fast if the LGTM label does not exist in the repository
+  const repoLabels = await github.paginate(github.rest.issues.listLabelsForRepo, {
+    owner, repo, per_page: 100
+  });
+  if (!repoLabels.some(l => l.name === lgtmLabelName)) {
+    core.setFailed(`LGTM label "${lgtmLabelName}" does not exist in the repository. Please create it before using the LGTM workflow.`);
+    return;
+  }
+
+  const commenter = context.payload.comment.user.login;
+  const prNumber = context.payload.issue.number;
 
   // Parse CODEOWNERS.md file
   let codeownersContent;


### PR DESCRIPTION
## Summary

Follow-up to #6074 as requested by @Skarlso.

Adds a label existence check at the very start of `lgtmProcessor()`. If the `lgtm` label doesn't exist in the repository, `core.setFailed()` is called with a descriptive error message and the workflow exits immediately — before any other logic runs.

## Changes

- **`.github/scripts/lgtm-processor.js`**: Uses `github.paginate(github.rest.issues.listLabelsForRepo)` to fetch all repo labels (handles pagination for repos with many labels). Fails fast with a clear message if `lgtm` is missing.
- **`.github/scripts/lgtm-processor-test.js`**: Added 2 integration tests with mocked GitHub API — one verifying `core.setFailed()` is called when the label is missing, one verifying it is not called when the label exists.

Signed-off-by: Mateen Anjum <mateenali66@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds a fail-fast check to ensure the "lgtm" label exists in the repository before proceeding with LGTM processing logic.

## Changes

**lgtm-processor.js**
- Adds a preflight check at the start of `lgtmProcessor()` that fetches all repository labels and verifies the "lgtm" label exists
- If the label is missing, calls `core.setFailed()` with a descriptive error message and exits immediately
- Reorders initialization so commenter and PR number retrieval occurs after the label-existence check

**lgtm-processor-test.js**
- Adds integration-style tests with mocked GitHub API using node:test describe/it structure
- Tests both scenarios: missing label (expects `core.setFailed()` to be called) and existing label (expects it not to be called)
- Includes mock context builder and simulates GitHub pagination for label listing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->