### PR TITLE
feat: add source null byte policy

### DIFF
--- a/apis/externalsecrets/v1/externalsecret_types.go
+++ b/apis/externalsecrets/v1/externalsecret_types.go
@@ -78,6 +78,18 @@ const (
 	DeletionPolicyRetain ExternalSecretDeletionPolicy = "Retain"
 )
 
+// ExternalSecretNullBytePolicy defines how rendered secret data containing NUL bytes should be handled.
+// +kubebuilder:validation:Enum=Ignore;Fail
+type ExternalSecretNullBytePolicy string
+
+const (
+	// ExternalSecretNullBytePolicyIgnore allows rendered secret data to contain NUL bytes.
+	ExternalSecretNullBytePolicyIgnore ExternalSecretNullBytePolicy = "Ignore"
+
+	// ExternalSecretNullBytePolicyFail fails reconciliation if rendered secret data contains NUL bytes.
+	ExternalSecretNullBytePolicyFail ExternalSecretNullBytePolicy = "Fail"
+)
+
 // ExternalSecretTemplateMetadata defines metadata fields for the Secret blueprint.
 type ExternalSecretTemplateMetadata struct {
 	// +optional
@@ -242,6 +254,11 @@ type ExternalSecretTarget struct {
 	// Warning: Using Generic target. Make sure access policies and encryption are properly configured.
 	// +optional
 	Manifest *ManifestReference `json:"manifest,omitempty"`
+
+	// NullBytePolicy controls how ESO handles rendered secret data containing NUL bytes.
+	// +optional
+	// +kubebuilder:default="Ignore"
+	NullBytePolicy ExternalSecretNullBytePolicy `json:"nullBytePolicy,omitempty"`
 
 	// Immutable defines if the final secret will be immutable
 	// +optional

--- a/apis/externalsecrets/v1/externalsecret_types.go
+++ b/apis/externalsecrets/v1/externalsecret_types.go
@@ -78,15 +78,15 @@ const (
 	DeletionPolicyRetain ExternalSecretDeletionPolicy = "Retain"
 )
 
-// ExternalSecretNullBytePolicy defines how rendered secret data containing NUL bytes should be handled.
+// ExternalSecretNullBytePolicy defines how fetched secret data containing NUL bytes should be handled.
 // +kubebuilder:validation:Enum=Ignore;Fail
 type ExternalSecretNullBytePolicy string
 
 const (
-	// ExternalSecretNullBytePolicyIgnore allows rendered secret data to contain NUL bytes.
+	// ExternalSecretNullBytePolicyIgnore allows fetched secret data to contain NUL bytes.
 	ExternalSecretNullBytePolicyIgnore ExternalSecretNullBytePolicy = "Ignore"
 
-	// ExternalSecretNullBytePolicyFail fails reconciliation if rendered secret data contains NUL bytes.
+	// ExternalSecretNullBytePolicyFail fails reconciliation if fetched secret data contains NUL bytes.
 	ExternalSecretNullBytePolicyFail ExternalSecretNullBytePolicy = "Fail"
 )
 
@@ -255,11 +255,6 @@ type ExternalSecretTarget struct {
 	// +optional
 	Manifest *ManifestReference `json:"manifest,omitempty"`
 
-	// NullBytePolicy controls how ESO handles rendered secret data containing NUL bytes.
-	// +optional
-	// +kubebuilder:default="Ignore"
-	NullBytePolicy ExternalSecretNullBytePolicy `json:"nullBytePolicy,omitempty"`
-
 	// Immutable defines if the final secret will be immutable
 	// +optional
 	Immutable bool `json:"immutable,omitempty"`
@@ -309,6 +304,11 @@ type ExternalSecretDataRemoteRef struct {
 	// Used to define a decoding Strategy
 	// +kubebuilder:default="None"
 	DecodingStrategy ExternalSecretDecodingStrategy `json:"decodingStrategy,omitempty"`
+
+	// +optional
+	// Controls how ESO handles fetched secret data containing NUL bytes for this source.
+	// +kubebuilder:default="Ignore"
+	NullBytePolicy ExternalSecretNullBytePolicy `json:"nullBytePolicy,omitempty"`
 }
 
 // ExternalSecretMetadataPolicy defines policies for fetching metadata from provider secrets.
@@ -494,6 +494,11 @@ type ExternalSecretFind struct {
 	// Used to define a decoding Strategy
 	// +kubebuilder:default="None"
 	DecodingStrategy ExternalSecretDecodingStrategy `json:"decodingStrategy,omitempty"`
+
+	// +optional
+	// Controls how ESO handles fetched secret data containing NUL bytes for this find source.
+	// +kubebuilder:default="Ignore"
+	NullBytePolicy ExternalSecretNullBytePolicy `json:"nullBytePolicy,omitempty"`
 }
 
 // FindName defines criteria for finding secrets by name patterns.

--- a/config/crds/bases/external-secrets.io_clusterexternalsecrets.yaml
+++ b/config/crds/bases/external-secrets.io_clusterexternalsecrets.yaml
@@ -119,6 +119,14 @@ spec:
                               - None
                               - Fetch
                               type: string
+                            nullBytePolicy:
+                              default: Ignore
+                              description: Controls how ESO handles fetched secret
+                                data containing NUL bytes for this source.
+                              enum:
+                              - Ignore
+                              - Fail
+                              type: string
                             property:
                               description: Used to select a specific property of the
                                 Provider value (if a map), if supported
@@ -253,6 +261,14 @@ spec:
                               - None
                               - Fetch
                               type: string
+                            nullBytePolicy:
+                              default: Ignore
+                              description: Controls how ESO handles fetched secret
+                                data containing NUL bytes for this source.
+                              enum:
+                              - Ignore
+                              - Fail
+                              type: string
                             property:
                               description: Used to select a specific property of the
                                 Provider value (if a map), if supported
@@ -292,6 +308,14 @@ spec:
                                   description: Finds secrets base
                                   type: string
                               type: object
+                            nullBytePolicy:
+                              default: Ignore
+                              description: Controls how ESO handles fetched secret
+                                data containing NUL bytes for this find source.
+                              enum:
+                              - Ignore
+                              - Fail
+                              type: string
                             path:
                               description: A root path to start the find operations.
                               type: string
@@ -560,14 +584,6 @@ spec:
                         maxLength: 253
                         minLength: 1
                         pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                        type: string
-                      nullBytePolicy:
-                        default: Ignore
-                        description: NullBytePolicy controls how ESO handles rendered
-                          secret data containing NUL bytes.
-                        enum:
-                        - Ignore
-                        - Fail
                         type: string
                       template:
                         description: Template defines a blueprint for the created

--- a/config/crds/bases/external-secrets.io_clusterexternalsecrets.yaml
+++ b/config/crds/bases/external-secrets.io_clusterexternalsecrets.yaml
@@ -561,6 +561,14 @@ spec:
                         minLength: 1
                         pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                         type: string
+                      nullBytePolicy:
+                        default: Ignore
+                        description: NullBytePolicy controls how ESO handles rendered
+                          secret data containing NUL bytes.
+                        enum:
+                        - Ignore
+                        - Fail
+                        type: string
                       template:
                         description: Template defines a blueprint for the created
                           Secret resource.

--- a/config/crds/bases/external-secrets.io_externalsecrets.yaml
+++ b/config/crds/bases/external-secrets.io_externalsecrets.yaml
@@ -542,6 +542,14 @@ spec:
                     minLength: 1
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
+                  nullBytePolicy:
+                    default: Ignore
+                    description: NullBytePolicy controls how ESO handles rendered
+                      secret data containing NUL bytes.
+                    enum:
+                    - Ignore
+                    - Fail
+                    type: string
                   template:
                     description: Template defines a blueprint for the created Secret
                       resource.

--- a/config/crds/bases/external-secrets.io_externalsecrets.yaml
+++ b/config/crds/bases/external-secrets.io_externalsecrets.yaml
@@ -105,6 +105,14 @@ spec:
                           - None
                           - Fetch
                           type: string
+                        nullBytePolicy:
+                          default: Ignore
+                          description: Controls how ESO handles fetched secret data
+                            containing NUL bytes for this source.
+                          enum:
+                          - Ignore
+                          - Fail
+                          type: string
                         property:
                           description: Used to select a specific property of the Provider
                             value (if a map), if supported
@@ -238,6 +246,14 @@ spec:
                           - None
                           - Fetch
                           type: string
+                        nullBytePolicy:
+                          default: Ignore
+                          description: Controls how ESO handles fetched secret data
+                            containing NUL bytes for this source.
+                          enum:
+                          - Ignore
+                          - Fail
+                          type: string
                         property:
                           description: Used to select a specific property of the Provider
                             value (if a map), if supported
@@ -277,6 +293,14 @@ spec:
                               description: Finds secrets base
                               type: string
                           type: object
+                        nullBytePolicy:
+                          default: Ignore
+                          description: Controls how ESO handles fetched secret data
+                            containing NUL bytes for this find source.
+                          enum:
+                          - Ignore
+                          - Fail
+                          type: string
                         path:
                           description: A root path to start the find operations.
                           type: string
@@ -541,14 +565,6 @@ spec:
                     maxLength: 253
                     minLength: 1
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                    type: string
-                  nullBytePolicy:
-                    default: Ignore
-                    description: NullBytePolicy controls how ESO handles rendered
-                      secret data containing NUL bytes.
-                    enum:
-                    - Ignore
-                    - Fail
                     type: string
                   template:
                     description: Template defines a blueprint for the created Secret

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -113,6 +113,13 @@ spec:
                                   - None
                                   - Fetch
                                 type: string
+                              nullBytePolicy:
+                                default: Ignore
+                                description: Controls how ESO handles fetched secret data containing NUL bytes for this source.
+                                enum:
+                                  - Ignore
+                                  - Fail
+                                type: string
                               property:
                                 description: Used to select a specific property of the Provider value (if a map), if supported
                                 type: string
@@ -240,6 +247,13 @@ spec:
                                   - None
                                   - Fetch
                                 type: string
+                              nullBytePolicy:
+                                default: Ignore
+                                description: Controls how ESO handles fetched secret data containing NUL bytes for this source.
+                                enum:
+                                  - Ignore
+                                  - Fail
+                                type: string
                               property:
                                 description: Used to select a specific property of the Provider value (if a map), if supported
                                 type: string
@@ -277,6 +291,13 @@ spec:
                                     description: Finds secrets base
                                     type: string
                                 type: object
+                              nullBytePolicy:
+                                default: Ignore
+                                description: Controls how ESO handles fetched secret data containing NUL bytes for this find source.
+                                enum:
+                                  - Ignore
+                                  - Fail
+                                type: string
                               path:
                                 description: A root path to start the find operations.
                                 type: string
@@ -529,13 +550,6 @@ spec:
                           maxLength: 253
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                          type: string
-                        nullBytePolicy:
-                          default: Ignore
-                          description: NullBytePolicy controls how ESO handles rendered secret data containing NUL bytes.
-                          enum:
-                            - Ignore
-                            - Fail
                           type: string
                         template:
                           description: Template defines a blueprint for the created Secret resource.
@@ -12449,6 +12463,13 @@ spec:
                               - None
                               - Fetch
                             type: string
+                          nullBytePolicy:
+                            default: Ignore
+                            description: Controls how ESO handles fetched secret data containing NUL bytes for this source.
+                            enum:
+                              - Ignore
+                              - Fail
+                            type: string
                           property:
                             description: Used to select a specific property of the Provider value (if a map), if supported
                             type: string
@@ -12576,6 +12597,13 @@ spec:
                               - None
                               - Fetch
                             type: string
+                          nullBytePolicy:
+                            default: Ignore
+                            description: Controls how ESO handles fetched secret data containing NUL bytes for this source.
+                            enum:
+                              - Ignore
+                              - Fail
+                            type: string
                           property:
                             description: Used to select a specific property of the Provider value (if a map), if supported
                             type: string
@@ -12613,6 +12641,13 @@ spec:
                                 description: Finds secrets base
                                 type: string
                             type: object
+                          nullBytePolicy:
+                            default: Ignore
+                            description: Controls how ESO handles fetched secret data containing NUL bytes for this find source.
+                            enum:
+                              - Ignore
+                              - Fail
+                            type: string
                           path:
                             description: A root path to start the find operations.
                             type: string
@@ -12865,13 +12900,6 @@ spec:
                       maxLength: 253
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                      type: string
-                    nullBytePolicy:
-                      default: Ignore
-                      description: NullBytePolicy controls how ESO handles rendered secret data containing NUL bytes.
-                      enum:
-                        - Ignore
-                        - Fail
                       type: string
                     template:
                       description: Template defines a blueprint for the created Secret resource.

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -530,6 +530,13 @@ spec:
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                           type: string
+                        nullBytePolicy:
+                          default: Ignore
+                          description: NullBytePolicy controls how ESO handles rendered secret data containing NUL bytes.
+                          enum:
+                            - Ignore
+                            - Fail
+                          type: string
                         template:
                           description: Template defines a blueprint for the created Secret resource.
                           properties:
@@ -12858,6 +12865,13 @@ spec:
                       maxLength: 253
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    nullBytePolicy:
+                      default: Ignore
+                      description: NullBytePolicy controls how ESO handles rendered secret data containing NUL bytes.
+                      enum:
+                        - Ignore
+                        - Fail
                       type: string
                     template:
                       description: Template defines a blueprint for the created Secret resource.

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -4081,6 +4081,20 @@ ExternalSecretDecodingStrategy
 <p>Used to define a decoding Strategy</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>nullBytePolicy</code></br>
+<em>
+<a href="#external-secrets.io/v1.ExternalSecretNullBytePolicy">
+ExternalSecretNullBytePolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Controls how ESO handles fetched secret data containing NUL bytes for this source.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="external-secrets.io/v1.ExternalSecretDecodingStrategy">ExternalSecretDecodingStrategy
@@ -4232,6 +4246,20 @@ ExternalSecretDecodingStrategy
 <p>Used to define a decoding Strategy</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>nullBytePolicy</code></br>
+<em>
+<a href="#external-secrets.io/v1.ExternalSecretNullBytePolicy">
+ExternalSecretNullBytePolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Controls how ESO handles fetched secret data containing NUL bytes for this find source.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="external-secrets.io/v1.ExternalSecretMetadata">ExternalSecretMetadata
@@ -4296,6 +4324,31 @@ map[string]string
 </td>
 </tr><tr><td><p>&#34;None&#34;</p></td>
 <td><p>ExternalSecretMetadataPolicyNone specifies that no metadata should be fetched from the provider.</p>
+</td>
+</tr></tbody>
+</table>
+<h3 id="external-secrets.io/v1.ExternalSecretNullBytePolicy">ExternalSecretNullBytePolicy
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#external-secrets.io/v1.ExternalSecretDataRemoteRef">ExternalSecretDataRemoteRef</a>, 
+<a href="#external-secrets.io/v1.ExternalSecretFind">ExternalSecretFind</a>)
+</p>
+<p>
+<p>ExternalSecretNullBytePolicy defines how fetched secret data containing NUL bytes should be handled.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;Fail&#34;</p></td>
+<td><p>ExternalSecretNullBytePolicyFail fails reconciliation if fetched secret data contains NUL bytes.</p>
+</td>
+</tr><tr><td><p>&#34;Ignore&#34;</p></td>
+<td><p>ExternalSecretNullBytePolicyIgnore allows fetched secret data to contain NUL bytes.</p>
 </td>
 </tr></tbody>
 </table>

--- a/pkg/controllers/clusterexternalsecret/clusterexternalsecret_controller_test.go
+++ b/pkg/controllers/clusterexternalsecret/clusterexternalsecret_controller_test.go
@@ -83,7 +83,8 @@ var _ = Describe("ClusterExternalSecret controller", func() {
 						{
 							SecretKey: "test-secret-key",
 							RemoteRef: esv1.ExternalSecretDataRemoteRef{
-								Key: "test-remote-key",
+								Key:            "test-remote-key",
+								NullBytePolicy: esv1.ExternalSecretNullBytePolicyIgnore,
 							},
 						},
 					},

--- a/pkg/controllers/externalsecret/externalsecret_controller.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller.go
@@ -18,6 +18,7 @@ limitations under the License.
 package externalsecret
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -524,6 +525,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 			if err != nil {
 				return fmt.Errorf(errApplyTemplate, err)
 			}
+
+			if err := validateNullBytePolicy(externalSecret, secret); err != nil {
+				return err
+			}
 		}
 
 		// we also use a label to keep track of the owner of the secret
@@ -849,6 +854,29 @@ func (r *Reconciler) cleanupManagedSecrets(ctx context.Context, log logr.Logger,
 			return err
 		}
 		log.V(1).Info("deleted managed secret", "secret", secretName)
+	}
+
+	return nil
+}
+
+func validateNullBytePolicy(es *esv1.ExternalSecret, secret *v1.Secret) error {
+	if es.Spec.Target.NullBytePolicy != esv1.ExternalSecretNullBytePolicyFail {
+		return nil
+	}
+
+	keys := make([]string, 0, len(secret.Data))
+	for key := range secret.Data {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+
+	for _, key := range keys {
+		if bytes.IndexByte(secret.Data[key], 0) >= 0 {
+			return fmt.Errorf(
+				"target secret key %q contains null bytes; use a text-safe format such as PEM/base64 or transform the value with spec.target.template",
+				key,
+			)
+		}
 	}
 
 	return nil

--- a/pkg/controllers/externalsecret/externalsecret_controller.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller.go
@@ -18,7 +18,6 @@ limitations under the License.
 package externalsecret
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -527,10 +526,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 			}
 		}
 
