### PR TITLE
fix(chart): add failurePolicy to ClusterSecretStore webhook

### DIFF
--- a/deploy/charts/external-secrets/templates/validatingwebhook.yaml
+++ b/deploy/charts/external-secrets/templates/validatingwebhook.yaml
@@ -48,6 +48,7 @@ webhooks:
   admissionReviewVersions: ["v1", "v1beta1"]
   sideEffects: None
   timeoutSeconds: 5
+  failurePolicy: {{ .Values.webhook.failurePolicy }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration


### PR DESCRIPTION
The ClusterSecretStore webhook entry in the secretstore-validate ValidatingWebhookConfiguration is missing the failurePolicy field, so it always defaults to Fail regardless of the webhook.failurePolicy Helm value.

This was fixed for the SecretStore webhook in #5605, but the ClusterSecretStore webhook entry was missed.

Without this fix, setting webhook.failurePolicy=Ignore only applies to the SecretStore and ExternalSecret webhooks — the ClusterSecretStore webhook still uses Fail, which causes the API server to reject ClusterSecretStore operations when the webhook pod is unreachable (e.g. during rolling restarts or initial bootstrap on managed clusters like EKS).

Change: Add failurePolicy: {{ .Values.webhook.failurePolicy }} to the ClusterSecretStore webhook entry, matching the SecretStore and ExternalSecret entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds the `failurePolicy` field to the ClusterSecretStore webhook entry in the `ValidatingWebhookConfiguration` Helm template. This makes the webhook failure behavior configurable via `.Values.webhook.failurePolicy`, matching the behavior of the SecretStore and ExternalSecret webhooks. Previously, ClusterSecretStore would always default to `Fail` regardless of the Helm configuration value, potentially causing API server rejections during webhook unavailability.

**File changed:** `deploy/charts/external-secrets/templates/validatingwebhook.yaml` (+1 line)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->