### PR TITLE
docs: document template.metadata labels/annotations behavior

### DIFF
--- a/docs/snippets/full-external-secret.yaml
+++ b/docs/snippets/full-external-secret.yaml
@@ -56,6 +56,10 @@ spec:
       type: kubernetes.io/dockerconfigjson # or TLS...
 
       metadata:
+        # Labels and annotations to set on the Secret.
+        # When a template is defined, these replace the default behavior
+        # of copying labels and annotations from the ExternalSecret.
+        # Set to an empty map ({}) to prevent any labels or annotations from being copied.
         annotations: {}
         labels: {}
         # The finalizers will be added to the Secret.


### PR DESCRIPTION
## Problem Statement

The `full-external-secret.yaml` snippet shows `template.metadata.labels: {}` and `template.metadata.annotations: {}` without explaining what these fields do or what setting them to an empty map means. This is a common source of confusion, since by default the ExternalSecret's own labels and annotations are copied to the managed Secret, and the opt-out mechanism is not documented.

## Related Issue

Related to https://github.com/kubernetes-sigs/kro/issues/1153

## Proposed Changes

Adds a comment to `docs/snippets/full-external-secret.yaml` above the `annotations` and `labels` fields in `template.metadata` explaining:
- These fields define the labels and annotations to set on the managed Secret
- When a template is defined, they replace the default behavior of copying from the ExternalSecret
- Setting them to an empty map (`{}`) prevents any labels or annotations from being copied

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added documentation comments in `docs/snippets/full-external-secret.yaml` above the `annotations` and `labels` fields in `template.metadata` to clarify that:
- These fields define labels and annotations to be set on the managed Secret
- When a template is defined, they replace the default behavior of copying labels/annotations from the ExternalSecret
- Setting them to an empty map (`{}`) prevents any labels or annotations from being copied

This addresses confusion about the default label/annotation copying mechanism and provides guidance on how to opt out of this behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->