### PR TITLE
feat(github): add orgSecretVisibility field to GithubProvider

### DIFF
--- a/apis/externalsecrets/v1/secretstore_github_types.go
+++ b/apis/externalsecrets/v1/secretstore_github_types.go
@@ -47,6 +47,14 @@ type GithubProvider struct {
 	// environment will be used to fetch secrets from a particular environment within a github repository
 	//+optional
 	Environment string `json:"environment,omitempty"`
+
+	// orgSecretVisibility controls the visibility of organization secrets pushed via PushSecret.
+	// Valid values are "all" or "private".
+	// When unset, new secrets are created with visibility "all" and existing secrets preserve
+	// whatever visibility they already have in GitHub.
+	//+optional
+	//+kubebuilder:validation:Enum=all;private
+	OrgSecretVisibility string `json:"orgSecretVisibility,omitempty"`
 }
 
 // GithubAppAuth defines authentication configuration using a GitHub App for accessing GitHub API.

--- a/config/crds/bases/external-secrets.io_clustersecretstores.yaml
+++ b/config/crds/bases/external-secrets.io_clustersecretstores.yaml
@@ -2256,6 +2256,16 @@ spec:
                           that will be used to authenticate the client
                         format: int64
                         type: integer
+                      orgSecretVisibility:
+                        description: |-
+                          orgSecretVisibility controls the visibility of organization secrets pushed via PushSecret.
+                          Valid values are "all" or "private".
+                          When unset, new secrets are created with visibility "all" and existing secrets preserve
+                          whatever visibility they already have in GitHub.
+                        enum:
+                        - all
+                        - private
+                        type: string
                       organization:
                         description: organization will be used to fetch secrets from
                           the Github organization

--- a/config/crds/bases/external-secrets.io_secretstores.yaml
+++ b/config/crds/bases/external-secrets.io_secretstores.yaml
@@ -2256,6 +2256,16 @@ spec:
                           that will be used to authenticate the client
                         format: int64
                         type: integer
+                      orgSecretVisibility:
+                        description: |-
+                          orgSecretVisibility controls the visibility of organization secrets pushed via PushSecret.
+                          Valid values are "all" or "private".
+                          When unset, new secrets are created with visibility "all" and existing secrets preserve
+                          whatever visibility they already have in GitHub.
+                        enum:
+                        - all
+                        - private
+                        type: string
                       organization:
                         description: organization will be used to fetch secrets from
                           the Github organization

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -4349,6 +4349,16 @@ spec:
                           description: installationID specifies the Github APP installation that will be used to authenticate the client
                           format: int64
                           type: integer
+                        orgSecretVisibility:
+                          description: |-
+                            orgSecretVisibility controls the visibility of organization secrets pushed via PushSecret.
+                            Valid values are "all" or "private".
+                            When unset, new secrets are created with visibility "all" and existing secrets preserve
+                            whatever visibility they already have in GitHub.
+                          enum:
+                            - all
+                            - private
+                          type: string
                         organization:
                           description: organization will be used to fetch secrets from the Github organization
                           type: string
@@ -16440,6 +16450,16 @@ spec:
                           description: installationID specifies the Github APP installation that will be used to authenticate the client
                           format: int64
                           type: integer
+                        orgSecretVisibility:
+                          description: |-
+                            orgSecretVisibility controls the visibility of organization secrets pushed via PushSecret.
+                            Valid values are "all" or "private".
+                            When unset, new secrets are created with visibility "all" and existing secrets preserve
+                            whatever visibility they already have in GitHub.
+                          enum:
+                            - all
+                            - private
+                          type: string
                         organization:
                           description: organization will be used to fetch secrets from the Github organization
                           type: string

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -6045,6 +6045,21 @@ string
 <p>environment will be used to fetch secrets from a particular environment within a github repository</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>orgSecretVisibility</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>orgSecretVisibility controls the visibility of organization secrets pushed via PushSecret.
