### PR TITLE
feat(charts): expose native/classic histogram fields in ServiceMonitor

### DIFF
--- a/deploy/charts/external-secrets/templates/_helpers.tpl
+++ b/deploy/charts/external-secrets/templates/_helpers.tpl
@@ -257,6 +257,38 @@ Fail the install if a cluster scoped reconciler is enabled while its namespace s
 {{- end -}}
 
 {{/*
+Render histogram scrape fields for a ServiceMonitor endpoint.
+"-" sentinel means "inherit from global" (or omit if global is also "-").
+*/}}
+{{- define "external-secrets.serviceMonitorHistogramConfig" -}}
+{{- $g := .global -}}
+{{- $o := .override | default dict -}}
+{{- $lines := list -}}
+{{- $scrapeClassic := index $o "scrapeClassicHistograms" -}}
+{{- if eq (toString $scrapeClassic) "-" -}}{{- $scrapeClassic = $g.scrapeClassicHistograms -}}{{- end -}}
+{{- if ne (toString $scrapeClassic) "-" -}}
+  {{- $lines = append $lines (printf "scrapeClassicHistograms: %v" $scrapeClassic) -}}
+{{- end -}}
+{{- $bucketLimit := index $o "nativeHistogramBucketLimit" -}}
+{{- if eq (toString $bucketLimit) "-" -}}{{- $bucketLimit = $g.nativeHistogramBucketLimit -}}{{- end -}}
+{{- if ne (toString $bucketLimit) "-" -}}
+  {{- $lines = append $lines (printf "nativeHistogramBucketLimit: %d" (int $bucketLimit)) -}}
+{{- end -}}
+{{- $minFactor := index $o "nativeHistogramMinBucketFactor" -}}
+{{- if eq $minFactor "-" -}}{{- $minFactor = $g.nativeHistogramMinBucketFactor -}}{{- end -}}
+{{- if ne $minFactor "-" -}}
+  {{- $lines = append $lines (printf "nativeHistogramMinBucketFactor: %q" $minFactor) -}}
+{{- end -}}
+{{- $protocols := index $o "scrapeProtocols" -}}
+{{- if eq (toString $protocols) "-" -}}{{- $protocols = $g.scrapeProtocols -}}{{- end -}}
+{{- if and (ne (toString $protocols) "-") $protocols -}}
+  {{- $protoYaml := toYaml $protocols | trimSuffix "\n" | replace "\n" "\n  " -}}
+  {{- $lines = append $lines (printf "scrapeProtocols:\n  %s" $protoYaml) -}}
+{{- end -}}
+{{- join "\n" $lines -}}
+{{- end -}}
+
+{{/*
 Decide whether to render the ServiceMonitor resource.
 */}}
 {{- define "external-secrets.shouldRenderServiceMonitor" -}}

--- a/deploy/charts/external-secrets/templates/servicemonitor.yaml
+++ b/deploy/charts/external-secrets/templates/servicemonitor.yaml
@@ -22,6 +22,9 @@ spec:
     interval: {{ .Values.serviceMonitor.interval }}
     scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
     honorLabels: {{ .Values.serviceMonitor.honorLabels }}
+    {{- with include "external-secrets.serviceMonitorHistogramConfig" (dict "global" .Values.serviceMonitor "override" .Values.serviceMonitor) | trim }}
+    {{- . | nindent 4 }}
+    {{- end }}
     {{- with .Values.serviceMonitor.metricRelabelings }}
     metricRelabelings:
       {{- toYaml . | nindent 6 }}
@@ -61,6 +64,9 @@ spec:
     interval: {{ .Values.serviceMonitor.interval }}
     scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
     honorLabels: {{ .Values.serviceMonitor.honorLabels }}
+    {{- with include "external-secrets.serviceMonitorHistogramConfig" (dict "global" .Values.serviceMonitor "override" .Values.webhook.serviceMonitor) | trim }}
+    {{- . | nindent 4 }}
+    {{- end }}
     {{- with .Values.serviceMonitor.metricRelabelings }}
     metricRelabelings:
       {{- toYaml . | nindent 6 }}
@@ -101,6 +107,9 @@ spec:
     interval: {{ .Values.serviceMonitor.interval }}
     scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
     honorLabels: {{ .Values.serviceMonitor.honorLabels }}
+    {{- with include "external-secrets.serviceMonitorHistogramConfig" (dict "global" .Values.serviceMonitor "override" .Values.certController.serviceMonitor) | trim }}
+    {{- . | nindent 4 }}
+    {{- end }}
     {{- with .Values.serviceMonitor.metricRelabelings }}
     metricRelabelings:
       {{- toYaml . | nindent 6 }}

