### PR TITLE
feat(provider/kubernetes): use system trust store when no CA or auth configured

### DIFF
--- a/providers/v1/kubernetes/auth.go
+++ b/providers/v1/kubernetes/auth.go
@@ -48,10 +48,6 @@ func (c *Client) getAuth(ctx context.Context) (*rest.Config, error) {
 		return clientcmd.RESTConfigFromKubeConfig(cfg)
 	}
 
-	if c.store.Auth == nil {
-		return nil, errors.New("no auth provider given")
-	}
-
 	if c.store.Server.URL == "" {
 		return nil, errors.New("no server URL provided")
 	}
@@ -77,6 +73,8 @@ func (c *Client) getAuth(ctx context.Context) (*rest.Config, error) {
 	}
 
 	switch {
+	case c.store.Auth == nil:
+		return cfg, nil
 	case c.store.Auth.Token != nil:
 		token, err := c.fetchSecretKey(ctx, c.store.Auth.Token.BearerToken)
 		if err != nil {

--- a/providers/v1/kubernetes/auth_test.go
+++ b/providers/v1/kubernetes/auth_test.go
@@ -88,14 +88,22 @@ func TestSetAuth(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "should return err if no ca provided",
+			name: "should use system trust store when no auth provided",
 			fields: fields{
 				store: &esv1.KubernetesProvider{
-					Server: esv1.KubernetesServer{},
+					Server: esv1.KubernetesServer{
+						URL: serverURL,
+					},
 				},
 			},
-			want:    nil,
-			wantErr: true,
+			want: &want{
+				Host: serverURL,
+				TLSClientConfig: rest.TLSClientConfig{
+					Insecure: false,
+					CAData:   nil,
+				},
+			},
+			wantErr: false,
 		},
 		{
 			name: "should return err if no auth provided",


### PR DESCRIPTION
Fixes #5393

## What

When neither `caBundle` nor `caProvider` is set and `Auth` is nil, the Kubernetes provider now falls back to the system trust store instead of returning an error. This matches `kubectl` behavior where publicly trusted certificates (e.g., Let's Encrypt) work without explicit CA configuration.

## Changes

- **auth.go**: Removed the early `Auth == nil` error check. Added `case c.store.Auth == nil` in the switch statement to return the TLS config as-is, allowing Go's `net/http` to use `x509.SystemCertPool()` automatically when `CAData` is nil.
- **auth_test.go**: Updated the first test case to verify system trust store behavior when no auth is provided (URL set, no CA, no auth → success with `CAData: nil, Insecure: false`).

## Notes

- `validate.go` already emits a warning (not error) when no CA is configured
- Documentation already covers system trust store behavior and edge cases (distroless images)
- When `rest.TLSClientConfig.CAData` is nil, Go automatically uses the system cert pool

## Test

```
go test github.com/external-secrets/external-secrets/providers/v1/kubernetes -v -run TestSetAuth
go test github.com/external-secrets/external-secrets/providers/v1/kubernetes -v -run TestValidateStore
```

All tests pass.