### PR TITLE
fix(onepasswordsdk): generate unique field IDs to prevent duplicate field ID errors

### DIFF
--- a/providers/v1/onepasswordsdk/client.go
+++ b/providers/v1/onepasswordsdk/client.go
@@ -20,6 +20,8 @@ package onepasswordsdk
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -296,12 +298,17 @@ func (p *SecretsClient) createItem(ctx context.Context, val []byte, ref esv1.Pus
 		tags = mdata.Spec.Tags
 	}
 
+	field, err := generateNewItemField(label, string(val))
+	if err != nil {
+		return fmt.Errorf("failed to generate item field: %w", err)
+	}
+
 	_, err = p.client.Items().Create(ctx, onepassword.ItemCreateParams{
 		Category: onepassword.ItemCategoryServer,
 		VaultID:  p.vaultID,
 		Title:    ref.GetRemoteKey(),
 		Fields: []onepassword.ItemField{
-			generateNewItemField(label, string(val)),
+			field,
 		},
 		Tags: tags,
 	})
@@ -338,7 +345,11 @@ func updateFieldValue(fields []onepassword.ItemField, title, newVal string) ([]o
 		}
 	}
 	if !found {
-		return append(fields, generateNewItemField(title, newVal)), nil
+		f, err := generateNewItemField(title, newVal)
+		if err != nil {
+			return nil, err
+		}
+		return append(fields, f), nil
 	}
 
 	if fields[index].Value != newVal {
@@ -348,15 +359,32 @@ func updateFieldValue(fields []onepassword.ItemField, title, newVal string) ([]o
 	return fields, nil
 }
 
+// generateFieldID generates a unique field ID.
+// 1Password SDK requires each field within an item to have a unique ID.
+// Without this, pushing multiple fields to the same item results in
+// "item contained duplicate field ids" errors.
+func generateFieldID() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("failed to generate field ID: %w", err)
+	}
+	return hex.EncodeToString(b), nil
+}
+
 // generateNewItemField generates a new item field with the given label and value.