--- a/deploy/charts/external-secrets/tests/service_monitor_test.yaml
+++ b/deploy/charts/external-secrets/tests/service_monitor_test.yaml
@@ -1,4 +1,8 @@
 suite: test service monitor
+# Coverage:
+#   Fields: scrapeClassicHistograms, nativeHistogramBucketLimit, nativeHistogramMinBucketFactor, scrapeProtocols
+#   Contracts: absent by default (backward-compat), global propagation to all 3 ServiceMonitors,
+#              per-component override, explicit false rendered (not omitted), string quoting for Quantity fields
 templates:
   - servicemonitor.yaml
 tests:
@@ -52,3 +56,136 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  # Histogram fields: backward compatibility — absent by default so old CRD versions are unaffected
+  - it: should not render histogram fields by default
+    set:
+      serviceMonitor.enabled: true
+      serviceMonitor.renderMode: alwaysRender
+    asserts:
+      - notExists:
+          path: spec.endpoints[0].scrapeClassicHistograms
+        documentIndex: 0
+      - notExists:
+          path: spec.endpoints[0].nativeHistogramBucketLimit
+        documentIndex: 0
+      - notExists:
+          path: spec.endpoints[0].nativeHistogramMinBucketFactor
+        documentIndex: 0
+      - notExists:
+          path: spec.endpoints[0].scrapeProtocols
+        documentIndex: 0
+      - notExists:
+          path: spec.endpoints[0].scrapeClassicHistograms
+        documentIndex: 1
+      - notExists:
+          path: spec.endpoints[0].scrapeClassicHistograms
+        documentIndex: 2
+
+  # Histogram fields: global settings apply to all three ServiceMonitors
+  - it: should render histogram fields in all three ServiceMonitors when set globally
+    set:
+      serviceMonitor.enabled: true
+      serviceMonitor.renderMode: alwaysRender
+      serviceMonitor.scrapeClassicHistograms: true
+      serviceMonitor.nativeHistogramBucketLimit: 160
+      serviceMonitor.nativeHistogramMinBucketFactor: "1.1"
+      serviceMonitor.scrapeProtocols:
+        - PrometheusProto
+        - OpenMetricsText1.0.0
+    asserts:
+      - equal:
+          path: spec.endpoints[0].scrapeClassicHistograms
+          value: true
+        documentIndex: 0
+      - equal:
+          path: spec.endpoints[0].nativeHistogramBucketLimit
+          value: 160
+        documentIndex: 0
+      - equal:
+          path: spec.endpoints[0].nativeHistogramMinBucketFactor
+          value: "1.1"
+        documentIndex: 0
+      - equal:
+          path: spec.endpoints[0].scrapeProtocols
+          value:
+            - PrometheusProto
+            - OpenMetricsText1.0.0
+        documentIndex: 0
+      - equal:
+          path: spec.endpoints[0].scrapeClassicHistograms
+          value: true
+        documentIndex: 1
+      - equal:
+          path: spec.endpoints[0].scrapeClassicHistograms
+          value: true
+        documentIndex: 2
+
+  # Histogram fields: per-component override for webhook — global off, webhook on
+  - it: should use webhook override while controller and cert-controller inherit global
+    set:
+      serviceMonitor.enabled: true
+      serviceMonitor.renderMode: alwaysRender
+      webhook.serviceMonitor.scrapeClassicHistograms: true
+    asserts:
+      - notExists:
+          path: spec.endpoints[0].scrapeClassicHistograms
+        documentIndex: 0
+      - equal:
+          path: spec.endpoints[0].scrapeClassicHistograms
+          value: true
+        documentIndex: 1
+      - notExists:
+          path: spec.endpoints[0].scrapeClassicHistograms
+        documentIndex: 2
+
+  # Histogram fields: per-component override for cert-controller — global off, cert-controller on
+  - it: should use cert-controller override while controller and webhook inherit global
+    set:
+      serviceMonitor.enabled: true
+      serviceMonitor.renderMode: alwaysRender
+      certController.serviceMonitor.scrapeClassicHistograms: true
+    asserts:
+      - notExists:
+          path: spec.endpoints[0].scrapeClassicHistograms
+        documentIndex: 0
+      - notExists:
+          path: spec.endpoints[0].scrapeClassicHistograms
+        documentIndex: 1
+      - equal:
+          path: spec.endpoints[0].scrapeClassicHistograms
+          value: true
+        documentIndex: 2
+
+  # Histogram fields: false override explicitly renders false (not the same as "-")
+  - it: should render scrapeClassicHistograms false when override is false
+    set:
+      serviceMonitor.enabled: true
+      serviceMonitor.renderMode: alwaysRender
+      serviceMonitor.scrapeClassicHistograms: true
+      webhook.serviceMonitor.scrapeClassicHistograms: false
+    asserts:
+      - equal:
+          path: spec.endpoints[0].scrapeClassicHistograms
+          value: true
+        documentIndex: 0
+      - equal:
+          path: spec.endpoints[0].scrapeClassicHistograms
+          value: false
+        documentIndex: 1
+      - equal:
+          path: spec.endpoints[0].scrapeClassicHistograms
+          value: true
+        documentIndex: 2
+
+  # Histogram fields: nativeHistogramMinBucketFactor must be a quoted string (not a float)
+  - it: should render nativeHistogramMinBucketFactor as a YAML string
+    set:
+      serviceMonitor.enabled: true
+      serviceMonitor.renderMode: alwaysRender
+      serviceMonitor.nativeHistogramMinBucketFactor: "1.1"
+    asserts:
+      - equal:
+          path: spec.endpoints[0].nativeHistogramMinBucketFactor
+          value: "1.1"
+        documentIndex: 0

