### PR TITLE
feat: Add initial Documentation for enabling fetching all available Versions.

### DIFF
--- a/apis/externalsecrets/v1/externalsecret_types.go
+++ b/apis/externalsecrets/v1/externalsecret_types.go
@@ -306,6 +306,11 @@ type ExternalSecretDataRemoteRef struct {
 	DecodingStrategy ExternalSecretDecodingStrategy `json:"decodingStrategy,omitempty"`
 
 	// +optional
+	// Used to define a version Strategy
+	// +kubebuilder:default="None"
+	VersionStrategy ExternalSecretVersionStrategy `json:"versionStrategy,omitempty"`
+
+	// +optional
 	// Controls how ESO handles fetched secret data containing NUL bytes for this source.
 	// +kubebuilder:default="Ignore"
 	NullBytePolicy ExternalSecretNullBytePolicy `json:"nullBytePolicy,omitempty"`
@@ -346,6 +351,20 @@ const (
 	ExternalSecretDecodeBase64URL ExternalSecretDecodingStrategy = "Base64URL"
 	// ExternalSecretDecodeNone specifies that no decoding should be performed.
 	ExternalSecretDecodeNone ExternalSecretDecodingStrategy = "None"
+)
+
+// ExternalSecretVersionStrategy defines strategies for handling multiple versions of secrets in the provider.
+// +kubebuilder:validation:Enum=Auto;Available
+type ExternalSecretVersionStrategy string
+
+const (
+	// ExternalSecretVersionAuto specifies that the version strategy should be determined automatically.
+	// This is the default strategy and will fetch the latest version of the secret.
+	ExternalSecretVersionAuto ExternalSecretVersionStrategy = "Auto"
+	// ExternalSecretVersionAvailable specifies that all available versions should be fetched.
+	// Many stores have a concept of soft or hard deleting secret versions.
+	// This strategy will fetch all secret versions that are neither soft nor hard deleted.
+	ExternalSecretVersionAvailable ExternalSecretVersionStrategy = "Available"
 )
 
 // ExternalSecretDataFromRemoteRef defines the connection between the Kubernetes Secret keys and the Provider data
@@ -484,6 +503,11 @@ type ExternalSecretFind struct {
 	// Find secrets based on tags.
 	// +optional
 	Tags map[string]string `json:"tags,omitempty"`
+
+	// +optional
+	// Used to define a version Strategy
+	// +kubebuilder:default="Default"
+	VersionStrategy ExternalSecretVersionStrategy `json:"versionStrategy,omitempty"`
 
 	// +optional
 	// Used to define a conversion Strategy

--- a/docs/api/externalsecret.md
+++ b/docs/api/externalsecret.md
@@ -94,6 +94,7 @@ Individual features are described in the [Guides section](../guides/introduction
 * [Secret Ownership and Deletion](../guides/ownership-deletion-policy.md)
 * [Key Rewriting](../guides/datafrom-rewrite.md)
 * [Decoding Strategy](../guides/decoding-strategy.md)
+* [Version Strategy](../guides/version-strategy.md)
 
 ## Example
 

--- a/docs/guides/version-strategy.md
+++ b/docs/guides/version-strategy.md
@@ -1,0 +1,84 @@
+# Version Strategy
+
+The `versionStrategy` field controls how ESO handles secret versioning when fetching secrets from a provider.
+It can be placed under `spec.data.remoteRef` or `spec.dataFrom.find`, and configures the versioning behavior for that specific operation.
+
+## Strategies
+
+### None (default)
+
+ESO fetches the default version (e.g. latest available) of the secret or the specific version indicated by `spec.data.remoteRef.version`.
+No additional filtering is applied.
+
+### Available
+
+ESO filters out all secret version data that has been soft or hard deleted.
+
+- For **`spec.data.remoteRef`**: If a `version` was also explicitly specified the Resource fails.
+  If no `version` was specified, all available secret versions get fetched.
+
+## Examples
+
+### Fetching a single Vault secret, skipping deleted and destroyed versions
+
+```yaml
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: vault-available-version
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: my-secret
+  data:
+    - secretKey: password
+      remoteRef:
+        key: secret/my-app/db
+        versionStrategy: Available
+```
+
+If Secret Manager contains a secret `my-app/db` with versions 1, 2 (destroyed) and 3, the resulting Kubernetes Secret will contain:
+
+```yaml
+data:
+  backend-path/secret/my-app/db?version=1: <base64-encoded value at version 1>
+  backend-path/secret/my-app/db?version=3: <base64-encoded value at version 3>
+```
+
+Version 2 is omitted because it has been destroyed.
+
+### Enumerating all available GCP secrets/versions with `dataFrom.find`
+
+Using `versionStrategy: Available` in a `find` operation causes ESO to return enabled secret versions.
+
+```yaml
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gcp-all-available-versions
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: gcp-backend
+    kind: SecretStore
+  target:
+    name: my-secret-versions
+  dataFrom:
+    - find:
+        name:
+          regexp: "my-.*"
+        versionStrategy: Available
+```
+
+If Secret Manager contains a secret `my-app` with versions 1, 2 (disabled) and 3, the resulting Kubernetes Secret will contain:
+
+```yaml
+data:
+  projects/my-project/secrets/my-app/versions/1: <base64-encoded value at version 1>
+  projects/my-project/secrets/my-app/versions/3: <base64-encoded value at version 3>
+```
+
+Version 2 is omitted because it has been disabled.


### PR DESCRIPTION
## Problem Statement

Enabling External Secrets to fetch all available Versions for a Secret.

## Related Issue

Fixes https://github.com/external-secrets/external-secrets/issues/6242

## Proposed Changes

Introduce a new field `versionStrategy` which can be set to `Available`.

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds API and documentation for a new versionStrategy field to allow External Secrets to fetch/enumerate all available secret versions (addresses issue `#6242`). Introduces a selectable strategy to return all non-deleted versions for downstream templating/processing.

## Changes

API
- Added `versionStrategy` to `ExternalSecretDataRemoteRef` and `ExternalSecretFind` with kubebuilder defaults (`None`/`Default` behavior).
- Added `ExternalSecretVersionStrategy` type and constants:
  - `Auto` (default)
  - `Available` (selects all versions that are neither soft- nor hard-deleted)
- Behavior notes: `Available` with a `remoteRef.version` that explicitly specifies one version is invalid (documented); `Available` on `remoteRef` without `version` causes fetching of all available versions.

Documentation
- New guide: docs/guides/version-strategy.md — describes usage, examples (Vault single-secret and GCP find enumeration), and expected Secret data outputs (omitting destroyed/disabled versions).
- Updated API docs to reference the new guide.

Other
- Checklist: contribution guidelines followed and commits signed; test coverage/execution remain unchecked and tests reported failing by a reviewer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->