### PR TITLE
feat(ibm): implement GetAllSecrets

### DIFF
--- a/docs/provider/ibm-secrets-manager.md
+++ b/docs/provider/ibm-secrets-manager.md
@@ -232,6 +232,54 @@ data:
 
 ```
 
+### Finding secrets with `dataFrom.find`
+
+The provider supports listing secrets via `dataFrom.find` for **every** IBM Secrets Manager secret type (arbitrary, username_password, iam_credentials, service_credentials, imported_cert, public_cert, private_cert, kv, custom_credentials).
+
+At least one of `name`, `tags`, or `path` must be supplied — an empty `find: {}` is rejected. Filters combine: server-side filters narrow the listing, and `name.regexp` filters the result client-side.
+
+#### Filters
+
+| Filter | How it is applied |
+| --- | --- |
+| `name.regexp` | Compiled once, matched **client-side** against each secret's bare name after the server returns the page. |
+| `path` | Forwarded **server-side** as the `search` parameter — a substring match across `id`, `name`, `description`, `labels`, and `secret_type`. |
+| `tags` | Forwarded **server-side** as the `match_all_labels` filter. The map is encoded as IBM SM label strings: an entry with a non-empty value becomes `"key=value"`, an entry with an empty value passes the bare `"key"`. The secret must carry **all** listed labels to match. |
+
+Tag encoding consequence: if your IBM secrets are labelled with bare strings (e.g. `prod`, `platform`), you must pass `tags: {prod: "", platform: ""}` — `tags: {env: prod}` looks for the label literal `env=prod`, which is a different label.
+
+#### Result shape
+
+Each entry in the returned map is the **full secret** marshalled as JSON, not the bare payload. Keys are the bare IBM secret names (sanitised per `conversionStrategy`). Use a `target.template` or rewrite to project the field you care about — typically `.payload` for arbitrary secrets:
+
+```yaml
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: app-passwords
+spec:
+  refreshInterval: 1h
+  secretStoreRef: { name: ibm-sm, kind: SecretStore }
+  target:
+    name: app-passwords
+    template:
+      data:
+        # Extract just .payload from the JSON-marshalled secret value.
+        "{{ .key }}": "{{ ( index .value | fromJson ).payload }}"
+  dataFrom:
+    - find:
+        tags: { env: prod, team: platform }
+        name:
+          regexp: "^app-"
+```
+
+#### Error cases
+
+- `find: {}` (no filter) — store reconcile fails with `at least one of find.name, find.tags or find.path must be set`.
+- Invalid regex in `name.regexp` — `could not compile find.name.regexp`.
+- Two secrets with the same bare name across groups — `secret name "<name>" is not unique in result; narrow find.path or find.tags`. Tighten filters or move the duplicate to a distinct group with a unique name.
+- A list page contains a metadata entry with empty `id` or `name` — `secret metadata missing id or name`. This indicates a malformed upstream response and is surfaced rather than silently skipped.
+
 ### Creating external secret
 
 To create a kubernetes secret from the IBM Secrets Manager, a `Kind=ExternalSecret` is needed.

--- a/docs/provider/ibm-secrets-manager.md
+++ b/docs/provider/ibm-secrets-manager.md
@@ -219,7 +219,7 @@ data:
   keyB: ... #2nd key-value pair from JSON object
   keyC: ... #3rd key-value pair from JSON object
 
-  # secrets from dataFrom with find regex method
+  # secrets from dataFrom with find regexp method
   _comp_key1: ... #secret value for /comp/key1
   key2_trigger: ... #secret value for key2/trigger
   _comp_trigger_keygen: ... #secret value for comp/trigger/keygen
@@ -276,7 +276,7 @@ spec:
 #### Error cases
 
 - `find: {}` (no filter) — store reconcile fails with `at least one of find.name, find.tags or find.path must be set`.
-- Invalid regex in `name.regexp` — `could not compile find.name.regexp`.
+- Invalid regexp in `name.regexp` — `could not compile find.name.regexp`.
 - Two secrets with the same bare name across groups — `secret name "<name>" is not unique in result; narrow find.path or find.tags`. Tighten filters or move the duplicate to a distinct group with a unique name.
 - A list page contains a metadata entry with empty `id` or `name` — `secret metadata missing id or name`. This indicates a malformed upstream response and is surfaced rather than silently skipped.
 

--- a/docs/provider/ibm-secrets-manager.md
+++ b/docs/provider/ibm-secrets-manager.md
@@ -265,7 +265,7 @@ spec:
     template:
       data:
         # Extract just .payload from the JSON-marshalled secret value.
-        "{{ .key }}": "{{ ( index .value | fromJson ).payload }}"
+        "{{ .key }}": "{{ (fromJson .value).payload }}"
   dataFrom:
     - find:
         tags: { env: prod, team: platform }

--- a/providers/v1/ibm/fake/fake.go
+++ b/providers/v1/ibm/fake/fake.go
@@ -54,7 +54,7 @@ func (mc *IBMMockClient) GetSecretByNameTypeWithContext(
 
 // ListSecretsWithContext delegates to the test-provided callback. Tests opt in by
 // calling WithListSecrets; the default is a nil callback which returns an empty page,
-// keeping existing tests that don't exercise list behaviour unchanged.
+// keeping existing tests that don't exercise list behavior unchanged.
 func (mc *IBMMockClient) ListSecretsWithContext(
 	ctx context.Context,
 	listSecretsOptions *sm.ListSecretsOptions,

--- a/providers/v1/ibm/fake/fake.go
+++ b/providers/v1/ibm/fake/fake.go
@@ -29,6 +29,7 @@ import (
 type IBMMockClient struct {
 	getSecretWithContext           func(ctx context.Context, getSecretOptions *sm.GetSecretOptions) (result sm.SecretIntf, response *core.DetailedResponse, err error)
 	getSecretByNameTypeWithContext func(ctx context.Context, getSecretByNameTypeOptions *sm.GetSecretByNameTypeOptions) (result sm.SecretIntf, response *core.DetailedResponse, err error)
+	listSecretsWithContext         func(ctx context.Context, listSecretsOptions *sm.ListSecretsOptions) (result *sm.SecretMetadataPaginatedCollection, response *core.DetailedResponse, err error)
 }
 
 type IBMMockClientParams struct {
@@ -49,6 +50,31 @@ func (mc *IBMMockClient) GetSecretByNameTypeWithContext(
 	getSecretByNameTypeOptions *sm.GetSecretByNameTypeOptions,
 ) (result sm.SecretIntf, response *core.DetailedResponse, err error) {
 	return mc.getSecretByNameTypeWithContext(ctx, getSecretByNameTypeOptions)
+}
+
+// ListSecretsWithContext delegates to the test-provided callback. Tests opt in by
+// calling WithListSecrets; the default is a nil callback which returns an empty page,
+// keeping existing tests that don't exercise list behaviour unchanged.
+func (mc *IBMMockClient) ListSecretsWithContext(
+	ctx context.Context,
+	listSecretsOptions *sm.ListSecretsOptions,
+) (result *sm.SecretMetadataPaginatedCollection, response *core.DetailedResponse, err error) {
+	if mc == nil || mc.listSecretsWithContext == nil {
+		return &sm.SecretMetadataPaginatedCollection{}, nil, nil
+	}
+	return mc.listSecretsWithContext(ctx, listSecretsOptions)
+}
+
+// WithListSecrets sets the callback used by ListSecretsWithContext. The callback is
+// invoked once per page; tests typically return the same page (with a length below
+// the requested limit) on the first call to terminate iteration, or use the options
+// argument to assert that filter parameters were forwarded.
+func (mc *IBMMockClient) WithListSecrets(
+	fn func(ctx context.Context, opts *sm.ListSecretsOptions) (*sm.SecretMetadataPaginatedCollection, *core.DetailedResponse, error),
+) {
+	if mc != nil {
+		mc.listSecretsWithContext = fn
+	}
 }
 
 func (mc *IBMMockClient) WithValue(params IBMMockClientParams) {

--- a/providers/v1/ibm/provider.go
+++ b/providers/v1/ibm/provider.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -39,6 +40,7 @@ import (
 	"github.com/external-secrets/external-secrets/runtime/constants"
 	"github.com/external-secrets/external-secrets/runtime/esutils"
 	"github.com/external-secrets/external-secrets/runtime/esutils/resolvers"
+	"github.com/external-secrets/external-secrets/runtime/find"
 	"github.com/external-secrets/external-secrets/runtime/metrics"
 )
 
@@ -78,7 +80,12 @@ var (
 type SecretManagerClient interface {
 	GetSecretWithContext(ctx context.Context, getSecretOptions *sm.GetSecretOptions) (result sm.SecretIntf, response *core.DetailedResponse, err error)
 	GetSecretByNameTypeWithContext(ctx context.Context, getSecretByNameTypeOptions *sm.GetSecretByNameTypeOptions) (result sm.SecretIntf, response *core.DetailedResponse, err error)
+	ListSecretsWithContext(ctx context.Context, listSecretsOptions *sm.ListSecretsOptions) (result *sm.SecretMetadataPaginatedCollection, response *core.DetailedResponse, err error)
 }
+
+// listSecretsPageSize is the page size used when iterating IBM Cloud Secrets Manager.
+// The SDK default is 200 and the maximum is 1000.
+const listSecretsPageSize int64 = 200
 
 type providerIBM struct {
 	IBMClient SecretManagerClient
@@ -114,10 +121,151 @@ func (ibm *providerIBM) PushSecret(_ context.Context, _ *corev1.Secret, _ esv1.P
 	return errors.New(errNotImplemented)
 }
 
-// GetAllSecrets empty.
-func (ibm *providerIBM) GetAllSecrets(_ context.Context, _ esv1.ExternalSecretFind) (map[string][]byte, error) {
-	// TO be implemented
-	return nil, errors.New(errNotImplemented)
+// GetAllSecrets lists secrets from IBM Cloud Secrets Manager and returns a map of secret
+// name to the full secret payload (JSON-marshalled).
+//
+// Filter mapping from ExternalSecretFind to the IBM ListSecrets API:
+//   - ref.Name.RegExp — applied client-side as a regex against each secret's bare name.
+//   - ref.Path        — passed to the server as the `search` parameter, a substring
+//     match against id, name, description, labels, and secret_type.
+//   - ref.Tags        — joined into IBM "match all labels" filter; an entry with an
+//     empty value passes the bare key, otherwise "key=value".
+//
+// At least one of Name, Path, or Tags must be supplied so listing is bounded.
+// Secret names are not unique across groups in IBM SM; a collision in the result map
+// surfaces as an error so the caller can narrow the filter.
+func (ibm *providerIBM) GetAllSecrets(ctx context.Context, ref esv1.ExternalSecretFind) (map[string][]byte, error) {
+	if esutils.IsNil(ibm.IBMClient) {
+		return nil, errors.New(errUninitializedIBMProvider)
+	}
+	if ref.Name == nil && len(ref.Tags) == 0 && (ref.Path == nil || *ref.Path == "") {
+		return nil, errors.New("ibm: at least one of find.name, find.tags or find.path must be set")
+	}
+
+	var matcher *find.Matcher
+	if ref.Name != nil {
+		m, err := find.New(*ref.Name)
+		if err != nil {
+			return nil, err
+		}
+		matcher = m
+	}
+
+	labels := buildLabelFilter(ref.Tags)
+	var search *string
+	if ref.Path != nil && *ref.Path != "" {
+		s := *ref.Path
+		search = &s
+	}
+
+	result := make(map[string][]byte)
+	limit := listSecretsPageSize
+	var offset int64
+
+	for {
+		opts := &sm.ListSecretsOptions{
+			Offset: &offset,
+			Limit:  &limit,
+		}
+		if search != nil {
+			opts.Search = search
+		}
+		if len(labels) > 0 {
+			opts.MatchAllLabels = labels
+		}
+
+		listCtx, cancel := context.WithTimeout(ctx, contextTimeout)
+		page, _, err := ibm.IBMClient.ListSecretsWithContext(listCtx, opts)
+		cancel()
+		metrics.ObserveAPICall(constants.ProviderIBMSM, constants.CallIBMSMListSecrets, err)
+		if err != nil {
+			return nil, fmt.Errorf("ibm: failed to list secrets: %w", err)
+		}
+		if page == nil || len(page.Secrets) == 0 {
+			break
+		}
+
+		for _, meta := range page.Secrets {
+			name, id := secretMetaIdentifiers(meta)
+			if name == "" || id == "" {
+				continue
+			}
+			if matcher != nil && !matcher.MatchName(name) {
+				continue
+			}
+			if _, dupe := result[name]; dupe {
+				return nil, fmt.Errorf("ibm: secret name %q is not unique in result; narrow find.path or find.tags", name)
+			}
+			value, err := ibm.fetchSecretJSON(ctx, id)
+			if err != nil {
+				return nil, err
+			}
+			result[name] = value
+		}
+
+		if int64(len(page.Secrets)) < limit {
+			break
+		}
+		offset += limit
+	}
+
+	return esutils.ConvertKeys(ref.ConversionStrategy, result)
+}
+
+// buildLabelFilter converts an ExternalSecretFind.Tags map into IBM Secrets Manager's
+// MatchAllLabels filter. IBM labels are flat strings (2-64 chars). A non-empty value is
+// encoded as "key=value"; an empty value passes the bare key. The result is sorted so
+// the API call is deterministic for tests.
+func buildLabelFilter(tags map[string]string) []string {
+	if len(tags) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(tags))
+	for k, v := range tags {
+		if v == "" {
+			out = append(out, k)
+		} else {
+			out = append(out, k+"="+v)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// secretMetaIdentifiers extracts the bare name and UUID id from a SecretMetadataIntf.
+// The interface itself exposes no field accessors, so we round-trip through JSON to
+// avoid type-switching every concrete subtype.
+func secretMetaIdentifiers(meta sm.SecretMetadataIntf) (string, string) {
+	b, err := json.Marshal(meta)
+	if err != nil {
+		return "", ""
+	}
+	var raw struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return "", ""
+	}
+	return raw.Name, raw.ID
+}
+
+// fetchSecretJSON retrieves a secret by ID and serialises the full payload to JSON.
+// The result includes every field the SDK returned (per-type values like Payload,
+// ApiKey, Data, etc.) so downstream consumers can pick keys via rewrite rules.
+func (ibm *providerIBM) fetchSecretJSON(ctx context.Context, id string) ([]byte, error) {
+	getCtx, cancel := context.WithTimeout(ctx, contextTimeout)
+	defer cancel()
+	secret, _, err := ibm.IBMClient.GetSecretWithContext(getCtx, &sm.GetSecretOptions{ID: &id})
+	metrics.ObserveAPICall(constants.ProviderIBMSM, constants.CallIBMSMGetSecret, err)
+	if err != nil {
+		return nil, fmt.Errorf("ibm: failed to fetch secret %s: %w", id, err)
+	}
+	b, err := json.Marshal(secret)
+	if err != nil {
+		return nil, fmt.Errorf("ibm: %w", fmt.Errorf(errJSONSecretMarshal, err))
+	}
+	return b, nil
 }
 
 func (ibm *providerIBM) GetSecret(_ context.Context, ref esv1.ExternalSecretDataRemoteRef) ([]byte, error) {

--- a/providers/v1/ibm/provider.go
+++ b/providers/v1/ibm/provider.go
@@ -186,9 +186,9 @@ func (ibm *providerIBM) GetAllSecrets(ctx context.Context, ref esv1.ExternalSecr
 		}
 
 		for _, meta := range page.Secrets {
-			name, id := secretMetaIdentifiers(meta)
-			if name == "" || id == "" {
-				continue
+			name, id, err := secretMetaIdentifiers(meta)
+			if err != nil {
+				return nil, err
 			}
 			if matcher != nil && !matcher.MatchName(name) {
 				continue
@@ -235,19 +235,27 @@ func buildLabelFilter(tags map[string]string) []string {
 // secretMetaIdentifiers extracts the bare name and UUID id from a SecretMetadataIntf.
 // The interface itself exposes no field accessors, so we round-trip through JSON to
 // avoid type-switching every concrete subtype.
-func secretMetaIdentifiers(meta sm.SecretMetadataIntf) (string, string) {
+//
+// Errors are surfaced rather than swallowed: a parse failure or a missing id/name in
+// the response is treated as a malformed listing rather than something to skip past
+// silently, because GetAllSecrets' result is written into a Kubernetes Secret and
+// silent gaps would be invisible to the user.
+func secretMetaIdentifiers(meta sm.SecretMetadataIntf) (string, string, error) {
 	b, err := json.Marshal(meta)
 	if err != nil {
-		return "", ""
+		return "", "", fmt.Errorf("ibm: failed to marshal secret metadata: %w", err)
 	}
 	var raw struct {
 		ID   string `json:"id"`
 		Name string `json:"name"`
 	}
 	if err := json.Unmarshal(b, &raw); err != nil {
-		return "", ""
+		return "", "", fmt.Errorf("ibm: failed to decode secret metadata: %w", err)
 	}
-	return raw.Name, raw.ID
+	if raw.ID == "" || raw.Name == "" {
+		return "", "", fmt.Errorf("ibm: secret metadata missing id or name (id=%q name=%q)", raw.ID, raw.Name)
+	}
+	return raw.Name, raw.ID, nil
 }
 
 // fetchSecretJSON retrieves a secret by ID and serialises the full payload to JSON.

--- a/providers/v1/ibm/provider.go
+++ b/providers/v1/ibm/provider.go
@@ -122,7 +122,7 @@ func (ibm *providerIBM) PushSecret(_ context.Context, _ *corev1.Secret, _ esv1.P
 }
 
 // GetAllSecrets lists secrets from IBM Cloud Secrets Manager and returns a map of secret
-// name to the full secret payload (JSON-marshalled).
+// name to the full secret payload (JSON-marshaled).
 //
 // Filter mapping from ExternalSecretFind to the IBM ListSecrets API:
 //   - ref.Name.RegExp — applied client-side as a regex against each secret's bare name.
@@ -258,7 +258,7 @@ func secretMetaIdentifiers(meta sm.SecretMetadataIntf) (string, string, error) {
 	return raw.Name, raw.ID, nil
 }
 
-// fetchSecretJSON retrieves a secret by ID and serialises the full payload to JSON.
+// fetchSecretJSON retrieves a secret by ID and serializes the full payload to JSON.
 // The result includes every field the SDK returned (per-type values like Payload,
 // ApiKey, Data, etc.) so downstream consumers can pick keys via rewrite rules.
 func (ibm *providerIBM) fetchSecretJSON(ctx context.Context, id string) ([]byte, error) {

--- a/providers/v1/ibm/provider_test.go
+++ b/providers/v1/ibm/provider_test.go
@@ -1500,7 +1500,7 @@ func TestGetAllSecrets(t *testing.T) {
 			GetSecretOptions: &sm.GetSecretOptions{ID: &id1},
 			GetSecretOutput: &sm.ArbitrarySecret{
 				SecretType: utilpointer.To(sm.Secret_SecretType_Arbitrary),
-				Name:       utilpointer.To("app-db"),
+				Name:       new("app-db"),
 				ID:         &id1,
 				Payload:    &payload1,
 			},
@@ -1575,7 +1575,7 @@ func TestGetAllSecrets(t *testing.T) {
 			GetSecretOptions: &sm.GetSecretOptions{ID: &id2},
 			GetSecretOutput: &sm.ArbitrarySecret{
 				SecretType: utilpointer.To(sm.Secret_SecretType_Arbitrary),
-				Name:       utilpointer.To("page2-only"),
+				Name:       new("page2-only"),
 				ID:         &id2,
 				Payload:    &payload2,
 			},
@@ -1608,7 +1608,7 @@ func TestGetAllSecrets(t *testing.T) {
 			GetSecretOptions: &sm.GetSecretOptions{ID: &id1},
 			GetSecretOutput: &sm.ArbitrarySecret{
 				SecretType: utilpointer.To(sm.Secret_SecretType_Arbitrary),
-				Name:       utilpointer.To("dup"),
+				Name:       new("dup"),
 				ID:         &id1,
 				Payload:    &payload1,
 			},
@@ -1667,7 +1667,7 @@ func TestGetAllSecrets(t *testing.T) {
 		})
 		p := &providerIBM{IBMClient: mock}
 		_, err := p.GetAllSecrets(ctx, esv1.ExternalSecretFind{
-			Path: utilpointer.To("anything"),
+			Path: new("anything"),
 		})
 		if err == nil || !strings.Contains(err.Error(), "failed to list secrets") {
 			t.Fatalf("expected list error, got %v", err)

--- a/providers/v1/ibm/provider_test.go
+++ b/providers/v1/ibm/provider_test.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/IBM/go-sdk-core/v5/core"
 	sm "github.com/IBM/secrets-manager-go-sdk/v2/secretsmanagerv2"
 	"github.com/go-openapi/strfmt"
 	corev1 "k8s.io/api/core/v1"
@@ -1436,6 +1437,243 @@ func TestValidRetryInput(t *testing.T) {
 
 	if !ErrorContains(err, expected) {
 		t.Errorf("CheckValidRetryInput unexpected error: %s, expected: '%s'", err.Error(), expected)
+	}
+}
+
+// listEntry is a compact representation of a SecretMetadata used in test fixtures.
+type listEntry struct {
+	id   string
+	name string
+}
+
+// metadataPage builds a SecretMetadataPaginatedCollection from a slice of
+// (id, name) pairs, with each entry typed as an ArbitrarySecretMetadata. Anything
+// the production code doesn't read off the metadata (CRN, dates, …) is left zero —
+// the production code only inspects id and name.
+func metadataPage(entries ...listEntry) *sm.SecretMetadataPaginatedCollection {
+	out := &sm.SecretMetadataPaginatedCollection{}
+	for _, e := range entries {
+		id, name := e.id, e.name
+		out.Secrets = append(out.Secrets, &sm.ArbitrarySecretMetadata{
+			SecretType: utilpointer.To(sm.Secret_SecretType_Arbitrary),
+			ID:         &id,
+			Name:       &name,
+		})
+	}
+	return out
+}
+
+func TestGetAllSecrets(t *testing.T) {
+	ctx := context.Background()
+	id1 := "00000000-0000-0000-0000-000000000001"
+	id2 := "00000000-0000-0000-0000-000000000002"
+	payload1, payload2 := "v1", "v2"
+
+	t.Run("rejects empty find", func(t *testing.T) {
+		p := &providerIBM{IBMClient: &fakesm.IBMMockClient{}}
+		_, err := p.GetAllSecrets(ctx, esv1.ExternalSecretFind{})
+		if err == nil || !strings.Contains(err.Error(), "at least one of find.name, find.tags or find.path") {
+			t.Fatalf("expected guard error, got %v", err)
+		}
+	})
+
+	t.Run("rejects uninitialised client", func(t *testing.T) {
+		p := &providerIBM{}
+		_, err := p.GetAllSecrets(ctx, esv1.ExternalSecretFind{Name: &esv1.FindName{RegExp: ".*"}})
+		if err == nil || !strings.Contains(err.Error(), errUninitializedIBMProvider) {
+			t.Fatalf("expected uninitialised error, got %v", err)
+		}
+	})
+
+	t.Run("name regex filters list and JSON payload is returned", func(t *testing.T) {
+		mock := &fakesm.IBMMockClient{}
+		mock.WithListSecrets(func(_ context.Context, opts *sm.ListSecretsOptions) (*sm.SecretMetadataPaginatedCollection, *core.DetailedResponse, error) {
+			if opts.Limit == nil || *opts.Limit != listSecretsPageSize {
+				return nil, nil, fmt.Errorf("expected default page limit, got %v", opts.Limit)
+			}
+			return metadataPage(
+				listEntry{id: id1, name: "app-db"},
+				listEntry{id: id2, name: "internal-cache"},
+			), nil, nil
+		})
+		mock.WithValue(fakesm.IBMMockClientParams{
+			GetSecretOptions: &sm.GetSecretOptions{ID: &id1},
+			GetSecretOutput: &sm.ArbitrarySecret{
+				SecretType: utilpointer.To(sm.Secret_SecretType_Arbitrary),
+				Name:       utilpointer.To("app-db"),
+				ID:         &id1,
+				Payload:    &payload1,
+			},
+		})
+
+		p := &providerIBM{IBMClient: mock}
+		got, err := p.GetAllSecrets(ctx, esv1.ExternalSecretFind{
+			Name: &esv1.FindName{RegExp: "^app-"},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, ok := got["app-db"]; !ok {
+			t.Fatalf("expected app-db in result, got keys %v", mapKeys(got))
+		}
+		if _, ok := got["internal-cache"]; ok {
+			t.Fatalf("internal-cache should have been filtered out, got keys %v", mapKeys(got))
+		}
+		var decoded map[string]any
+		if err := json.Unmarshal(got["app-db"], &decoded); err != nil {
+			t.Fatalf("payload not JSON: %v", err)
+		}
+		if decoded["payload"] != payload1 {
+			t.Fatalf("expected payload %q in JSON, got %v", payload1, decoded["payload"])
+		}
+	})
+
+	t.Run("path forwards to server search and tags map to labels", func(t *testing.T) {
+		var receivedOpts *sm.ListSecretsOptions
+		mock := &fakesm.IBMMockClient{}
+		mock.WithListSecrets(func(_ context.Context, opts *sm.ListSecretsOptions) (*sm.SecretMetadataPaginatedCollection, *core.DetailedResponse, error) {
+			receivedOpts = opts
+			return metadataPage(), nil, nil
+		})
+
+		p := &providerIBM{IBMClient: mock}
+		path := "db-creds"
+		_, err := p.GetAllSecrets(ctx, esv1.ExternalSecretFind{
+			Path: &path,
+			Tags: map[string]string{"env": "prod", "team": ""},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if receivedOpts == nil || receivedOpts.Search == nil || *receivedOpts.Search != path {
+			t.Fatalf("expected Search=%q, got %+v", path, receivedOpts)
+		}
+		// buildLabelFilter sorts entries; "env=prod" before "team".
+		want := []string{"env=prod", "team"}
+		if !reflect.DeepEqual(receivedOpts.MatchAllLabels, want) {
+			t.Fatalf("MatchAllLabels = %v, want %v", receivedOpts.MatchAllLabels, want)
+		}
+	})
+
+	t.Run("pages until a short page", func(t *testing.T) {
+		mock := &fakesm.IBMMockClient{}
+		page1 := make([]listEntry, listSecretsPageSize)
+		for i := range page1 {
+			id := fmt.Sprintf("page1-id-%03d", i)
+			page1[i] = listEntry{id: id, name: id}
+		}
+		var calls int
+		mock.WithListSecrets(func(_ context.Context, opts *sm.ListSecretsOptions) (*sm.SecretMetadataPaginatedCollection, *core.DetailedResponse, error) {
+			calls++
+			if *opts.Offset == 0 {
+				return metadataPage(page1...), nil, nil
+			}
+			// short page → terminates iteration
+			return metadataPage(listEntry{id: id2, name: "page2-only"}), nil, nil
+		})
+		mock.WithValue(fakesm.IBMMockClientParams{
+			GetSecretOptions: &sm.GetSecretOptions{ID: &id2},
+			GetSecretOutput: &sm.ArbitrarySecret{
+				SecretType: utilpointer.To(sm.Secret_SecretType_Arbitrary),
+				Name:       utilpointer.To("page2-only"),
+				ID:         &id2,
+				Payload:    &payload2,
+			},
+		})
+
+		p := &providerIBM{IBMClient: mock}
+		got, err := p.GetAllSecrets(ctx, esv1.ExternalSecretFind{
+			Name: &esv1.FindName{RegExp: "^page2-only$"}, // only one secret survives client filter
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if calls != 2 {
+			t.Fatalf("expected 2 List calls, got %d", calls)
+		}
+		if _, ok := got["page2-only"]; !ok {
+			t.Fatalf("expected page2-only in result, keys=%v", mapKeys(got))
+		}
+	})
+
+	t.Run("name collision returns error", func(t *testing.T) {
+		mock := &fakesm.IBMMockClient{}
+		mock.WithListSecrets(func(_ context.Context, _ *sm.ListSecretsOptions) (*sm.SecretMetadataPaginatedCollection, *core.DetailedResponse, error) {
+			return metadataPage(
+				listEntry{id: id1, name: "dup"},
+				listEntry{id: id2, name: "dup"},
+			), nil, nil
+		})
+		mock.WithValue(fakesm.IBMMockClientParams{
+			GetSecretOptions: &sm.GetSecretOptions{ID: &id1},
+			GetSecretOutput: &sm.ArbitrarySecret{
+				SecretType: utilpointer.To(sm.Secret_SecretType_Arbitrary),
+				Name:       utilpointer.To("dup"),
+				ID:         &id1,
+				Payload:    &payload1,
+			},
+		})
+
+		p := &providerIBM{IBMClient: mock}
+		_, err := p.GetAllSecrets(ctx, esv1.ExternalSecretFind{
+			Name: &esv1.FindName{RegExp: ".*"},
+		})
+		if err == nil || !strings.Contains(err.Error(), "not unique") {
+			t.Fatalf("expected collision error, got %v", err)
+		}
+	})
+
+	t.Run("invalid regex surfaces error", func(t *testing.T) {
+		p := &providerIBM{IBMClient: &fakesm.IBMMockClient{}}
+		_, err := p.GetAllSecrets(ctx, esv1.ExternalSecretFind{
+			Name: &esv1.FindName{RegExp: "("},
+		})
+		if err == nil || !strings.Contains(err.Error(), "could not compile") {
+			t.Fatalf("expected regex compile error, got %v", err)
+		}
+	})
+
+	t.Run("list error propagates", func(t *testing.T) {
+		mock := &fakesm.IBMMockClient{}
+		mock.WithListSecrets(func(_ context.Context, _ *sm.ListSecretsOptions) (*sm.SecretMetadataPaginatedCollection, *core.DetailedResponse, error) {
+			return nil, nil, errors.New("boom")
+		})
+		p := &providerIBM{IBMClient: mock}
+		_, err := p.GetAllSecrets(ctx, esv1.ExternalSecretFind{
+			Path: utilpointer.To("anything"),
+		})
+		if err == nil || !strings.Contains(err.Error(), "failed to list secrets") {
+			t.Fatalf("expected list error, got %v", err)
+		}
+	})
+}
+
+func mapKeys(m map[string][]byte) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+func TestBuildLabelFilter(t *testing.T) {
+	cases := []struct {
+		name string
+		in   map[string]string
+		want []string
+	}{
+		{name: "nil"},
+		{name: "empty value passes bare key", in: map[string]string{"app": ""}, want: []string{"app"}},
+		{name: "value encoded as key=value", in: map[string]string{"env": "prod"}, want: []string{"env=prod"}},
+		{name: "sorted for determinism", in: map[string]string{"team": "x", "env": "prod"}, want: []string{"env=prod", "team=x"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := buildLabelFilter(c.in)
+			if !reflect.DeepEqual(got, c.want) {
+				t.Fatalf("got %v, want %v", got, c.want)
+			}
+		})
 	}
 }
 

--- a/providers/v1/ibm/provider_test.go
+++ b/providers/v1/ibm/provider_test.go
@@ -1673,6 +1673,28 @@ func TestGetAllSecrets(t *testing.T) {
 			t.Fatalf("expected list error, got %v", err)
 		}
 	})
+
+	t.Run("fetch error propagates", func(t *testing.T) {
+		// List succeeds and a secret matches the filter, but the per-secret
+		// fetch (GetSecretWithContext) fails. The error must surface rather
+		// than the entry being silently dropped.
+		mock := &fakesm.IBMMockClient{}
+		mock.WithListSecrets(func(_ context.Context, _ *sm.ListSecretsOptions) (*sm.SecretMetadataPaginatedCollection, *core.DetailedResponse, error) {
+			return metadataPage(listEntry{id: id1, name: "app-db"}), nil, nil
+		})
+		mock.WithValue(fakesm.IBMMockClientParams{
+			GetSecretOptions: &sm.GetSecretOptions{ID: &id1},
+			GetSecretErr:     errors.New("boom"),
+		})
+
+		p := &providerIBM{IBMClient: mock}
+		_, err := p.GetAllSecrets(ctx, esv1.ExternalSecretFind{
+			Name: &esv1.FindName{RegExp: "^app-"},
+		})
+		if err == nil || !strings.Contains(err.Error(), "failed to fetch secret") {
+			t.Fatalf("expected fetch error, got %v", err)
+		}
+	})
 }
 
 func mapKeys(m map[string][]byte) []string {

--- a/providers/v1/ibm/provider_test.go
+++ b/providers/v1/ibm/provider_test.go
@@ -1633,6 +1633,33 @@ func TestGetAllSecrets(t *testing.T) {
 		}
 	})
 
+	t.Run("missing id or name in metadata fails fast", func(t *testing.T) {
+		// A metadata entry with id="" simulates a malformed IBM SM response.
+		// Silent skip would write a partial Kubernetes Secret to the user; we
+		// surface it as an error instead.
+		mock := &fakesm.IBMMockClient{}
+		mock.WithListSecrets(func(_ context.Context, _ *sm.ListSecretsOptions) (*sm.SecretMetadataPaginatedCollection, *core.DetailedResponse, error) {
+			emptyID := ""
+			validName := "broken-secret"
+			return &sm.SecretMetadataPaginatedCollection{
+				Secrets: []sm.SecretMetadataIntf{
+					&sm.ArbitrarySecretMetadata{
+						SecretType: utilpointer.To(sm.Secret_SecretType_Arbitrary),
+						ID:         &emptyID,
+						Name:       &validName,
+					},
+				},
+			}, nil, nil
+		})
+		p := &providerIBM{IBMClient: mock}
+		_, err := p.GetAllSecrets(ctx, esv1.ExternalSecretFind{
+			Name: &esv1.FindName{RegExp: ".*"},
+		})
+		if err == nil || !strings.Contains(err.Error(), "missing id or name") {
+			t.Fatalf("expected metadata error, got %v", err)
+		}
+	})
+
 	t.Run("list error propagates", func(t *testing.T) {
 		mock := &fakesm.IBMMockClient{}
 		mock.WithListSecrets(func(_ context.Context, _ *sm.ListSecretsOptions) (*sm.SecretMetadataPaginatedCollection, *core.DetailedResponse, error) {


### PR DESCRIPTION
## Problem Statement

Providing GetAllSecrets functionality to IBM provider

## Related Issue

Related: https://github.com/external-secrets/external-secrets/issues/1110


## Notes
I have based myself on the IBM SDk, however, since I do not have access to the IBM Secret manager instance, I am unable to test it E2E. Someone who has access should do a final verification


## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] My changes have reasonable test coverage
- [X] All tests pass with `make test`
- [X] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## GetAllSecrets Implementation for IBM Provider

Implements GetAllSecrets for the IBM Secrets Manager provider (addresses `#1110`).