+Valid values are &ldquo;all&rdquo; or &ldquo;private&rdquo;.
+When unset, new secrets are created with visibility &ldquo;all&rdquo; and existing secrets preserve
+whatever visibility they already have in GitHub.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="external-secrets.io/v1.GitlabAuth">GitlabAuth

--- a/providers/v1/github/client.go
+++ b/providers/v1/github/client.go
@@ -123,10 +123,9 @@ func (g *Client) PushSecret(ctx context.Context, secret *corev1.Secret, remoteRe
 		return fmt.Errorf("box.SealAnonymous failed with error %w", err)
 	}
 	name := remoteRef.GetRemoteKey()
-	visibility := "all"
+	visibility := g.resolveOrgSecretVisibility(githubSecret)
 	if githubSecret != nil {
 		name = githubSecret.Name
-		visibility = githubSecret.Visibility
 	}
 	encryptedString := base64.StdEncoding.EncodeToString(encryptedBytes)
 	keyID := publicKey.GetKeyID()
@@ -142,6 +141,22 @@ func (g *Client) PushSecret(ctx context.Context, secret *corev1.Secret, remoteRe
 	}
 
 	return nil
+}
+
+// resolveOrgSecretVisibility returns the visibility to use when creating or updating an org secret.
+//
+// Rules:
+//   - If OrgSecretVisibility is set on the provider, that value is always used.
+//   - Otherwise, if the secret already exists in GitHub, its current visibility is preserved.
+//   - Otherwise (new secret, no provider override), visibility defaults to "all".
+func (g *Client) resolveOrgSecretVisibility(existing *github.Secret) string {
+	if g.provider != nil && g.provider.OrgSecretVisibility != "" {
+		return g.provider.OrgSecretVisibility
+	}
+	if existing != nil && existing.Visibility != "" {
+		return existing.Visibility
+	}
+	return "all"
 }
 
 // GetAllSecrets is not implemented as this provider is write-only.

--- a/providers/v1/github/client_test.go
+++ b/providers/v1/github/client_test.go
@@ -240,6 +240,78 @@ func TestPushSecret(t *testing.T) {
 	}
 }
 
