### PR TITLE
fix: cached uid after deleting a store

### DIFF
--- a/pkg/controllers/secretstore/common.go
+++ b/pkg/controllers/secretstore/common.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/go-logr/logr"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -95,7 +96,21 @@ func reconcile(ctx context.Context, req ctrl.Request, ss esapi.GenericStore, cl 
 
 	// patch status when done processing
 	p := client.MergeFrom(ss.Copy())
+	storeUID := ss.GetObjectMeta().UID
 	defer func() {
+		current := ss.Copy()
+		if getErr := cl.Get(ctx, req.NamespacedName, current); getErr != nil {
+			if apierrors.IsNotFound(getErr) {
+				log.V(1).Info("store was deleted, skipping status patch")
+				return
+			}
+			log.Error(getErr, "unable to get store for status patch")
+			return
+		}
+		if current.GetObjectMeta().UID != storeUID {
+			log.V(1).Info("store was replaced, skipping status patch")
+			return
+		}
 		err := cl.Status().Patch(ctx, ss, p)
 		if err != nil {
 			log.Error(err, errPatchStatus)

--- a/pkg/controllers/secretstore/common_test.go
+++ b/pkg/controllers/secretstore/common_test.go
@@ -87,6 +87,23 @@ var _ = Describe("SecretStore Controller", func() {
 			spc := tc.store.GetSpec()
 			spc.Controller = "something-else"
 			tc.assert = func() {
+				Eventually(func() bool {
+					ss := tc.store.Copy()
+					err := k8sClient.Get(context.Background(), types.NamespacedName{
+						Name:      defaultStoreName,
+						Namespace: ss.GetObjectMeta().Namespace,
+					}, ss)
+					if err != nil {
+						return false
+					}
+					return ss.GetObjectMeta().GetResourceVersion() != "" &&
+						ss.GetSpec().Controller == "something-else" &&
+						len(ss.GetStatus().Conditions) == 0
+				}).
+					WithTimeout(time.Second*10).
+					WithPolling(time.Millisecond*250).
+					Should(BeTrue(), "cache should reflect the new store with no conditions")
+
 				Consistently(func() bool {
 					ss := tc.store.Copy()
 					err := k8sClient.Get(context.Background(), types.NamespacedName{


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Fix: Cached UID after deleting a store

Fixes an issue where a SecretStore's UID could become stale if the resource was deleted and recreated during reconciliation, causing status patch operations to be applied to the wrong resource.

**Changes:**
- **pkg/controllers/secretstore/common.go**: Capture the reconciled store's UID before deferring the status patch. The deferred function now re-reads the Store from the API server and:
  - Skips the status patch if the Store is not found (deleted).
  - Skips the status patch if the current Store UID differs from the captured UID (resource replaced).
  - Logs these cases (verbosity level 1) and logs errors when unable to fetch the Store.
- **pkg/controllers/secretstore/common_test.go**: In `ignoreControllerClass` test, adds an Eventually assertion (10s timeout, 250ms polling) to verify the fetched SecretStore has a non-empty resourceVersion, retains `spec.controller == "something-else"`, and maintains empty `status.conditions`. This ensures the cache reflects the new store without conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->