### PR TITLE
docs: Explanation of our labels

### DIFF
--- a/.github/config/labeler.yml
+++ b/.github/config/labeler.yml
@@ -9,7 +9,7 @@ component/github-actions:
 - any:
   - changed-files:
     - any-glob-to-any-file: ['.github/**']
-kind/documentation:
+area/documentation:
 - any:
   - changed-files:
     - any-glob-to-any-file: ['docs/**', 'examples/**']

--- a/.github/config/labeler.yml
+++ b/.github/config/labeler.yml
@@ -12,4 +12,4 @@ component/github-actions:
 area/documentation:
 - any:
   - changed-files:
-    - any-glob-to-any-file: ['docs/**', 'examples/**']
+    - any-glob-to-any-file: ['docs/**', 'examples/**', '**/*.md']

--- a/.github/workflows/pull-request-label.yml
+++ b/.github/workflows/pull-request-label.yml
@@ -30,8 +30,8 @@ jobs:
               "ref":"kind/refactor",
               "clean":"kind/cleanup",
               "design":"kind/design",
-              "docs":"kind/documentation",
-              "test":"kind/testing",
+              "docs":"area/documentation",
+              "test":"area/testing",
               "perf":"kind/performance"
             }
         with:
@@ -155,5 +155,5 @@ jobs:
       - name: PRs should have at least one qualifying label
         uses: docker://agilepathway/pull-request-label-checker:latest@sha256:14f5f3dfda922496d07d53494e2d2b42885165f90677a1c03d600059b7706a61
         with:
-          any_of: kind/chore,kind/bug,kind/feature,kind/dependency,kind/refactor,kind/design,kind/documentation,kind/testing,kind/performance,kind/cleanup
+          any_of: kind/chore,kind/bug,kind/feature,kind/dependency,kind/refactor,kind/design,area/documentation,area/testing,kind/performance,kind/cleanup
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/contributing/process.md
+++ b/docs/contributing/process.md
@@ -8,23 +8,49 @@ We have a [Roadmap](roadmap.md) to track progress for our road towards GA.
 
 Features, bugs and any issues regarding the documentation should be filed as
 [GitHub Issue](https://github.com/external-secrets/external-secrets/issues) in
-our repository. We use labels like `kind/feature`, `kind/bug`, `area/aws` to
-organize the issues. Issues labeled `good first issue` and `help wanted` are
-especially good for a first contribution. If you want to pick up an issue just
-leave a comment.
+our repository.
+
+## Issues and pull requests labels
+
+We have [our github labels](https://github.com/external-secrets/external-secrets/labels) to help classify the issues and pull requests.
+
+They are categorized as this:
+
+| Label                       | Purpose                                                                                                                                                                                                                                                                                                                                                                                               |
+|-----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `kind/`                     | Kinds classification allows maintainer to easily spot what the issue is about (not where is the code touched). Bugs (kind/bug), features (kind/feature), maintenance items (kind/chore, kind/refactor, kind/cleanup, kind/dependency), initiatives (kind/design), performance changes (kind/performance), support-questions (kind/support).                                                                            |
+| `triage/`                   | Triage labels tracks the issue's lifecycle (or change's lifecycle). Suggested mappings: `triage/pending-triage` (not triaged yet), `triage/needs-information` (missing details from reporter), `triage/not-reproducible` (cannot reproduce with provided info), `triage/confirmed` (valid/reproducible report), `triage/invalid` (incorrect bug report/PR), `triage/duplicate` (duplicate bug report) |
+| `priority/`                 | Priority shows an increasing urgency from "important-long-term", "important-soon" to "urgent"                                                                                                                                                                                                                                                                                                         |
+| `size/`                     | Allows maintainers to better guess the amount of work required to review the issue/PR                                                                                                                                                                                                                                                                                                                 |
+| `area/`                     | Areas allow the routing of the work (issues/PR) based on our knowledge areas. It's intent is to target specific experts in their domain. Each provider has its own area. Examples: `area/aws`, `area/azure`, `area/charts`, `area/documentation`, `area/dependencies`.                                                                                                                                |
+| `breaking-change`           | Highlights the impact on future users on the issue/change                                                                                                                                                                                                                                                                                                                                             |
+| `cncf`                      | Highlights the impact on the CNCF (foundation work, support, maturity tracking)                                                                                                                                                                                                                                                                                                                       |
+| `discuss-community-meeting` | Highlights the need to discuss this in a community meeting for consensus building                                                                                                                                                                                                                                                                                                                     |
+| `release-blocker`           | Issue/PR that block next release                                                                                                                                                                                                                                                                                                                                                                      |
+| `good-first-issue`          | An issue/PR good for newcomers. Do not hesitate to comment on it to mark your interest and tackle the work!                                                                                                                                                                                                                                                                                           |
+| `help-wanted`               | Extra attention of the maintainers team is requested                                                                                                                                                                                                                                                                                                                                                  |
+| `Stale`                     | Is used by a bot to highlight stale PRs/issues that will automatically close if no further activity happens                                                                                                                                                                                                                                                                                           |
+
+With those labels, maintainers are able to efficiently see where they can help better.
+
+Note: Some labels  like `size` and `kind` are applied automatically to Pull Requests by semantic conventions. See also the section below about submitting a pull request.
 
 ## Submitting a Pull Request
 
 This project uses the well-known pull request process from GitHub. To submit a
 pull request, fork the repository and push any changes to a branch on the copy,
-from there a pull request can be made in the main repo. Merging a pull request
-requires the following steps to be completed before the pull request will
-be merged:
+from there you can create a pull request to our main repo.
 
-* ideally, there is an issue that documents the problem or feature in depth.
-* code must have a reasonable amount of test coverage
-* tests must pass
-* PR needs be reviewed and approved
+Please note we are following the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) .
+The use of the right semantics helps the maintaining team to classify your PR effectively.
+**We will only merge PRs matching those conventions.**
+
+Merging a pull request only happens when:
+
+* there is ideally an issue that documents the problem or feature in depth.
+* code has a reasonable amount of test coverage
+* tests pass
+* At least one review approves the change
 
 Once these steps are completed the PR will be merged by a code owner.
 We're using the pull request `assignee` feature to track who is responsible
