### PR TITLE
fix(provider): validate vault kv mount configuration

### DIFF
--- a/providers/v1/vault/provider_test.go
+++ b/providers/v1/vault/provider_test.go
@@ -891,6 +891,14 @@ func TestValidateTokenExpiry(t *testing.T) {
 			store:           makeValidSecretStore().Spec.Provider.Vault,
 			storeKind:       esv1.SecretStoreKind,
 			tokenExpiryTime: &futureExpiry,
+			logical: fake.Logical{
+				ReadWithDataWithContextFn: fake.NewReadWithContextFn(map[string]any{
+					"type": "kv",
+					"options": map[string]any{
+						"version": "2",
+					},
+				}, nil),
+			},
 		}
 		result, err := c.Validate()
 		if err != nil {

--- a/providers/v1/vault/validate.go
+++ b/providers/v1/vault/validate.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -49,6 +50,9 @@ const (
 	errInvalidClientTLSSecret = "invalid ClientTLS.SecretRef: %w"
 	errInvalidClientTLS       = "when provided, both ClientTLS.ClientCert and ClientTLS.SecretRef should be provided"
 	errCASNotSupportedInKVv1  = "checkAndSet is not supported with Vault KV version v1"
+	errVaultMountNotFound     = "vault mount path %q was not found"
+	errVaultMountNotKV        = "vault mount path %q is not a kv secret engine, got %q"
+	errVaultMountVersion      = "vault mount path %q uses kv version %s but store is configured for kv version %s"
 )
 
 // ValidateStore validates the Vault provider configuration in the SecretStore.
@@ -185,12 +189,98 @@ func (c *client) Validate() (esv1.ValidationResult, error) {
 	if c.storeKind == esv1.ClusterSecretStoreKind && isReferentSpec(c.store) {
 		return esv1.ValidationResultUnknown, nil
 	}
+	ctx := context.Background()
 	if c.tokenExpiryTime != nil && c.tokenExpiryTime.After(time.Now()) {
+		if err := c.validateKVMount(ctx); err != nil {
+			return esv1.ValidationResultError, err
+		}
 		return esv1.ValidationResultReady, nil
 	}
-	_, _, err := checkToken(context.Background(), c.token)
+	_, _, err := checkToken(ctx, c.token)
 	if err != nil {
 		return esv1.ValidationResultError, fmt.Errorf(errInvalidCredentials, err)
 	}
+	if err := c.validateKVMount(ctx); err != nil {
+		return esv1.ValidationResultError, err
+	}
 	return esv1.ValidationResultReady, nil
+}
+
+func (c *client) validateKVMount(ctx context.Context) error {
+	if c.store == nil || c.store.Path == nil {
+		return nil
+	}
+
+	mountPath := strings.Trim(*c.store.Path, "/")
+	if mountPath == "" {
+		return nil
+	}
+
+	secret, err := c.logical.ReadWithDataWithContext(ctx, "sys/internal/ui/mounts/"+mountPath, nil)
+	if err != nil {
+		return nil
+	}
+	if secret == nil {
+		return fmt.Errorf(errVaultMountNotFound, mountPath)
+	}
+
+	return validateVaultKVMountData(mountPath, c.store.Version, secret.Data)
+}
+
+func validateVaultKVMountData(mountPath string, configured esv1.VaultKVStoreVersion, data map[string]any) error {
+	mountType := vaultMountType(data)
+	if mountType != "kv" {
+		return fmt.Errorf(errVaultMountNotKV, mountPath, mountType)
+	}
+
+	wantV2, configuredVersion := configuredKVVersion(configured)
+	gotV2 := vaultMountIsKVv2(data)
+	if wantV2 != gotV2 {
+		return fmt.Errorf(errVaultMountVersion, mountPath, vaultKVVersion(gotV2), configuredVersion)
+	}
+
+	return nil
+}
+
+func vaultMountType(data map[string]any) string {
+	if data == nil {
+		return "<missing>"
+	}
+	mountType, ok := data["type"]
+	if !ok {
+		return "<missing>"
+	}
+	return fmt.Sprint(mountType)
+}
+
+func configuredKVVersion(version esv1.VaultKVStoreVersion) (bool, string) {
+	if version == esv1.VaultKVStoreV1 {
+		return false, string(esv1.VaultKVStoreV1)
+	}
+	return true, string(esv1.VaultKVStoreV2)
+}
+
+func vaultKVVersion(isV2 bool) string {
+	if isV2 {
+		return string(esv1.VaultKVStoreV2)
+	}
+	return string(esv1.VaultKVStoreV1)
+}
+
+func vaultMountIsKVv2(data map[string]any) bool {
+	if data == nil {
+		return false
+	}
+	options, ok := data["options"]
+	if !ok {
+		return false
+	}
+	switch opts := options.(type) {
+	case map[string]any:
+		return fmt.Sprint(opts["version"]) == "2"
+	case map[string]string:
+		return opts["version"] == "2"
+	default:
+		return false
+	}
 }

--- a/providers/v1/vault/validate_test.go
+++ b/providers/v1/vault/validate_test.go
@@ -16,10 +16,17 @@ limitations under the License.
 package vault
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
 	"testing"
+
+	vaultapi "github.com/hashicorp/vault/api"
 
 	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
 	esmeta "github.com/external-secrets/external-secrets/apis/meta/v1"
+	"github.com/external-secrets/external-secrets/providers/v1/vault/fake"
 )
 
 const fakeValidationValue = "fake-value"
