### PR TITLE
fix: remove getHostByName from template funcs

### DIFF
--- a/runtime/template/v2/template.go
+++ b/runtime/template/v2/template.go
@@ -87,7 +87,7 @@ func init() {
 	sprigFuncs := sprig.TxtFuncMap()
 	delete(sprigFuncs, "env")
 	delete(sprigFuncs, "expandenv")
-
+	delete(sprigFuncs, "getHostByName")
 	maps.Copy(tplFuncs, sprigFuncs)
 	fs := pflag.NewFlagSet("template", pflag.ExitOnError)
 	fs.StringVar(&leftDelim, "template-left-delimiter", "{{", "templating left delimiter")

--- a/runtime/template/v2/template_test.go
+++ b/runtime/template/v2/template_test.go
@@ -222,6 +222,12 @@ func rsaEncryptOAEP(t testing.TB, publicKeyPEM []byte, hash, plaintext string) [
 	return ciphertext
 }
 
+func TestFuncMapDoesNotExposeGetHostByName(t *testing.T) {
+	if _, ok := FuncMap()["getHostByName"]; ok {
+		t.Fatalf("getHostByName should not be exposed in the template function map")
+	}
+}
+
 func TestExecute(t *testing.T) {
 	tbl := []struct {
 		name                string


### PR DESCRIPTION
## Problem Statement

Remove function that allows DNS lookup.  

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Removes the `getHostByName` function from the template function map to prevent DNS lookups through template expressions.

### Changes

- **`runtime/template/v2/template.go`** (line 90): Added explicit deletion of `getHostByName` from Sprig's template function map in the `init()` function before merging with application-specific functions.
- **`runtime/template/v2/template_test.go`**: Added `TestFuncMapDoesNotExposeGetHostByName` test to verify the function is not accessible in the template function map.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->