@@ -150,13 +176,6 @@ We have three different channels through which support questions arise:
 
 1. Kubernetes Slack [#external-secrets](https://kubernetes.slack.com/archives/C017BF84G2Y)
 2. [GitHub Issues](https://github.com/external-secrets/external-secrets/issues/new/choose)
-
-We use labels to identify GitHub Issues. Specifically for managing support cases we use the following labels to identify the state a support case is in:
-
-* `triage/needs-information`: Indicates an issue needs more information in order to work on it.
-* `triage/not-reproducible`: Indicates an issue can not be reproduced as described.
-* `triage/support`: Indicates an issue that is a support question.
-
 
 ## Cutting Releases
 


### PR DESCRIPTION
## Problem Statement

Without this, labels are inconsistent and people (or bots) do not know why they exist and how to use them (especially on duplicate labels!).

This should make our life more clear, improve the triaging speed, but also make the life of the maintainers more efficient by directly targetting the work they are most useful at.

## Related Issue

None

## Proposed Changes

Improve the docs around the labels. I would then adapt the labels and the CODEOWNERS (if necessary).

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Yeah, I will do that, but right now I want to show this so we have a base of conversation.


## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- docs/contributing/process.md: Added an “Issues and pull requests labels” section with a label taxonomy and usage guidance for families `kind/`, `triage/`, `priority/`, `size/`, `area/`, plus standalone labels such as `breaking-change`, `cncf`, `discuss-community-meeting`, `release-blocker`, `good-first-issue`, `help-wanted`, and `Stale`. Removed the explicit bullet mapping of support-case states to `triage/*` labels and left open NOTES/Q&A for follow-ups (label matrix, simplification, CODEOWNERS updates).
  - Motivation: address inconsistent label usage and give clearer guidance for contributors/bots to speed triage and maintainer workflows.
  - Changes: +36 / -18 lines.

- .github/workflows/pull-request-label.yml: Aligned automation with the new label taxonomy by remapping Conventional Commit types `docs` → `area/documentation` and `test` → `area/testing` (previously `kind/*`), and updated the label verification allowlist to accept these `area/*` values.
  - Changes: +3 / -3 lines.

Checklist/status: author confirms contributing guidelines read and commits signed; CI/tests and review-readiness items remain unchecked.

Discussion highlights: proposal of a `new-provider` label; preference for `kind/support-question` over a top-level SUPPORT-QUESTION; ensure any label changes are mirrored in the PR-title/labeler workflow (existing validation must not break); suggestion to add automated PR-title validation (can be follow-up); author plans to clean up the MR and pursue follow-ups for stricter commit-message validation and broader automation/CODEOWNERS updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/external-secrets/external-secrets/pull/6306?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->