### PR TITLE
docs: fix templating.md

### DIFF
--- a/docs/guides/templating.md
+++ b/docs/guides/templating.md
@@ -9,7 +9,7 @@ Each data value is interpreted as a [Go template](https://golang.org/pkg/text/te
     Consider using camelcase when defining  **.'spec.data.secretkey'**, example: serviceAccountToken
 
     If your secret keys contain **`-` (dashes)**, you will need to reference them using **`index`** </br>
-    Example: **`\{\{ index .data "service-account-token" \}\}`**
+    Example: {% raw %}**`{{ index .data "service-account-token" }}`**{% endraw %}
 
 ## Helm
 


### PR DESCRIPTION
## Problem Statement
This page renders incorrectly https://external-secrets.io/latest/guides/templating/ it says:

````txt
Macro Syntax Error

File: guides/templating.md

Line 12 in Markdown file: unexpected '.'

    Example: **`\{\{ index .data "service-account-token" \}\}`**
````

## Related Issue

(none, jumping straight to a PR)

## Proposed Changes

See diff

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Fix templating guide rendering by preventing the docs engine from interpreting Go-template delimiters.

## Changes

Updated docs/guides/templating.md to wrap the Go-template example that accesses keys with dashes in a Jinja raw block so the docs site renders the snippet verbatim. Replaced the previously-escaped snippet (\{\{ index .data "service-account-token" \}\}) with: {% raw %}`{{ index .data "service-account-token" }}`{% endraw %}, resolving the "Macro Syntax Error" (unexpected '.') that broke the page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->