### PR TITLE
docs: add OVHcloud in ADOPTERS

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -21,6 +21,7 @@
 - [Mercedes-Benz Tech Innovation](https://www.mercedes-benz-techinnovation.com/)
 - [Mixpanel](https://mixpanel.com)
 - [OpenClassrooms](https://openclassrooms.com)
+- [OVHcloud](https://www.ovhcloud.com)
 - [Pento](https://www.pento.io/)
 - [Petco Health and Wellness Company, Inc](https://www.petco.com/)
 - [Pets at Home Group plc](https://petsathome.com)


### PR DESCRIPTION
## Problem Statement

Add OVHcloud as an official Adopter :)

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds OVHcloud to the ADOPTERS.md file, registering it as an official adopter of the project.

**Changes:**
- Added OVHcloud entry with URL to `ADOPTERS.md`

**Impact:**
- Documentation-only change with minimal scope (+1 line)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->