### PR TITLE
feat(charts): default scopedNamespace to .Release.Namespace when scopedRBAC is true

### DIFF
--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -213,7 +213,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | resources | object | `{}` |  |
 | revisionHistoryLimit | int | `10` | Specifies the amount of historic ReplicaSets k8s should keep (see https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy) |
 | scopedNamespace | string | `""` | If set external secrets are only reconciled in the provided namespace |
-| scopedRBAC | bool | `false` | Must be used with scopedNamespace. If true, create scoped RBAC roles under the scoped namespace and implicitly disable cluster stores and cluster external secrets |
+| scopedRBAC | bool | `false` | If true, create scoped RBAC roles and implicitly disable cluster-scoped controllers. Scoped to scopedNamespace if set, otherwise to .Release.Namespace. |
 | securityContext.allowPrivilegeEscalation | bool | `false` |  |
 | securityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | securityContext.enabled | bool | `true` |  |

--- a/deploy/charts/external-secrets/templates/deployment.yaml
+++ b/deploy/charts/external-secrets/templates/deployment.yaml
@@ -69,7 +69,7 @@ spec:
           {{- end }}
           image: {{ include "external-secrets.image" (dict "chartAppVersion" .Chart.AppVersion "image" .Values.image "context" .) | trim }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if or (.Values.leaderElect) (.Values.scopedNamespace) (.Values.processClusterStore) (.Values.processClusterExternalSecret) (.Values.processClusterPushSecret) (.Values.concurrent) (.Values.extraArgs) }}
+          {{- if or (.Values.leaderElect) (.Values.scopedNamespace) (.Values.scopedRBAC) (.Values.processClusterStore) (.Values.processClusterExternalSecret) (.Values.processClusterPushSecret) (.Values.concurrent) (.Values.extraArgs) }}
           args:
           {{- if .Values.leaderElect }}
           - --enable-leader-election=true
@@ -77,10 +77,10 @@ spec:
           {{- if .Values.leaderElectionID }}
           - --leader-election-id={{ .Values.leaderElectionID }}
           {{- end }}
-          {{- if .Values.scopedNamespace }}
-          - --namespace={{ .Values.scopedNamespace }}
+          {{- if or .Values.scopedNamespace .Values.scopedRBAC }}
+          - --namespace={{ .Values.scopedNamespace | default .Release.Namespace }}
           {{- end }}
-          {{- if and .Values.scopedNamespace .Values.scopedRBAC }}
+          {{- if .Values.scopedRBAC }}
           - --enable-cluster-store-reconciler=false
           - --enable-cluster-external-secret-reconciler=false
           - --enable-cluster-push-secret-reconciler=false

