### PR TITLE
chore: add error handling to the client creation providers/v1/gcp/secretmanager/provider.go

### DIFF
--- a/providers/v1/gcp/secretmanager/provider.go
+++ b/providers/v1/gcp/secretmanager/provider.go
@@ -98,7 +98,11 @@ func (p *Provider) NewClient(ctx context.Context, store esv1.GenericStore, kube 
 	// when using referent namespace.
 	if namespace == "" && isClusterKind && isReferentSpec(gcpStore) {
 		// placeholder smClient to prevent closing the client twice
-		client.smClient, _ = secretmanager.NewClient(ctx, option.WithTokenSource(oauth2.StaticTokenSource(&oauth2.Token{})))
+		smClient, err := secretmanager.NewClient(ctx, option.WithTokenSource(oauth2.StaticTokenSource(&oauth2.Token{})))
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", errUnableCreateGCPSMClient, err)
+		}
+		client.smClient = smClient
 		return client, nil
 	}
 


### PR DESCRIPTION
requires login

Fix: requires login

Affected: provider.go

Closes N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Security: Fix error handling for GCP Secret Manager client creation

Fixes a security vulnerability in `Provider.NewClient` where errors during the placeholder Secret Manager client creation (in the referent namespace code path) were silently ignored. The updated code now properly captures and returns errors from `secretmanager.NewClient()` instead of proceeding with an uninitialized client, implementing fail-fast error handling to prevent invalid client states from being propagated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->