### PR TITLE
docs: add TLS certificate authentication example for Vault provider

### DIFF
--- a/docs/provider/hashicorp-vault.md
+++ b/docs/provider/hashicorp-vault.md
@@ -378,7 +378,15 @@ set of AWS Programmatic access credentials stored in a `Kind=Secret` and referen
 
 #### TLS certificates authentication
 
-[TLS certificates auth method](https://developer.hashicorp.com/vault/docs/auth/cert)  allows authentication using SSL/TLS client certificates which are either signed by a CA or self-signed. SSL/TLS client certificates are defined as having an ExtKeyUsage extension with the usage set to either ClientAuth or Any.
+[TLS certificates auth method](https://developer.hashicorp.com/vault/docs/auth/cert) allows authentication using SSL/TLS client certificates which are either signed by a CA or self-signed. SSL/TLS client certificates are defined as having an ExtKeyUsage extension with the usage set to either ClientAuth or Any.
+
+To use TLS certificate authentication, create a `kubernetes.io/tls` Secret containing the client certificate and private key, then reference it in the SecretStore. The Secret keys must be `tls.crt` and `tls.key`. If your Vault server uses a custom or private CA, also configure `caProvider` or `caBundle` so that ESO can verify the server certificate.
+
+```yaml
+{% include 'vault-cert-store.yaml' %}
+```
+
+**NOTE:** For a `ClusterSecretStore`, you must specify `namespace` in both `clientCert` and `secretRef` to indicate where the TLS Secret resides.
 
 ### Mutual authentication (mTLS)
 

--- a/docs/snippets/vault-cert-store.yaml
+++ b/docs/snippets/vault-cert-store.yaml
@@ -4,9 +4,15 @@ metadata:
   name: vault-tls-cert
   namespace: external-secrets
 type: kubernetes.io/tls
-data:
-  tls.crt: "<base64-encoded-client-certificate>"
-  tls.key: "<base64-encoded-client-private-key>"
+stringData:
+  tls.crt: |
+    -----BEGIN CERTIFICATE-----
+    <your-client-certificate>
+    -----END CERTIFICATE-----
+  tls.key: |
+    -----BEGIN PRIVATE KEY-----
+    <your-client-private-key>
+    -----END PRIVATE KEY-----
 ---
 apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore

--- a/docs/snippets/vault-cert-store.yaml
+++ b/docs/snippets/vault-cert-store.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vault-tls-cert
+  namespace: external-secrets
+type: kubernetes.io/tls
+data:
+  tls.crt: "<base64-encoded-client-certificate>"
+  tls.key: "<base64-encoded-client-private-key>"
+---
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: vault-cert-auth
+spec:
+  provider:
+    vault:
+      server: "https://vault.example.com"
+      path: "secret"
+      version: "v2"
+      caProvider:
+        type: "ConfigMap"
+        namespace: "external-secrets"
+        name: "vault-ca-bundle"
+        key: "ca.crt"
+      auth:
+        cert:
+          clientCert:
+            name: vault-tls-cert
+            namespace: "external-secrets"
+            key: tls.crt
+          secretRef:
+            name: vault-tls-cert
+            namespace: "external-secrets"
+            key: tls.key


### PR DESCRIPTION
## Summary

Add a complete configuration example for TLS certificate authentication with the Hashicorp Vault provider.

## Motivation

The TLS cert auth section (#5604) had a one-line description but no example YAML, making it unclear how to:
- Structure the Kubernetes Secret (must use `tls.crt` and `tls.key` keys)
- Reference the cert and key in the SecretStore `auth.cert` block
- Set `namespace` for `ClusterSecretStore` (required but not documented)
- Configure `caProvider` for custom/private CAs

A previous PR (#5788) was closed due to inactivity.

## Changes

- **New file:** `docs/snippets/vault-cert-store.yaml` — complete example with Secret + ClusterSecretStore
- **Updated:** `docs/provider/hashicorp-vault.md` — added explanatory text and snippet include to the TLS certificates authentication section

Fixes #5604

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
Adds comprehensive TLS certificate authentication documentation and a complete, copy-paste-friendly example for the HashiCorp Vault provider to address gaps in the existing docs.

## Changes
- **docs/provider/hashicorp-vault.md**: Expanded the "TLS certificates authentication" section to document:
  - Use of a `kubernetes.io/tls` Secret with keys `tls.crt` and `tls.key` (supports certificate chains in `tls.crt`).
  - How to reference the cert and key in the store's `auth.cert` block (`clientCert` and `secretRef`), and that `namespace` is required when using a `ClusterSecretStore`.
  - CA configuration options: inline `caBundle` or external retrieval via `caProvider` (Secret or ConfigMap) with required fields `type`, `namespace`, `name`, `key`.
  - Included the snippet via `{% include 'vault-cert-store.yaml' %}`.
- **docs/snippets/vault-cert-store.yaml** (new): Adds a TLS Secret (uses `stringData` with PEM placeholders) and a `ClusterSecretStore` example demonstrating client-certificate auth, CA sourcing via `caProvider` (ConfigMap), required `namespace` fields, and Vault connection fields (`server`, `path`, `version`).

## Impact
Clarifies required Secret key names and structure, shows how to reference certs/keys and CA configuration in SecretStore/ClusterSecretStore, provides a ready-to-use example, and resolves the issues raised in #5604.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->