### PR TITLE
feat: make ExternalSecret finalizer optional

### DIFF
--- a/cmd/controller/root.go
+++ b/cmd/controller/root.go
@@ -93,7 +93,7 @@ var (
 	enablePushSecretReconciler            bool
 	enableFloodGate                       bool
 	enableGeneratorState                  bool
-	enableExternalSecretFinalizer         bool
+	enableExternalSecretCleanupFinalizer  bool
 	enableExtendedMetricLabels            bool
 	storeRequeueInterval                  time.Duration
 	serviceName, serviceNamespace         string
@@ -258,7 +258,7 @@ var rootCmd = &cobra.Command{
 			ClusterSecretStoreEnabled:          enableClusterStoreReconciler,
 			EnableFloodGate:                    enableFloodGate,
 			EnableGeneratorState:               enableGeneratorState,
-			EnableFinalizer:                    enableExternalSecretFinalizer,
+			EnableCleanupFinalizer:             enableExternalSecretCleanupFinalizer,
 			AllowGenericTargets:                allowGenericTargets,
 		}).SetupWithManager(cmd.Context(), mgr, ctrlcommon.BuildControllerOptions(concurrent)); err != nil {
 			setupLog.Error(err, errCreateController, "controller", "ExternalSecret")
@@ -374,7 +374,7 @@ func init() {
 	rootCmd.Flags().DurationVar(&storeRequeueInterval, "store-requeue-interval", time.Minute*5, "Default Time duration between reconciling (Cluster)SecretStores")
 	rootCmd.Flags().BoolVar(&enableFloodGate, "enable-flood-gate", true, "Enable flood gate. External secret will be reconciled only if the ClusterStore or Store have an healthy or unknown state.")
 	rootCmd.Flags().BoolVar(&enableGeneratorState, "enable-generator-state", true, "Whether the Controller should manage GeneratorState")
-	rootCmd.Flags().BoolVar(&enableExternalSecretFinalizer, "enable-external-secret-finalizer", true, "Add a finalizer to ExternalSecret resources to ensure managed secret cleanup on deletion. Disable to avoid blocking namespace deletion when the operator cannot reconcile.")
+	rootCmd.Flags().BoolVar(&enableExternalSecretCleanupFinalizer, "enable-external-secret-cleanup-finalizer", true, "Add the externalsecret-cleanup finalizer to ExternalSecret resources to ensure managed secret cleanup on deletion. Disable to avoid blocking namespace deletion when the operator cannot reconcile. Does not affect the ClusterExternalSecret finalizer.")
 	rootCmd.Flags().BoolVar(&enableExtendedMetricLabels, "enable-extended-metric-labels", false, "Enable recommended kubernetes annotations as labels in metrics.")
 	rootCmd.Flags().BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics server")

--- a/cmd/controller/root.go
+++ b/cmd/controller/root.go
@@ -93,6 +93,7 @@ var (
 	enablePushSecretReconciler            bool
 	enableFloodGate                       bool
 	enableGeneratorState                  bool
+	enableExternalSecretFinalizer         bool
 	enableExtendedMetricLabels            bool
 	storeRequeueInterval                  time.Duration
 	serviceName, serviceNamespace         string
@@ -257,6 +258,7 @@ var rootCmd = &cobra.Command{
 			ClusterSecretStoreEnabled:          enableClusterStoreReconciler,
 			EnableFloodGate:                    enableFloodGate,
 			EnableGeneratorState:               enableGeneratorState,
+			EnableFinalizer:                    enableExternalSecretFinalizer,
 			AllowGenericTargets:                allowGenericTargets,
 		}).SetupWithManager(cmd.Context(), mgr, ctrlcommon.BuildControllerOptions(concurrent)); err != nil {
 			setupLog.Error(err, errCreateController, "controller", "ExternalSecret")
@@ -372,6 +374,7 @@ func init() {
 	rootCmd.Flags().DurationVar(&storeRequeueInterval, "store-requeue-interval", time.Minute*5, "Default Time duration between reconciling (Cluster)SecretStores")
 	rootCmd.Flags().BoolVar(&enableFloodGate, "enable-flood-gate", true, "Enable flood gate. External secret will be reconciled only if the ClusterStore or Store have an healthy or unknown state.")
 	rootCmd.Flags().BoolVar(&enableGeneratorState, "enable-generator-state", true, "Whether the Controller should manage GeneratorState")
+	rootCmd.Flags().BoolVar(&enableExternalSecretFinalizer, "enable-external-secret-finalizer", true, "Add a finalizer to ExternalSecret resources to ensure managed secret cleanup on deletion. Disable to avoid blocking namespace deletion when the operator cannot reconcile.")
 	rootCmd.Flags().BoolVar(&enableExtendedMetricLabels, "enable-extended-metric-labels", false, "Enable recommended kubernetes annotations as labels in metrics.")
 	rootCmd.Flags().BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics server")

--- a/deploy/charts/external-secrets/templates/deployment.yaml
+++ b/deploy/charts/external-secrets/templates/deployment.yaml
@@ -118,6 +118,9 @@ spec:
           {{- if .Values.concurrent }}
           - --concurrent={{ .Values.concurrent }}
           {{- end }}
+          {{- if not .Values.enableExternalSecretFinalizer }}
+          - --enable-external-secret-finalizer=false
+          {{- end }}
           {{- if .Values.genericTargets.enabled }}
           - --unsafe-allow-generic-targets=true
           {{- end }}

--- a/deploy/charts/external-secrets/templates/deployment.yaml
+++ b/deploy/charts/external-secrets/templates/deployment.yaml
@@ -118,8 +118,8 @@ spec:
           {{- if .Values.concurrent }}
           - --concurrent={{ .Values.concurrent }}
           {{- end }}
-          {{- if not .Values.enableExternalSecretFinalizer }}
-          - --enable-external-secret-finalizer=false
+          {{- if not .Values.enableExternalSecretCleanupFinalizer }}
+          - --enable-external-secret-cleanup-finalizer=false
           {{- end }}
           {{- if .Values.genericTargets.enabled }}
           - --unsafe-allow-generic-targets=true

--- a/deploy/charts/external-secrets/values.schema.json
+++ b/deploy/charts/external-secrets/values.schema.json
@@ -705,7 +705,7 @@
         "priorityClassName": {
             "type": "string"
         },
-        "enableExternalSecretFinalizer": {
+        "enableExternalSecretCleanupFinalizer": {
             "type": "boolean",
             "default": true
         },

--- a/deploy/charts/external-secrets/values.schema.json
+++ b/deploy/charts/external-secrets/values.schema.json
@@ -705,6 +705,9 @@
         "priorityClassName": {
             "type": "string"
         },
+        "enableExternalSecretFinalizer": {
+            "type": "boolean"
+        },
         "processClusterExternalSecret": {
             "type": "boolean"
         },

--- a/deploy/charts/external-secrets/values.schema.json
+++ b/deploy/charts/external-secrets/values.schema.json
@@ -706,7 +706,8 @@
             "type": "string"
         },
         "enableExternalSecretFinalizer": {
-            "type": "boolean"
+            "type": "boolean",
+            "default": true
         },
         "processClusterExternalSecret": {
             "type": "boolean"

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -118,9 +118,10 @@ openshiftFinalizers: true
 # -- If true the system:auth-delegator ClusterRole will be added to RBAC
 systemAuthDelegator: false
 
-# -- If true, add a finalizer to ExternalSecret resources to ensure managed secret cleanup on deletion.
-# Disable to avoid blocking namespace deletion when the operator cannot reconcile.
-enableExternalSecretFinalizer: true
+# -- If true, add the externalsecret-cleanup finalizer to ExternalSecret resources to ensure
+# managed secret cleanup on deletion. Disable to avoid blocking namespace deletion when the
+# operator cannot reconcile. Does not affect the ClusterExternalSecret finalizer.
+enableExternalSecretCleanupFinalizer: true
 
 # -- if true, the operator will process cluster external secret. Else, it will ignore them.
 # When enabled, this adds update/patch permissions on namespaces to handle finalizers for proper

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -118,7 +118,7 @@ openshiftFinalizers: true
 # -- If true the system:auth-delegator ClusterRole will be added to RBAC
 systemAuthDelegator: false
 
-# -- if true, add a finalizer to ExternalSecret resources to ensure managed secret cleanup on deletion.
+# -- If true, add a finalizer to ExternalSecret resources to ensure managed secret cleanup on deletion.
 # Disable to avoid blocking namespace deletion when the operator cannot reconcile.
 enableExternalSecretFinalizer: true
 

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -118,6 +118,10 @@ openshiftFinalizers: true
 # -- If true the system:auth-delegator ClusterRole will be added to RBAC
 systemAuthDelegator: false
 
+# -- if true, add a finalizer to ExternalSecret resources to ensure managed secret cleanup on deletion.
+# Disable to avoid blocking namespace deletion when the operator cannot reconcile.
+enableExternalSecretFinalizer: true
+
 # -- if true, the operator will process cluster external secret. Else, it will ignore them.
 # When enabled, this adds update/patch permissions on namespaces to handle finalizers for proper
 # cleanup during namespace deletion, preventing race conditions with ExternalSecrets.

--- a/pkg/controllers/externalsecret/externalsecret_controller.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller.go
@@ -152,6 +152,8 @@ type Reconciler struct {
 	ClusterSecretStoreEnabled          bool
 	EnableFloodGate                    bool
 	EnableGeneratorState               bool
+	// EnableCleanupFinalizer gates adding the externalsecret-cleanup finalizer.
+	// When false, existing finalizers are still removed and cleanup still runs on deletion.
 	EnableCleanupFinalizer             bool
 	AllowGenericTargets                bool
 	recorder                           record.EventRecorder

--- a/pkg/controllers/externalsecret/externalsecret_controller.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller.go
@@ -152,7 +152,7 @@ type Reconciler struct {
 	ClusterSecretStoreEnabled          bool
 	EnableFloodGate                    bool
 	EnableGeneratorState               bool
-	EnableFinalizer                    bool
+	EnableCleanupFinalizer             bool
 	AllowGenericTargets                bool
 	recorder                           record.EventRecorder
 
@@ -233,7 +233,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 
 	// Add finalizer if it doesn't exist and finalizer is enabled
 	// Use Patch instead of Update to avoid claiming ownership of spec fields like refreshInterval
-	if r.EnableFinalizer {
+	if r.EnableCleanupFinalizer {
 		patch := client.MergeFrom(externalSecret.DeepCopy())
 		if updated := controllerutil.AddFinalizer(externalSecret, ExternalSecretFinalizer); updated {
 			if err := r.Patch(ctx, externalSecret, patch); err != nil {

--- a/pkg/controllers/externalsecret/externalsecret_controller.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller.go
@@ -152,6 +152,7 @@ type Reconciler struct {
 	ClusterSecretStoreEnabled          bool
 	EnableFloodGate                    bool
 	EnableGeneratorState               bool
+	EnableFinalizer                    bool
 	AllowGenericTargets                bool
 	recorder                           record.EventRecorder
 
@@ -230,12 +231,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 		return ctrl.Result{}, nil
 	}
 
-	// Add finalizer if it doesn't exist
+	// Add finalizer if it doesn't exist and finalizer is enabled
 	// Use Patch instead of Update to avoid claiming ownership of spec fields like refreshInterval
-	patch := client.MergeFrom(externalSecret.DeepCopy())
-	if updated := controllerutil.AddFinalizer(externalSecret, ExternalSecretFinalizer); updated {
-		if err := r.Patch(ctx, externalSecret, patch); err != nil {
-			return ctrl.Result{}, err
+	if r.EnableFinalizer {
+		patch := client.MergeFrom(externalSecret.DeepCopy())
+		if updated := controllerutil.AddFinalizer(externalSecret, ExternalSecretFinalizer); updated {
+			if err := r.Patch(ctx, externalSecret, patch); err != nil {
+				return ctrl.Result{}, err
+			}
 		}
 	}
 

--- a/pkg/controllers/externalsecret/suite_test.go
+++ b/pkg/controllers/externalsecret/suite_test.go
@@ -118,6 +118,7 @@ var _ = BeforeSuite(func() {
 		Log:                                ctrl.Log.WithName("controllers").WithName("ExternalSecrets"),
 		RequeueInterval:                    time.Second,
 		ClusterSecretStoreEnabled:          true,
+		EnableFinalizer:                    true,
 	}).SetupWithManager(ctx, k8sManager, controller.Options{
 		MaxConcurrentReconciles: 1,
 		RateLimiter:             ctrlcommon.BuildRateLimiter(),

--- a/pkg/controllers/externalsecret/suite_test.go
+++ b/pkg/controllers/externalsecret/suite_test.go
@@ -118,7 +118,7 @@ var _ = BeforeSuite(func() {
 		Log:                                ctrl.Log.WithName("controllers").WithName("ExternalSecrets"),
 		RequeueInterval:                    time.Second,
 		ClusterSecretStoreEnabled:          true,
-		EnableFinalizer:                    true,
+		EnableCleanupFinalizer:             true,
 	}).SetupWithManager(ctx, k8sManager, controller.Options{
 		MaxConcurrentReconciles: 1,
 		RateLimiter:             ctrlcommon.BuildRateLimiter(),


### PR DESCRIPTION
## Summary

Add `--enable-external-secret-cleanup-finalizer` flag (default `true`) and corresponding Helm value `enableExternalSecretCleanupFinalizer` to allow disabling the `externalsecret-cleanup` finalizer on ExternalSecret resources.

### Problem

When the operator cannot reconcile an ExternalSecret (e.g. Vault 403 permission denied, missing SecretStores, nonexistent Vault paths), the `externalsecret-cleanup` finalizer blocks namespace deletion indefinitely. This is particularly problematic in environments with many broken ExternalSecrets or low `--concurrent` values, where healthy namespace deletions are starved by erroring reconciliations.

### Solution

Gate the finalizer addition behind a new `--enable-external-secret-cleanup-finalizer` flag:
- **Default `true`**: no behavior change — finalizer is added as before
- **Set to `false`**: finalizer is not added to new ExternalSecrets, namespace deletion proceeds without waiting for operator reconciliation
- The deletion cleanup path still runs (and removes existing finalizers) regardless of this flag, ensuring a safe transition when disabling

### Scope

This flag controls only the `externalsecret-cleanup` finalizer on **ExternalSecret** resources — the one responsible for cleaning up managed Secrets on deletion. It does **not** affect:
- The `clusterexternalsecret-cleanup` finalizer on ClusterExternalSecret resources (parent-child lifecycle cleanup)
- The per-namespace CES finalizers (`ces-<name>`) that prevent namespace deletion race conditions

The CES finalizers serve a different purpose (preventing orphaned ExternalSecrets across namespaces) and are less likely to cause namespace blocking since their cleanup doesn't depend on external provider connectivity.

### Changes

| File | Change |
|---|---|
| `cmd/controller/root.go` | Add `--enable-external-secret-cleanup-finalizer` flag (default `true`) and pass to Reconciler |
| `pkg/controllers/externalsecret/externalsecret_controller.go` | Add `EnableCleanupFinalizer` field to Reconciler, gate finalizer addition on it |
| `pkg/controllers/externalsecret/suite_test.go` | Set `EnableCleanupFinalizer: true` in test suite to match production default |
| `deploy/charts/external-secrets/values.yaml` | Add `enableExternalSecretCleanupFinalizer: true` |
| `deploy/charts/external-secrets/values.schema.json` | Add schema entry with default |
| `deploy/charts/external-secrets/templates/deployment.yaml` | Wire Helm value to CLI flag |

### Testing

Tested on a production-like EKS cluster with ~3900 ExternalSecrets:
- With finalizer enabled (default): namespace deletion takes 13-19s
- Without finalizer: namespace deletion is instant
- Disabling does not affect secret sync, only cleanup-on-delete behavior

Fixes a subset of the problem described in #4175 and #5426.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
Makes the externalsecret-cleanup finalizer optional on ExternalSecret resources via a new CLI flag and Helm value (both default true), preserving current behavior by default.

## Changes
- CLI: added --enable-external-secret-cleanup-finalizer flag (bool, default: true) and wired it into controller startup.
- Helm: added enableExternalSecretCleanupFinalizer value with schema default true and wired it into the Deployment args.
- Reconciler: added EnableCleanupFinalizer bool field; adding the externalsecret-cleanup finalizer is gated on this flag. Deletion cleanup still runs and will remove existing finalizers regardless of the flag.
- Tests: set EnableCleanupFinalizer: true in externalsecret suite to exercise finalizer paths.

## Motivation
Operator reconciliation failures can leave externalsecret-cleanup finalizers that block namespace deletion. Default-on preserves existing behavior; disabling prevents new ExternalSecrets from receiving the finalizer while still allowing the controller to remove existing finalizers during cleanup. Tested on large clusters — namespace deletion latency improved when disabled. Addresses parts of issues `#4175` and `#5426`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/external-secrets/external-secrets/pull/6380?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->