### PR TITLE
fix(doc): Adds missing doc reference for VaultDynamicSecret example using GET

### DIFF
--- a/docs/snippets/generator-vault-get.yaml
+++ b/docs/snippets/generator-vault-get.yaml
@@ -1,0 +1,26 @@
+{% raw %}
+
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: VaultDynamicSecret
+metadata:
+  name: "vault-get-example"
+spec:
+  path: "/kv/data/example"
+  method: "GET"
+  # Query string parameters for GET calls (each key may map to multiple values).
+  # These are ignored for non-GET methods; use `parameters` for write bodies.
+  getParameters:
+    version:
+    - "1"
+  resultType: "Data"  # "Auth" and "Raw" are also available
+  provider:
+    # For production, always use "https" and ensure the additional TLS parameters are configured accordingly.
+    server: "http://vault.default.svc.cluster.local:8200"
+    auth:
+      kubernetes:
+        mountPath: "kubernetes"
+        role: "external-secrets-operator"
+        serviceAccountRef:
+          name: "default"
+{% endraw %}
+


### PR DESCRIPTION
## Problem Statement

Adds missing `VaultDynamicSecret` GET example referenced in the generator API doc, which is causing the rendering error in live doc at https://external-secrets.io/v2.4.1/api/generator/vault/ 

## Proposed Changes

Adds the missing referenced example manifest.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Adds missing VaultDynamicSecret GET example documentation

Adds a new documentation snippet file (`docs/snippets/generator-vault-get.yaml`) containing a `VaultDynamicSecret` example that issues a Vault `GET` request to `/kv/data/example` with query parameters.

The example includes:
- apiVersion: generators.external-secrets.io/v1alpha1, kind: VaultDynamicSecret, metadata name `vault-get-example`
- method: "GET" and getParameters specifying `version: ["1"]`
- resultType: "Data"
- Vault provider server URL and note to use HTTPS in production
- Kubernetes authentication (mountPath `kubernetes`, role `external-secrets-operator`, serviceAccountRef `default`)
- Wrapped in raw template tags to prevent rendering

This resolves the missing documentation reference that caused a rendering error on the live generator API docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->