### PR TITLE
docs: Add Grafana generator documentation

### DIFF
--- a/docs/api/generator/grafana.md
+++ b/docs/api/generator/grafana.md
@@ -1,0 +1,37 @@
+The Grafana generator creates short-lived [Grafana Service Account Tokens](https://grafana.com/docs/grafana/latest/administration/service-accounts/).
+It creates or reuses a service account and generates a new token for it. When the ExternalSecret is deleted, the generated token is cleaned up automatically.
+
+## Authentication
+
+You can authenticate against the Grafana instance using either a service account token or basic auth credentials.
+The credentials must have sufficient permissions to create service accounts and tokens.
+See the [Grafana RBAC documentation](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions/) for details on required roles.
+
+## Output Keys
+
+The generator produces two keys:
+
+| Key     | Description                                |
+|---------|--------------------------------------------|
+| `login` | The login name of the created service account |
+| `token` | The generated service account token         |
+
+## Example Manifests
+
+### Using Token Auth
+
+```yaml
+{% include 'generator-grafana.yaml' %}
+```
+
+### Using Basic Auth
+
+```yaml
+{% include 'generator-grafana-basicauth.yaml' %}
+```
+
+### ExternalSecret referencing the Grafana generator
+
+```yaml
+{% include 'generator-grafana-example.yaml' %}
+```

--- a/docs/api/generator/grafana.md
+++ b/docs/api/generator/grafana.md
@@ -1,5 +1,6 @@
 The Grafana generator creates short-lived [Grafana Service Account Tokens](https://grafana.com/docs/grafana/latest/administration/service-accounts/).
-It creates or reuses a service account and generates a new token for it. When the ExternalSecret is deleted, the generated token is cleaned up automatically. Note that the service account itself is not deleted.
+It creates or reuses a Grafana service account (not a Kubernetes ServiceAccount) and generates a new API token for it.
+When the ExternalSecret is deleted, the generated token is cleaned up automatically. Note that the Grafana service account itself is not deleted.
 
 ## Authentication
 
@@ -13,12 +14,16 @@ The generator produces two keys:
 
 | Key     | Description                                |
 |---------|--------------------------------------------|
-| `login` | The login name of the created service account |
-| `token` | The generated service account token         |
+| `login` | The login name of the created Grafana service account |
+| `token` | The generated Grafana service account token         |
 
 ## Example Manifests
 
 ### Using Token Auth
+
+Use a Grafana [Service Account Token](https://grafana.com/docs/grafana/latest/administration/service-accounts/#service-account-tokens) to authenticate.
+The token must belong to a service account with `Admin` role so it can create other service accounts and tokens.
+Store the token in a Kubernetes Secret and reference it via `spec.auth.token`.
 
 ```yaml
 {% include 'generator-grafana.yaml' %}
@@ -26,12 +31,15 @@ The generator produces two keys:
 
 ### Using Basic Auth
 
+Alternatively, you can use basic auth credentials (username and password) to authenticate against the Grafana instance.
+The user must have sufficient permissions to manage service accounts.
+Store the password in a Kubernetes Secret and reference it via `spec.auth.basic.password`.
+
 ```yaml
 {% include 'generator-grafana-basicauth.yaml' %}
 ```
 
-### ExternalSecret referencing the Grafana generator
-
+Example `ExternalSecret` that references the Grafana generator:
 ```yaml
 {% include 'generator-grafana-example.yaml' %}
 ```

--- a/docs/api/generator/grafana.md
+++ b/docs/api/generator/grafana.md
@@ -1,5 +1,5 @@
 The Grafana generator creates short-lived [Grafana Service Account Tokens](https://grafana.com/docs/grafana/latest/administration/service-accounts/).
-It creates or reuses a service account and generates a new token for it. When the ExternalSecret is deleted, the generated token is cleaned up automatically.
+It creates or reuses a service account and generates a new token for it. When the ExternalSecret is deleted, the generated token is cleaned up automatically. Note that the service account itself is not deleted.
 
 ## Authentication
 

--- a/docs/api/generator/grafana.md
+++ b/docs/api/generator/grafana.md
@@ -19,11 +19,13 @@ The generator produces two keys:
 
 ## Example Manifests
 
+Regardless of the authentication method, the credentials (token or user) must have permissions to manage service accounts and tokens in Grafana.
+The simplest approach is to use the `Admin` role.
+Alternatively, with Grafana's [fine-grained RBAC](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/), you can grant a non-Admin role the following permissions: `serviceaccounts:read`, `serviceaccounts:write`, `serviceaccounts.tokens:write`, and `serviceaccounts.tokens:delete`.
+
 ### Using Token Auth
 
-Use a Grafana [Service Account Token](https://grafana.com/docs/grafana/latest/administration/service-accounts/#service-account-tokens) to authenticate.
-The token must belong to a service account with `Admin` role so it can create other service accounts and tokens.
-Store the token in a Kubernetes Secret and reference it via `spec.auth.token`.
+Use a Grafana [Service Account Token](https://grafana.com/docs/grafana/latest/administration/service-accounts/#service-account-tokens) stored in a Kubernetes Secret, referenced via `spec.auth.token`.
 
 ```yaml
 {% include 'generator-grafana.yaml' %}
@@ -31,15 +33,16 @@ Store the token in a Kubernetes Secret and reference it via `spec.auth.token`.
 
 ### Using Basic Auth
 
-Alternatively, you can use basic auth credentials (username and password) to authenticate against the Grafana instance.
-The user must have sufficient permissions to manage service accounts.
-Store the password in a Kubernetes Secret and reference it via `spec.auth.basic.password`.
+Use a Grafana user's username and password. The password is stored in a Kubernetes Secret and referenced via `spec.auth.basic.password`, while the username is set directly in the spec.
 
 ```yaml
 {% include 'generator-grafana-basicauth.yaml' %}
 ```
 
-Example `ExternalSecret` that references the Grafana generator:
+### Example ExternalSecret
+
+An `ExternalSecret` that references the Grafana generator:
+
 ```yaml
 {% include 'generator-grafana-example.yaml' %}
 ```

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -27217,6 +27217,18 @@ See here for the documentation on basic roles offered by Grafana:
 <a href="https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions/">https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions/</a></p>
 </td>
 </tr>
+<tr>
+<td>
+<code>secondsToLive</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<p>SecondsToLive is the number of seconds before the generated service account token will expire.
+Grafana requires this value to be set.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="generators.external-secrets.io/v1alpha1.GrafanaServiceAccountTokenState">GrafanaServiceAccountTokenState

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -27217,18 +27217,6 @@ See here for the documentation on basic roles offered by Grafana:
 <a href="https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions/">https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions/</a></p>
 </td>
 </tr>
-<tr>
-<td>
-<code>secondsToLive</code></br>
-<em>
-int64
-</em>
-</td>
-<td>
-<p>SecondsToLive is the number of seconds before the generated service account token will expire.
-Grafana requires this value to be set.</p>
-</td>
-</tr>
 </tbody>
 </table>
 <h3 id="generators.external-secrets.io/v1alpha1.GrafanaServiceAccountTokenState">GrafanaServiceAccountTokenState

--- a/docs/snippets/generator-grafana-basicauth.yaml
+++ b/docs/snippets/generator-grafana-basicauth.yaml
@@ -1,0 +1,15 @@
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: Grafana
+metadata:
+  name: grafana-token
+spec:
+  url: https://grafana.example.com
+  auth:
+    basic:
+      username: admin
+      password:
+        name: grafana-basic-auth
+        key: password
+  serviceAccount:
+    name: my-service-account
+    role: Editor

--- a/docs/snippets/generator-grafana-example.yaml
+++ b/docs/snippets/generator-grafana-example.yaml
@@ -1,0 +1,14 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: grafana-token
+spec:
+  refreshInterval: "30m0s"
+  target:
+    name: grafana-token
+  dataFrom:
+  - sourceRef:
+      generatorRef:
+        apiVersion: generators.external-secrets.io/v1alpha1
+        kind: Grafana
+        name: grafana-token

--- a/docs/snippets/generator-grafana.yaml
+++ b/docs/snippets/generator-grafana.yaml
@@ -1,0 +1,13 @@
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: Grafana
+metadata:
+  name: grafana-token
+spec:
+  url: https://grafana.example.com
+  auth:
+    token:
+      name: grafana-admin-token
+      key: token
+  serviceAccount:
+    name: my-service-account
+    role: Viewer

--- a/hack/api-docs/mkdocs.yml
+++ b/hack/api-docs/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
           - Cloudsmith: api/generator/cloudsmith.md
           - Cluster Generator: api/generator/cluster.md
           - Google Container Registry: api/generator/gcr.md
+          - Grafana: api/generator/grafana.md
           - Quay: api/generator/quay.md
           - Vault Dynamic Secret: api/generator/vault.md
           - Password: api/generator/password.md


### PR DESCRIPTION
## Problem Statement

There is no documentation for Grafana generator.

## Related Issue

Fixes #6226 

## Proposed Changes

Add a documentation under the /api/generator/ for the Grafana generator

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Documentation

Added comprehensive documentation and examples for the Grafana generator:

- **`docs/api/generator/grafana.md`**: New page describing how the Grafana generator provisions short-lived Grafana service account tokens (creates/reuses a Grafana service account — not a Kubernetes ServiceAccount), token cleanup behavior when the ExternalSecret is deleted (token removed, service account retained), supported authentication methods (service account token and basic auth), required Grafana permissions, and generator output keys (`login`, `token`).
- **Example YAML snippets**:
  - `docs/snippets/generator-grafana.yaml` — token-based auth example (service account role: Viewer).
  - `docs/snippets/generator-grafana-basicauth.yaml` — basic auth example (role: Editor, password from Kubernetes Secret).
  - `docs/snippets/generator-grafana-example.yaml` — ExternalSecret referencing the Grafana generator with a 30m refresh interval.
- **Navigation update**: Added Grafana entry to the API → Generators section in `hack/api-docs/mkdocs.yml`.

All changes are documentation-only with no code or public API modifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->