### PR TITLE
fix(oracle): fix caching logic for oracle vault provider default sa config

### DIFF
--- a/providers/v1/oracle/oracle.go
+++ b/providers/v1/oracle/oracle.go
@@ -70,8 +70,10 @@ const (
 )
 
 // https://github.com/external-secrets/external-secrets/issues/644
-var _ esv1.SecretsClient = &VaultManagementService{}
-var _ esv1.Provider = &VaultManagementService{}
+var (
+	_ esv1.SecretsClient = &VaultManagementService{}
+	_ esv1.Provider      = &VaultManagementService{}
+)
 
 // VaultManagementService implements the External Secrets provider interface for Oracle Cloud Infrastructure Vault.
 type VaultManagementService struct {
@@ -609,23 +611,34 @@ func (vms *VaultManagementService) getWorkloadIdentityProvider(
 	if err := os.Setenv(auth.ResourcePrincipalRegionEnvVar, region); err != nil {
 		return nil, fmt.Errorf(errSettingOCIEnvVariables, auth.ResourcePrincipalRegionEnvVar, err)
 	}
+
+	var providerWithClaim auth.ConfigurationProviderWithClaimAccess
+
 	// If no service account is specified, use the pod service account to create the Workload Identity provider.
 	if serviceAcccountRef == nil {
-		return auth.OkeWorkloadIdentityConfigurationProvider()
+		providerWithClaim, err = auth.OkeWorkloadIdentityConfigurationProvider()
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// Ensure the service account ref is being used appropriately, so arbitrary tokens are not minted by the provider.
+		if err = esutils.ValidateServiceAccountSelector(store, *serviceAcccountRef); err != nil {
+			return nil, fmt.Errorf("invalid ServiceAccountRef: %w", err)
+		}
+		cfg, err := ctrlcfg.GetConfig()
+		if err != nil {
+			return nil, err
+		}
+		clientset, err := kubernetes.NewForConfig(cfg)
+		if err != nil {
+			return nil, err
+		}
+		tokenProvider := NewTokenProvider(clientset, serviceAcccountRef, namespace)
+		providerWithClaim, err = auth.OkeWorkloadIdentityConfigurationProviderWithServiceAccountTokenProvider(tokenProvider)
+		if err != nil {
+			return nil, err
+		}
 	}
-	// Ensure the service account ref is being used appropriately, so arbitrary tokens are not minted by the provider.
-	if err = esutils.ValidateServiceAccountSelector(store, *serviceAcccountRef); err != nil {
-		return nil, fmt.Errorf("invalid ServiceAccountRef: %w", err)
-	}
-	cfg, err := ctrlcfg.GetConfig()
-	if err != nil {
-		return nil, err
-	}
-	clientset, err := kubernetes.NewForConfig(cfg)
-	if err != nil {
-		return nil, err
-	}
-	tokenProvider := NewTokenProvider(clientset, serviceAcccountRef, namespace)
 
 	// Cache OKE token providers per SecretStore to avoid creating multiple providers for the same store.
 	// We also reset the cache if it exceeds a certain size to avoid unbounded memory growth.
@@ -636,10 +649,7 @@ func (vms *VaultManagementService) getWorkloadIdentityProvider(
 	// Caching by resource version to ensure that updates to the SecretStore are reflected in the cached provider.
 	_, ok := vms.authConfigurationsCache[store.GetResourceVersion()]
 	if !ok {
-		vms.authConfigurationsCache[store.GetResourceVersion()], err = auth.OkeWorkloadIdentityConfigurationProviderWithServiceAccountTokenProvider(tokenProvider)
-		if err != nil {
-			return nil, err
-		}
+		vms.authConfigurationsCache[store.GetResourceVersion()] = providerWithClaim
 	}
 
 	return vms.authConfigurationsCache[store.GetResourceVersion()], nil


### PR DESCRIPTION
## Problem Statement

Default service account based client caching on oracle vault provider.

## Related Issue

Fixes #6191 

## Proposed Changes

Change the caching logic so that both branches follow through to the cache registry for the operator.

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix Oracle vault provider caching for default service account configuration

**Problem:** The Oracle vault provider was not caching vault clients when `serviceAccountRef` was not specified (default service account flow), causing new clients to be created on each secret check. This led to ephemeral port exhaustion and token renewal failures in deployments with many ExternalSecrets.

**Solution:** Refactored the caching logic in `getWorkloadIdentityProvider()` to ensure both the default service account and explicit service account ref paths flow through the cache registry. Previously, the default service account path returned early without caching; now it assigns the provider to a variable and continues through the standard cache-miss handling logic that applies to both branches.

**Changes:**
- Refactored `getWorkloadIdentityProvider()` to construct the configuration provider into a local variable regardless of whether a service account ref is provided
- Updated cache-miss handling to cache the provider for both code paths
- Consolidated compile-time interface assertions into a parenthesized `var` block

**Files changed:** `providers/v1/oracle/oracle.go` (+30/-20)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->