### PR TITLE
docs: add missing specs to GeneratorSpec example

### DIFF
--- a/docs/guides/generator.md
+++ b/docs/guides/generator.md
@@ -56,15 +56,19 @@ exactly. The following Spec fields are available:
 ```go
 type GeneratorSpec struct {
 	ACRAccessTokenSpec        *ACRAccessTokenSpec        `json:"acrAccessTokenSpec,omitempty"`
+	CloudsmithAccessTokenSpec *CloudsmithAccessTokenSpec `json:"cloudsmithAccessTokenSpec,omitempty"`
 	ECRAuthorizationTokenSpec *ECRAuthorizationTokenSpec `json:"ecrAuthorizationTokenSpec,omitempty"`
 	FakeSpec                  *FakeSpec                  `json:"fakeSpec,omitempty"`
 	GCRAccessTokenSpec        *GCRAccessTokenSpec        `json:"gcrAccessTokenSpec,omitempty"`
 	GithubAccessTokenSpec     *GithubAccessTokenSpec     `json:"githubAccessTokenSpec,omitempty"`
+	QuayAccessTokenSpec       *QuayAccessTokenSpec       `json:"quayAccessTokenSpec,omitempty"`
 	PasswordSpec              *PasswordSpec              `json:"passwordSpec,omitempty"`
 	SSHKeySpec                *SSHKeySpec                `json:"sshKeySpec,omitempty"`
 	STSSessionTokenSpec       *STSSessionTokenSpec       `json:"stsSessionTokenSpec,omitempty"`
 	UUIDSpec                  *UUIDSpec                  `json:"uuidSpec,omitempty"`
 	VaultDynamicSecretSpec    *VaultDynamicSecretSpec    `json:"vaultDynamicSecretSpec,omitempty"`
 	WebhookSpec               *WebhookSpec               `json:"webhookSpec,omitempty"`
+	GrafanaSpec               *GrafanaSpec               `json:"grafanaSpec,omitempty"`
+	MFASpec                   *MFASpec                   `json:"mfaSpec,omitempty"`
 }
 ```


### PR DESCRIPTION
## Problem Statement
While reading through the generator documents, i see some items are missing from the GeneratorSpec code snippet. including...
- CloudsmithAccessToken
- QuayAccessTokenSpec
- GrafanaSpec
- MFASpec

<img width="820" height="405" alt="image" src="https://github.com/user-attachments/assets/4e4b3a76-838e-4721-964b-e8790222ce2d" />

## Proposed Changes
Add the missing ones to the snippet.

- CloudsmithAccessToken
- QuayAccessTokenSpec
- GrafanaSpec
- MFASpec

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This documentation update adds four missing generator spec fields to the `GeneratorSpec` example in `docs/guides/generator.md`:
- `CloudsmithAccessTokenSpec`
- `QuayAccessTokenSpec`
- `GrafanaSpec`
- `MFASpec`

Each field is added as an optional pointer type with the appropriate JSON omitempty tag, following the existing pattern used by other fields in the struct.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->