### PR TITLE
fix(infisical): dataFrom.find.path should filter by secret path not name

### DIFF
--- a/providers/v1/infisical/client.go
+++ b/providers/v1/infisical/client.go
@@ -174,7 +174,7 @@ func (p *Provider) GetAllSecrets(_ context.Context, ref esv1.ExternalSecretFind)
 
 	selected := map[string][]byte{}
 	for _, secret := range secrets {
-		if (matcher != nil && !matcher.MatchName(secret.SecretKey)) || (ref.Path != nil && !strings.HasPrefix(secret.SecretKey, *ref.Path)) {
+		if (matcher != nil && !matcher.MatchName(secret.SecretKey)) || (ref.Path != nil && !strings.HasPrefix(secret.SecretPath, *ref.Path)) {
 			continue
 		}
 		selected[secret.SecretKey] = []byte(secret.SecretValue)


### PR DESCRIPTION
## Problem Statement

When using dataFrom.find.path with the Infisical provider, the path parameter filters secrets by their name prefix rather than their folder path in Infisical.

## Related Issue

Fixes #5900

## Proposed Changes

Change from secret.SecretKey to secret.SecretPath

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Fix for Infisical path-based secret filtering

**Change:** Modified the `GetAllSecrets` method in `providers/v1/infisical/client.go` to filter secrets by their folder path rather than secret name when `dataFrom.find.path` is specified.

**What changed:** The path-prefix check now uses `secret.SecretPath` instead of `secret.SecretKey` in the selection condition:
(ref.Path != nil && !strings.HasPrefix(secret.SecretPath, *ref.Path))

**Why:** Previously, path-based filtering matched against secret keys (names) instead of folder paths, preventing folder-scoped retrieval. This change ensures `dataFrom.find.path` filters by Infisical folder path.

**Impact:** Enables correct path-scoped secret retrieval for multi-tenant or multi-application folder layouts, aligning Infisical's behavior with other providers and removing workarounds like separate SecretStores per folder.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->