### PR TITLE
fix(docs): hide Scarf tracking pixel to remove page whitespace

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,12 +1,14 @@
 {% extends "base.html" %}
 {% block outdated %}
-  You're not viewing the latest version.
-  <a href="{{ '../' ~ base_url }}">
-    <strong>Click here to go to latest.</strong>
-  </a>
+You're not viewing the latest version.
+<a href="{{ '../' ~ base_url }}">
+  <strong>Click here to go to latest.</strong>
+</a>
 {% endblock %}
 
 {% block footer %}
-<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=6658a9eb-067d-49f1-94f2-b8b00f21451e"  alt=""/>
-  {{ super() }}
+<img referrerpolicy="no-referrer-when-downgrade"
+  src="https://static.scarf.sh/a.png?x-pxid=6658a9eb-067d-49f1-94f2-b8b00f21451e" alt=""
+  style="position:absolute;width:0;height:0;overflow:hidden;" />
+{{ super() }}
 {% endblock %}

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,14 +1,14 @@
 {% extends "base.html" %}
 {% block outdated %}
-You're not viewing the latest version.
-<a href="{{ '../' ~ base_url }}">
-  <strong>Click here to go to latest.</strong>
-</a>
+  You're not viewing the latest version.
+  <a href="{{ '../' ~ base_url }}">
+    <strong>Click here to go to latest.</strong>
+  </a>
 {% endblock %}
 
 {% block footer %}
 <img referrerpolicy="no-referrer-when-downgrade"
   src="https://static.scarf.sh/a.png?x-pxid=6658a9eb-067d-49f1-94f2-b8b00f21451e" alt=""
-  style="position:absolute;width:0;height:0;overflow:hidden;" />
-{{ super() }}
+  hidden />
+  {{ super() }}
 {% endblock %}


### PR DESCRIPTION
## Problem Statement

All pages on the documentation site have a large whitespace gap between the page content and the footer. Scrolling to the bottom also causes the navbar to break visually.

## Related Issue

Fixes #6193 

## Proposed Changes

The Scarf analytics pixel <img> in `overrides/main.html` had no dimensions or positioning, causing the browser to render it as a visible block element that consumed significant vertical space within the footer block.

To resolve this, added `hidden` attribute to the tracking pixel so it remains invisible while still firing the analytics HTTP request.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`

---
## Local test
#### Current behavior

<img width="2543" height="1332" alt="image" src="https://github.com/user-attachments/assets/2c25098a-291e-4a58-8556-446c0f907a0a" />

#### After fix

<img width="2559" height="1325" alt="image" src="https://github.com/user-attachments/assets/6d5234c2-410f-4fe3-b4bb-6d0c17304752" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes

Updated overrides/main.html to hide the Scarf analytics tracking pixel and tidy markup:

- Added the HTML hidden attribute to the tracking <img> in the footer so the pixel remains invisible while still firing the analytics request, removing the visible whitespace that caused the docs sidebar/footer layout issue.
- Reformatted the <img> tag (normalized alt attribute and surrounding whitespace) and preserved existing template flow.

Fixes #6193.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->