### PR TITLE
fix(docs): resolve macro syntax error in templating guide

### DIFF
--- a/docs/guides/templating.md
+++ b/docs/guides/templating.md
@@ -9,7 +9,7 @@ Each data value is interpreted as a [Go template](https://golang.org/pkg/text/te
     Consider using camelcase when defining  **.'spec.data.secretkey'**, example: serviceAccountToken
 
     If your secret keys contain **`-` (dashes)**, you will need to reference them using **`index`** </br>
-    Example: {% raw %}**`{{ index .data "service-account-token" }}`**{% endraw %}
+    Example: **`{% raw %}{{ index .data "service-account-token" }}{% endraw %}`**
 
 ## Helm
 


### PR DESCRIPTION
The templating guide page (https://external-secrets.io/latest/guides/templating/) 
shows a "Macro Syntax Error" because the `{% raw %}` / `{% endraw %}` tags wrap 
the markdown bold/backtick formatting along with the Go template expression. 

Moved the raw tags to wrap only the Go template curly braces.

Fixes #6135

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Fix macro syntax error in templating guide documentation

Corrected the placement of `{% raw %}` / `{% endraw %}` tags in the templating guide's Go template example so the Go template curly-brace expression renders without triggering a macro syntax error. This fixes the rendering issue seen on the templating page.

Changes:
- docs/guides/templating.md: adjusted `{% raw %}` wrapping around the Go template snippet (+1/-1)

Impact: documentation only. Fixes issue #6135.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->