### PR TITLE
[WIP]feat(Kubernetes): allow TLS without caBundle using system trust store

### DIFF
--- a/apis/externalsecrets/v1/secretstore_kubernetes_types.go
+++ b/apis/externalsecrets/v1/secretstore_kubernetes_types.go
@@ -27,10 +27,14 @@ type KubernetesServer struct {
 	// +optional
 	URL string `json:"url,omitempty"`
 
-	// CABundle is a base64-encoded CA certificate
+	// CABundle is a base64-encoded CA certificate. If neither CABundle nor CAProvider is set,
+	// TLS uses the controller process trust store (public/system roots), matching kubectl when
+	// no certificate-authority is configured.
 	// +optional
 	CABundle []byte `json:"caBundle,omitempty"`
 
+	// CAProvider references a Secret or ConfigMap holding PEM CA certificate(s). If unset
+	// together with CABundle, TLS uses the process trust store; see CABundle.
 	// see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider
 	// +optional
 	CAProvider *CAProvider `json:"caProvider,omitempty"`

--- a/apis/externalsecrets/v1beta1/secretstore_kubernetes_types.go
+++ b/apis/externalsecrets/v1beta1/secretstore_kubernetes_types.go
@@ -28,10 +28,14 @@ type KubernetesServer struct {
 	// +optional
 	URL string `json:"url,omitempty"`
 
-	// CABundle is a base64-encoded CA certificate
+	// CABundle is a base64-encoded CA certificate. If neither CABundle nor CAProvider is set,
+	// TLS uses the controller process trust store (public/system roots), matching kubectl when
+	// no certificate-authority is configured.
 	// +optional
 	CABundle []byte `json:"caBundle,omitempty"`
 
+	// CAProvider references a Secret or ConfigMap holding PEM CA certificate(s). If unset
+	// together with CABundle, TLS uses the process trust store; see CABundle.
 	// see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider
 	// +optional
 	CAProvider *CAProvider `json:"caProvider,omitempty"`

--- a/config/crds/bases/external-secrets.io_clustersecretstores.yaml
+++ b/config/crds/bases/external-secrets.io_clustersecretstores.yaml
@@ -3526,11 +3526,17 @@ spec:
                         description: configures the Kubernetes server Address.
                         properties:
                           caBundle:
-                            description: CABundle is a base64-encoded CA certificate
+                            description: |-
+                              CABundle is a base64-encoded CA certificate. If neither CABundle nor CAProvider is set,
+                              TLS uses the controller process trust store (public/system roots), matching kubectl when
+                              no certificate-authority is configured.
                             format: byte
                             type: string
                           caProvider:
-                            description: 'see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider'
+                            description: |-
+                              CAProvider references a Secret or ConfigMap holding PEM CA certificate(s). If unset
+                              together with CABundle, TLS uses the process trust store; see CABundle.
+                              see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider
                             properties:
                               key:
                                 description: The key where the CA certificate can
@@ -8855,11 +8861,17 @@ spec:
                         description: configures the Kubernetes server Address.
                         properties:
                           caBundle:
-                            description: CABundle is a base64-encoded CA certificate
+                            description: |-
+                              CABundle is a base64-encoded CA certificate. If neither CABundle nor CAProvider is set,
+                              TLS uses the controller process trust store (public/system roots), matching kubectl when
+                              no certificate-authority is configured.
                             format: byte
                             type: string
                           caProvider:
-                            description: 'see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider'
+                            description: |-
+                              CAProvider references a Secret or ConfigMap holding PEM CA certificate(s). If unset
+                              together with CABundle, TLS uses the process trust store; see CABundle.
+                              see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider
                             properties:
                               key:
                                 description: The key where the CA certificate can

--- a/config/crds/bases/external-secrets.io_secretstores.yaml
+++ b/config/crds/bases/external-secrets.io_secretstores.yaml
@@ -3526,11 +3526,17 @@ spec:
                         description: configures the Kubernetes server Address.
                         properties:
                           caBundle:
-                            description: CABundle is a base64-encoded CA certificate
+                            description: |-
+                              CABundle is a base64-encoded CA certificate. If neither CABundle nor CAProvider is set,
+                              TLS uses the controller process trust store (public/system roots), matching kubectl when
+                              no certificate-authority is configured.
                             format: byte
                             type: string
                           caProvider:
-                            description: 'see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider'
+                            description: |-
+                              CAProvider references a Secret or ConfigMap holding PEM CA certificate(s). If unset
+                              together with CABundle, TLS uses the process trust store; see CABundle.
+                              see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider
                             properties:
                               key:
                                 description: The key where the CA certificate can
@@ -8855,11 +8861,17 @@ spec:
                         description: configures the Kubernetes server Address.
                         properties:
                           caBundle:
-                            description: CABundle is a base64-encoded CA certificate
+                            description: |-
+                              CABundle is a base64-encoded CA certificate. If neither CABundle nor CAProvider is set,
+                              TLS uses the controller process trust store (public/system roots), matching kubectl when
+                              no certificate-authority is configured.
                             format: byte
                             type: string
                           caProvider:
-                            description: 'see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider'
+                            description: |-
+                              CAProvider references a Secret or ConfigMap holding PEM CA certificate(s). If unset
+                              together with CABundle, TLS uses the process trust store; see CABundle.
+                              see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider
                             properties:
                               key:
                                 description: The key where the CA certificate can

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -5537,11 +5537,17 @@ spec:
                           description: configures the Kubernetes server Address.
                           properties:
                             caBundle:
-                              description: CABundle is a base64-encoded CA certificate
+                              description: |-
+                                CABundle is a base64-encoded CA certificate. If neither CABundle nor CAProvider is set,
+                                TLS uses the controller process trust store (public/system roots), matching kubectl when
+                                no certificate-authority is configured.
                               format: byte
                               type: string
                             caProvider:
-                              description: 'see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider'
+                              description: |-
+                                CAProvider references a Secret or ConfigMap holding PEM CA certificate(s). If unset
+                                together with CABundle, TLS uses the process trust store; see CABundle.
+                                see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider
                               properties:
                                 key:
                                   description: The key where the CA certificate can be found in the Secret or ConfigMap.
@@ -10479,11 +10485,17 @@ spec:
                           description: configures the Kubernetes server Address.
                           properties:
                             caBundle:
-                              description: CABundle is a base64-encoded CA certificate
+                              description: |-
+                                CABundle is a base64-encoded CA certificate. If neither CABundle nor CAProvider is set,
+                                TLS uses the controller process trust store (public/system roots), matching kubectl when
+                                no certificate-authority is configured.
                               format: byte
                               type: string
                             caProvider:
-                              description: 'see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider'
+                              description: |-
+                                CAProvider references a Secret or ConfigMap holding PEM CA certificate(s). If unset
+                                together with CABundle, TLS uses the process trust store; see CABundle.
+                                see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider
                               properties:
                                 key:
                                   description: The key where the CA certificate can be found in the Secret or ConfigMap.
@@ -17641,11 +17653,17 @@ spec:
                           description: configures the Kubernetes server Address.
                           properties:
                             caBundle:
-                              description: CABundle is a base64-encoded CA certificate
+                              description: |-
+                                CABundle is a base64-encoded CA certificate. If neither CABundle nor CAProvider is set,
+                                TLS uses the controller process trust store (public/system roots), matching kubectl when
+                                no certificate-authority is configured.
                               format: byte
                               type: string
                             caProvider:
-                              description: 'see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider'
+                              description: |-
+                                CAProvider references a Secret or ConfigMap holding PEM CA certificate(s). If unset
+                                together with CABundle, TLS uses the process trust store; see CABundle.
+                                see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider
                               properties:
                                 key:
                                   description: The key where the CA certificate can be found in the Secret or ConfigMap.
@@ -22583,11 +22601,17 @@ spec:
                           description: configures the Kubernetes server Address.
                           properties:
                             caBundle:
-                              description: CABundle is a base64-encoded CA certificate
+                              description: |-
+                                CABundle is a base64-encoded CA certificate. If neither CABundle nor CAProvider is set,
+                                TLS uses the controller process trust store (public/system roots), matching kubectl when
+                                no certificate-authority is configured.
                               format: byte
                               type: string
                             caProvider:
-                              description: 'see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider'
+                              description: |-
+                                CAProvider references a Secret or ConfigMap holding PEM CA certificate(s). If unset
+                                together with CABundle, TLS uses the process trust store; see CABundle.
+                                see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider
                               properties:
                                 key:
                                   description: The key where the CA certificate can be found in the Secret or ConfigMap.

--- a/docs/provider/kubernetes.md
+++ b/docs/provider/kubernetes.md
@@ -82,11 +82,13 @@ spec:
 
 ### Target API-Server Configuration
 
-The servers `url` can be omitted and defaults to `kubernetes.default`. If no `caBundle` or `caProvider` is specified, the operator uses the system certificate roots from the container image. Both the default (`distroless/static`) and UBI images include standard CA certificates, so connections to servers using well-known CAs (e.g., Let's Encrypt) work without explicit CA configuration.
+The servers `url` can be omitted and defaults to `kubernetes.default`.
+
+For TLS, you may set `caBundle` or `caProvider` with the PEM CA used to verify the API server (typical for cluster-signed certificates). If you omit both, the operator uses the **process trust store** (system/public roots from the container image), similar to `kubectl` when no `certificate-authority` is set—useful for API servers with publicly trusted certificates. Both the default (`distroless/static`) and UBI images include standard CA certificates, so connections to servers using well-known CAs (e.g., Let's Encrypt) work without explicit CA configuration.
+
 For your convenience, each namespace has a ConfigMap `kube-root-ca.crt` that contains the CA certificate of the internal API Server (see `RootCAConfigMap` [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/)).
-Use that if you want to connect to the same API server.
-If you want to connect to a remote API Server you need to fetch it and store it inside the cluster as ConfigMap or Secret.
-You may also define it inline as base64 encoded value using the `caBundle` property.
+Use that if you want to connect to the same API server and pin the cluster CA.
+If you want to connect to a remote API Server with a private CA, fetch that CA and store it inside the cluster as ConfigMap or Secret, or define it inline as a base64-encoded value using the `caBundle` property.
 
 ```yaml
 apiVersion: external-secrets.io/v1

--- a/providers/v1/kubernetes/validate.go
+++ b/providers/v1/kubernetes/validate.go
@@ -41,6 +41,8 @@ func (p *Provider) ValidateStore(store esv1.GenericStore) (admission.Warnings, e
 	storeSpec := store.GetSpec()
 	k8sSpec := storeSpec.Provider.Kubernetes
 	var warnings admission.Warnings
+	// When neither caBundle nor caProvider is set, the client uses the process trust store
+	// for TLS verification (same idea as kubectl with no certificate-authority set).
 	if k8sSpec.AuthRef == nil && k8sSpec.Server.CABundle == nil && k8sSpec.Server.CAProvider == nil {
 		warnings = append(warnings, warnNoCAConfigured)
 	}

--- a/providers/v1/kubernetes/validate_test.go
+++ b/providers/v1/kubernetes/validate_test.go
@@ -27,6 +27,7 @@ import (
 
 	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
 	v1 "github.com/external-secrets/external-secrets/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 type fakeReviewClient struct {
@@ -70,7 +71,19 @@ func TestValidateStore(t *testing.T) {
 			store: &esv1.SecretStore{
 				Spec: esv1.SecretStoreSpec{
 					Provider: &esv1.SecretStoreProvider{
-						Kubernetes: &esv1.KubernetesProvider{},
+						Kubernetes: &esv1.KubernetesProvider{
+							Server: esv1.KubernetesServer{
+								URL: "https://api.example.com",
+							},
+							Auth: &esv1.KubernetesAuth{
+								Token: &esv1.TokenAuth{
+									BearerToken: v1.SecretKeySelector{
+										Name: "token-secret",
+										Key:  "token",
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -189,7 +202,7 @@ func TestValidateStore(t *testing.T) {
 							Server: esv1.KubernetesServer{
 								CAProvider: &esv1.CAProvider{
 									Name:      "foobar",
-									Namespace: new("noop"),
+									Namespace: ptr.To("noop"),
 								},
 							},
 						},
@@ -235,7 +248,7 @@ func TestValidateStore(t *testing.T) {
 									ClientCert: v1.SecretKeySelector{
 										Name:      "foobar",
 										Key:       "foobar",
-										Namespace: new("noop"),
+										Namespace: ptr.To("noop"),
 									},
 								},
 							},
@@ -304,7 +317,7 @@ func TestValidateStore(t *testing.T) {
 									BearerToken: v1.SecretKeySelector{
 										Name:      "foobar",
 										Key:       "foobar",
-										Namespace: new("nop"),
+										Namespace: ptr.To("nop"),
 									},
 								},
 							},
@@ -326,7 +339,7 @@ func TestValidateStore(t *testing.T) {
 							Auth: &esv1.KubernetesAuth{
 								ServiceAccount: &v1.ServiceAccountSelector{
 									Name:      "foobar",
-									Namespace: new("foobar"),
+									Namespace: ptr.To("foobar"),
 								},
 							},
 						},

--- a/runtime/esutils/k8s_rest_config_test.go
+++ b/runtime/esutils/k8s_rest_config_test.go
@@ -89,14 +89,41 @@ func TestBuildRESTConfigFromKubernetesConnection(t *testing.T) {
 		wantErrIs error
 	}{
 		{
-			name: "should return err if no ca provided",
+			name: "omit caBundle and caProvider leaves CAData unset for system TLS trust",
 			fields: fields{
+				namespace: "default",
+				kube: fclient.NewClientBuilder().WithObjects(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foobar",
+						Namespace: "default",
+					},
+					Data: map[string][]byte{
+						"token": []byte("mytoken"),
+					},
+				}).Build(),
 				store: &esv1.KubernetesProvider{
-					Server: esv1.KubernetesServer{},
+					Server: esv1.KubernetesServer{
+						URL: serverURL,
+					},
+					Auth: &esv1.KubernetesAuth{
+						Token: &esv1.TokenAuth{
+							BearerToken: v1.SecretKeySelector{
+								Name:      "foobar",
+								Namespace: pointer.To("shouldnotberelevant"),
+								Key:       "token",
+							},
+						},
+					},
 				},
 			},
-			want:    nil,
-			wantErr: true,
+			want: &want{
+				Host:        serverURL,
+				BearerToken: "mytoken",
+				TLSClientConfig: rest.TLSClientConfig{
+					CAData: nil,
+				},
+			},
+			wantErr: false,
 		},
 		{
 			name: "should return err if no auth provided",


### PR DESCRIPTION
## Problem Statement

Most Kubernetes API servers use a TLS certificate signed by the Kubernetes API server CA. In the [Kubernetes provider for External Secrets](https://external-secrets.io/latest/provider/kubernetes/#target-api-server-configuration), clients need to trust this CA to establish a secure connection, using the caBundle or caProvider configuration options.

However, some API servers expose their endpoints with publicly trusted, regularly rotated certificates (e.g., Let's Encrypt), such as https://demo.gardener.cloud. For these systems, hardcoding a caBundle is impractical because the certificate authority may change over time without prior notice (e.g., when the certificate authority changes or rotates the root).

## Related Issue

https://github.com/external-secrets/external-secrets/issues/5393 

## Proposed Changes

Kubernetes provider store validation : Stop requiring server.caBundle or server.caProvider when using inline auth (i.e. when authRef is not used). If both are omitted, TLS verification uses the controller process trust store (same idea as kubectl with no certificate-authority set).
Runtime behavior: No change to the REST client setup path—CAData was already left unset when no CA is supplied, which client-go treats as “use default/system roots.” This change only removes the artificial validation block.

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] My changes have reasonable test coverage
- [X] All tests pass with `make test`
- [X] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR removes the requirement for Kubernetes provider configurations to specify either `CABundle` or `CAProvider` when using inline authentication (i.e., when `AuthRef` is not set). When neither option is provided, TLS certificate validation now falls back to the controller process/system trust store, aligning with kubectl behavior.

## Key Changes

- **Validation Logic**: Removed the enforced requirement for `CABundle` or `CAProvider` in `validate.go`, allowing these to be omitted for inline auth configurations
- **Documentation**: Updated Go type definitions, CRD schemas, and provider documentation across `v1` and `v1beta1` APIs to explain the trust store fallback behavior
- **Tests**: Updated validation tests to confirm that configurations without `CABundle`/`CAProvider` are now valid when inline auth is used

## Impact

Users can now configure the Kubernetes provider to connect to API servers with publicly trusted certificates (e.g., Let's Encrypt) without manually specifying or maintaining certificate bundles, while still supporting custom CAs via the existing `CABundle` and `CAProvider` options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->