### PR TITLE
docs(cloudsmith): Improve cloudsmith generator documentation

### DIFF
--- a/docs/api/generator/cloudsmith.md
+++ b/docs/api/generator/cloudsmith.md
@@ -31,12 +31,12 @@ Use these values when configuring the OIDC service in your Cloudsmith Workspace 
 
 ## Configuration Parameters
 
-| Parameter           | Description                                                              | Required |
-| ------------------- | ------------------------------------------------------------------------ | -------- |
-| `apiHost`          | The Cloudsmith API host. Defaults to `api.cloudsmith.io`.               | No       |
-| `orgSlug`          | The organization slug in Cloudsmith.                                    | Yes      |
-| `serviceSlug`      | The OIDC service slug configured in Cloudsmith.                         | Yes      |
-| `serviceAccountRef` | Reference to the Kubernetes service account for OIDC token exchange.    | Yes      |
+| Parameter           | Description                                                                   | Required |
+| ------------------- | ----------------------------------------------------------------------------- | -------- |
+| `apiHost`           | The Cloudsmith API host. Defaults to `api.cloudsmith.io`.                     | No       |
+| `orgSlug`           | The organization slug in Cloudsmith.                                          | Yes      |
+| `serviceSlug`       | The service account slug associated with the OIDC provider within cloudsmith. | Yes      |
+| `serviceAccountRef` | Reference to the Kubernetes service account for OIDC token exchange.          | Yes      |
 
 ## Example Manifest
 


### PR DESCRIPTION
## Problem Statement

Make it easier for users to understand the exposed configuration attributes and what values should go into them.

## Proposed Changes

Improves the documentation for the cloudsmith generator so that it is clearer.

## Format

generator/cloudsmith documentation

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Cloudsmith Generator Documentation Improvements

Updated the cloudsmith generator configuration documentation to improve clarity for users. Specifically, revised the `serviceSlug` parameter description in the Configuration Parameters table from "The OIDC service slug configured in Cloudsmith" to "The service account slug associated with the OIDC provider within cloudsmith." to more accurately describe the expected value.

**Changes:** `docs/api/generator/cloudsmith.md` (+6/-6 lines)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->