### PR TITLE
fix: CAProvider cm access

### DIFF
--- a/runtime/esutils/utils.go
+++ b/runtime/esutils/utils.go
@@ -697,7 +697,7 @@ func FetchCACertFromSource(ctx context.Context, opts CreateCertOpts) ([]byte, er
 
 		return cert, nil
 	case esv1.CAProviderTypeConfigMap:
-		cert, err := getCertFromConfigMap(ctx, opts.Namespace, opts.Client, opts.CAProvider)
+		cert, err := getCertFromConfigMap(ctx, opts.Namespace, opts.Client, opts.CAProvider, opts.StoreKind)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get cert from configmap: %w", err)
 		}
@@ -810,13 +810,13 @@ func getCertFromSecret(ctx context.Context, c client.Client, provider *esv1.CAPr
 	return []byte(cert), nil
 }
 
-func getCertFromConfigMap(ctx context.Context, namespace string, c client.Client, provider *esv1.CAProvider) ([]byte, error) {
+func getCertFromConfigMap(ctx context.Context, namespace string, c client.Client, provider *esv1.CAProvider, storeKind string) ([]byte, error) {
 	objKey := client.ObjectKey{
 		Name:      provider.Name,
 		Namespace: namespace,
 	}
 
-	if provider.Namespace != nil {
+	if provider.Namespace != nil && storeKind == esv1.ClusterSecretStoreKind {
 		objKey.Namespace = *provider.Namespace
 	}
 

--- a/runtime/esutils/utils.go
+++ b/runtime/esutils/utils.go
@@ -683,6 +683,13 @@ func FetchCACertFromSource(ctx context.Context, opts CreateCertOpts) ([]byte, er
 	}
 
 	if opts.CAProvider != nil &&
+		opts.StoreKind != esv1.ClusterSecretStoreKind &&
+		opts.CAProvider.Namespace != nil &&
+		*opts.CAProvider.Namespace != opts.Namespace {
+		return nil, errNamespaceNotAllowed
+	}
+
+	if opts.CAProvider != nil &&
 		opts.StoreKind == esv1.ClusterSecretStoreKind &&
 		opts.CAProvider.Namespace == nil {
 		return nil, errors.New("missing namespace on caProvider secret")

--- a/runtime/esutils/utils_test.go
+++ b/runtime/esutils/utils_test.go
@@ -1439,16 +1439,27 @@ func TestValidateReferentServiceAccountSelector(t *testing.T) {
 	}
 }
 
-func TestFetchCACertFromSourceSecretStoreIgnoresCrossNamespaceConfigMap(t *testing.T) {
-	fakeClient := clientfake.NewClientBuilder().WithObjects(&v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "ca-cm",
-			Namespace: "other",
+func TestFetchCACertFromSourceRejectsCrossNamespaceCAProviderConfigMapForSecretStore(t *testing.T) {
+	fakeClient := clientfake.NewClientBuilder().WithObjects(
+		&v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ca-cm",
+				Namespace: "default",
+			},
+			Data: map[string]string{
+				"ca.crt": "local-cert",
+			},
 		},
-		Data: map[string]string{
-			"ca.crt": caCert,
+		&v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ca-cm",
+				Namespace: "other",
+			},
+			Data: map[string]string{
+				"ca.crt": "other-cert",
+			},
 		},
-	}).Build()
+	).Build()
 
 	cert, err := FetchCACertFromSource(context.Background(), CreateCertOpts{
 		CAProvider: &esv1.CAProvider{
@@ -1462,11 +1473,46 @@ func TestFetchCACertFromSourceSecretStoreIgnoresCrossNamespaceConfigMap(t *testi
 		Client:    fakeClient,
 	})
 
-	if err == nil {
-		t.Fatalf("expected an error when resolving a cross-namespace CAProvider ConfigMap for SecretStore, got cert length %d", len(cert))
-	}
+	assert.ErrorIs(t, err, errNamespaceNotAllowed)
 	assert.Nil(t, cert)
-	assert.Contains(t, err.Error(), "failed to get cert from configmap")
+}
+
+func TestFetchCACertFromSourceRejectsCrossNamespaceCAProviderSecretForSecretStore(t *testing.T) {
+	fakeClient := clientfake.NewClientBuilder().WithObjects(
+		&v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ca-secret",
+				Namespace: "default",
+			},
+			Data: map[string][]byte{
+				"tls.crt": []byte("local-cert"),
+			},
+		},
+		&v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ca-secret",
+				Namespace: "other",
+			},
+			Data: map[string][]byte{
+				"tls.crt": []byte("other-cert"),
+			},
+		},
+	).Build()
+
+	cert, err := FetchCACertFromSource(context.Background(), CreateCertOpts{
+		CAProvider: &esv1.CAProvider{
+			Type:      esv1.CAProviderTypeSecret,
+			Name:      "ca-secret",
+			Key:       "tls.crt",
+			Namespace: Ptr("other"),
+		},
+		StoreKind: esv1.SecretStoreKind,
+		Namespace: "default",
+		Client:    fakeClient,
+	})
+
+	assert.ErrorIs(t, err, errNamespaceNotAllowed)
+	assert.Nil(t, cert)
 }
 
 const mockJWTToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiZXhwIjoxNzAwMDAwMDAwfQ.signature"

