### PR TITLE
fix: use a separate parameter for GET calls in VaultDynamicSecrets

### DIFF
--- a/apis/generators/v1alpha1/types_vault.go
+++ b/apis/generators/v1alpha1/types_vault.go
@@ -37,9 +37,10 @@ type VaultDynamicSecretSpec struct {
 	Parameters *apiextensions.JSON `json:"parameters,omitempty"`
 
 	// GetParameters are query-string parameters passed to Vault on GET calls.
+	// Each key may map to multiple values, matching HTTP query-string semantics.
 	// Ignored for non-GET methods; use Parameters for write bodies.
 	// +optional
-	GetParameters map[string]string `json:"getParameters,omitempty"`
+	GetParameters map[string][]string `json:"getParameters,omitempty"`
 
 	// Result type defines which data is returned from the generator.
 	// By default, it is the "data" section of the Vault API response.

--- a/apis/generators/v1alpha1/types_vault.go
+++ b/apis/generators/v1alpha1/types_vault.go
@@ -33,8 +33,13 @@ type VaultDynamicSecretSpec struct {
 	// Vault API method to use (GET/POST/other)
 	Method string `json:"method,omitempty"`
 
-	// Parameters to pass to Vault for write and Get calls. GET calls only support string value types.
+	// Parameters to pass to Vault write (for non-GET methods)
 	Parameters *apiextensions.JSON `json:"parameters,omitempty"`
+
+	// GetParameters are query-string parameters passed to Vault on GET calls.
+	// Ignored for non-GET methods; use Parameters for write bodies.
+	// +optional
+	GetParameters map[string]string `json:"getParameters,omitempty"`
 
 	// Result type defines which data is returned from the generator.
 	// By default, it is the "data" section of the Vault API response.

--- a/apis/generators/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/generators/v1alpha1/zz_generated.deepcopy.go
@@ -1862,9 +1862,18 @@ func (in *VaultDynamicSecretSpec) DeepCopyInto(out *VaultDynamicSecretSpec) {
 	}
 	if in.GetParameters != nil {
 		in, out := &in.GetParameters, &out.GetParameters
-		*out = make(map[string]string, len(*in))
+		*out = make(map[string][]string, len(*in))
 		for key, val := range *in {
-			(*out)[key] = val
+			var outVal []string
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				inVal := (*in)[key]
+				in, out := &inVal, &outVal
+				*out = make([]string, len(*in))
+				copy(*out, *in)
+			}
+			(*out)[key] = outVal
 		}
 	}
 	if in.RetrySettings != nil {

--- a/apis/generators/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/generators/v1alpha1/zz_generated.deepcopy.go
@@ -1860,6 +1860,13 @@ func (in *VaultDynamicSecretSpec) DeepCopyInto(out *VaultDynamicSecretSpec) {
 		*out = new(v1.JSON)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.GetParameters != nil {
+		in, out := &in.GetParameters, &out.GetParameters
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.RetrySettings != nil {
 		in, out := &in.RetrySettings, &out.RetrySettings
 		*out = new(externalsecretsv1.SecretStoreRetrySettings)

--- a/config/crds/bases/generators.external-secrets.io_clustergenerators.yaml
+++ b/config/crds/bases/generators.external-secrets.io_clustergenerators.yaml
@@ -1174,12 +1174,19 @@ spec:
                           Used to select the correct ESO controller (think: ingress.ingressClassName)
                           The ESO controller is instantiated with a specific controller name and filters VDS based on this property
                         type: string
+                      getParameters:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          GetParameters are query-string parameters passed to Vault on GET calls.
+                          Ignored for non-GET methods; use Parameters for write bodies.
+                        type: object
                       method:
                         description: Vault API method to use (GET/POST/other)
                         type: string
                       parameters:
-                        description: Parameters to pass to Vault for write and Get
-                          calls. GET calls only support string value types.
+                        description: Parameters to pass to Vault write (for non-GET
+                          methods)
                         x-kubernetes-preserve-unknown-fields: true
                       path:
                         description: Vault path to obtain the dynamic secret from

--- a/config/crds/bases/generators.external-secrets.io_clustergenerators.yaml
+++ b/config/crds/bases/generators.external-secrets.io_clustergenerators.yaml
@@ -1176,9 +1176,12 @@ spec:
                         type: string
                       getParameters:
                         additionalProperties:
-                          type: string
+                          items:
+                            type: string
+                          type: array
                         description: |-
                           GetParameters are query-string parameters passed to Vault on GET calls.
+                          Each key may map to multiple values, matching HTTP query-string semantics.
                           Ignored for non-GET methods; use Parameters for write bodies.
                         type: object
                       method:

--- a/config/crds/bases/generators.external-secrets.io_vaultdynamicsecrets.yaml
+++ b/config/crds/bases/generators.external-secrets.io_vaultdynamicsecrets.yaml
@@ -54,12 +54,18 @@ spec:
                   Used to select the correct ESO controller (think: ingress.ingressClassName)
                   The ESO controller is instantiated with a specific controller name and filters VDS based on this property
                 type: string
+              getParameters:
+                additionalProperties:
+                  type: string
+                description: |-
+                  GetParameters are query-string parameters passed to Vault on GET calls.
+                  Ignored for non-GET methods; use Parameters for write bodies.
+                type: object
               method:
                 description: Vault API method to use (GET/POST/other)
                 type: string
               parameters:
-                description: Parameters to pass to Vault for write and Get calls.
-                  GET calls only support string value types.
+                description: Parameters to pass to Vault write (for non-GET methods)
                 x-kubernetes-preserve-unknown-fields: true
               path:
                 description: Vault path to obtain the dynamic secret from

--- a/config/crds/bases/generators.external-secrets.io_vaultdynamicsecrets.yaml
+++ b/config/crds/bases/generators.external-secrets.io_vaultdynamicsecrets.yaml
@@ -56,9 +56,12 @@ spec:
                 type: string
               getParameters:
                 additionalProperties:
-                  type: string
+                  items:
+                    type: string
+                  type: array
                 description: |-
                   GetParameters are query-string parameters passed to Vault on GET calls.
+                  Each key may map to multiple values, matching HTTP query-string semantics.
                   Ignored for non-GET methods; use Parameters for write bodies.
                 type: object
               method:

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -25891,11 +25891,18 @@ spec:
                             Used to select the correct ESO controller (think: ingress.ingressClassName)
                             The ESO controller is instantiated with a specific controller name and filters VDS based on this property
                           type: string
+                        getParameters:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            GetParameters are query-string parameters passed to Vault on GET calls.
+                            Ignored for non-GET methods; use Parameters for write bodies.
+                          type: object
                         method:
                           description: Vault API method to use (GET/POST/other)
                           type: string
                         parameters:
-                          description: Parameters to pass to Vault for write and Get calls. GET calls only support string value types.
+                          description: Parameters to pass to Vault write (for non-GET methods)
                           x-kubernetes-preserve-unknown-fields: true
                         path:
                           description: Vault path to obtain the dynamic secret from
@@ -28581,11 +28588,18 @@ spec:
                     Used to select the correct ESO controller (think: ingress.ingressClassName)
                     The ESO controller is instantiated with a specific controller name and filters VDS based on this property
                   type: string
+                getParameters:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    GetParameters are query-string parameters passed to Vault on GET calls.
+                    Ignored for non-GET methods; use Parameters for write bodies.
+                  type: object
                 method:
                   description: Vault API method to use (GET/POST/other)
                   type: string
                 parameters:
-                  description: Parameters to pass to Vault for write and Get calls. GET calls only support string value types.
+                  description: Parameters to pass to Vault write (for non-GET methods)
                   x-kubernetes-preserve-unknown-fields: true
                 path:
                   description: Vault path to obtain the dynamic secret from

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -25893,9 +25893,12 @@ spec:
                           type: string
                         getParameters:
                           additionalProperties:
-                            type: string
+                            items:
+                              type: string
+                            type: array
                           description: |-
                             GetParameters are query-string parameters passed to Vault on GET calls.
+                            Each key may map to multiple values, matching HTTP query-string semantics.
                             Ignored for non-GET methods; use Parameters for write bodies.
                           type: object
                         method:
@@ -28590,9 +28593,12 @@ spec:
                   type: string
                 getParameters:
                   additionalProperties:
-                    type: string
+                    items:
+                      type: string
+                    type: array
                   description: |-
                     GetParameters are query-string parameters passed to Vault on GET calls.
+                    Each key may map to multiple values, matching HTTP query-string semantics.
                     Ignored for non-GET methods; use Parameters for write bodies.
                   type: object
                 method:

--- a/docs/api/generator/vault.md
+++ b/docs/api/generator/vault.md
@@ -14,10 +14,26 @@ are stored into the resulting Secret in JSON format. The generator exposes `data
 section of the response from Vault API by default. To adjust the behaviour, use
 `resultType` key.
 
+### Passing parameters
+
+- `parameters` is a JSON body sent on write methods (POST, PUT, etc.) and
+  supports arbitrary nested JSON. It is **ignored** on `GET` and `LIST`.
+- `getParameters` is a `map[string][]string` sent as the query string on `GET`
+  calls. Each key may map to multiple values, matching HTTP query-string
+  semantics. It is ignored for non-GET methods.
+
 ## Example manifest
+
+Write method (POST) with a JSON body:
 
 ```yaml
 {% include 'generator-vault.yaml' %}
+```
+
+GET method with query-string parameters:
+
+```yaml
+{% include 'generator-vault-get.yaml' %}
 ```
 
 Example `ExternalSecret` that references the Vault generator:

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -28548,7 +28548,21 @@ k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1.JSON
 </em>
 </td>
 <td>
-<p>Parameters to pass to Vault for write and Get calls. GET calls only support string value types.</p>
+<p>Parameters to pass to Vault write (for non-GET methods)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>getParameters</code></br>
+<em>
+map[string][]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>GetParameters are query-string parameters passed to Vault on GET calls.
+Each key may map to multiple values, matching HTTP query-string semantics.
+Ignored for non-GET methods; use Parameters for write bodies.</p>
 </td>
 </tr>
 <tr>
@@ -28701,7 +28715,21 @@ k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1.JSON
 </em>
 </td>
 <td>
-<p>Parameters to pass to Vault for write and Get calls. GET calls only support string value types.</p>
+<p>Parameters to pass to Vault write (for non-GET methods)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>getParameters</code></br>
+<em>
+map[string][]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>GetParameters are query-string parameters passed to Vault on GET calls.
+Each key may map to multiple values, matching HTTP query-string semantics.
+Ignored for non-GET methods; use Parameters for write bodies.</p>
 </td>
 </tr>
 <tr>

--- a/generators/v1/vault/vault.go
+++ b/generators/v1/vault/vault.go
@@ -116,14 +116,7 @@ func (g *Generator) fetchVaultSecret(ctx context.Context, res *genv1alpha1.Vault
 	)
 
 	if res.Spec.Method == "" || res.Spec.Method == "GET" {
-		var params map[string][]string
-		if len(res.Spec.GetParameters) > 0 {
-			params = make(map[string][]string, len(res.Spec.GetParameters))
-			for k, v := range res.Spec.GetParameters {
-				params[k] = []string{v}
-			}
-		}
-		result, err = cl.Logical().ReadWithDataWithContext(ctx, res.Spec.Path, params)
+		result, err = cl.Logical().ReadWithDataWithContext(ctx, res.Spec.Path, res.Spec.GetParameters)
 	} else if res.Spec.Method == "LIST" {
 		result, err = cl.Logical().ListWithContext(ctx, res.Spec.Path)
 	} else if res.Spec.Method == "DELETE" {

--- a/generators/v1/vault/vault.go
+++ b/generators/v1/vault/vault.go
@@ -116,19 +116,12 @@ func (g *Generator) fetchVaultSecret(ctx context.Context, res *genv1alpha1.Vault
 	)
 
 	if res.Spec.Method == "" || res.Spec.Method == "GET" {
-		var raw map[string]any
-		if res.Spec.Parameters != nil {
-			if err := json.Unmarshal(res.Spec.Parameters.Raw, &raw); err != nil {
-				return nil, fmt.Errorf("failed to parse parameters for GET call: %w", err)
+		var params map[string][]string
+		if len(res.Spec.GetParameters) > 0 {
+			params = make(map[string][]string, len(res.Spec.GetParameters))
+			for k, v := range res.Spec.GetParameters {
+				params[k] = []string{v}
 			}
-		}
-		params := make(map[string][]string, len(raw))
-		for k, v := range raw {
-			s, ok := v.(string)
-			if !ok {
-				return nil, fmt.Errorf("unsupported type for GET parameter %q: %T", k, v)
-			}
-			params[k] = []string{s}
 		}
 		result, err = cl.Logical().ReadWithDataWithContext(ctx, res.Spec.Path, params)
 	} else if res.Spec.Method == "LIST" {

--- a/generators/v1/vault/vault_test.go
+++ b/generators/v1/vault/vault_test.go
@@ -439,7 +439,11 @@ spec:
           name: "testing"
   method: GET
   getParameters:
-    scope: "applied-permissions/user"
+    scope:
+      - "applied-permissions/user"
+    tag:
+      - "prod"
+      - "blue"
   path: "github/token/example"`)}
 		_, _, err := (&Generator{}).generate(context.Background(),
 			c, spec,
@@ -448,7 +452,11 @@ spec:
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if diff := cmp.Diff(map[string][]string{"scope": {"applied-permissions/user"}}, got); diff != "" {
+		want := map[string][]string{
+			"scope": {"applied-permissions/user"},
+			"tag":   {"prod", "blue"},
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
 			t.Errorf("forwarded params mismatch:\n%s", diff)
 		}
 	})

--- a/generators/v1/vault/vault_test.go
+++ b/generators/v1/vault/vault_test.go
@@ -418,8 +418,17 @@ func TestVaultDynamicSecretGetParameters(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "testing", Namespace: "testing"},
 		Secrets:    []corev1.ObjectReference{{Name: "test"}},
 	}
-	spec := func(params string) *apiextensions.JSON {
-		return &apiextensions.JSON{Raw: []byte(`apiVersion: generators.external-secrets.io/v1alpha1
+
+	t.Run("ForwardsGetParameters", func(t *testing.T) {
+		var got map[string][]string
+		clientFn := fake.ModifiableClientWithLoginMock(func(cl *fake.VaultClient) {
+			cl.MockLogical.ReadWithDataWithContextFn = func(_ context.Context, _ string, data map[string][]string) (*vaultapi.Secret, error) {
+				got = data
+				return &vaultapi.Secret{Data: map[string]any{"key": "value"}}, nil
+			}
+		})
+		c := &provider.Provider{NewVaultClient: clientFn}
+		spec := &apiextensions.JSON{Raw: []byte(`apiVersion: generators.external-secrets.io/v1alpha1
 kind: VaultDynamicSecret
 spec:
   provider:
@@ -429,22 +438,11 @@ spec:
         serviceAccountRef:
           name: "testing"
   method: GET
-  parameters:
-    ` + params + `
+  getParameters:
+    scope: "applied-permissions/user"
   path: "github/token/example"`)}
-	}
-
-	t.Run("ForwardsStringParams", func(t *testing.T) {
-		var got map[string][]string
-		clientFn := fake.ModifiableClientWithLoginMock(func(cl *fake.VaultClient) {
-			cl.MockLogical.ReadWithDataWithContextFn = func(_ context.Context, _ string, data map[string][]string) (*vaultapi.Secret, error) {
-				got = data
-				return &vaultapi.Secret{Data: map[string]any{"key": "value"}}, nil
-			}
-		})
-		c := &provider.Provider{NewVaultClient: clientFn}
 		_, _, err := (&Generator{}).generate(context.Background(),
-			c, spec(`scope: "applied-permissions/user"`),
+			c, spec,
 			clientfake.NewClientBuilder().WithObjects(sa).Build(),
 			utilfake.NewCreateTokenMock().WithToken("ok"), "testing")
 		if err != nil {
@@ -455,14 +453,44 @@ spec:
 		}
 	})
 
-	t.Run("RejectsNonStringParams", func(t *testing.T) {
-		c := &provider.Provider{NewVaultClient: fake.ClientWithLoginMock}
+	t.Run("IgnoresParametersOnGET", func(t *testing.T) {
+		var got map[string][]string
+		called := false
+		clientFn := fake.ModifiableClientWithLoginMock(func(cl *fake.VaultClient) {
+			cl.MockLogical.ReadWithDataWithContextFn = func(_ context.Context, _ string, data map[string][]string) (*vaultapi.Secret, error) {
+				called = true
+				got = data
+				return &vaultapi.Secret{Data: map[string]any{"key": "value"}}, nil
+			}
+		})
+		c := &provider.Provider{NewVaultClient: clientFn}
+		spec := &apiextensions.JSON{Raw: []byte(`apiVersion: generators.external-secrets.io/v1alpha1
+kind: VaultDynamicSecret
+spec:
+  provider:
+    auth:
+      kubernetes:
+        role: test
+        serviceAccountRef:
+          name: "testing"
+  method: GET
+  parameters:
+    ttl: 60
+    nested:
+      key: "value"
+  path: "github/token/example"`)}
 		_, _, err := (&Generator{}).generate(context.Background(),
-			c, spec(`ttl: 60`),
+			c, spec,
 			clientfake.NewClientBuilder().WithObjects(sa).Build(),
 			utilfake.NewCreateTokenMock().WithToken("ok"), "testing")
-		if err == nil || err.Error() != `unsupported type for GET parameter "ttl": float64` {
-			t.Errorf("want unsupported-type error, got: %v", err)
+		if err != nil {
+			t.Fatalf("Parameters on GET should be ignored, got error: %v", err)
+		}
+		if !called {
+			t.Fatal("expected ReadWithDataWithContext to be called")
+		}
+		if got != nil {
+			t.Errorf("expected nil params on GET when only Parameters is set, got: %v", got)
 		}
 	})
 }

--- a/tests/__snapshot__/clustergenerator-v1alpha1.yaml
+++ b/tests/__snapshot__/clustergenerator-v1alpha1.yaml
@@ -177,6 +177,7 @@ spec:
     vaultDynamicSecretSpec:
       allowEmptyResponse: false
       controller: string
+      getParameters: {}
       method: string
       parameters: 
       path: string

--- a/tests/__snapshot__/vaultdynamicsecret-v1alpha1.yaml
+++ b/tests/__snapshot__/vaultdynamicsecret-v1alpha1.yaml
@@ -4,6 +4,7 @@ metadata: {}
 spec:
   allowEmptyResponse: false
   controller: string
+  getParameters: {}
   method: string
   parameters: 
   path: string


### PR DESCRIPTION
## Problem Statement

Fix the breaking change in https://github.com/external-secrets/external-secrets/pull/6267.

The GET calls would start failing if people set up parameters for the Write calls since that has a different Type. Get calls only support map[string]string.

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
Restore correct VaultDynamicSecret GET behavior by adding a dedicated getParameters field for query-string parameters (map[string][]string) and restricting parameters to write bodies.

## Changes Made

**API and Type Definitions**
- Added VaultDynamicSecretSpec.GetParameters (map[string][]string) for GET query parameters.
- Clarified Parameters (JSON) applies only to Vault write (non-GET) requests.
- Updated deepcopy generation to deep-copy GetParameters.

**CRD Schema & Manifests**
- Added spec.getParameters to CRDs and bundle manifests.
- Updated parameters documentation in CRD schemas to specify write-only usage.

**Implementation**
- generators/v1/vault: GET requests now forward Spec.GetParameters (map[string][]string) directly to the Vault read call; JSON parsing and GET-specific validation of Parameters removed.

**Tests, Snapshots & Docs**
- Updated TestVaultDynamicSecretGetParameters to use getParameters and to assert correct map[string][]string forwarding; test case verifying that parameters provided under Parameters are ignored for GET was added.
- Updated snapshots to include getParameters.
- Documentation updated (docs/api/generator/vault.md and docs/api/spec.md) with examples and explanation: parameters = write body, getParameters = GET query params (supports multiple values per key).

## Notes
- getParameters supports multi-valued query keys (array of strings) to match HTTP semantics.
- Checklist items in PR body remain unchecked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->