### PR TITLE
fix(conjur): return error for unimplemented PushSecret and DeleteSecret

### DIFF
--- a/providers/v1/conjur/client.go
+++ b/providers/v1/conjur/client.go
@@ -97,14 +97,12 @@ func (c *Client) GetConjurClient(ctx context.Context) (SecretsClient, error) {
 
 // PushSecret will write a single secret into the provider.
 func (c *Client) PushSecret(_ context.Context, _ *corev1.Secret, _ esv1.PushSecretData) error {
-	// NOT IMPLEMENTED
-	return nil
+	return errors.New("pushing secrets is not implemented for the Conjur provider")
 }
 
 // DeleteSecret removes a secret from the provider.
 func (c *Client) DeleteSecret(_ context.Context, _ esv1.PushSecretRemoteRef) error {
-	// NOT IMPLEMENTED
-	return nil
+	return errors.New("deleting secrets is not implemented for the Conjur provider")
 }
 
 // SecretExists checks if a secret exists in the provider.


### PR DESCRIPTION
**What this PR does:**

The Conjur provider's `PushSecret` and `DeleteSecret` methods silently return `nil`, misleading users into thinking the operation succeeded. This changes them to return explicit "not implemented" errors, consistent with `SecretExists` which already does this.

**Which issue(s) this PR fixes:**

Fixes #4698

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes

Modified the Conjur provider's PushSecret and DeleteSecret methods in providers/v1/conjur/client.go to return explicit "not implemented" errors instead of nil. Previously these methods were no-ops that returned nil, which could mislead users into thinking push/delete operations succeeded. No function signatures were changed.

**Lines changed:** +2/-4

## Impact

Users attempting to use PushSecret or DeleteSecret with the Conjur provider will now receive clear error messages indicating these operations are not implemented, preventing silent failures and aligning behavior with the existing SecretExists method. This change addresses issue #4698 by making the current non-implementation explicit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->