### Changes

- Core implementation (providers/v1/ibm/provider.go)
  - Implements GetAllSecrets: validates inputs (requires at least one of find.name/tags/path), builds server-side filters (path → substring search, tags → match_all_labels with deterministic ordering), supports client-side name regexp matching, paginates ListSecretsWithContext, detects duplicate bare secret names, fetches each secret by ID and JSON-marshals the payload, and converts keys via esutils.ConvertKeys.
  - Adds helpers: buildLabelFilter, secretMetaIdentifiers, fetchSecretJSON (with timeout and API call metrics).
  - Extends SecretManagerClient interface to include ListSecretsWithContext.

- Mock client (providers/v1/ibm/fake/fake.go)
  - Adds listSecretsWithContext callback, ListSecretsWithContext method, and WithListSecrets setter for tests.

- Tests (providers/v1/ibm/provider_test.go)
  - New unit tests covering input validation, name-regex filtering, path/tag behavior, deterministic tag ordering, pagination, duplicate-name detection, regex compile failures, malformed metadata (missing id/name), and propagation of list/fetch errors.
  - Tests for buildLabelFilter formatting.

- Documentation (docs/provider/ibm-secrets-manager.md)
  - Adds "Finding secrets with dataFrom.find" section documenting validation, name/path/tags semantics, result shape (full secret JSON under bare secret name), example manifest, and error cases.

### Notes & Caveats
- Author could not perform end-to-end testing against a real IBM Secrets Manager instance and requests final verification by someone with access.
- Reviewer guidance: if the contributor cannot push a branch to the main repo for CI image builds, a custom image can be built and published (example docker buildx command provided in thread) to test the changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->