+func TestResolveOrgSecretVisibility(t *testing.T) {
+	ptr := func(s string) *string { return &s }
+	tests := []struct {
+		name        string
+		nilProvider bool
+		providerViz string
+		existing    *github.Secret
+		want        string
+	}{
+		{
+			name:        "nil provider, no existing secret — defaults to all",
+			nilProvider: true,
+			existing:    nil,
+			want:        "all",
+		},
+		{
+			name:        "nil provider, existing secret has private — preserves private",
+			nilProvider: true,
+			existing:    &github.Secret{Visibility: *ptr("private")},
+			want:        "private",
+		},
+		{
+			name:        "provider unset, no existing secret — defaults to all",
+			providerViz: "",
+			existing:    nil,
+			want:        "all",
+		},
+		{
+			name:        "provider unset, existing secret has all — preserves all",
+			providerViz: "",
+			existing:    &github.Secret{Visibility: *ptr("all")},
+			want:        "all",
+		},
+		{
+			name:        "provider unset, existing secret has private — preserves private",
+			providerViz: "",
+			existing:    &github.Secret{Visibility: *ptr("private")},
+			want:        "private",
+		},
+		{
+			name:        "provider set to private, no existing secret",
+			providerViz: "private",
+			existing:    nil,
+			want:        "private",
+		},
+		{
+			name:        "provider set to private, existing secret has all — provider wins",
+			providerViz: "private",
+			existing:    &github.Secret{Visibility: *ptr("all")},
+			want:        "private",
+		},
+		{
+			name:        "provider set to all, existing secret has private — provider wins",
+			providerViz: "all",
+			existing:    &github.Secret{Visibility: *ptr("private")},
+			want:        "all",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &Client{}
+			if !tt.nilProvider {
+				g.provider = &esv1.GithubProvider{
+					OrgSecretVisibility: tt.providerViz,
+				}
+			}
+			got := g.resolveOrgSecretVisibility(tt.existing)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 // generateTestPrivateKey generates a PEM-encoded RSA private key for testing.
 func generateTestPrivateKey() (string, error) {
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)

--- a/tests/__snapshot__/clustersecretstore-v1.yaml
+++ b/tests/__snapshot__/clustersecretstore-v1.yaml
@@ -342,6 +342,7 @@ spec:
           namespace: string
       environment: string
       installationID: 1
+      orgSecretVisibility: "all" # "all", "private"
       organization: string
       repository: string
       uploadURL: string

--- a/tests/__snapshot__/secretstore-v1.yaml
+++ b/tests/__snapshot__/secretstore-v1.yaml
@@ -342,6 +342,7 @@ spec:
           namespace: string
       environment: string
       installationID: 1
+      orgSecretVisibility: "all" # "all", "private"
       organization: string
       repository: string
       uploadURL: string


### PR DESCRIPTION
Fixes #6201

## Problem

Org secrets pushed via PushSecret are always created with `visibility: all`, which exposes them to every repository in the organization — including public forks. For secrets that should only reach private and internal repositories (license keys, internal credentials, etc.) there is no way to enforce the correct scope. Any ESO reconcile that creates the secret silently resets it to `all`, so manual out-of-band corrections don't hold.

## Solution

Adds an optional `orgSecretVisibility` field to `GithubProvider` accepting `"all"` or `"private"`. `selected` is intentionally excluded: it requires specifying repository IDs, which this provider has no mechanism to express.

Visibility resolution rules (extracted to `resolveOrgSecretVisibility()`):

| `orgSecretVisibility` | Secret exists | Result |
|---|---|---|
| unset | no | `"all"` (unchanged default) |
| unset | yes | existing GitHub visibility (preserved) |
| `"private"` | no | `"private"` |
| `"private"` | yes | `"private"` |
| `"all"` | yes (was `"private"`) | `"all"` |

## Usage

```yaml
apiVersion: external-secrets.io/v1
kind: SecretStore
spec:
  provider:
    github:
      organization: my-org
      appID: 12345
      installationID: 67890
      orgSecretVisibility: private
      auth:
        privateKey:
          name: eso-github-app
          key: private-key
```

## Changes

- `GithubProvider` gains `orgSecretVisibility` (`"all"` | `"private"`, optional, no default) in both `v1` and `v1beta1` API packages
- `client.go`: extracts `resolveOrgSecretVisibility()` and uses it in `PushSecret()`
- `client_test.go`: table tests for all six visibility resolution cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Add orgSecretVisibility field to GithubProvider

Adds an optional `orgSecretVisibility` field to the GithubProvider API to control visibility of organization-level secrets pushed via PushSecret. Accepted values are "all" or "private" (kubebuilder enum validation).

### Changes

- API Types: Added `OrgSecretVisibility string` (json: `orgSecretVisibility,omitempty`) to GithubProvider with enum validation and docs.
- Client Logic: Implemented `resolveOrgSecretVisibility(existing *github.Secret)` and updated `PushSecret()` to use it. Resolution rules:
  - Provider-configured visibility (OrgSecretVisibility) takes precedence.
  - Otherwise preserve existing GitHub secret's visibility if present.
  - Otherwise default to "all".
- Tests: Added table-driven test `TestResolveOrgSecretVisibility` covering all resolution cases (provider unset/ set × existing secret present/absent and visibility combinations).
- CRDs / Docs / Manifests: CRD schemas, bundled YAML, snapshots and API docs updated to include `orgSecretVisibility` with allowed values and behavior description.
- Examples: Included SecretStore YAML demonstrating `orgSecretVisibility: private`.

### Behavior

When `orgSecretVisibility` is unset, new org secrets default to "all" and existing secrets keep their current GitHub visibility. When set to `"private"` or `"all"`, the provider-configured value overrides existing visibility for created or updated org secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->