### PR TITLE
docs(ovhcloud): fix heterogeneous configuration documentation

### DIFF
--- a/docs/provider/ovhcloud.md
+++ b/docs/provider/ovhcloud.md
@@ -26,8 +26,8 @@ metadata:
 spec:
   provider:
     ovh:
-      server: <kms-endpoint>
-      okmsid: <okms-id>
+      server: <kms-endpoint> # for example: "https://eu-west-rbx.okms.ovh.net"
+      okmsid: <okms-id> # for example: "734b9b45-8b1a-469c-b140-b10bd6540017" 
       auth:
         token:
           tokenSecretRef:
@@ -51,8 +51,8 @@ metadata:
 spec:
   provider:
     ovh:
-      server: "https://eu-west-rbx.okms.ovh.net"
-      okmsid: "734b9b45-8b1a-469c-b140-b10bd6540017"
+      server: <kms-endpoint> # for example: "https://eu-west-rbx.okms.ovh.net"
+      okmsid: <okms-id> # for example: "734b9b45-8b1a-469c-b140-b10bd6540017" 
       auth:
         mtls:
           certSecretRef:
@@ -381,8 +381,8 @@ metadata:
 spec:
   provider:
     ovh:
-      server: <kms-endpoint>
-      okmsid: <okms-id>
+      server: <kms-endpoint> # for example: "https://eu-west-rbx.okms.ovh.net"
+      okmsid: <okms-id> # for example: "734b9b45-8b1a-469c-b140-b10bd6540017" 
       auth:
         token:
           tokenSecretRef:
@@ -478,8 +478,8 @@ metadata:
 spec:
   provider:
     ovh:
-      server: <kms-endpoint>
-      okmsid: <okms-id>
+      server: <kms-endpoint> # for example: "https://eu-west-rbx.okms.ovh.net"
+      okmsid: <okms-id> # for example: "734b9b45-8b1a-469c-b140-b10bd6540017" 
       auth:
         token:
           tokenSecretRef:


### PR DESCRIPTION
## Problem Statement

The documentation of OVHcloud provider have heterogeneous information in the examples of provider documentation. 

## Related Issue

None

## Proposed Changes

I unified the examples in the provider's configuration

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Unified OVHcloud provider documentation examples to be consistent across SecretStore, ExternalSecret, and PushSecret sections. Example placeholders (<kms-endpoint>, <okms-id>) are retained but now include inline comments (e.g. # for example: "https://eu-west-rbx.okms.ovh.net") instead of using quoted example literals in the YAML. Token and mTLS authentication examples, as well as SecretStore/ExternalSecret/PushSecret snippets, were aligned for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->