### PR TITLE
fix(infisical): dataFrom.find.path should filter by secret path not name

### DIFF
--- a/providers/v1/infisical/client.go
+++ b/providers/v1/infisical/client.go
@@ -174,7 +174,7 @@ func (p *Provider) GetAllSecrets(_ context.Context, ref esv1.ExternalSecretFind)
 
 	selected := map[string][]byte{}
 	for _, secret := range secrets {
-		if (matcher != nil && !matcher.MatchName(secret.SecretKey)) || (ref.Path != nil && !strings.HasPrefix(secret.SecretKey, *ref.Path)) {
+		if (matcher != nil && !matcher.MatchName(secret.SecretKey)) || (ref.Path != nil && !strings.HasPrefix(secret.SecretPath, *ref.Path)) {
 			continue
 		}
 		selected[secret.SecretKey] = []byte(secret.SecretValue)


### PR DESCRIPTION
## Problem Statement

When using dataFrom.find.path with the Infisical provider, the path parameter filters secrets by their name prefix rather than their folder path in Infisical.

## Related Issue

Fixes #5900

## Proposed Changes

Change from secret.SecretKey to secret.SecretPath

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix dataFrom.find.path filtering for Infisical provider

**Problem**: The Infisical provider's `dataFrom.find.path` feature was incorrectly filtering secrets by their name prefix (SecretKey) instead of by their folder path (SecretPath).

**Solution**: Updated the path-filtering logic in `GetAllSecrets()` to compare against `secret.SecretPath` instead of `secret.SecretKey` when applying prefix matching against the provided path parameter. This enables users to fetch all secrets from a specific folder in Infisical without requiring separate SecretStores per folder.

**Changes**:
- `providers/v1/infisical/client.go`: Modified path-matching condition to filter by secret folder location
- Single line change (+1/-1)

Fixes #5900.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->