### PR TITLE
fix(docs): use grep -F for fixed-string version check in docs.check

### DIFF
--- a/hack/api-docs/Makefile
+++ b/hack/api-docs/Makefile
@@ -59,7 +59,7 @@ stability-support.update:
 .PHONY: check
 check:
 	@echo "Checking for version: $(VERSION_TO_CHECK)"
-	cat $(ROOT)/docs/introduction/stability-support.md | grep "$(VERSION_TO_CHECK)"
+	cat $(ROOT)/docs/introduction/stability-support.md | grep -F "$(VERSION_TO_CHECK)"
 
 .PHONY: build
 build: image generate $(SOURCES)


### PR DESCRIPTION
## Problem Statement

The `docs.check` target greps for `$(VERSION_TO_CHECK)` but grep treats the pattern as a regex. a version like `2.2` matches the year `2022` (and `2023`, `2024`, etc.) in the date columns of `stability-support.md`, so the check passes even when the version isn't actually in the supported versions table.

## Related Issue

Fixes #6116

## Proposed Changes

switch to `grep -F` (fixed strings) so the check does a literal match. one-line change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Fix:** Updated the `check` target in `hack/api-docs/Makefile` to use `grep -F` for version matching.

**Problem:** The version check was using regex matching, causing false positives (e.g., version `2.2` matching `2022` in date columns of `stability-support.md`).

**Solution:** Added the `-F` flag to grep to perform literal string matching, ensuring only exact version strings are detected.

**Change:** Line 62 in `hack/api-docs/Makefile`: `grep "$(VERSION_TO_CHECK)"` → `grep -F "$(VERSION_TO_CHECK)"`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->