-		if err := validateNullBytePolicy(externalSecret, secret); err != nil {
-			return err
-		}
-
 		// we also use a label to keep track of the owner of the secret
 		// this lets us remove secrets that are no longer needed if the target secret name changes
 		if externalSecret.Spec.Target.CreationPolicy == esv1.CreatePolicyOwner {
@@ -854,29 +849,6 @@ func (r *Reconciler) cleanupManagedSecrets(ctx context.Context, log logr.Logger,
 			return err
 		}
 		log.V(1).Info("deleted managed secret", "secret", secretName)
-	}
-
-	return nil
-}
-
-func validateNullBytePolicy(es *esv1.ExternalSecret, secret *v1.Secret) error {
-	if es.Spec.Target.NullBytePolicy != esv1.ExternalSecretNullBytePolicyFail {
-		return nil
-	}
-
-	keys := make([]string, 0, len(secret.Data))
-	for key := range secret.Data {
-		keys = append(keys, key)
-	}
-	slices.Sort(keys)
-
-	for _, key := range keys {
-		if bytes.IndexByte(secret.Data[key], 0) >= 0 {
-			return fmt.Errorf(
-				"target secret key %q contains null bytes; use a text-safe format such as PEM/base64 or transform the value with spec.target.template",
-				key,
-			)
-		}
 	}
 
 	return nil

--- a/pkg/controllers/externalsecret/externalsecret_controller.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller.go
@@ -525,10 +525,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 			if err != nil {
 				return fmt.Errorf(errApplyTemplate, err)
 			}
+		}
 