-func generateNewItemField(title, newVal string) onepassword.ItemField {
+func generateNewItemField(title, newVal string) (onepassword.ItemField, error) {
+	id, err := generateFieldID()
+	if err != nil {
+		return onepassword.ItemField{}, err
+	}
 	field := onepassword.ItemField{
+		ID:        id,
 		Title:     title,
 		Value:     newVal,
 		FieldType: onepassword.ItemFieldTypeConcealed,
 	}
 
-	return field
+	return field, nil
 }
 
 // PushSecret creates or updates a secret in 1Password.

--- a/providers/v1/onepasswordsdk/client_test.go
+++ b/providers/v1/onepasswordsdk/client_test.go
@@ -635,7 +635,11 @@ type fakeFileLister struct {
 	readContent []byte
 }
 
-func (f *fakeFileLister) Attach(ctx context.Context, item onepassword.Item, fileParams onepassword.FileCreateParams) (onepassword.Item, error) {
+func (f *fakeFileLister) Attach(
+	ctx context.Context,
+	item onepassword.Item,
+	fileParams onepassword.FileCreateParams,
+) (onepassword.Item, error) {
 	return onepassword.Item{}, nil
 }
 
@@ -647,7 +651,11 @@ func (f *fakeFileLister) Delete(ctx context.Context, item onepassword.Item, sect
 	return onepassword.Item{}, nil
 }
 
-func (f *fakeFileLister) ReplaceDocument(ctx context.Context, item onepassword.Item, docParams onepassword.DocumentCreateParams) (onepassword.Item, error) {
+func (f *fakeFileLister) ReplaceDocument(
+	ctx context.Context,
+	item onepassword.Item,
+	docParams onepassword.DocumentCreateParams,
+) (onepassword.Item, error) {
 	return onepassword.Item{}, nil
 }
 
@@ -702,7 +710,11 @@ func (f *statefulFakeLister) Archive(ctx context.Context, vaultID, itemID string
 	return nil
 }
 
-func (f *statefulFakeLister) List(ctx context.Context, vaultID string, opts ...onepassword.ItemListFilter) ([]onepassword.ItemOverview, error) {
+func (f *statefulFakeLister) List(
+	ctx context.Context,
+	vaultID string,
+	opts ...onepassword.ItemListFilter,
+) ([]onepassword.ItemOverview, error) {
 	return f.listAllResult, nil
 }
 
@@ -1168,7 +1180,11 @@ func (f *fakeListerWithCounter) Archive(ctx context.Context, vaultID, itemID str
 	return f.fakeLister.Archive(ctx, vaultID, itemID)
 }
 
-func (f *fakeListerWithCounter) List(ctx context.Context, vaultID string, opts ...onepassword.ItemListFilter) ([]onepassword.ItemOverview, error) {
+func (f *fakeListerWithCounter) List(
+	ctx context.Context,
+	vaultID string,
+	opts ...onepassword.ItemListFilter,
+) ([]onepassword.ItemOverview, error) {
 	return f.fakeLister.List(ctx, vaultID, opts...)
 }
 
@@ -1215,4 +1231,55 @@ func TestIsNativeItemID(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGenerateNewItemFieldHasUniqueID(t *testing.T) {
+	field, err := generateNewItemField("username", "admin")
+	require.NoError(t, err)
+	assert.NotEmpty(t, field.ID, "field ID must not be empty")
+	assert.Equal(t, "username", field.Title)
+	assert.Equal(t, "admin", field.Value)
+	assert.Equal(t, onepassword.ItemFieldTypeConcealed, field.FieldType)
+}
+
+func TestGenerateNewItemFieldIDsAreUnique(t *testing.T) {
+	seen := make(map[string]bool)
+	for range 100 {
+		field, err := generateNewItemField("field", "value")
+		require.NoError(t, err)
+		require.NotEmpty(t, field.ID)
+		require.False(t, seen[field.ID], "duplicate field ID generated: %s", field.ID)
+		seen[field.ID] = true
+	}
+}
+
+func TestUpdateFieldValueMultipleFieldsUniqueIDs(t *testing.T) {
+	// Simulate pushing multiple different properties to the same item.
+	// Each new field must get a unique ID so the 1Password API does not
+	// reject the update with "item contained duplicate field ids".
+	firstField, err := generateNewItemField("password", "secret123")
+	require.NoError(t, err)
+	fields := []onepassword.ItemField{firstField}
+
+	fields, err = updateFieldValue(fields, "username", "admin")
+	require.NoError(t, err)
+	require.Len(t, fields, 2)
+
+	fields, err = updateFieldValue(fields, "host", "db.example.com")
+	require.NoError(t, err)
+	require.Len(t, fields, 3)
+
+	// All IDs must be non-empty and unique.
+	ids := make(map[string]bool)
+	for _, f := range fields {
+		assert.NotEmpty(t, f.ID, "field %q must have a non-empty ID", f.Title)
+		assert.False(t, ids[f.ID], "duplicate field ID %q found", f.ID)
+		ids[f.ID] = true
+	}
+}
+
+func TestGenerateFieldIDFormat(t *testing.T) {
+	id, err := generateFieldID()
+	require.NoError(t, err)
+	assert.Regexp(t, `^[0-9a-f]{32}$`, id, "field ID should be 32 lowercase hex characters (16 bytes)")
 }


### PR DESCRIPTION
## Problem Statement

When pushing multiple fields to the same 1Password item via PushSecret (e.g. `username` and `password`), the `generateNewItemField()` function creates fields with an empty `ID`. The 1Password SDK API requires each field within an item to have a unique ID, so pushing a second field to an existing item fails with:

> "item contained duplicate field ids. Make sure every id is unique.; file and field IDs must be unique within an item"

The first PushSecret data entry succeeds (creates the item with one field), but the second entry fails when trying to add another field to the same item because both fields end up with an empty `ID`.

## Related Issue

Fixes #5303

## Proposed Changes

- Add a `generateFieldID()` helper that produces a cryptographically random 32-character hex string (16 bytes from `crypto/rand`).
- Update `generateNewItemField()` to set `ID: generateFieldID()` on every new field, ensuring each field gets a unique ID.
- Add 4 unit tests:
  - `TestGenerateNewItemFieldHasUniqueID` — verifies a new field has a non-empty ID with correct title/value/type.
  - `TestGenerateNewItemFieldIDsAreUnique` — generates 100 fields and asserts all IDs are unique.
  - `TestUpdateFieldValueMultipleFieldsUniqueIDs` — simulates pushing 3 different properties to the same item and verifies all field IDs are non-empty and unique.
  - `TestGenerateFieldIDFormat` — verifies the generated ID is 32 hex characters.

The Connect provider (`onepassword`) does not have this issue because its SDK (`connect-sdk-go`) generates field IDs server-side. The native SDK (`onepassword-sdk-go`) requires client-side unique IDs.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Fix: Generate unique field IDs for 1Password SDK PushSecret

Resolves duplicate field ID errors when pushing multiple fields to the same 1Password item via the native SDK by ensuring each new field has a unique ID.

### Changes
- Added generateFieldID() to produce a cryptographically-random 32-character hex ID (16 bytes from crypto/rand).
- Updated generateNewItemField() to assign IDs with generateFieldID() and return (onepassword.ItemField, error).
- Adjusted createItem() and updateFieldValue() to precompute/handle field ID generation and propagate errors instead of creating fields with empty IDs.
- Added 4 unit tests:
  - TestGenerateNewItemFieldHasUniqueID — non-empty ID, correct title/value/type.
  - TestGenerateNewItemFieldIDsAreUnique — uniqueness across 100 IDs.
  - TestUpdateFieldValueMultipleFieldsUniqueIDs — multi-field push produces unique non-empty IDs.
  - TestGenerateFieldIDFormat — ID matches 32 lowercase hex chars.

### Files changed
- providers/v1/onepasswordsdk/client.go (+32/-4): add ID generation, error-aware field creation/propagation.
- providers/v1/onepasswordsdk/client_test.go (+71/-4): new tests for ID generation/uniqueness and minor test signature formatting.

Note: This targets the native onepassword-sdk-go client; the Connect provider (server-side ID generation) is unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->