### PR TITLE
fix(charts): remove stale args guard in controller deployment

### DIFF
--- a/deploy/charts/external-secrets/templates/deployment.yaml
+++ b/deploy/charts/external-secrets/templates/deployment.yaml
@@ -69,7 +69,6 @@ spec:
           {{- end }}
           image: {{ include "external-secrets.image" (dict "chartAppVersion" .Chart.AppVersion "image" .Values.image "context" .) | trim }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if or (.Values.leaderElect) (.Values.scopedNamespace) (.Values.scopedRBAC) (.Values.processClusterStore) (.Values.processClusterExternalSecret) (.Values.processClusterPushSecret) (.Values.concurrent) (.Values.extraArgs) }}
           args:
           {{- if .Values.leaderElect }}
           - --enable-leader-election=true
@@ -128,7 +127,6 @@ spec:
             {{- else }}
           - --{{ $key }}
             {{- end }}
-          {{- end }}
           {{- end }}
           - --metrics-addr=:{{ .Values.metrics.listen.port }}
           - --loglevel={{ .Values.log.level }}

--- a/deploy/charts/external-secrets/tests/controller_test.yaml
+++ b/deploy/charts/external-secrets/tests/controller_test.yaml
@@ -450,3 +450,25 @@ tests:
             httpGet:
               port: live
               path: /readyz
+  - it: should always render args with unconditional entries
+    set:
+      leaderElect: false
+      scopedNamespace: ""
+      scopedRBAC: false
+      processClusterStore: false
+      processClusterExternalSecret: false
+      processClusterPushSecret: false
+      concurrent: 0
+      extraArgs: {}
+    asserts:
+      - exists:
+          path: spec.template.spec.containers[0].args
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--metrics-addr=:8080"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--loglevel=info"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--zap-time-encoding=epoch"


### PR DESCRIPTION
## Problem Statement

The controller deployment template wraps the `args:` key in a conditional guard,
but unconditional args (`--metrics-addr`, `--loglevel`, `--zap-time-encoding`)
are rendered outside the guard. When all guard conditions are falsy, the template
produces bare list items without an `args:` key, resulting in invalid YAML.

## Related Issue

Fixes #6346

## Proposed Changes

Remove the stale conditional guard around `args:`. Since the block always has at
least the unconditional metrics/log entries, the `args:` key must always be
rendered. Add a helm unit test that reproduces the bug scenario.

## Checklist

- [x] I have read the contribution guidelines
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
Fixes a Helm templating bug in the controller Deployment template: the `args:` key was conditionally rendered while some arguments (`--metrics-addr`, `--loglevel`, `--zap-time-encoding`) were always emitted unconditionally. If all guard conditions were false, Helm produced list items without an `args:` key, causing invalid YAML. The PR removes the stale guard so `args:` is always rendered.

## Changes
deploy/charts/external-secrets/templates/deployment.yaml
- Remove outer conditional guard around the `args:` key so the `args:` list is always emitted.
- Keep existing inner conditionals/ranges for individual flags and `extraArgs`.
- Ensure metrics/logging/probe args remain part of the same `args:` list in all cases.

deploy/charts/external-secrets/tests/controller_test.yaml
- Add a Helm unit test reproducing the bug scenario and asserting the rendered pod args include `--metrics-addr=:8080`, `--loglevel=info`, `--zap-time-encoding=epoch` and that the `args:` field is present.

## Notes
- No exported/public code changes (template and test only).
- Commits include tests and follow contribution guidelines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/external-secrets/external-secrets/pull/6347)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->