-			if err := validateNullBytePolicy(externalSecret, secret); err != nil {
-				return err
-			}
+		if err := validateNullBytePolicy(externalSecret, secret); err != nil {
+			return err
 		}
 
 		// we also use a label to keep track of the owner of the secret

--- a/pkg/controllers/externalsecret/externalsecret_controller_secret.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller_secret.go
@@ -17,10 +17,12 @@ limitations under the License.
 package externalsecret
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 
 	v1 "k8s.io/api/core/v1"
@@ -136,6 +138,9 @@ func (r *Reconciler) handleSecretData(ctx context.Context, externalSecret *esv1.
 	if err != nil {
 		return fmt.Errorf(errDecode, secretRef.RemoteRef.DecodingStrategy, err)
 	}
+	if err := validateFetchedSecretValue(secretRef.RemoteRef.NullBytePolicy, secretRef.SecretKey, secretData); err != nil {
+		return err
+	}
 
 	// store the secret data
 	providerData[secretRef.SecretKey] = secretData
@@ -246,6 +251,9 @@ func (r *Reconciler) handleExtractSecrets(
 	if err != nil {
 		return nil, fmt.Errorf(errDecode, remoteRef.Extract.DecodingStrategy, err)
 	}
+	if err := validateFetchedSecretMap(remoteRef.Extract.NullBytePolicy, secretMap); err != nil {
+		return nil, err
+	}
 	if genState != nil {
 		genState.EnqueueFlagLatestStateForGC(generatorStateKey(i))
 	}
@@ -294,10 +302,41 @@ func (r *Reconciler) handleFindAllSecrets(
 	if err != nil {
 		return nil, fmt.Errorf(errDecode, remoteRef.Find.DecodingStrategy, err)
 	}
+	if err := validateFetchedSecretMap(remoteRef.Find.NullBytePolicy, secretMap); err != nil {
+		return nil, err
+	}
 	if genState != nil {
 		genState.EnqueueFlagLatestStateForGC(generatorStateKey(i))
 	}
 	return secretMap, nil
+}
+
+func validateFetchedSecretValue(policy esv1.ExternalSecretNullBytePolicy, key string, value []byte) error {
+	if policy != esv1.ExternalSecretNullBytePolicyFail || !bytes.Contains(value, []byte{0}) {
+		return nil
+	}
+
+	return fmt.Errorf(`fetched secret value for key %q contains null bytes; use a text-safe format such as PEM/base64 or leave nullBytePolicy unset for intentional binary data`, key)
+}
+
+func validateFetchedSecretMap(policy esv1.ExternalSecretNullBytePolicy, secretMap map[string][]byte) error {
+	if policy != esv1.ExternalSecretNullBytePolicyFail {
+		return nil
+	}
+
+	keys := make([]string, 0, len(secretMap))
+	for key := range secretMap {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+
+	for _, key := range keys {
+		if err := validateFetchedSecretValue(policy, key, secretMap[key]); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func shouldSkipGenerator(r *Reconciler, generatorDef *apiextensions.JSON) (bool, error) {

--- a/pkg/controllers/externalsecret/externalsecret_controller_test.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller_test.go
@@ -2125,6 +2125,39 @@ var _ = Describe("ExternalSecret controller", Serial, func() {
 			Expect(string(secret.Data[targetProp])).To(Equal(secretVal))
 		}
 	}
+	failWhenRenderedSecretContainsNullBytes := func(tc *testCase) {
+		tc.externalSecret.Spec.Target.NullBytePolicy = esv1.ExternalSecretNullBytePolicyFail
+		fakeProvider.WithGetSecret([]byte("A\x00B"), nil)
+		tc.checkCondition = func(es *esv1.ExternalSecret) bool {
+			cond := GetExternalSecretCondition(es.Status, esv1.ExternalSecretReady)
+			if cond == nil || cond.Status != v1.ConditionFalse || cond.Reason != esv1.ConditionReasonSecretSyncedError {
+				return false
+			}
+			return true
+		}
+		tc.checkExternalSecret = func(_ *esv1.ExternalSecret) {
+			secretLookupKey := types.NamespacedName{
+				Name:      tc.targetSecretName,
+				Namespace: ExternalSecretNamespace,
+			}
+			Consistently(func() bool {
+				err := k8sClient.Get(context.Background(), secretLookupKey, &v1.Secret{})
+				return apierrors.IsNotFound(err)
+			}, time.Second, interval).Should(BeTrue())
+		}
+	}
+	allowTemplateConversionWhenRenderedSecretHasNoNullBytes := func(tc *testCase) {
+		tc.externalSecret.Spec.Target.NullBytePolicy = esv1.ExternalSecretNullBytePolicyFail
+		tc.externalSecret.Spec.Target.Template = &esv1.ExternalSecretTemplate{
+			Data: map[string]string{
+				targetProp: "{{ .targetProperty | b64enc }}",
+			},
+		}
+		fakeProvider.WithGetSecret([]byte("A\x00B"), nil)
+		tc.checkSecret = func(_ *esv1.ExternalSecret, secret *v1.Secret) {
+			Expect(string(secret.Data[targetProp])).To(Equal("QQBC"))
+		}
+	}
 	useClusterSecretStore := func(tc *testCase) {
 		tc.secretStore = &esv1.ClusterSecretStore{
 			ObjectMeta: metav1.ObjectMeta{
@@ -2398,6 +2431,8 @@ var _ = Describe("ExternalSecret controller", Serial, func() {
 		Entry("should sync template with correct value precedence", syncWithTemplatePrecedence),
 		Entry("should sync template from keys and values", syncTemplateFromKeysAndValues),
 		Entry("should sync template from literal", syncTemplateFromLiteral),
+		Entry("should fail when rendered secret data contains null bytes and nullBytePolicy=Fail", failWhenRenderedSecretContainsNullBytes),
+		Entry("should allow template conversion when nullBytePolicy=Fail and rendered data has no null bytes", allowTemplateConversionWhenRenderedSecretHasNoNullBytes),
 		Entry("should update template if ExternalSecret is updated", templateShouldRewrite),
 		Entry("should keep data with templates if MergePolicy=Merge", templateShouldMerge),
 		Entry("should refresh secret from template", refreshWithTemplate),

--- a/pkg/controllers/externalsecret/externalsecret_controller_test.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller_test.go
@@ -59,6 +59,8 @@ const (
 	annotationValue    = "annotation-value"
 	existingLabelKey   = "existing-label-key"
 	existingLabelValue = "existing-label-value"
+	nullByteSecretVal  = "A\x00B"
+	nullByteBase64Val  = "QQBC"
 )
 
 var (
@@ -2128,7 +2130,7 @@ var _ = Describe("ExternalSecret controller", Serial, func() {
 	}
 	failWhenRenderedSecretContainsNullBytes := func(tc *testCase) {
 		tc.externalSecret.Spec.Target.NullBytePolicy = esv1.ExternalSecretNullBytePolicyFail
-		fakeProvider.WithGetSecret([]byte("A\x00B"), nil)
+		fakeProvider.WithGetSecret([]byte(nullByteSecretVal), nil)
 		tc.checkCondition = func(es *esv1.ExternalSecret) bool {
 			cond := GetExternalSecretCondition(es.Status, esv1.ExternalSecretReady)
 			if cond == nil || cond.Status != v1.ConditionFalse || cond.Reason != esv1.ConditionReasonSecretSyncedError {
@@ -2154,9 +2156,9 @@ var _ = Describe("ExternalSecret controller", Serial, func() {
 				targetProp: "{{ .targetProperty | b64enc }}",
 			},
 		}
-		fakeProvider.WithGetSecret([]byte("A\x00B"), nil)
+		fakeProvider.WithGetSecret([]byte(nullByteSecretVal), nil)
 		tc.checkSecret = func(_ *esv1.ExternalSecret, secret *v1.Secret) {
-			Expect(string(secret.Data[targetProp])).To(Equal("QQBC"))
+			Expect(string(secret.Data[targetProp])).To(Equal(nullByteBase64Val))
 		}
 	}
 	failWhenImmutableExistingSecretContainsNullBytes := func(tc *testCase) {
@@ -2170,7 +2172,7 @@ var _ = Describe("ExternalSecret controller", Serial, func() {
 				Namespace: ExternalSecretNamespace,
 			},
 			Data: map[string][]byte{
-				targetProp: []byte("A\x00B"),
+				targetProp: []byte(nullByteSecretVal),
 			},
 			Immutable: ptr.To(true),
 		}, client.FieldOwner(FakeManager))).To(Succeed())
@@ -2186,7 +2188,7 @@ var _ = Describe("ExternalSecret controller", Serial, func() {
 		tc.checkSecret = func(_ *esv1.ExternalSecret, secret *v1.Secret) {
 			Expect(secret.Immutable).ToNot(BeNil())
 			Expect(*secret.Immutable).To(BeTrue())
-			Expect(secret.Data[targetProp]).To(Equal([]byte("A\x00B")))
+			Expect(secret.Data[targetProp]).To(Equal([]byte(nullByteSecretVal)))
 		}
 	}
 	useClusterSecretStore := func(tc *testCase) {

--- a/pkg/controllers/externalsecret/externalsecret_controller_test.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller_test.go
@@ -36,7 +36,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
@@ -60,7 +59,6 @@ const (
 	existingLabelKey   = "existing-label-key"
 	existingLabelValue = "existing-label-value"
 	nullByteSecretVal  = "A\x00B"
-	nullByteBase64Val  = "QQBC"
 )
 
 var (
@@ -2128,8 +2126,8 @@ var _ = Describe("ExternalSecret controller", Serial, func() {
 			Expect(string(secret.Data[targetProp])).To(Equal(secretVal))
 		}
 	}
-	failWhenRenderedSecretContainsNullBytes := func(tc *testCase) {
-		tc.externalSecret.Spec.Target.NullBytePolicy = esv1.ExternalSecretNullBytePolicyFail
+	failWhenFetchedSecretContainsNullBytes := func(tc *testCase) {
+		tc.externalSecret.Spec.Data[0].RemoteRef.NullBytePolicy = esv1.ExternalSecretNullBytePolicyFail
 		fakeProvider.WithGetSecret([]byte(nullByteSecretVal), nil)
 		tc.checkCondition = func(es *esv1.ExternalSecret) bool {
 			cond := GetExternalSecretCondition(es.Status, esv1.ExternalSecretReady)
@@ -2149,35 +2147,19 @@ var _ = Describe("ExternalSecret controller", Serial, func() {
 			}, time.Second, interval).Should(BeTrue())
 		}
 	}
-	allowTemplateConversionWhenRenderedSecretHasNoNullBytes := func(tc *testCase) {
-		tc.externalSecret.Spec.Target.NullBytePolicy = esv1.ExternalSecretNullBytePolicyFail
-		tc.externalSecret.Spec.Target.Template = &esv1.ExternalSecretTemplate{
-			Data: map[string]string{
-				targetProp: "{{ .targetProperty | b64enc }}",
+	failWhenExtractedSecretContainsNullBytes := func(tc *testCase) {
+		tc.externalSecret.Spec.Data = nil
+		tc.externalSecret.Spec.DataFrom = []esv1.ExternalSecretDataFromRemoteRef{
+			{
+				Extract: &esv1.ExternalSecretDataRemoteRef{
+					Key:            remoteKey,
+					NullBytePolicy: esv1.ExternalSecretNullBytePolicyFail,
+				},
 			},
 		}
-		fakeProvider.WithGetSecret([]byte(nullByteSecretVal), nil)
-		tc.checkSecret = func(_ *esv1.ExternalSecret, secret *v1.Secret) {
-			Expect(string(secret.Data[targetProp])).To(Equal(nullByteBase64Val))
-		}
-	}
-	failWhenImmutableExistingSecretContainsNullBytes := func(tc *testCase) {
-		tc.externalSecret.Spec.Target.CreationPolicy = esv1.CreatePolicyOrphan
-		tc.externalSecret.Spec.Target.Immutable = true
-		tc.externalSecret.Spec.Target.NullBytePolicy = esv1.ExternalSecretNullBytePolicyFail
-
-		Expect(k8sClient.Create(context.Background(), &v1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      ExternalSecretTargetSecretName,
-				Namespace: ExternalSecretNamespace,
-			},
-			Data: map[string][]byte{
-				targetProp: []byte(nullByteSecretVal),
-			},
-			Immutable: ptr.To(true),
-		}, client.FieldOwner(FakeManager))).To(Succeed())
-
-		fakeProvider.WithGetSecret([]byte("safe"), nil)
+		fakeProvider.WithGetSecretMap(map[string][]byte{
+			"payload": []byte(nullByteSecretVal),
+		}, nil)
 		tc.checkCondition = func(es *esv1.ExternalSecret) bool {
 			cond := GetExternalSecretCondition(es.Status, esv1.ExternalSecretReady)
 			if cond == nil || cond.Status != v1.ConditionFalse || cond.Reason != esv1.ConditionReasonSecretSyncedError {
@@ -2185,10 +2167,48 @@ var _ = Describe("ExternalSecret controller", Serial, func() {
 			}
 			return true
 		}
-		tc.checkSecret = func(_ *esv1.ExternalSecret, secret *v1.Secret) {
-			Expect(secret.Immutable).ToNot(BeNil())
-			Expect(*secret.Immutable).To(BeTrue())
-			Expect(secret.Data[targetProp]).To(Equal([]byte(nullByteSecretVal)))
+		tc.checkExternalSecret = func(_ *esv1.ExternalSecret) {
+			secretLookupKey := types.NamespacedName{
+				Name:      tc.targetSecretName,
+				Namespace: ExternalSecretNamespace,
+			}
+			Consistently(func() bool {
+				err := k8sClient.Get(context.Background(), secretLookupKey, &v1.Secret{})
+				return apierrors.IsNotFound(err)
+			}, time.Second, interval).Should(BeTrue())
+		}
+	}
+	failWhenFoundSecretContainsNullBytes := func(tc *testCase) {
+		tc.externalSecret.Spec.Data = nil
+		tc.externalSecret.Spec.DataFrom = []esv1.ExternalSecretDataFromRemoteRef{
+			{
+				Find: &esv1.ExternalSecretFind{
+					Name: &esv1.FindName{
+						RegExp: "foobar",
+					},
+					NullBytePolicy: esv1.ExternalSecretNullBytePolicyFail,
+				},
+			},
+		}
+		fakeProvider.WithGetAllSecrets(map[string][]byte{
+			"payload": []byte(nullByteSecretVal),
+		}, nil)
+		tc.checkCondition = func(es *esv1.ExternalSecret) bool {
+			cond := GetExternalSecretCondition(es.Status, esv1.ExternalSecretReady)
+			if cond == nil || cond.Status != v1.ConditionFalse || cond.Reason != esv1.ConditionReasonSecretSyncedError {
+				return false
+			}
+			return true
+		}
+		tc.checkExternalSecret = func(_ *esv1.ExternalSecret) {
+			secretLookupKey := types.NamespacedName{
+				Name:      tc.targetSecretName,
+				Namespace: ExternalSecretNamespace,
+			}
+			Consistently(func() bool {
+				err := k8sClient.Get(context.Background(), secretLookupKey, &v1.Secret{})
+				return apierrors.IsNotFound(err)
+			}, time.Second, interval).Should(BeTrue())
 		}
 	}
 	useClusterSecretStore := func(tc *testCase) {
@@ -2464,9 +2484,9 @@ var _ = Describe("ExternalSecret controller", Serial, func() {
 		Entry("should sync template with correct value precedence", syncWithTemplatePrecedence),
 		Entry("should sync template from keys and values", syncTemplateFromKeysAndValues),
 		Entry("should sync template from literal", syncTemplateFromLiteral),
-		Entry("should fail when rendered secret data contains null bytes and nullBytePolicy=Fail", failWhenRenderedSecretContainsNullBytes),
-		Entry("should allow template conversion when nullBytePolicy=Fail and rendered data has no null bytes", allowTemplateConversionWhenRenderedSecretHasNoNullBytes),
-		Entry("should fail when an immutable existing secret contains null bytes and nullBytePolicy=Fail", failWhenImmutableExistingSecretContainsNullBytes),
+		Entry("should fail when fetched secret data contains null bytes and remoteRef.nullBytePolicy=Fail", failWhenFetchedSecretContainsNullBytes),
+		Entry("should fail when extracted secret data contains null bytes and extract.nullBytePolicy=Fail", failWhenExtractedSecretContainsNullBytes),
+		Entry("should fail when found secret data contains null bytes and find.nullBytePolicy=Fail", failWhenFoundSecretContainsNullBytes),
 		Entry("should update template if ExternalSecret is updated", templateShouldRewrite),
 		Entry("should keep data with templates if MergePolicy=Merge", templateShouldMerge),
 		Entry("should refresh secret from template", refreshWithTemplate),

--- a/pkg/controllers/externalsecret/externalsecret_controller_test.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller_test.go
@@ -36,6 +36,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
@@ -2158,6 +2159,36 @@ var _ = Describe("ExternalSecret controller", Serial, func() {
 			Expect(string(secret.Data[targetProp])).To(Equal("QQBC"))
 		}
 	}
+	failWhenImmutableExistingSecretContainsNullBytes := func(tc *testCase) {
+		tc.externalSecret.Spec.Target.CreationPolicy = esv1.CreatePolicyOrphan
+		tc.externalSecret.Spec.Target.Immutable = true
+		tc.externalSecret.Spec.Target.NullBytePolicy = esv1.ExternalSecretNullBytePolicyFail
+
+		Expect(k8sClient.Create(context.Background(), &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      ExternalSecretTargetSecretName,
+				Namespace: ExternalSecretNamespace,
+			},
+			Data: map[string][]byte{
+				targetProp: []byte("A\x00B"),
+			},
+			Immutable: ptr.To(true),
+		}, client.FieldOwner(FakeManager))).To(Succeed())
+
+		fakeProvider.WithGetSecret([]byte("safe"), nil)
+		tc.checkCondition = func(es *esv1.ExternalSecret) bool {
+			cond := GetExternalSecretCondition(es.Status, esv1.ExternalSecretReady)
+			if cond == nil || cond.Status != v1.ConditionFalse || cond.Reason != esv1.ConditionReasonSecretSyncedError {
+				return false
+			}
+			return true
+		}
+		tc.checkSecret = func(_ *esv1.ExternalSecret, secret *v1.Secret) {
+			Expect(secret.Immutable).ToNot(BeNil())
+			Expect(*secret.Immutable).To(BeTrue())
+			Expect(secret.Data[targetProp]).To(Equal([]byte("A\x00B")))
+		}
+	}
 	useClusterSecretStore := func(tc *testCase) {
 		tc.secretStore = &esv1.ClusterSecretStore{
 			ObjectMeta: metav1.ObjectMeta{
@@ -2433,6 +2464,7 @@ var _ = Describe("ExternalSecret controller", Serial, func() {
 		Entry("should sync template from literal", syncTemplateFromLiteral),
 		Entry("should fail when rendered secret data contains null bytes and nullBytePolicy=Fail", failWhenRenderedSecretContainsNullBytes),
 		Entry("should allow template conversion when nullBytePolicy=Fail and rendered data has no null bytes", allowTemplateConversionWhenRenderedSecretHasNoNullBytes),
+		Entry("should fail when an immutable existing secret contains null bytes and nullBytePolicy=Fail", failWhenImmutableExistingSecretContainsNullBytes),
 		Entry("should update template if ExternalSecret is updated", templateShouldRewrite),
 		Entry("should keep data with templates if MergePolicy=Merge", templateShouldMerge),
 		Entry("should refresh secret from template", refreshWithTemplate),

--- a/pkg/controllers/externalsecret/externalsecret_controller_validation_test.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller_validation_test.go
@@ -38,14 +38,14 @@ func TestValidateNullBytePolicy(t *testing.T) {
 			name:   "zero value policy behaves like ignore",
 			policy: "",
 			data: map[string][]byte{
-				"payload": []byte("A\x00B"),
+				"payload": []byte(nullByteSecretVal),
 			},
 		},
 		{
 			name:   "ignores null bytes when policy is not fail",
 			policy: esv1.ExternalSecretNullBytePolicyIgnore,
 			data: map[string][]byte{
-				"payload": []byte("A\x00B"),
+				"payload": []byte(nullByteSecretVal),
 			},
 		},
 		{
@@ -65,7 +65,7 @@ func TestValidateNullBytePolicy(t *testing.T) {
 			policy: esv1.ExternalSecretNullBytePolicyFail,
 			data: map[string][]byte{
 				"safe":    []byte("value"),
-				"payload": []byte("A\x00B"),
+				"payload": []byte(nullByteSecretVal),
 			},
 			wantErr: `target secret key "payload" contains null bytes`,
 		},
@@ -73,7 +73,7 @@ func TestValidateNullBytePolicy(t *testing.T) {
 			name:   "reports the first offending key in sorted order",
 			policy: esv1.ExternalSecretNullBytePolicyFail,
 			data: map[string][]byte{
-				"zeta":  []byte("A\x00B"),
+				"zeta":  []byte(nullByteSecretVal),
 				"alpha": []byte("C\x00D"),
 			},
 			wantErr: `target secret key "alpha" contains null bytes`,
@@ -95,18 +95,25 @@ func TestValidateNullBytePolicy(t *testing.T) {
 				Data: tt.data,
 			}
 
-			err := validateNullBytePolicy(es, secret)
-			if tt.wantErr == "" && err != nil {
-				t.Fatalf("validateNullBytePolicy() unexpected error = %v", err)
-			}
-			if tt.wantErr != "" {
-				if err == nil {
-					t.Fatalf("validateNullBytePolicy() error = nil, want substring %q", tt.wantErr)
-				}
-				if got := err.Error(); !strings.Contains(got, tt.wantErr) {
-					t.Fatalf("validateNullBytePolicy() error = %q, want substring %q", got, tt.wantErr)
-				}
-			}
+			assertValidateNullBytePolicyError(t, validateNullBytePolicy(es, secret), tt.wantErr)
 		})
+	}
+}
+
+func assertValidateNullBytePolicyError(t *testing.T, err error, wantErr string) {
+	t.Helper()
+
+	if wantErr == "" {
+		if err != nil {
+			t.Fatalf("validateNullBytePolicy() unexpected error = %v", err)
+		}
+		return
+	}
+
+	if err == nil {
+		t.Fatalf("validateNullBytePolicy() error = nil, want substring %q", wantErr)
+	}
+	if got := err.Error(); !strings.Contains(got, wantErr) {
+		t.Fatalf("validateNullBytePolicy() error = %q, want substring %q", got, wantErr)
 	}
 }

--- a/pkg/controllers/externalsecret/externalsecret_controller_validation_test.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller_validation_test.go
@@ -20,12 +20,61 @@ import (
 	"strings"
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
-
 	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
 )
 
-func TestValidateNullBytePolicy(t *testing.T) {
+func TestValidateFetchedSecretValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		policy  esv1.ExternalSecretNullBytePolicy
+		key     string
+		value   []byte
+		wantErr string
+	}{
+		{
+			name:   "zero value policy behaves like ignore",
+			policy: "",
+			key:    "payload",
+			value:  []byte(nullByteSecretVal),
+		},
+		{
+			name:   "ignores null bytes when policy is not fail",
+			policy: esv1.ExternalSecretNullBytePolicyIgnore,
+			key:    "payload",
+			value:  []byte(nullByteSecretVal),
+		},
+		{
+			name:   "allows nil values",
+			policy: esv1.ExternalSecretNullBytePolicyFail,
+			key:    "payload",
+			value:  nil,
+		},
+		{
+			name:   "allows fetched data without null bytes",
+			policy: esv1.ExternalSecretNullBytePolicyFail,
+			key:    "payload",
+			value:  []byte("QQBC"),
+		},
+		{
+			name:    "fails on fetched data containing null bytes",
+			policy:  esv1.ExternalSecretNullBytePolicyFail,
+			key:     "payload",
+			value:   []byte(nullByteSecretVal),
+			wantErr: `fetched secret value for key "payload" contains null bytes`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assertFetchedSecretValidationError(t, validateFetchedSecretValue(tt.policy, tt.key, tt.value), tt.wantErr)
+		})
+	}
+}
+
+func TestValidateFetchedSecretMap(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -35,39 +84,9 @@ func TestValidateNullBytePolicy(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name:   "zero value policy behaves like ignore",
-			policy: "",
-			data: map[string][]byte{
-				"payload": []byte(nullByteSecretVal),
-			},
-		},
-		{
-			name:   "ignores null bytes when policy is not fail",
-			policy: esv1.ExternalSecretNullBytePolicyIgnore,
-			data: map[string][]byte{
-				"payload": []byte(nullByteSecretVal),
-			},
-		},
-		{
 			name:   "allows nil secret data map",
 			policy: esv1.ExternalSecretNullBytePolicyFail,
 			data:   nil,
-		},
-		{
-			name:   "allows rendered data without null bytes",
-			policy: esv1.ExternalSecretNullBytePolicyFail,
-			data: map[string][]byte{
-				"payload": []byte("QQBC"),
-			},
-		},
-		{
-			name:   "fails on the offending key when rendered data contains null bytes",
-			policy: esv1.ExternalSecretNullBytePolicyFail,
-			data: map[string][]byte{
-				"safe":    []byte("value"),
-				"payload": []byte(nullByteSecretVal),
-			},
-			wantErr: `target secret key "payload" contains null bytes`,
 		},
 		{
 			name:   "reports the first offending key in sorted order",
@@ -76,44 +95,32 @@ func TestValidateNullBytePolicy(t *testing.T) {
 				"zeta":  []byte(nullByteSecretVal),
 				"alpha": []byte("C\x00D"),
 			},
-			wantErr: `target secret key "alpha" contains null bytes`,
+			wantErr: `fetched secret value for key "alpha" contains null bytes`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-
-			es := &esv1.ExternalSecret{
-				Spec: esv1.ExternalSecretSpec{
-					Target: esv1.ExternalSecretTarget{
-						NullBytePolicy: tt.policy,
-					},
-				},
-			}
-			secret := &v1.Secret{
-				Data: tt.data,
-			}
-
-			assertValidateNullBytePolicyError(t, validateNullBytePolicy(es, secret), tt.wantErr)
+			assertFetchedSecretValidationError(t, validateFetchedSecretMap(tt.policy, tt.data), tt.wantErr)
 		})
 	}
 }
 
-func assertValidateNullBytePolicyError(t *testing.T, err error, wantErr string) {
+func assertFetchedSecretValidationError(t *testing.T, err error, wantErr string) {
 	t.Helper()
 
 	if wantErr == "" {
 		if err != nil {
-			t.Fatalf("validateNullBytePolicy() unexpected error = %v", err)
+			t.Fatalf("unexpected error = %v", err)
 		}
 		return
 	}
 
 	if err == nil {
-		t.Fatalf("validateNullBytePolicy() error = nil, want substring %q", wantErr)
+		t.Fatalf("error = nil, want substring %q", wantErr)
 	}
 	if got := err.Error(); !strings.Contains(got, wantErr) {
-		t.Fatalf("validateNullBytePolicy() error = %q, want substring %q", got, wantErr)
+		t.Fatalf("error = %q, want substring %q", got, wantErr)
 	}
 }

--- a/pkg/controllers/externalsecret/externalsecret_controller_validation_test.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller_validation_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright © The ESO Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package externalsecret
+
+import (
+	"strings"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+
+	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
+)
+
+func TestValidateNullBytePolicy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		policy  esv1.ExternalSecretNullBytePolicy
+		data    map[string][]byte
+		wantErr string
+	}{
+		{
+			name:   "zero value policy behaves like ignore",
+			policy: "",
+			data: map[string][]byte{
+				"payload": []byte("A\x00B"),
+			},
+		},
+		{
+			name:   "ignores null bytes when policy is not fail",
+			policy: esv1.ExternalSecretNullBytePolicyIgnore,
+			data: map[string][]byte{
+				"payload": []byte("A\x00B"),
+			},
+		},
+		{
+			name:   "allows nil secret data map",
+			policy: esv1.ExternalSecretNullBytePolicyFail,
+			data:   nil,
+		},
+		{
+			name:   "allows rendered data without null bytes",
+			policy: esv1.ExternalSecretNullBytePolicyFail,
+			data: map[string][]byte{
+				"payload": []byte("QQBC"),
+			},
+		},
+		{
+			name:   "fails on the offending key when rendered data contains null bytes",
+			policy: esv1.ExternalSecretNullBytePolicyFail,
+			data: map[string][]byte{
+				"safe":    []byte("value"),
+				"payload": []byte("A\x00B"),
+			},
+			wantErr: `target secret key "payload" contains null bytes`,
+		},
+		{
+			name:   "reports the first offending key in sorted order",
+			policy: esv1.ExternalSecretNullBytePolicyFail,
+			data: map[string][]byte{
+				"zeta":  []byte("A\x00B"),
+				"alpha": []byte("C\x00D"),
+			},
+			wantErr: `target secret key "alpha" contains null bytes`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			es := &esv1.ExternalSecret{
+				Spec: esv1.ExternalSecretSpec{
+					Target: esv1.ExternalSecretTarget{
+						NullBytePolicy: tt.policy,
+					},
+				},
+			}
+			secret := &v1.Secret{
+				Data: tt.data,
+			}
+
+			err := validateNullBytePolicy(es, secret)
+			if tt.wantErr == "" && err != nil {
+				t.Fatalf("validateNullBytePolicy() unexpected error = %v", err)
+			}
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("validateNullBytePolicy() error = nil, want substring %q", tt.wantErr)
+				}
+				if got := err.Error(); !strings.Contains(got, tt.wantErr) {
+					t.Fatalf("validateNullBytePolicy() error = %q, want substring %q", got, tt.wantErr)
+				}
+			}
+		})
+	}
+}

--- a/tests/__snapshot__/clusterexternalsecret-v1.yaml
+++ b/tests/__snapshot__/clusterexternalsecret-v1.yaml
@@ -13,6 +13,7 @@ spec:
         decodingStrategy: "None"
         key: string
         metadataPolicy: "None"
+        nullBytePolicy: "Ignore"
         property: string
         version: string
       secretKey: string
@@ -30,6 +31,7 @@ spec:
         decodingStrategy: "None"
         key: string
         metadataPolicy: "None"
+        nullBytePolicy: "Ignore"
         property: string
         version: string
       find:
@@ -37,6 +39,7 @@ spec:
         decodingStrategy: "None"
         name:
           regexp: string
+        nullBytePolicy: "Ignore"
         path: string
         tags: {}
       rewrite:

--- a/tests/__snapshot__/externalsecret-v1.yaml
+++ b/tests/__snapshot__/externalsecret-v1.yaml
@@ -8,6 +8,7 @@ spec:
       decodingStrategy: "None"
       key: string
       metadataPolicy: "None"
+      nullBytePolicy: "Ignore"
       property: string
       version: string
     secretKey: string
@@ -25,6 +26,7 @@ spec:
       decodingStrategy: "None"
       key: string
       metadataPolicy: "None"
+      nullBytePolicy: "Ignore"
       property: string
       version: string
     find:
@@ -32,6 +34,7 @@ spec:
       decodingStrategy: "None"
       name:
         regexp: string
+      nullBytePolicy: "Ignore"
       path: string
       tags: {}
     rewrite:


### PR DESCRIPTION
First of all, I want to apologise for coming back here with one more PR for you to review 😅 

## Problem Statement

Basically this: https://github.com/external-secrets/external-secrets/issues/4592

We had a pretty annoying incident related to this issue.

I think there are some other issues that are adjacent. 

If ESO tries to sync source secrets that contain NULL bytes (e.g., DER certificates), things will break if folks consume those secrets as environment variables.

We can already circumvent this by:

- Well, just don't use DER certificates, enforce this somehow in your org, and use PEM
- Use templating to transform the data or to force a fail
- Mount the secrets as files. Things will fail only if you try to throw NULL bytes at a evn var

But I don't think this is sufficient. Using env vars is too common with "12 factors" and all that. Creating a certificate by dragging and dropping it into your Secret Manager is also too common especialy for certificates. Then this will break all workloads mounting that secret as env var by default if it is a DER (which is also pretty common).

## Proposed Changes

I was initially adding a new CRD field as a toggle, something like `FailNullByte` (True | False). Reading some other issues, I decided we might want to implement additional behaviors in the future after noticing NULL bytes in the generated secret. I am not tackling that in my PR (And I am not listing those issues here to not bloat this implementation direction), but I landed on `NullBytePolicy` with explicit enum desired behavior (Fail | Ignore, default Ignore).

~I also thought about failing (or not failing) right after noticing the NULL byte coming from the source. That was not great, because the person might want to have this fail check in place, but at the same time transform the data with templating. So I landed on warning the user after we have the final shape, right before creating the final target secret , with something like: `target secret key "%q" contains null bytes; use a text-safe format such as PEM/base64 or transform the value with spec.target.template`~ only if `NullBytePolicy` is `Fail`. 


(actually I changed this based on https://github.com/external-secrets/external-secrets/pull/6194#discussion_r3052839533 and https://github.com/external-secrets/external-secrets/pull/6194#discussion_r3052902347)
(new message since I now check before rendenring: `error processing spec.data[0] (key: /nullbytes/raw), err: fetched secret value for key "payload" contains null bytes; use a text-safe format such as PEM/base64 or leave nullBytePolicy unset for intentional binary data`)

Not saying we want to expand this beyond the Fail+Ignore options (but it doesn't hurt to keep it expandable to that); also not adamant about including this feature. I know our CRDs are getting kinda bloated with config options, so I'd understand if this didn't land.

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
Introduces a new NullBytePolicy enum to control handling of NUL (0x00) bytes in fetched secret data. Values: Ignore (default) and Fail. When set to Fail, the controller rejects target secret creation if any final value contains NUL bytes.

## Changes
- Type & constants: Added ExternalSecretNullBytePolicy (string) with ExternalSecretNullBytePolicyIgnore and ExternalSecretNullBytePolicyFail.
- API/CRD: Added optional nullBytePolicy (default "Ignore", enum ["Ignore","Fail"]) to:
  - ExternalSecretDataRemoteRef (spec.data[].remoteRef)
  - ExternalSecretFind and extract (spec.dataFrom[].find / spec.dataFrom[].extract)
  - Target locations in CRD manifests (v1 CRDs and bundle)
- Controller logic: Added null-byte validation after decoding/templating:
  - handleSecretData() validates single values via validateFetchedSecretValue()
  - handleExtractSecrets() and handleFindAllSecrets() validate fetched maps via validateFetchedSecretMap() with deterministic key ordering
- Tests: Added unit and controller tests covering Ignore/Fail behavior for remoteRef, extract, and find sources; added validation tests ensuring proper error messages and deterministic offending-key reporting.
- Docs: Updated API docs to describe ExternalSecretNullBytePolicy and new fields.

## Impact
Default behavior unchanged (Ignore). Setting nullBytePolicy=Fail prevents syncing secrets that contain NUL bytes, protecting consumers that cannot accept binary data in env vars and guiding users to use text-safe formats or transforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->