### PR TITLE
feat: add healthz check for liveness probe to cert and webhook

### DIFF
--- a/cmd/controller/certcontroller.go
+++ b/cmd/controller/certcontroller.go
@@ -32,6 +32,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -136,6 +137,10 @@ var certcontrollerCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
+		if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+			setupLog.Error(err, "unable to add cert controller healthz check")
+			os.Exit(1)
+		}
 		err = mgr.AddReadyzCheck("crd-inject", crdctrl.ReadyCheck)
 		if err != nil {
 			setupLog.Error(err, "unable to add crd readyz check")

--- a/cmd/controller/webhook.go
+++ b/cmd/controller/webhook.go
@@ -31,6 +31,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
@@ -161,6 +162,10 @@ var webhookCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
+		if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+			setupLog.Error(err, "unable to add webhook healthz check")
+			os.Exit(1)
+		}
 		err = mgr.AddReadyzCheck("certs", func(_ *http.Request) error {
 			return crds.CheckCerts(c, dnsName, time.Now().Add(time.Hour))
 		})


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?

## Related Issue

Adds missing hooks from https://github.com/external-secrets/external-secrets/pull/6276.

## Proposed Changes

How do you like to solve the issue and why?

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds `healthz` liveness probe support to the certificate controller and webhook components to enable Kubernetes liveness probe health checks.

**Changes:**
- **cmd/controller/certcontroller.go**: Imports `sigs.k8s.io/controller-runtime/pkg/healthz` and registers a health check with `mgr.AddHealthzCheck("healthz", healthz.Ping)`
- **cmd/controller/webhook.go**: Imports `sigs.k8s.io/controller-runtime/pkg/healthz` and registers a health check with `mgr.AddHealthzCheck("healthz", healthz.Ping)`

These changes provide parity with the main controller (cmd/controller/root.go) which already includes similar health checks, completing the integration of liveness probes across all controller components.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/external-secrets/external-secrets/pull/6319)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->