--- a/deploy/charts/external-secrets/templates/rbac.yaml
+++ b/deploy/charts/external-secrets/templates/rbac.yaml
@@ -1,14 +1,14 @@
 {{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
-{{- if and .Values.scopedNamespace .Values.scopedRBAC }}
+{{- if .Values.scopedRBAC }}
 kind: Role
 {{- else }}
 kind: ClusterRole
 {{- end }}
 metadata:
   name: {{ include "external-secrets.fullname" . }}-controller
-  {{- if and .Values.scopedNamespace .Values.scopedRBAC }}
-  namespace: {{ .Values.scopedNamespace | quote }}
+  {{- if .Values.scopedRBAC }}
+  namespace: {{ .Values.scopedNamespace | default .Release.Namespace | quote }}
   {{- end }}
   labels:
     {{- include "external-secrets.labels" . | nindent 4 }}
@@ -217,15 +217,15 @@ rules:
   {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-{{- if and .Values.scopedNamespace .Values.scopedRBAC }}
+{{- if .Values.scopedRBAC }}
 kind: Role
 {{- else }}
 kind: ClusterRole
 {{- end }}
 metadata:
   name: {{ include "external-secrets.fullname" . }}-view
-  {{- if and .Values.scopedNamespace .Values.scopedRBAC }}
-  namespace: {{ .Values.scopedNamespace | quote }}
+  {{- if .Values.scopedRBAC }}
+  namespace: {{ .Values.scopedNamespace | default .Release.Namespace | quote }}
   {{- end }}
   labels:
     {{- include "external-secrets.labels" . | nindent 4 }}
@@ -282,15 +282,15 @@ rules:
       - "list"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-{{- if and .Values.scopedNamespace .Values.scopedRBAC }}
+{{- if .Values.scopedRBAC }}
 kind: Role
 {{- else }}
 kind: ClusterRole
 {{- end }}
 metadata:
   name: {{ include "external-secrets.fullname" . }}-edit
-  {{- if and .Values.scopedNamespace .Values.scopedRBAC }}
-  namespace: {{ .Values.scopedNamespace | quote }}
+  {{- if .Values.scopedRBAC }}
+  namespace: {{ .Values.scopedNamespace | default .Release.Namespace | quote }}
   {{- end }}
   labels:
     {{- include "external-secrets.labels" . | nindent 4 }}
@@ -348,21 +348,21 @@ rules:
       - "update"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-{{- if and .Values.scopedNamespace .Values.scopedRBAC }}
+{{- if .Values.scopedRBAC }}
 kind: RoleBinding
 {{- else }}
 kind: ClusterRoleBinding
 {{- end }}
 metadata:
   name: {{ include "external-secrets.fullname" . }}-controller
-  {{- if and .Values.scopedNamespace .Values.scopedRBAC }}
-  namespace: {{ .Values.scopedNamespace | quote }}
+  {{- if .Values.scopedRBAC }}
+  namespace: {{ .Values.scopedNamespace | default .Release.Namespace | quote }}
   {{- end }}
   labels:
     {{- include "external-secrets.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  {{- if and .Values.scopedNamespace .Values.scopedRBAC }}
+  {{- if .Values.scopedRBAC }}
   kind: Role
   {{- else }}
   kind: ClusterRole

--- a/deploy/charts/external-secrets/tests/rbac_test.yaml
+++ b/deploy/charts/external-secrets/tests/rbac_test.yaml
@@ -70,7 +70,6 @@ tests:
   - it: should configure custom lease name when leaderElectionID is set
     set:
       leaderElectionID: "custom-eso-lease"
-      scopedRBAC: true
     asserts:
       - matchSnapshot: {}
 
@@ -169,3 +168,147 @@ tests:
             - "create"
             - "update"
             - "delete"
+
+  - it: should render controller Role with explicit scopedNamespace when scopedRBAC is true
+    set:
+      scopedRBAC: true
+      scopedNamespace: "my-ns"
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: Role
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-external-secrets-controller
+      - equal:
+          path: metadata.namespace
+          value: "my-ns"
+
+  - it: should render controller Role with release namespace when scopedRBAC is true and scopedNamespace is empty
+    set:
+      scopedRBAC: true
+      scopedNamespace: ""
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: Role
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-external-secrets-controller
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+
+  - it: should render controller ClusterRole when scopedRBAC is false
+    set:
+      scopedRBAC: false
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: ClusterRole
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-external-secrets-controller
+      - notExists:
+          path: metadata.namespace
+
+  - it: should render view Role with release namespace when scopedRBAC is true
+    set:
+      scopedRBAC: true
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-external-secrets-view
+    asserts:
+      - isKind:
+          of: Role
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+
+  - it: should render edit Role with release namespace when scopedRBAC is true
+    set:
+      scopedRBAC: true
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-external-secrets-edit
+    asserts:
+      - isKind:
+          of: Role
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+
+  - it: should render ClusterRole when scopedNamespace is set without scopedRBAC
+    set:
+      scopedRBAC: false
+      scopedNamespace: "my-ns"
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: ClusterRole
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-external-secrets-controller
+      - notExists:
+          path: metadata.namespace
+
+  - it: should render controller RoleBinding when scopedRBAC is true and scopedNamespace is empty
+    set:
+      scopedRBAC: true
+      scopedNamespace: ""
+    documentIndex: 3
+    asserts:
+      - isKind:
+          of: RoleBinding
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-external-secrets-controller
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+      - equal:
+          path: roleRef.kind
+          value: Role
+      - equal:
+          path: roleRef.name
+          value: RELEASE-NAME-external-secrets-controller
+
+  - it: should render controller RoleBinding with explicit scopedNamespace when scopedRBAC is true
+    set:
+      scopedRBAC: true
+      scopedNamespace: "my-ns"
+    documentIndex: 3
+    asserts:
+      - isKind:
+          of: RoleBinding
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-external-secrets-controller
+      - equal:
+          path: metadata.namespace
+          value: "my-ns"
+      - equal:
+          path: roleRef.kind
+          value: Role
+      - equal:
+          path: roleRef.name
+          value: RELEASE-NAME-external-secrets-controller
+
+  - it: should render controller ClusterRoleBinding when scopedRBAC is false
+    set:
+      scopedRBAC: false
+    documentIndex: 3
+    asserts:
+      - isKind:
+          of: ClusterRoleBinding
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-external-secrets-controller
+      - notExists:
+          path: metadata.namespace
+      - equal:
+          path: roleRef.kind
+          value: ClusterRole
+      - equal:
+          path: roleRef.name
+          value: RELEASE-NAME-external-secrets-controller

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -108,8 +108,8 @@ extendedMetricLabels: false
 # provided namespace
 scopedNamespace: ""
 
-# -- Must be used with scopedNamespace. If true, create scoped RBAC roles under the scoped namespace
-# and implicitly disable cluster stores and cluster external secrets
+# -- If true, create scoped RBAC roles and implicitly disable cluster-scoped
+# controllers. Scoped to scopedNamespace if set, otherwise to .Release.Namespace.
 scopedRBAC: false
 
 # -- If true the OpenShift finalizer permissions will be added to RBAC


### PR DESCRIPTION
## Problem Statement

When `scopedRBAC: true` and `scopedNamespace` is left empty, the chart silently falls back to cluster-wide RBAC.

The condition `if and .Values.scopedNamespace .Values.scopedRBAC` is falsy because empty string is falsy in Go templates.

The user believes they have a scoped deployment but actually has cluster-wide RBAC and an unscoped controller.

## Related Issue

Fixes #6341

## Proposed Changes

Make `scopedRBAC` the sole gate for scoped mode:
- Replace `if and .Values.scopedNamespace .Values.scopedRBAC` with `if .Values.scopedRBAC`
- Default namespace to `.Release.Namespace` via `| default .Release.Namespace`
- Gate `--namespace=` in deployment.yaml on `or .Values.scopedNamespace .Values.scopedRBAC`
- Update `values.yaml` comments
- Add helm unit tests for scoped RBAC: controller Role/ClusterRole rendering, view/edit Role rendering, and the independent `scopedNamespace` without `scopedRBAC` case
- Remove unrelated `scopedRBAC: true` from the leaderElectionID snapshot test (it was only set to trigger Role rendering for the leaderelection resource, which is always a Role regardless of `scopedRBAC`)

## Checklist

- [x] I have read the contribution guidelines
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes

Fixed a bug where setting scopedRBAC: true without an explicit scopedNamespace incorrectly fell back to cluster-wide RBAC because templates used `and .Values.scopedNamespace .Values.scopedRBAC` (empty scopedNamespace is falsy).

Key changes:
- RBAC template: use `.Values.scopedRBAC` as the sole gate; set effective namespace to `.Values.scopedNamespace | default .Release.Namespace` when scoped.
- Deployment template: emit the `--namespace=` flag when either `scopedNamespace` or `scopedRBAC` is set, so the controller watch scope matches RBAC scope.
- Documentation: updated values.yaml and README to state scopedNamespace defaults to the release namespace when scopedRBAC is true and that scopedRBAC implicitly disables cluster-scoped controllers.
- Tests: added Helm unit tests covering controller Role/ClusterRole rendering, view/edit Role rendering, and the case of scopedNamespace without scopedRBAC (supported independent use).

Fixes: #6341

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/external-secrets/external-secrets/pull/6343)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->