@@ -324,5 +331,204 @@ func TestValidateStore(t *testing.T) {
 				t.Errorf("connector.ValidateStore() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestValidateKVMount(t *testing.T) {
+	path := "secret"
+	emptyPath := ""
+	readErr := errors.New("permission denied")
+
+	tests := []struct {
+		name             string
+		storePath        *string
+		storeVersion     esv1.VaultKVStoreVersion
+		mountData        map[string]any
+		readErr          error
+		wantRead         bool
+		wantReadPaths    []string
+		wantResult       esv1.ValidationResult
+		wantErrSubstring string
+	}{
+		{
+			name:         "token valid and kv v2 matching",
+			storePath:    &path,
+			storeVersion: esv1.VaultKVStoreV2,
+			mountData: map[string]any{
+				"type": "kv",
+				"options": map[string]any{
+					"version": "2",
+				},
+			},
+			wantRead:   true,
+			wantResult: esv1.ValidationResultReady,
+		},
+		{
+			name:         "token valid and kv v2 matching with string options map",
+			storePath:    &path,
+			storeVersion: esv1.VaultKVStoreV2,
+			mountData: map[string]any{
+				"type": "kv",
+				"options": map[string]string{
+					"version": "2",
+				},
+			},
+			wantRead:   true,
+			wantResult: esv1.ValidationResultReady,
+		},
+		{
+			name:         "token valid and kv v1 matching",
+			storePath:    &path,
+			storeVersion: esv1.VaultKVStoreV1,
+			mountData: map[string]any{
+				"type": "kv",
+			},
+			wantRead:   true,
+			wantResult: esv1.ValidationResultReady,
+		},
+		{
+			name:             "token valid and mount missing",
+			storePath:        &path,
+			storeVersion:     esv1.VaultKVStoreV2,
+			wantRead:         true,
+			wantResult:       esv1.ValidationResultError,
+			wantErrSubstring: "was not found",
+		},
+		{
+			name:         "token valid and mount is not kv",
+			storePath:    &path,
+			storeVersion: esv1.VaultKVStoreV2,
+			mountData: map[string]any{
+				"type": "database",
+			},
+			wantRead:         true,
+			wantResult:       esv1.ValidationResultError,
+			wantErrSubstring: "is not a kv secret engine",
+		},
+		{
+			name:         "token valid and version mismatch",
+			storePath:    &path,
+			storeVersion: esv1.VaultKVStoreV1,
+			mountData: map[string]any{
+				"type": "kv",
+				"options": map[string]any{
+					"version": "2",
+				},
+			},
+			wantRead:         true,
+			wantResult:       esv1.ValidationResultError,
+			wantErrSubstring: "configured for kv version v1",
+		},
+		{
+			name:         "nil path skips mount validation",
+			storePath:    nil,
+			storeVersion: esv1.VaultKVStoreV2,
+			wantResult:   esv1.ValidationResultReady,
+		},
+		{
+			name:         "empty path skips mount validation",
+			storePath:    &emptyPath,
+			storeVersion: esv1.VaultKVStoreV2,
+			wantResult:   esv1.ValidationResultReady,
+		},
+		{
+			name:         "internal ui mount read error preserves ready",
+			storePath:    &path,
+			storeVersion: esv1.VaultKVStoreV2,
+			readErr:      readErr,
+			wantReadPaths: []string{
+				"sys/internal/ui/mounts/secret",
+			},
+			wantResult: esv1.ValidationResultReady,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var readPaths []string
+			var readIssue string
+			c := &client{
+				store: &esv1.VaultProvider{
+					Path:    tt.storePath,
+					Version: tt.storeVersion,
+				},
+				storeKind: esv1.SecretStoreKind,
+				token:     validValidationToken(),
+				logical: fake.Logical{
+					ReadWithDataWithContextFn: func(_ context.Context, readPath string, data map[string][]string) (*vaultapi.Secret, error) {
+						readPaths = append(readPaths, readPath)
+						if data != nil {
+							readIssue = "unexpected mount read data"
+						}
+						switch readPath {
+						case "sys/internal/ui/mounts/" + path:
+							if tt.readErr != nil {
+								return nil, tt.readErr
+							}
+							if tt.mountData == nil {
+								return nil, nil
+							}
+							return &vaultapi.Secret{Data: tt.mountData}, nil
+						default:
+							readIssue = "unexpected mount path: " + readPath
+							return nil, nil
+						}
+					},
+				},
+			}
+
+			got, err := c.Validate()
+			if got != tt.wantResult {
+				t.Fatalf("client.Validate() result = %v, want %v", got, tt.wantResult)
+			}
+			wantReadPaths := tt.wantReadPaths
+			if wantReadPaths == nil && tt.wantRead {
+				wantReadPaths = []string{"sys/internal/ui/mounts/" + path}
+			}
+			if !equalStringSlices(readPaths, wantReadPaths) {
+				t.Fatalf("mount read paths = %v, want %v", readPaths, wantReadPaths)
+			}
+			if readIssue != "" {
+				t.Fatal(readIssue)
+			}
+			if tt.wantErrSubstring == "" {
+				if err != nil {
+					t.Fatalf("client.Validate() error = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("client.Validate() error = nil, want substring %q", tt.wantErrSubstring)
+			}
+			if !strings.Contains(err.Error(), tt.wantErrSubstring) {
+				t.Fatalf("client.Validate() error = %v, want substring %q", err, tt.wantErrSubstring)
+			}
+		})
+	}
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func validValidationToken() fake.Token {
+	return fake.Token{
+		LookupSelfWithContextFn: func(context.Context) (*vaultapi.Secret, error) {
+			return &vaultapi.Secret{
+				Data: map[string]any{
+					"expire_time": nil,
+					"ttl":         json.Number("0"),
+					"type":        "service",
+				},
+			}, nil
+		},
 	}
 }


### PR DESCRIPTION
## Problem

Vault `SecretStore` validation currently confirms that the Vault client/token is usable, but it can still report `Ready=True` when the configured KV mount path points to a non-KV mount or when the configured KV engine version does not match the real Vault mount. Those errors are only discovered later when an `ExternalSecret` tries to read data.

## Change

This updates Vault provider validation to check the configured KV mount after token validation when a SecretStore-level Vault path is configured:

- skip the new mount check when `spec.provider.vault.path` is nil or empty, because the actual mount may be supplied by each `ExternalSecret.remoteRef.key`
- read Vault mount metadata via `sys/internal/ui/mounts/<path>`
- if that metadata lookup returns an error, preserve the existing compatibility behavior and keep validation `Ready`
- if mount metadata is available, return validation errors for:
  - missing mount response
  - non-`kv` secret engine
  - KV v1/v2 mismatch between Vault and `spec.provider.vault.version`

## Tests

- `cd providers/v1/vault && go test ./...`

Manual kind/Vault validation performed with a local image built from this branch:

1. Built and loaded the controller image:
   - `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -tags all_providers -o bin/external-secrets-linux-amd64 main.go`
   - `docker build -t external-secrets:se7en-vault-validation --platform linux/amd64 .`
   - `kind create cluster --name eso-vault-validation --image kindest/node:v1.33.2`
   - `kind load docker-image external-secrets:se7en-vault-validation --name eso-vault-validation`
2. Deployed a Vault dev pod in kind using `hashicorp/vault:1.20.4` and root token `root`.
3. Configured Vault mounts:
   - `secretv1` as KV v1
   - `secretv2` as KV v2
   - `database` as a non-KV database secrets engine
   - wrote test values to `secretv1/foo` and `secretv2/foo`
4. Deployed external-secrets from the local Helm chart with controller image `external-secrets:se7en-vault-validation`.
5. Applied SecretStores and ExternalSecrets for the validation matrix.

Observed results during manual validation:

- `vault-valid-v1`: `Ready=True`, `Valid`, and ExternalSecret synced value `v1`
- `vault-valid-v2`: `Ready=True`, `Valid`, and ExternalSecret synced value `v2`
- `vault-non-kv`: `Ready=False`, `InvalidProviderConfig`, event: `vault mount path "database" is not a kv secret engine, got "database"`
- `vault-v1-configured-v2`: `Ready=False`, `InvalidProviderConfig`, event: `vault mount path "secretv1" uses kv version v1 but store is configured for kv version v2`
- `vault-v2-configured-v1`: `Ready=False`, `InvalidProviderConfig`, event: `vault mount path "secretv2" uses kv version v2 but store is configured for kv version v1`

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Vault KV Mount Configuration Validation

This PR enhances Vault SecretStore validation to verify the configured KV mount so mismatches are caught during validation instead of at ExternalSecret sync.

### Changes

- validate.go
  - client.Validate() now calls validateKVMount after token validation (and when token expiry indicates no re-check).
  - Added validateKVMount which:
    - Skips when spec.provider.vault.path is nil/empty (supports per-key mounts).
    - Reads mount metadata via sys/internal/ui/mounts/<path>.
    - If metadata is unavailable (read error), preserves existing compatibility and returns Ready.
    - Returns explicit errors for: mount not found, non-kv engine, and kv v1/v2 mismatch with store configuration.
  - Added helper validateVaultKVMountData and related mount error constants; normalizes mount path with strings.Trim.

- validate_test.go
  - Added table-driven TestValidateKVMount covering valid v1/v2, non-KV mounts, version mismatches, skipped validation when path unset, and preserving Ready on internal read errors.
  - Added test helpers (equalStringSlices, validValidationToken) and uses the fake Vault provider to assert ReadWithDataWithContext calls and error messages.

- provider_test.go
  - Updated TestValidateTokenExpiry fixture to include a fake logical client response representing a KV v2 mount to align with new mount validation behavior.

### Testing
- Unit tests added/updated.
- Manual validation performed with local controller and Vault 1.20.4 demonstrating expected Ready/InvalidProviderConfig states and ExternalSecret sync behavior for the tested combinations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/external-secrets/external-secrets/pull/6373?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->