### PR TITLE
fix: prevent creation of specific type of secrets

### DIFF
--- a/apis/externalsecrets/v1/externalsecret_validator.go
+++ b/apis/externalsecrets/v1/externalsecret_validator.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -57,6 +59,10 @@ func validateExternalSecret(es *ExternalSecret) (admission.Warnings, error) {
 
 	if len(es.Spec.Data) == 0 && len(es.Spec.DataFrom) == 0 {
 		errs = errors.Join(errs, errors.New("either data or dataFrom should be specified"))
+	}
+
+	if err := validatePrivilegedTemplate(es); err != nil {
+		errs = errors.Join(errs, err)
 	}
 
 	for _, ref := range es.Spec.DataFrom {
@@ -114,6 +120,29 @@ func validatePolicies(es *ExternalSecret) error {
 	}
 
 	return errs
+}
+
+// validatePrivilegedTemplate rejects templates with specific types and annotations combinations
+// to prevent users from creating long-lived tokens beyond the scope of the defined RBAC.
+func validatePrivilegedTemplate(es *ExternalSecret) error {
+	tpl := es.Spec.Target.Template
+	if tpl == nil {
+		return nil
+	}
+	switch tpl.Type {
+	case corev1.SecretTypeServiceAccountToken:
+		if _, ok := tpl.Metadata.Annotations[corev1.ServiceAccountNameKey]; ok {
+			return fmt.Errorf("template.type=%q with annotation %q is not allowed", corev1.SecretTypeServiceAccountToken, corev1.ServiceAccountNameKey)
+		}
+		for _, tf := range tpl.TemplateFrom {
+			if strings.EqualFold(tf.Target, TemplateTargetAnnotations) {
+				return fmt.Errorf("template.type=%q with templateFrom target=%q is not allowed", corev1.SecretTypeServiceAccountToken, TemplateTargetAnnotations)
+			}
+		}
+	case corev1.SecretTypeBootstrapToken:
+		return fmt.Errorf("template.type=%q is not allowed", corev1.SecretTypeBootstrapToken)
+	}
+	return nil
 }
 
 func validateDuplicateKeys(es *ExternalSecret, errs error) error {

--- a/apis/externalsecrets/v1/externalsecret_validator.go
+++ b/apis/externalsecrets/v1/externalsecret_validator.go
@@ -129,6 +129,7 @@ func validatePrivilegedTemplate(es *ExternalSecret) error {
 	if tpl == nil {
 		return nil
 	}
+	//nolint:exhaustive // don't need exhaustive
 	switch tpl.Type {
 	case corev1.SecretTypeServiceAccountToken:
 		if _, ok := tpl.Metadata.Annotations[corev1.ServiceAccountNameKey]; ok {

--- a/apis/externalsecrets/v1/externalsecret_validator_test.go
+++ b/apis/externalsecrets/v1/externalsecret_validator_test.go
@@ -18,6 +18,8 @@ package v1
 
 import (
 	"testing"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -201,6 +203,162 @@ either data or dataFrom should be specified`,
 				},
 			},
 			expectedErr: "duplicate secretKey found: SERVICE_NAME",
+		},
+		{
+			name: "service account token template with name annotation is rejected",
+			obj: &ExternalSecret{
+				Spec: ExternalSecretSpec{
+					DataFrom: []ExternalSecretDataFromRemoteRef{
+						{
+							SourceRef: &StoreGeneratorSourceRef{
+								GeneratorRef: &GeneratorRef{},
+							},
+						},
+					},
+					Target: ExternalSecretTarget{
+						Template: &ExternalSecretTemplate{
+							Type: corev1.SecretTypeServiceAccountToken,
+							Metadata: ExternalSecretTemplateMetadata{
+								Annotations: map[string]string{
+									corev1.ServiceAccountNameKey: "external-secrets",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedErr: `template.type="kubernetes.io/service-account-token" with annotation "kubernetes.io/service-account.name" is not allowed`,
+		},
+		{
+			name: "service account token template without name annotation is allowed",
+			obj: &ExternalSecret{
+				Spec: ExternalSecretSpec{
+					DataFrom: []ExternalSecretDataFromRemoteRef{
+						{
+							SourceRef: &StoreGeneratorSourceRef{
+								GeneratorRef: &GeneratorRef{},
+							},
+						},
+					},
+					Target: ExternalSecretTarget{
+						Template: &ExternalSecretTemplate{
+							Type: corev1.SecretTypeServiceAccountToken,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "service account token template with templateFrom annotations target is rejected",
+			obj: &ExternalSecret{
+				Spec: ExternalSecretSpec{
+					DataFrom: []ExternalSecretDataFromRemoteRef{
+						{
+							SourceRef: &StoreGeneratorSourceRef{
+								GeneratorRef: &GeneratorRef{},
+							},
+						},
+					},
+					Target: ExternalSecretTarget{
+						Template: &ExternalSecretTemplate{
+							Type: corev1.SecretTypeServiceAccountToken,
+							TemplateFrom: []TemplateFrom{
+								{Target: TemplateTargetAnnotations},
+							},
+						},
+					},
+				},
+			},
+			expectedErr: `template.type="kubernetes.io/service-account-token" with templateFrom target="Annotations" is not allowed`,
+		},
+		{
+			name: "service account token template with lowercase templateFrom annotations target is rejected",
+			obj: &ExternalSecret{
+				Spec: ExternalSecretSpec{
+					DataFrom: []ExternalSecretDataFromRemoteRef{
+						{
+							SourceRef: &StoreGeneratorSourceRef{
+								GeneratorRef: &GeneratorRef{},
+							},
+						},
+					},
+					Target: ExternalSecretTarget{
+						Template: &ExternalSecretTemplate{
+							Type: corev1.SecretTypeServiceAccountToken,
+							TemplateFrom: []TemplateFrom{
+								{Target: "annotations"},
+							},
+						},
+					},
+				},
+			},
+			expectedErr: `template.type="kubernetes.io/service-account-token" with templateFrom target="Annotations" is not allowed`,
+		},
+		{
+			name: "service account token template with templateFrom data target is allowed",
+			obj: &ExternalSecret{
+				Spec: ExternalSecretSpec{
+					DataFrom: []ExternalSecretDataFromRemoteRef{
+						{
+							SourceRef: &StoreGeneratorSourceRef{
+								GeneratorRef: &GeneratorRef{},
+							},
+						},
+					},
+					Target: ExternalSecretTarget{
+						Template: &ExternalSecretTemplate{
+							Type: corev1.SecretTypeServiceAccountToken,
+							TemplateFrom: []TemplateFrom{
+								{Target: TemplateTargetData},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "bootstrap token template is rejected",
+			obj: &ExternalSecret{
+				Spec: ExternalSecretSpec{
+					DataFrom: []ExternalSecretDataFromRemoteRef{
+						{
+							SourceRef: &StoreGeneratorSourceRef{
+								GeneratorRef: &GeneratorRef{},
+							},
+						},
+					},
+					Target: ExternalSecretTarget{
+						Template: &ExternalSecretTemplate{
+							Type: corev1.SecretTypeBootstrapToken,
+						},
+					},
+				},
+			},
+			expectedErr: `template.type="bootstrap.kubernetes.io/token" is not allowed`,
+		},
+		{
+			name: "service account name annotation without service account token type is allowed",
+			obj: &ExternalSecret{
+				Spec: ExternalSecretSpec{
+					DataFrom: []ExternalSecretDataFromRemoteRef{
+						{
+							SourceRef: &StoreGeneratorSourceRef{
+								GeneratorRef: &GeneratorRef{},
+							},
+						},
+					},
+					Target: ExternalSecretTarget{
+						Template: &ExternalSecretTemplate{
+							Type: corev1.SecretTypeOpaque,
+							Metadata: ExternalSecretTemplateMetadata{
+								Annotations: map[string]string{
+									corev1.ServiceAccountNameKey: "external-secrets",
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 	for _, tt := range tests {

--- a/apis/externalsecrets/v1beta1/externalsecret_validator.go
+++ b/apis/externalsecrets/v1beta1/externalsecret_validator.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -57,6 +58,10 @@ func validateExternalSecret(es *ExternalSecret) (admission.Warnings, error) {
 
 	if len(es.Spec.Data) == 0 && len(es.Spec.DataFrom) == 0 {
 		errs = errors.Join(errs, errors.New("either data or dataFrom should be specified"))
+	}
+
+	if err := validatePrivilegedTemplate(es); err != nil {
+		errs = errors.Join(errs, err)
 	}
 
 	for _, ref := range es.Spec.DataFrom {
@@ -114,6 +119,29 @@ func validatePolicies(es *ExternalSecret) error {
 	}
 
 	return errs
+}
+
+// validatePrivilegedTemplate rejects templates with specific types and annotations combinations
+// to prevent users from creating long-lived tokens beyond the scope of the defined RBAC.
+func validatePrivilegedTemplate(es *ExternalSecret) error {
+	tpl := es.Spec.Target.Template
+	if tpl == nil {
+		return nil
+	}
+	switch tpl.Type {
+	case corev1.SecretTypeServiceAccountToken:
+		if _, ok := tpl.Metadata.Annotations[corev1.ServiceAccountNameKey]; ok {
+			return fmt.Errorf("template.type=%q with annotation %q is not allowed", corev1.SecretTypeServiceAccountToken, corev1.ServiceAccountNameKey)
+		}
+		for _, tf := range tpl.TemplateFrom {
+			if tf.Target == TemplateTargetAnnotations {
+				return fmt.Errorf("template.type=%q with templateFrom target=%q is not allowed", corev1.SecretTypeServiceAccountToken, TemplateTargetAnnotations)
+			}
+		}
+	case corev1.SecretTypeBootstrapToken:
+		return fmt.Errorf("template.type=%q is not allowed", corev1.SecretTypeBootstrapToken)
+	}
+	return nil
 }
 
 func validateDuplicateKeys(es *ExternalSecret, errs error) error {

--- a/apis/externalsecrets/v1beta1/externalsecret_validator.go
+++ b/apis/externalsecrets/v1beta1/externalsecret_validator.go
@@ -128,6 +128,7 @@ func validatePrivilegedTemplate(es *ExternalSecret) error {
 	if tpl == nil {
 		return nil
 	}
+	//nolint:exhaustive // don't need exhaustive
 	switch tpl.Type {
 	case corev1.SecretTypeServiceAccountToken:
 		if _, ok := tpl.Metadata.Annotations[corev1.ServiceAccountNameKey]; ok {

--- a/apis/externalsecrets/v1beta1/externalsecret_validator_test.go
+++ b/apis/externalsecrets/v1beta1/externalsecret_validator_test.go
@@ -18,6 +18,8 @@ package v1beta1
 
 import (
 	"testing"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -201,6 +203,139 @@ either data or dataFrom should be specified`,
 				},
 			},
 			expectedErr: "duplicate secretKey found: SERVICE_NAME",
+		},
+		{
+			name: "service account token template with name annotation is rejected",
+			obj: &ExternalSecret{
+				Spec: ExternalSecretSpec{
+					DataFrom: []ExternalSecretDataFromRemoteRef{
+						{
+							SourceRef: &StoreGeneratorSourceRef{
+								GeneratorRef: &GeneratorRef{},
+							},
+						},
+					},
+					Target: ExternalSecretTarget{
+						Template: &ExternalSecretTemplate{
+							Type: corev1.SecretTypeServiceAccountToken,
+							Metadata: ExternalSecretTemplateMetadata{
+								Annotations: map[string]string{
+									corev1.ServiceAccountNameKey: "external-secrets",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedErr: `template.type="kubernetes.io/service-account-token" with annotation "kubernetes.io/service-account.name" is not allowed`,
+		},
+		{
+			name: "service account token template without name annotation is allowed",
+			obj: &ExternalSecret{
+				Spec: ExternalSecretSpec{
+					DataFrom: []ExternalSecretDataFromRemoteRef{
+						{
+							SourceRef: &StoreGeneratorSourceRef{
+								GeneratorRef: &GeneratorRef{},
+							},
+						},
+					},
+					Target: ExternalSecretTarget{
+						Template: &ExternalSecretTemplate{
+							Type: corev1.SecretTypeServiceAccountToken,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "service account token template with templateFrom annotations target is rejected",
+			obj: &ExternalSecret{
+				Spec: ExternalSecretSpec{
+					DataFrom: []ExternalSecretDataFromRemoteRef{
+						{
+							SourceRef: &StoreGeneratorSourceRef{
+								GeneratorRef: &GeneratorRef{},
+							},
+						},
+					},
+					Target: ExternalSecretTarget{
+						Template: &ExternalSecretTemplate{
+							Type: corev1.SecretTypeServiceAccountToken,
+							TemplateFrom: []TemplateFrom{
+								{Target: TemplateTargetAnnotations},
+							},
+						},
+					},
+				},
+			},
+			expectedErr: `template.type="kubernetes.io/service-account-token" with templateFrom target="Annotations" is not allowed`,
+		},
+		{
+			name: "service account token template with templateFrom data target is allowed",
+			obj: &ExternalSecret{
+				Spec: ExternalSecretSpec{
+					DataFrom: []ExternalSecretDataFromRemoteRef{
+						{
+							SourceRef: &StoreGeneratorSourceRef{
+								GeneratorRef: &GeneratorRef{},
+							},
+						},
+					},
+					Target: ExternalSecretTarget{
+						Template: &ExternalSecretTemplate{
+							Type: corev1.SecretTypeServiceAccountToken,
+							TemplateFrom: []TemplateFrom{
+								{Target: TemplateTargetData},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "bootstrap token template is rejected",
+			obj: &ExternalSecret{
+				Spec: ExternalSecretSpec{
+					DataFrom: []ExternalSecretDataFromRemoteRef{
+						{
+							SourceRef: &StoreGeneratorSourceRef{
+								GeneratorRef: &GeneratorRef{},
+							},
+						},
+					},
+					Target: ExternalSecretTarget{
+						Template: &ExternalSecretTemplate{
+							Type: corev1.SecretTypeBootstrapToken,
+						},
+					},
+				},
+			},
+			expectedErr: `template.type="bootstrap.kubernetes.io/token" is not allowed`,
+		},
+		{
+			name: "service account name annotation without service account token type is allowed",
+			obj: &ExternalSecret{
+				Spec: ExternalSecretSpec{
+					DataFrom: []ExternalSecretDataFromRemoteRef{
+						{
+							SourceRef: &StoreGeneratorSourceRef{
+								GeneratorRef: &GeneratorRef{},
+							},
+						},
+					},
+					Target: ExternalSecretTarget{
+						Template: &ExternalSecretTemplate{
+							Type: corev1.SecretTypeOpaque,
+							Metadata: ExternalSecretTemplateMetadata{
+								Annotations: map[string]string{
+									corev1.ServiceAccountNameKey: "external-secrets",
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 	for _, tt := range tests {

--- a/runtime/template/v2/template_test.go
+++ b/runtime/template/v2/template_test.go
@@ -837,6 +837,19 @@ func TestExecuteInvalidTemplateScope(t *testing.T) {
 	assert.ErrorContains(t, err, "expected 'Values' or 'KeysAndValues'")
 }
 
+// Target dispatch is case-insensitive; validators rely on this.
+func TestExecuteTargetCaseInsensitive(t *testing.T) {
+	for _, target := range []string{"Annotations", "annotations", "ANNOTATIONS", "AnNoTaTiOnS"} {
+		t.Run(target, func(t *testing.T) {
+			sec := &corev1.Secret{}
+			require.NoError(t, Execute(map[string][]byte{"foo": []byte("bar")}, nil, esapi.TemplateScopeValues, target, sec))
+			assert.Equal(t, "bar", sec.Annotations["foo"])
+			assert.Empty(t, sec.Labels)
+			assert.Empty(t, sec.Data)
+		})
+	}
+}
+
 func TestScopeKeysAndValues(t *testing.T) {
 	tbl := []struct {
 		name               string


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes

Adds validation to prevent creating privileged Kubernetes secret templates in ExternalSecrets and expands test coverage.

### New Validation Rules

A new validatePrivilegedTemplate check (applied in v1 and v1beta1 validators) enforces:
- Blocks kubernetes.io/service-account-token when the kubernetes.io/service-account.name annotation is present.
- Blocks kubernetes.io/service-account-token when TemplateFrom targets annotations (v1 performs a case-insensitive match; v1beta1 uses an exact match).
- Blocks bootstrap.kubernetes.io/token unconditionally.

Errors include the forbidden template.type and, where relevant, the offending annotation or templateFrom target.

### Testing

Adds table-driven tests (v1 and v1beta1) covering:
- Rejection of service-account-token with service-account.name annotation
- Rejection when templateFrom targets annotations (both TemplateTargetAnnotations constant and the literal "annotations")
- Acceptance of service-account-token when the annotation is absent or when templateFrom targets data
- Rejection of bootstrap token templates
- Allowing service-account.name annotation for non-service-account-token secret types

Also adds a runtime/template/v2 unit test verifying templateFrom target dispatch is case-insensitive for "Annotations".

### Impact

- Modified files: apis/externalsecrets/v1/externalsecret_validator.go, apis/externalsecrets/v1/externalsecret_validator_test.go, apis/externalsecrets/v1beta1/externalsecret_validator.go, apis/externalsecrets/v1beta1/externalsecret_validator_test.go, runtime/template/v2/template_test.go
- No public API/type declarations changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->