--- a/deploy/charts/external-secrets/values.schema.json
+++ b/deploy/charts/external-secrets/values.schema.json
@@ -315,6 +315,32 @@
                         }
                     }
                 },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "scrapeClassicHistograms": {
+                            "oneOf": [
+                                {"type": "boolean"},
+                                {"const": "-"}
+                            ]
+                        },
+                        "nativeHistogramBucketLimit": {
+                            "oneOf": [
+                                {"type": "integer", "minimum": 0},
+                                {"const": "-"}
+                            ]
+                        },
+                        "nativeHistogramMinBucketFactor": {
+                            "type": "string"
+                        },
+                        "scrapeProtocols": {
+                            "oneOf": [
+                                {"type": "array", "items": {"type": "string"}},
+                                {"const": "-"}
+                            ]
+                        }
+                    }
+                },
                 "startupProbe": {
                     "type": "object",
                     "properties": {
@@ -896,6 +922,15 @@
                 "namespace": {
                     "type": "string"
                 },
+                "nativeHistogramBucketLimit": {
+                    "oneOf": [
+                        {"type": "integer", "minimum": 0},
+                        {"const": "-"}
+                    ]
+                },
+                "nativeHistogramMinBucketFactor": {
+                    "type": "string"
+                },
                 "relabelings": {
                     "type": "array"
                 },
@@ -905,6 +940,18 @@
                         "skipIfMissing",
                         "failIfMissing",
                         "alwaysRender"
+                    ]
+                },
+                "scrapeClassicHistograms": {
+                    "oneOf": [
+                        {"type": "boolean"},
+                        {"const": "-"}
+                    ]
+                },
+                "scrapeProtocols": {
+                    "oneOf": [
+                        {"type": "array", "items": {"type": "string"}},
+                        {"const": "-"}
                     ]
                 },
                 "scrapeTimeout": {
@@ -1312,6 +1359,32 @@
                         },
                         "name": {
                             "type": "string"
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "scrapeClassicHistograms": {
+                            "oneOf": [
+                                {"type": "boolean"},
+                                {"const": "-"}
+                            ]
+                        },
+                        "nativeHistogramBucketLimit": {
+                            "oneOf": [
+                                {"type": "integer", "minimum": 0},
+                                {"const": "-"}
+                            ]
+                        },
+                        "nativeHistogramMinBucketFactor": {
+                            "type": "string"
+                        },
+                        "scrapeProtocols": {
+                            "oneOf": [
+                                {"type": "array", "items": {"type": "string"}},
+                                {"const": "-"}
+                            ]
                         }
                     }
                 },

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -317,6 +317,21 @@ serviceMonitor:
   #   replacement: $1
   #   action: replace
 
+  # -- Whether to scrape a classic histogram that is also exposed as a native histogram ("-" = do not set). Requires Prometheus Operator >= v0.65.0.
+  # @schema type: [boolean, string]
+  scrapeClassicHistograms: "-"
+
+  # -- Upper limit on the number of buckets for a single native histogram ("-" = do not set). Requires Prometheus Operator >= v0.65.0.
+  # @schema type: [integer, string]
+  nativeHistogramBucketLimit: "-"
+
+  # -- Minimum bucket factor for native histograms, e.g. "1.1" ("-" = do not set). Requires Prometheus Operator >= v0.71.0.
+  nativeHistogramMinBucketFactor: "-"
+
+  # -- Ordered list of accepted scrape protocols ("-" = do not set). Requires Prometheus Operator >= v0.68.0.
+  # @schema type: [array, string]
+  scrapeProtocols: "-"
+
 metrics:
 
   listen:
@@ -582,6 +597,18 @@ webhook:
       # -- Additional service annotations
       annotations: {}
 
+  serviceMonitor:
+    # -- Override .Values.serviceMonitor.scrapeClassicHistograms for the webhook ("-" = inherit)
+    # @schema type: [boolean, string]
+    scrapeClassicHistograms: "-"
+    # -- Override .Values.serviceMonitor.nativeHistogramBucketLimit for the webhook ("-" = inherit)
+    # @schema type: [integer, string]
+    nativeHistogramBucketLimit: "-"
+    # -- Override .Values.serviceMonitor.nativeHistogramMinBucketFactor for the webhook ("-" = inherit)
+    nativeHistogramMinBucketFactor: "-"
+    # -- Override .Values.serviceMonitor.scrapeProtocols for the webhook ("-" = inherit)
+    # @schema type: [array, string]
+    scrapeProtocols: "-"
 
   livenessProbe:
     enabled: false
@@ -757,6 +784,19 @@ certController:
 
       # -- Additional service annotations
       annotations: {}
+
+  serviceMonitor:
+    # -- Override .Values.serviceMonitor.scrapeClassicHistograms for the cert-controller ("-" = inherit)
+    # @schema type: [boolean, string]
+    scrapeClassicHistograms: "-"
+    # -- Override .Values.serviceMonitor.nativeHistogramBucketLimit for the cert-controller ("-" = inherit)
+    # @schema type: [integer, string]
+    nativeHistogramBucketLimit: "-"
+    # -- Override .Values.serviceMonitor.nativeHistogramMinBucketFactor for the cert-controller ("-" = inherit)
+    nativeHistogramMinBucketFactor: "-"
+    # -- Override .Values.serviceMonitor.scrapeProtocols for the cert-controller ("-" = inherit)
+    # @schema type: [array, string]
+    scrapeProtocols: "-"
 
   livenessProbe:
     enabled: false


### PR DESCRIPTION
## Problem Statement

The Prometheus Operator `Endpoint` spec has supported native histogram scraping since v0.65.0 via four fields (`scrapeClassicHistograms`, `nativeHistogramBucketLimit`, `nativeHistogramMinBucketFactor`, `scrapeProtocols`), but the external-secrets Helm chart does not expose them. Users who want to enable native histograms must patch the rendered manifests.

## Proposed Changes

Expose four Prometheus Operator histogram fields in the ServiceMonitor endpoints, with optional per-component overrides for the webhook and cert-controller (see [Endpoint API reference](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.Endpoint)):

| Field | Min Prometheus Operator version |
|---|---|
| `scrapeClassicHistograms` | v0.65.0 |
| `nativeHistogramBucketLimit` | v0.65.0 |
| `nativeHistogramMinBucketFactor` | v0.71.0 |
| `scrapeProtocols` | v0.68.0 |

Global defaults live under `.Values.serviceMonitor.*`. Per-component overrides are available at `.Values.webhook.serviceMonitor.*` and `.Values.certController.serviceMonitor.*`.

All fields default to `"-"` (sentinel), which means the field is omitted from the rendered manifest entirely. This preserves backward compatibility with Prometheus Operator versions that predate these fields.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/)
- [x] All commits are signed off (DCO)
- [x] All tests pass with `make test`
- [x] The changes include reasonable test coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds support for Prometheus Operator native histogram configuration fields in the external-secrets Helm chart's ServiceMonitor resources. 

**Changes include:**
- New Helm helper template (`serviceMonitorHistogramConfig`) to conditionally render histogram scrape settings
- ServiceMonitor templates updated to use the helper for main metrics, webhook, and cert-controller ServiceMonitors
- Values schema extended with histogram and scrapeProtocols fields for global and per-component configuration
- Default values added for `scrapeClassicHistograms`, `nativeHistogramBucketLimit`, `nativeHistogramMinBucketFactor`, and `scrapeProtocols` at both global and per-component levels
- Comprehensive test coverage verifying backward compatibility, global propagation, and per-component overrides

**Design:** All fields default to the sentinel value `"-"` to omit from rendered manifests when not configured, ensuring compatibility with older Prometheus Operator versions. Per-component overrides are supported for webhook and cert-controller ServiceMonitors.

**Files modified:** `_helpers.tpl`, `servicemonitor.yaml`, `values.yaml`, `values.schema.json`, and `service_monitor_test.yaml` (+252 lines).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/external-secrets/external-secrets/pull/6397?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->