### PR TITLE
fix(docs): fix metadata structure in Google Secrets Manager docs

### DIFF
--- a/docs/provider/google-secrets-manager.md
+++ b/docs/provider/google-secrets-manager.md
@@ -349,9 +349,12 @@ spec:
   data:
     - conversionStrategy: None
       metadata:
-        mergePolicy: Merge
-        labels:
-          anotherLabel: anotherValue
+        apiVersion: kubernetes.external-secrets.io/v1alpha1
+        kind: PushSecretMetadata
+        spec:
+          mergePolicy: Merge
+          labels:
+            anotherLabel: anotherValue
       match:
         secretKey: bestpokemon
         remoteRef:


### PR DESCRIPTION


## Problem Statement

When using the example from the docs, you get the following error:

```
set secret failed: could not write remote ref to target secretstore gsm-store: failed to parse PushSecret metadata: failed to parse kubernetes.external-secrets.io/v1alpha1 PushSecretMetadata: error unmarshaling JSON: while decoding JSON: json: unknown field "mergePolicy"
```

## Related Issue

See https://github.com/external-secrets/external-secrets/issues/5554#issuecomment-4132739147

## Proposed Changes

Let's fix the example in the docs.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- ~[ ] My changes have reasonable test coverage~
- ~[ ] All tests pass with `make test`~
- ~[ ] I ensured my PR is ready for review with `make reviewable`~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Fix metadata structure in Google Secrets Manager documentation

Corrects the `PushSecret` metadata example in the Google Secrets Manager docs that caused parsing errors ("unknown field 'mergePolicy'"). The example previously placed `mergePolicy` and `labels` directly under `spec.data[].metadata`; the fix wraps them in a `kubernetes.external-secrets.io/v1alpha1` `PushSecretMetadata` object by adding `apiVersion` and `kind` and moving `mergePolicy` and `labels` under `spec`.

Changes:
- Updated docs/provider/google-secrets-manager.md example to use the proper `PushSecretMetadata` wrapper and nesting
- +6/-3 lines changed
<!-- end of auto-generated comment: release notes by coderabbit.ai -->