### PR TITLE
fix(passworddepot): handle reads without a remote property

### DIFF
--- a/providers/v1/passworddepot/passworddepot.go
+++ b/providers/v1/passworddepot/passworddepot.go
@@ -174,6 +174,10 @@ func (p *PasswordDepot) GetSecret(_ context.Context, ref esv1.ExternalSecretData
 	if err != nil {
 		return nil, err
 	}
+	if ref.Property == "" {
+		return esutils.JSONMarshal(data)
+	}
+
 	mappedData := data.ToMap()
 	value, ok := mappedData[ref.Property]
 	if !ok {
@@ -185,6 +189,10 @@ func (p *PasswordDepot) GetSecret(_ context.Context, ref esv1.ExternalSecretData
 
 // GetSecretMap retrieves a secret and returns it as a map of key/value pairs.
 func (p *PasswordDepot) GetSecretMap(_ context.Context, ref esv1.ExternalSecretDataRemoteRef) (map[string][]byte, error) {
+	if esutils.IsNil(p.client) {
+		return nil, errors.New(errUninitalizedPasswordDepotProvider)
+	}
+
 	data, err := p.client.GetSecret(p.database, ref.Key)
 	if err != nil {
 		return nil, fmt.Errorf("error getting secret %s: %w", ref.Key, err)

--- a/providers/v1/passworddepot/passworddepot_test.go
+++ b/providers/v1/passworddepot/passworddepot_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright © The ESO Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package passworddepot
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
+)
+
+type staticPasswordDepotClient struct {
+	secret SecretEntry
+}
+
+func (s staticPasswordDepotClient) GetSecret(_, _ string) (SecretEntry, error) {
+	return s.secret, nil
+}
+
+func TestPasswordDepotGetSecretWithoutProperty(t *testing.T) {
+	provider := &PasswordDepot{
+		client: staticPasswordDepotClient{
+			secret: SecretEntry{
+				Name:  mySecret,
+				Login: "user",
+				Pass:  "secret",
+			},
+		},
+		database: someDB,
+	}
+
+	got, err := provider.GetSecret(context.Background(), esv1.ExternalSecretDataRemoteRef{Key: mySecret})
+	if err != nil {
+		t.Fatalf("expected full secret JSON, got error: %v", err)
+	}
+
+	var decoded map[string]string
+	if err := json.Unmarshal(got, &decoded); err != nil {
+		t.Fatalf("expected JSON encoded secret, got %q: %v", string(got), err)
+	}
+	if decoded["name"] != mySecret {
+		t.Fatalf("unexpected name: %q", decoded["name"])
+	}
+	if decoded["login"] != "user" {
+		t.Fatalf("unexpected login: %q", decoded["login"])
+	}
+	if decoded["pass"] != "secret" {
+		t.Fatalf("unexpected pass: %q", decoded["pass"])
+	}
+}
+
+func TestPasswordDepotGetSecretMapUninitialized(t *testing.T) {
+	provider := &PasswordDepot{}
+
+	_, err := provider.GetSecretMap(context.Background(), esv1.ExternalSecretDataRemoteRef{Key: mySecret})
+	if err == nil {
+		t.Fatal("expected error for uninitialized provider")
+	}
+	if err.Error() != errUninitalizedPasswordDepotProvider {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## What
Tiny PasswordDepot fix. When `remoteRef.property` is omitted, return the full entry as JSON instead of looking up the empty property and failing. lowkey annoying bug.

Also adds a guard so `GetSecretMap` returns a normal error if the client is not ready, no panic.

## Repro
Add an ExternalSecret data item with only `remoteRef.key` for PasswordDepot:

```yaml
data:
- secretKey: entry
  remoteRef:
    key: Production.mySecret
```

Before this change the provider returns `key not found in secret data`.

Focused test without the fix:

```sh
cd providers/v1/passworddepot
go test -run TestPasswordDepotGetSecretWithoutProperty -count=1
```

## Test
```sh
cd providers/v1/passworddepot
go test ./...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Fixes a PasswordDepot provider bug where omitting `remoteRef.property` caused provider failures. When the property is not specified, the provider now returns the full secret entry as JSON instead of attempting to lookup an empty map key.

## Changes

### passworddepot.go
- **GetSecret**: Special-cases requests with empty `ref.Property` by marshaling the full secret payload to JSON; continues to return map values for non-empty properties with error handling for missing keys
- **GetSecretMap**: Added initialization check to return "provider passworddepot is not initialized" error instead of panicking when client is not ready

### passworddepot_test.go
- Added `staticPasswordDepotClient` stub for testing
- **TestPasswordDepotGetSecretWithoutProperty**: Verifies `GetSecret` returns JSON with full secret fields when property is omitted
- **TestPasswordDepotGetSecretMapUninitialized**: Verifies `GetSecretMap` returns proper error when provider is uninitialized

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/external-secrets/external-secrets/pull/6357?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->