--- a/runtime/esutils/utils_test.go
+++ b/runtime/esutils/utils_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package esutils
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"reflect"
@@ -29,6 +30,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
 	esv1alpha1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
@@ -1435,6 +1437,36 @@ func TestValidateReferentServiceAccountSelector(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFetchCACertFromSourceSecretStoreIgnoresCrossNamespaceConfigMap(t *testing.T) {
+	fakeClient := clientfake.NewClientBuilder().WithObjects(&v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ca-cm",
+			Namespace: "other",
+		},
+		Data: map[string]string{
+			"ca.crt": caCert,
+		},
+	}).Build()
+
+	cert, err := FetchCACertFromSource(context.Background(), CreateCertOpts{
+		CAProvider: &esv1.CAProvider{
+			Type:      esv1.CAProviderTypeConfigMap,
+			Name:      "ca-cm",
+			Key:       "ca.crt",
+			Namespace: Ptr("other"),
+		},
+		StoreKind: esv1.SecretStoreKind,
+		Namespace: "default",
+		Client:    fakeClient,
+	})
+
+	if err == nil {
+		t.Fatalf("expected an error when resolving a cross-namespace CAProvider ConfigMap for SecretStore, got cert length %d", len(cert))
+	}
+	assert.Nil(t, cert)
+	assert.Contains(t, err.Error(), "failed to get cert from configmap")
 }
 
 const mockJWTToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiZXhwIjoxNzAwMDAwMDAwfQ.signature"


### PR DESCRIPTION
## Problem Statement

The usage of CAProvider is all over the place across many providers. Unfortunately, the ref.namespace is not properly validated which allows a SecretStore to reference ConfigMaps/Secrets from other namespaces.

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Fix: Properly scope namespaced CAProvider access for ConfigMap/Secret

### Changes

Prevent cross-namespace CAProvider references for namespaced SecretStore resources and ensure ConfigMap CA lookups use correct store scoping:

- runtime/esutils/utils.go
  - `FetchCACertFromSource` now rejects a `CAProvider` that specifies a namespace when the store kind is not `ClusterSecretStoreKind` (returns `errNamespaceNotAllowed`).
  - `getCertFromConfigMap` gained a `storeKind` parameter; the ConfigMap namespace override is applied only when `storeKind == esv1.ClusterSecretStoreKind`. Call sites now pass `opts.StoreKind`.
  - This prevents unintended cross-namespace access for ConfigMap-backed CAProviders used by namespaced SecretStore resources.

- runtime/esutils/utils_test.go
  - Added tests that assert `errNamespaceNotAllowed` is returned when a namespaced SecretStore tries to reference a ConfigMap or Secret in a different namespace.

No public API changes; only internal behavior and a helper signature were modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->