### PR TITLE
fix(volcengine): use secretRef.Namespace when resolving credentials for ClusterSecretStore

### DIFF
--- a/providers/v1/volcengine/auth.go
+++ b/providers/v1/volcengine/auth.go
@@ -84,8 +84,12 @@ func NewSession(ctx context.Context, provider *esv1.VolcengineProvider, kube cli
 // getSecretValue retrieves a value from a Kubernetes secret.
 func getSecretValue(ctx context.Context, kube client.Client, namespace string, secretSelector esmeta.SecretKeySelector) ([]byte, error) {
 	secret := &v1.Secret{}
+	ns := namespace
+	if secretSelector.Namespace != nil && *secretSelector.Namespace != "" {
+		ns = *secretSelector.Namespace
+	}
 	ref := types.NamespacedName{
-		Namespace: namespace,
+		Namespace: ns,
 		Name:      secretSelector.Name,
 	}
 

--- a/providers/v1/volcengine/auth_test.go
+++ b/providers/v1/volcengine/auth_test.go
@@ -299,3 +299,52 @@ func TestNewSession_should_return_error_when_region_is_empty(t *testing.T) {
 	assert.Nil(t, sess)
 	assert.Equal(t, "region must be specified", err.Error())
 }
+
+// TestNewSession_ClusterSecretStore_should_use_secretRef_namespace reproduces the bug:
+// When using ClusterSecretStore, the framework passes namespace="" to NewClient/NewSession.
+// The secretRef.Namespace field ("external-secrets") must be used instead of the empty string,
+// otherwise the Kubernetes API returns "an empty namespace may not be set when a resource name is provided".
+func TestNewSession_ClusterSecretStore_should_use_secretRef_namespace(t *testing.T) {
+	secretNamespace := "external-secrets"
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: secretNamespace, // secret lives in "external-secrets", not "default"
+		},
+		Data: map[string][]byte{
+			accessKeyIDKey:     []byte(testAccessKeyID),
+			secretAccessKeyKey: []byte(testSecretAccessKey),
+		},
+	}
+	store := &esv1.VolcengineProvider{
+		Region: testRegion,
+		Auth: &esv1.VolcengineAuth{
+			SecretRef: &esv1.VolcengineAuthSecretRef{
+				AccessKeyID: esmeta.SecretKeySelector{
+					Name:      secretName,
+					Namespace: &secretNamespace, // explicitly set namespace in secretRef
+					Key:       accessKeyIDKey,
+				},
+				SecretAccessKey: esmeta.SecretKeySelector{
+					Name:      secretName,
+					Namespace: &secretNamespace,
+					Key:       secretAccessKeyKey,
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	_ = v1.AddToScheme(scheme)
+	kube := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+	// Simulate ClusterSecretStore: framework passes namespace="" (cluster-scoped has no namespace)
+	sess, err := NewSession(context.Background(), store, kube, "")
+
+	assert.NoError(t, err)
+	assert.NotNil(t, sess)
+	creds, err := sess.Config.Credentials.Get()
+	assert.NoError(t, err)
+	assert.Equal(t, testAccessKeyID, creds.AccessKeyID)
+	assert.Equal(t, testSecretAccessKey, creds.SecretAccessKey)
+}


### PR DESCRIPTION
## What happened?

When using `ClusterSecretStore` with the Volcengine provider, the ESO framework passes an empty string as `namespace` to `NewClient`/`NewSession` because `ClusterSecretStore` is cluster-scoped and has no namespace.

The `getSecretValue` function in `auth.go` was using this empty namespace directly, completely ignoring the `Namespace` field in `SecretKeySelector`. This caused the Kubernetes API to return:

```
failed to get accessKeyID: failed to get secret <name> in namespace : an empty namespace may not be set when a resource name is provided
```

The error occurs even when `namespace` is correctly set in the `ClusterSecretStore` spec:

```yaml
spec:
  provider:
    volcengine:
      auth:
        secretRef:
          accessKeyID:
            name: volcengine-credentials
            namespace: external-secrets  # this was being ignored
            key: VOLCENGINE_ACCESS_KEY_ID
```

## Root cause

`getSecretValue` in `providers/v1/volcengine/auth.go` built a `NamespacedName` using the `namespace` parameter (always `""` for `ClusterSecretStore`) and never checked `secretSelector.Namespace`.

## Fix

Prefer `secretSelector.Namespace` over the passed-in `namespace` when it is explicitly set. This is consistent with how other ESO providers handle `ClusterSecretStore` referent auth.

## Testing

Added a regression test `TestNewSession_ClusterSecretStore_should_use_secretRef_namespace` in `auth_test.go` that:
- Creates a secret in namespace `external-secrets`
- Calls `NewSession` with `namespace=""` (simulating `ClusterSecretStore`)
- Sets `secretRef.Namespace = "external-secrets"`
- Verifies the session is created successfully with correct credentials

The test fails before this fix and passes after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Fix Volcengine ClusterSecretStore Namespace Resolution

**Problem:** The Volcengine provider resolved credential secrets for ClusterSecretStore using an empty namespace, causing Kubernetes errors when the ESO framework passed an empty namespace for cluster-scoped resources.

**Solution:** `getSecretValue` in providers/v1/volcengine/auth.go now prefers `secretSelector.Namespace` when it is explicitly set, falling back to the provided `namespace` argument. This matches other ESO providers' behavior.

**Changes:**
- providers/v1/volcengine/auth.go: Use `secretSelector.Namespace` if non-empty when building the NamespacedName for kube.Get (+5/-1).
- providers/v1/volcengine/auth_test.go: Add regression test `TestNewSession_ClusterSecretStore_should_use_secretRef_namespace` that creates a Secret in `external-secrets`, calls `NewSession` with `namespace=""` and `secretRef.Namespace="external-secrets"`, and verifies credentials are resolved correctly (+49/-0).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->