### PR TITLE
docs(release): Update support table to show that v2.2.0 is not at EOL

### DIFF
--- a/docs/introduction/stability-support.md
+++ b/docs/introduction/stability-support.md
@@ -18,7 +18,7 @@ As of version 0.14.x , this is the only kubernetes version that we will guarante
 
 | ESO Version | Kubernetes Version | Release Date | End of Life           |
 |-------------|--------------------|--------------|-----------------------|
-| 2.2         | 1.34-1.35          | Mar 20, 2026 | Mar 20, 2026          |
+| 2.2         | 1.34-1.35          | Mar 20, 2026 | Release of next minor |
 | 2.1         | 1.34-1.35          | Mar 06, 2026 | Mar 20, 2026          |
 | 2.0         | 1.34-1.35          | Feb 06, 2026 | Mar 06, 2026          |
 | 1.3         | 1.34               | Jan 23, 2026 | Feb 06, 2026          |


### PR DESCRIPTION
## Problem Statement

At the moment, the end of life table shows that the newly released v2.2.0 went EOL the day it was released.  This is probably due to a simple copy/paste error.  This commit/PR fixes the table entry.

## Related Issue

Fixes #...

## Proposed Changes

Update table to show that 2.2.0 is current.

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] My changes have reasonable test coverage
- [X] All tests pass with `make test`
- [X] I ensured my PR is ready for review with `make reviewable`
