### PR TITLE
feat(test): Add performance benchmark tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,5 @@ tests/crds/*.yml
 .env.test.local
 .env.production.local
 .envrc
+
+pkg/perf/**/perf-results-*.json

--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ tests/crds/*.yml
 .envrc
 
 pkg/perf/**/perf-results-*.json
+perf-*.log

--- a/Makefile
+++ b/Makefile
@@ -146,21 +146,21 @@ perf-test-burst-es: envtest ## N ExternalSecrets on 1 SecretStore
 	@$(INFO) perf test burst-es
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(KUBERNETES_VERSION) -p path --bin-dir $(LOCALBIN))" \
 	PERF_ES_CONCURRENCY=20 \
-		script -q -e -c "go test -v -tags=perf -timeout=30m ./pkg/perf/burst-es/..." perf-burst-es.log
+		bash -c 'set -o pipefail; go test -v -tags=perf -timeout=30m ./pkg/perf/burst-es/... 2>&1 | tee perf-burst-es.log'
 	@$(OK) perf test burst-es done
 
 .PHONY: perf-test-burst-ss
 perf-test-burst-ss: envtest ## 10k SecretStores across 10k namespaces
 	@$(INFO) perf test burst-ss
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(KUBERNETES_VERSION) -p path --bin-dir $(LOCALBIN))" \
-		script -q -e -c "go test -v -tags=perf -timeout=30m ./pkg/perf/burst-ss/..." perf-burst-ss.log
+		bash -c 'set -o pipefail; go test -v -tags=perf -timeout=30m ./pkg/perf/burst-ss/... 2>&1 | tee perf-burst-ss.log'
 	@$(OK) perf test burst-ss done
 
 .PHONY: perf-test-fanout
 perf-test-fanout: envtest ## N stores * M ExternalSecrets (with default 100 x 100)
 	@$(INFO) perf test fanout
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(KUBERNETES_VERSION) -p path --bin-dir $(LOCALBIN))" \
-		script -q -e -c "go test -v -tags=perf -timeout=60m ./pkg/perf/fanout/..." perf-fanout.log
+		bash -c 'set -o pipefail; go test -v -tags=perf -timeout=60m ./pkg/perf/fanout/... 2>&1 | tee perf-fanout.log'
 	@$(OK) perf test fanout done
 
 .PHONY: perf-test-steady-es
@@ -168,7 +168,7 @@ perf-test-steady-es: envtest ## steady-state: observe N ExternalSecrets re-recon
 	@$(INFO) perf test steady-es
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(KUBERNETES_VERSION) -p path --bin-dir $(LOCALBIN))" \
 	PERF_ES_CONCURRENCY=20 PERF_REQUEUE_INTERVAL_SECS=30 \
-		script -q -e -c "go test -v -tags=perf -timeout=60m ./pkg/perf/steady-es/..." perf-steady-es.log
+		bash -c 'set -o pipefail; go test -v -tags=perf -timeout=60m ./pkg/perf/steady-es/... 2>&1 | tee perf-steady-es.log'
 	@$(OK) perf test steady-es done
 
 .PHONY: perf-test-fanout-fullscale
@@ -177,7 +177,7 @@ perf-test-fanout-fullscale: envtest ## Larger scale needs beefy machine. Perform
 	PERF_NUM_STORES=1000 PERF_ES_PER_STORE=20 PERF_ES_CONCURRENCY=32 PERF_STORE_CONCURRENCY=32 \
 		PERF_QPS=1000 PERF_BURST=2000 \
 		KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(KUBERNETES_VERSION) -p path --bin-dir $(LOCALBIN))" \
-		script -q -e -c "go test -v -tags=perf -timeout=120m ./pkg/perf/fanout/..." perf-fanout-fullscale.log
+		bash -c 'set -o pipefail; go test -v -tags=perf -timeout=120m ./pkg/perf/fanout/... 2>&1 | tee perf-fanout-fullscale.log'
 	@$(OK) perf test fanout fullscale done
 
 .PHONY: build

--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,45 @@ test.crds.update: cty crds.generate.tests ## Update the snapshots used by the CR
 	$(CTY) test tests -u
 	@$(OK) Successfully updated all test snapshots
 
+.PHONY: perf-test-burst-es
+perf-test-burst-es: envtest ## N ExternalSecrets on 1 SecretStore
+	@$(INFO) perf test burst-es
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(KUBERNETES_VERSION) -p path --bin-dir $(LOCALBIN))" \
+	PERF_ES_CONCURRENCY=20 \
+		script -q -e -c "go test -v -tags=perf -timeout=30m ./pkg/perf/burst-es/..." perf-burst-es.log
+	@$(OK) perf test burst-es done
+
+.PHONY: perf-test-burst-ss
+perf-test-burst-ss: envtest ## 10k SecretStores across 10k namespaces
+	@$(INFO) perf test burst-ss
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(KUBERNETES_VERSION) -p path --bin-dir $(LOCALBIN))" \
+		script -q -e -c "go test -v -tags=perf -timeout=30m ./pkg/perf/burst-ss/..." perf-burst-ss.log
+	@$(OK) perf test burst-ss done
+
+.PHONY: perf-test-fanout
+perf-test-fanout: envtest ## N stores * M ExternalSecrets (with default 100 x 100)
+	@$(INFO) perf test fanout
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(KUBERNETES_VERSION) -p path --bin-dir $(LOCALBIN))" \
+		script -q -e -c "go test -v -tags=perf -timeout=60m ./pkg/perf/fanout/..." perf-fanout.log
+	@$(OK) perf test fanout done
+
+.PHONY: perf-test-steady-es
+perf-test-steady-es: envtest ## steady-state: observe N ExternalSecrets re-reconciling after warmup
+	@$(INFO) perf test steady-es
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(KUBERNETES_VERSION) -p path --bin-dir $(LOCALBIN))" \
+	PERF_ES_CONCURRENCY=20 PERF_REQUEUE_INTERVAL_SECS=30 \
+		script -q -e -c "go test -v -tags=perf -timeout=60m ./pkg/perf/steady-es/..." perf-steady-es.log
+	@$(OK) perf test steady-es done
+
+.PHONY: perf-test-fanout-fullscale
+perf-test-fanout-fullscale: envtest ## Larger scale needs beefy machine. Performance collapses above 20.
+	@$(INFO) perf test fanout fullscale
+	PERF_NUM_STORES=1000 PERF_ES_PER_STORE=20 PERF_ES_CONCURRENCY=32 PERF_STORE_CONCURRENCY=32 \
+		PERF_QPS=1000 PERF_BURST=2000 \
+		KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(KUBERNETES_VERSION) -p path --bin-dir $(LOCALBIN))" \
+		script -q -e -c "go test -v -tags=perf -timeout=120m ./pkg/perf/fanout/..." perf-fanout-fullscale.log
+	@$(OK) perf test fanout fullscale done
+
 .PHONY: build
 build: $(addprefix build-,$(ARCH)) ## Build binary
 

--- a/pkg/perf/burst-es/burst_test.go
+++ b/pkg/perf/burst-es/burst_test.go
@@ -1,0 +1,90 @@
+// /*
+// Copyright © The ESO Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+//go:build perf
+
+package burst_es
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	perf "github.com/external-secrets/external-secrets/pkg/perf"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ExternalSecret burst reconciliation", func() {
+	DescribeTable("N ExternalSecrets on 1 SecretStore",
+		func(n int) {
+			ctx := context.Background()
+			concurrency := perf.EnvOrInt("PERF_ES_CONCURRENCY", 4)
+			scenario := fmt.Sprintf("burst-n%d-c%d", n, concurrency)
+
+			before := perf.Snapshot("externalsecret")
+
+			By(fmt.Sprintf("creating %d ExternalSecrets", n))
+			Expect(perf.CreateExternalSecrets(ctx, k8sClient, testNamespace, n, storeRef, time.Hour)).To(Succeed())
+
+			By("waiting for all to reach Ready")
+			wallTime, err := perf.WaitAllReady(ctx, k8sClient, testNamespace, n, 30*time.Minute) // I need more than 45 minutes for N = 50k.
+			Expect(err).ToNot(HaveOccurred())
+
+			after := perf.Snapshot("externalsecret")
+			_, errorsDelta, heapDelta, gcDelta := perf.DiffSnapshots(before, after)
+
+			result := perf.PerfResult{
+				Plan:               "burst",
+				Scenario:           scenario,
+				NumStores:          1,
+				NumESPerStore:      n,
+				Concurrency:        concurrency,
+				WallTimeSec:        wallTime.Seconds(),
+				ThroughputRPS:      float64(n) / wallTime.Seconds(),
+				ReconcileP50ms:     perf.HistogramPercentile(after.ReconcileTime, 0.50) * 1000,
+				ReconcileP90ms:     perf.HistogramPercentile(after.ReconcileTime, 0.90) * 1000,
+				ReconcileP99ms:     perf.HistogramPercentile(after.ReconcileTime, 0.99) * 1000,
+				QueueP50ms:         perf.HistogramPercentile(after.QueueDuration, 0.50) * 1000,
+				QueueP90ms:         perf.HistogramPercentile(after.QueueDuration, 0.90) * 1000,
+				HeapDeltaMB:        float64(heapDelta) / (1024 * 1024),
+				NumGCDelta:         gcDelta,
+				PauseTotalMs:       float64(after.PauseTotalNs-before.PauseTotalNs) / 1e6,
+				ErrorsDelta:        errorsDelta,
+				TotalObjects:       n + 1, // n ES + 1 Store
+				HeapBytesPerObject: float64(heapDelta) / float64(n+1),
+				GCsPerKObject:      float64(gcDelta) / float64(n+1) * 1000,
+			}
+
+			AddReportEntry("perf-result", result)
+			allResults = append(allResults, result)
+
+			GinkgoWriter.Printf(
+				"\n[burst] n=%d concurrency=%d wall=%.2fs rps=%.1f p50=%.2fms p90=%.2fms p99=%.2fms heap/obj=%.0fB gc/kobj=%.2f errors=%.0f\n",
+				n, concurrency, result.WallTimeSec, result.ThroughputRPS,
+				result.ReconcileP50ms, result.ReconcileP90ms, result.ReconcileP99ms,
+				result.HeapBytesPerObject, result.GCsPerKObject, errorsDelta,
+			)
+		},
+		Entry("N=100", 100),
+		Entry("N=500", 500),
+		Entry("N=1000", 1000),
+		Entry("N=5000", 5000),
+		// Entry("N=10000", 10000),
+		// Entry("N=50000", 50000), // This one seems off, commented by default. Needs analysis!
+	)
+})

--- a/pkg/perf/burst-es/doc.go
+++ b/pkg/perf/burst-es/doc.go
@@ -22,9 +22,11 @@
 //
 // Run with:
 //
-//	go test -v -tags=perf -timeout=15m ./pkg/perf/burst-es/...
+//	go test -v -tags=perf -timeout=30m ./pkg/perf/burst-es/...
 //
 // Environment variables:
 //
 //	PERF_ES_CONCURRENCY  MaxConcurrentReconciles for the ES controller (default 4)
+//	PERF_QPS             Client-side QPS for the REST client (default 500)
+//	PERF_BURST           Client-side burst for the REST client (default 1000)
 package burst_es

--- a/pkg/perf/burst-es/doc.go
+++ b/pkg/perf/burst-es/doc.go
@@ -1,0 +1,30 @@
+// /*
+// Copyright © The ESO Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+//go:build perf
+
+// Package burst_es contains the first aspect of the ESO performance test suite:
+// N ExternalSecrets created simultaneously (burst) against a single SecretStore,
+// measuring reconcile throughput and latency via controller-runtime Prometheus metrics.
+//
+// Run with:
+//
+//	go test -v -tags=perf -timeout=15m ./pkg/perf/burst-es/...
+//
+// Environment variables:
+//
+//	PERF_ES_CONCURRENCY  MaxConcurrentReconciles for the ES controller (default 4)
+package burst_es

--- a/pkg/perf/burst-es/suite_test.go
+++ b/pkg/perf/burst-es/suite_test.go
@@ -1,0 +1,197 @@
+// /*
+// Copyright © The ESO Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+//go:build perf
+
+package burst_es
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go.uber.org/zap/zapcore"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
+	genv1alpha1 "github.com/external-secrets/external-secrets/apis/generators/v1alpha1"
+	ctrlcommon "github.com/external-secrets/external-secrets/pkg/controllers/common"
+	"github.com/external-secrets/external-secrets/pkg/controllers/externalsecret"
+	"github.com/external-secrets/external-secrets/pkg/controllers/externalsecret/esmetrics"
+	ctrlmetrics "github.com/external-secrets/external-secrets/pkg/controllers/metrics"
+	perf "github.com/external-secrets/external-secrets/pkg/perf"
+	"github.com/external-secrets/external-secrets/runtime/testing/fake"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	testEnv      *envtest.Environment
+	k8sClient    client.Client
+	cancelSuite  context.CancelFunc
+	fakeProvider *fake.Client
+
+	// storeRef is created per-scenario in BeforeEach.
+	testNamespace string
+	storeRef      esv1.SecretStoreRef
+
+	// allResults accumulates PerfResults across all scenarios; written to JSON in AfterSuite.
+	allResults []perf.PerfResult
+)
+
+func TestPerf(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Burst Perf Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.Level(zapcore.WarnLevel)))
+
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "deploy", "crds")},
+	}
+	testEnv.ControlPlane.GetAPIServer().Configure().
+		Set("max-requests-inflight", "1000").
+		Set("max-mutating-requests-inflight", "500")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancelSuite = cancel
+
+	cfg, err := testEnv.Start()
+	Expect(err).ToNot(HaveOccurred())
+
+	// Raise client-side rate limits; defaults (5 QPS / burst 10) starve the controller at scale.
+	cfg.QPS = float32(perf.EnvOrInt("PERF_QPS", 500))
+	cfg.Burst = perf.EnvOrInt("PERF_BURST", 1000)
+
+	Expect(esv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(genv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme.Scheme,
+		Metrics: server.Options{BindAddress: "0"},
+		Client: client.Options{
+			Cache: &client.CacheOptions{
+				DisableFor: []client.Object{&v1.Secret{}, &v1.ConfigMap{}},
+			},
+		},
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).ToNot(HaveOccurred())
+
+	secretClient, err := ctrlcommon.BuildManagedSecretClient(mgr, "")
+	Expect(err).ToNot(HaveOccurred())
+
+	Expect((&externalsecret.Reconciler{
+		Client:                             mgr.GetClient(),
+		SecretClient:                       secretClient,
+		EnableSecretAPIReadOnCacheMismatch: true,
+		RestConfig:                         cfg,
+		Scheme:                             mgr.GetScheme(),
+		Log:                                ctrl.Log.WithName("controllers").WithName("ExternalSecrets"),
+		RequeueInterval:                    time.Hour,
+		ClusterSecretStoreEnabled:          true,
+	}).SetupWithManager(ctx, mgr, controller.Options{
+		MaxConcurrentReconciles: perf.EnvOrInt("PERF_ES_CONCURRENCY", 4),
+		RateLimiter:             ctrlcommon.BuildRateLimiter(),
+	})).To(Succeed())
+
+	go func() {
+		defer GinkgoRecover()
+		Expect(mgr.Start(ctx)).To(Succeed())
+	}()
+})
+
+var _ = AfterSuite(func() {
+	cancelSuite()
+	// Work around a controller-runtime race (https://github.com/kubernetes-sigs/controller-runtime/issues/1571)
+	// where the manager has not yet released its API server connections by the time Stop() is called,
+	// causing envtest to fail tearing down the control plane. Retrying with exponential backoff gives the
+	// manager enough time to drain its connections and exit cleanly.
+	sleepTime := time.Millisecond
+	var err error
+	for range 12 {
+		if err = testEnv.Stop(); err == nil {
+			break
+		}
+		sleepTime *= 2
+		time.Sleep(sleepTime)
+	}
+	Expect(err).ToNot(HaveOccurred())
+
+	if len(allResults) > 0 {
+		Expect(perf.WriteResultsJSON(allResults, ".")).To(Succeed())
+		perf.PrintResultsTable(allResults, GinkgoWriter)
+	}
+})
+
+var _ = BeforeEach(func() {
+	ns := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "perf-burst-",
+		},
+	}
+	Expect(k8sClient.Create(context.Background(), ns)).To(Succeed())
+	testNamespace = ns.Name
+
+	store := &esv1.SecretStore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "perf-store",
+			Namespace: testNamespace,
+		},
+		Spec: esv1.SecretStoreSpec{
+			Provider: fakeProviderSpec(),
+		},
+	}
+	Expect(k8sClient.Create(context.Background(), store)).To(Succeed())
+	storeRef = esv1.SecretStoreRef{Name: store.Name}
+})
+
+var _ = AfterEach(func() {
+	Expect(k8sClient.Delete(context.Background(), &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: testNamespace},
+	})).To(Succeed())
+})
+
+func fakeProviderSpec() *esv1.SecretStoreProvider {
+	return &esv1.SecretStoreProvider{
+		AWS: &esv1.AWSProvider{
+			Service: esv1.AWSServiceSecretsManager,
+		},
+	}
+}
+
+func init() {
+	fakeProvider = fake.New()
+	fakeProvider.WithGetSecret([]byte("perf-value"), nil)
+	esv1.ForceRegister(fakeProvider, fakeProviderSpec(), esv1.MaintenanceStatusMaintained)
+
+	ctrlmetrics.SetUpLabelNames(false)
+	esmetrics.SetUpMetrics()
+}

--- a/pkg/perf/burst-ss/doc.go
+++ b/pkg/perf/burst-ss/doc.go
@@ -1,0 +1,31 @@
+// /*
+// Copyright © The ESO Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+//go:build perf
+
+// Package burst_ss contains the second aspect of the ESO performance test suite:
+// PERF_NUM_STORES SecretStores (one per namespace) reconciled simultaneously,
+// measuring SecretStore controller throughput via controller-runtime Prometheus metrics.
+//
+// Run with:
+//
+//	go test -v -tags=perf -timeout=30m ./pkg/perf/burst-ss/...
+//
+// Environment variables:
+//
+//	PERF_NUM_STORES        Number of SecretStores / namespaces (default 10000)
+//	PERF_STORE_CONCURRENCY MaxConcurrentReconciles for the SecretStore controller (default 16)
+package burst_ss

--- a/pkg/perf/burst-ss/suite_test.go
+++ b/pkg/perf/burst-ss/suite_test.go
@@ -81,6 +81,10 @@ var _ = BeforeSuite(func() {
 	cfg, err := testEnv.Start()
 	Expect(err).ToNot(HaveOccurred())
 
+	// Raise client-side rate limits; defaults (5 QPS / burst 10) starve creation at scale.
+	cfg.QPS = float32(perf.EnvOrInt("PERF_QPS", 500))
+	cfg.Burst = perf.EnvOrInt("PERF_BURST", 1000)
+
 	Expect(esv1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(esv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
 
@@ -90,7 +94,8 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	k8sClient = mgr.GetClient()
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).ToNot(HaveOccurred())
 
 	Expect((&secretstore.StoreReconciler{
 		Client:          mgr.GetClient(),
@@ -110,7 +115,20 @@ var _ = BeforeSuite(func() {
 
 var _ = AfterSuite(func() {
 	cancelSuite()
-	Expect(testEnv.Stop()).To(Succeed())
+	// Work around a controller-runtime race (https://github.com/kubernetes-sigs/controller-runtime/issues/1571)
+	// where the manager has not yet released its API server connections by the time Stop() is called,
+	// causing envtest to fail tearing down the control plane. Retrying with exponential backoff gives the
+	// manager enough time to drain its connections and exit cleanly.
+	sleepTime := time.Millisecond
+	var err error
+	for range 12 {
+		if err = testEnv.Stop(); err == nil {
+			break
+		}
+		sleepTime *= 2
+		time.Sleep(sleepTime)
+	}
+	Expect(err).ToNot(HaveOccurred())
 
 	if len(allResults) > 0 {
 		Expect(perf.WriteResultsJSON(allResults, ".")).To(Succeed())

--- a/pkg/perf/burst-ss/suite_test.go
+++ b/pkg/perf/burst-ss/suite_test.go
@@ -1,0 +1,135 @@
+// /*
+// Copyright © The ESO Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+//go:build perf
+
+package burst_ss
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go.uber.org/zap/zapcore"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
+	esv1alpha1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
+	ctrlcommon "github.com/external-secrets/external-secrets/pkg/controllers/common"
+	ctrlmetrics "github.com/external-secrets/external-secrets/pkg/controllers/metrics"
+	"github.com/external-secrets/external-secrets/pkg/controllers/secretstore"
+	"github.com/external-secrets/external-secrets/pkg/controllers/secretstore/ssmetrics"
+	perf "github.com/external-secrets/external-secrets/pkg/perf"
+	"github.com/external-secrets/external-secrets/runtime/testing/fake"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	testEnv     *envtest.Environment
+	k8sClient   client.Client
+	cancelSuite context.CancelFunc
+
+	fakeProvider *fake.Client
+
+	// allResults accumulates PerfResults; written to JSON in AfterSuite.
+	allResults []perf.PerfResult
+)
+
+func TestPerf(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Stores Perf Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.Level(zapcore.WarnLevel)))
+
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:        []string{filepath.Join("..", "..", "..", "deploy", "crds")},
+		ControlPlaneStartTimeout: 5 * time.Minute,
+	}
+
+	testEnv.ControlPlane.GetAPIServer().Configure().
+		Set("max-requests-inflight", "1000").
+		Set("max-mutating-requests-inflight", "500")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancelSuite = cancel
+
+	cfg, err := testEnv.Start()
+	Expect(err).ToNot(HaveOccurred())
+
+	Expect(esv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(esv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:  scheme.Scheme,
+		Metrics: server.Options{BindAddress: "0"},
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	k8sClient = mgr.GetClient()
+
+	Expect((&secretstore.StoreReconciler{
+		Client:          mgr.GetClient(),
+		Scheme:          mgr.GetScheme(),
+		Log:             ctrl.Log.WithName("controllers").WithName("SecretStore"),
+		RequeueInterval: time.Hour,
+	}).SetupWithManager(mgr, controller.Options{
+		MaxConcurrentReconciles: perf.EnvOrInt("PERF_STORE_CONCURRENCY", 16),
+		RateLimiter:             ctrlcommon.BuildRateLimiter(),
+	})).To(Succeed())
+
+	go func() {
+		defer GinkgoRecover()
+		Expect(mgr.Start(ctx)).To(Succeed())
+	}()
+})
+
+var _ = AfterSuite(func() {
+	cancelSuite()
+	Expect(testEnv.Stop()).To(Succeed())
+
+	if len(allResults) > 0 {
+		Expect(perf.WriteResultsJSON(allResults, ".")).To(Succeed())
+		perf.PrintResultsTable(allResults, GinkgoWriter)
+	}
+})
+
+func fakeProviderSpec() *esv1.SecretStoreProvider {
+	return &esv1.SecretStoreProvider{
+		AWS: &esv1.AWSProvider{
+			Service: esv1.AWSServiceSecretsManager,
+		},
+	}
+}
+
+func init() {
+	fakeProvider = fake.New()
+	esv1.ForceRegister(fakeProvider, fakeProviderSpec(), esv1.MaintenanceStatusMaintained)
+
+	ctrlmetrics.SetUpLabelNames(false)
+	ssmetrics.SetUpMetrics()
+}

--- a/pkg/perf/burst-ss/throughput_test.go
+++ b/pkg/perf/burst-ss/throughput_test.go
@@ -1,0 +1,88 @@
+// /*
+// Copyright © The ESO Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+//go:build perf
+
+package burst_ss
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	perf "github.com/external-secrets/external-secrets/pkg/perf"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("SecretStore reconciler throughput", func() {
+	It("reconciles PERF_NUM_STORES SecretStores across as many namespaces", func() {
+		ctx := context.Background()
+		numStores := perf.EnvOrInt("PERF_NUM_STORES", 10_000)
+		concurrency := perf.EnvOrInt("PERF_STORE_CONCURRENCY", 16)
+		scenario := fmt.Sprintf("stores-n%d-c%d", numStores, concurrency)
+
+		By(fmt.Sprintf("creating %d namespaces", numStores))
+		namespaces, err := perf.CreateNamespaces(ctx, k8sClient, numStores, "perf-store")
+		Expect(err).ToNot(HaveOccurred())
+
+		By(fmt.Sprintf("creating %d SecretStores", numStores))
+		before := perf.Snapshot("secretstore")
+		start := time.Now()
+		Expect(perf.CreateSecretStores(ctx, k8sClient, namespaces, fakeProviderSpec())).To(Succeed())
+
+		By("waiting for all stores to reach Ready")
+		_, err = perf.WaitAllStoresReady(ctx, k8sClient, namespaces, 30*time.Minute)
+		Expect(err).ToNot(HaveOccurred())
+		wallTime := time.Since(start)
+
+		after := perf.Snapshot("secretstore")
+		_, errorsDelta, heapDelta, gcDelta := perf.DiffSnapshots(before, after)
+
+		result := perf.PerfResult{
+			Plan:               "stores",
+			Scenario:           scenario,
+			NumStores:          numStores,
+			NumESPerStore:      0,
+			Concurrency:        concurrency,
+			WallTimeSec:        wallTime.Seconds(),
+			ThroughputRPS:      float64(numStores) / wallTime.Seconds(),
+			ReconcileP50ms:     perf.HistogramPercentile(after.ReconcileTime, 0.50) * 1000,
+			ReconcileP90ms:     perf.HistogramPercentile(after.ReconcileTime, 0.90) * 1000,
+			ReconcileP99ms:     perf.HistogramPercentile(after.ReconcileTime, 0.99) * 1000,
+			QueueP50ms:         perf.HistogramPercentile(after.QueueDuration, 0.50) * 1000,
+			QueueP90ms:         perf.HistogramPercentile(after.QueueDuration, 0.90) * 1000,
+			HeapDeltaMB:        float64(heapDelta) / (1024 * 1024),
+			NumGCDelta:         gcDelta,
+			PauseTotalMs:       float64(after.PauseTotalNs-before.PauseTotalNs) / 1e6,
+			ErrorsDelta:        errorsDelta,
+			TotalObjects:       numStores,
+			HeapBytesPerObject: float64(heapDelta) / float64(numStores),
+			GCsPerKObject:      float64(gcDelta) / float64(numStores) * 1000,
+		}
+
+		AddReportEntry("perf-result", result)
+		allResults = append(allResults, result)
+
+		GinkgoWriter.Printf(
+			"\n[stores] n=%d concurrency=%d wall=%.2fs rps=%.1f p50=%.2fms p90=%.2fms p99=%.2fms heap/obj=%.0fB gc/kobj=%.2f errors=%.0f\n",
+			numStores, concurrency, result.WallTimeSec, result.ThroughputRPS,
+			result.ReconcileP50ms, result.ReconcileP90ms, result.ReconcileP99ms,
+			result.HeapBytesPerObject, result.GCsPerKObject, errorsDelta,
+		)
+	})
+})

--- a/pkg/perf/fanout/doc.go
+++ b/pkg/perf/fanout/doc.go
@@ -1,0 +1,39 @@
+// /*
+// Copyright © The ESO Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+//go:build perf
+
+// Package fanout contains Plan 3 of the ESO performance test suite:
+// PERF_NUM_STORES SecretStores each with PERF_ES_PER_STORE ExternalSecrets,
+// testing the combined fan-out case under realistic multi-tenant conditions.
+//
+// Default: 100 stores × 100 ES = 10k ExternalSecrets total.
+// Full scale: 1000 × 100 = 100k (dedicated machine).
+// Maximum scale (1M ES) requires a real cluster, not envtest.
+//
+// Run with:
+//
+//	go test -v -tags=perf -timeout=60m ./pkg/perf/fanout/...
+//
+// Environment variables:
+//
+//	PERF_NUM_STORES        SecretStores / namespaces (default 100)
+//	PERF_ES_PER_STORE      ExternalSecrets per store (default 100)
+//	PERF_ES_CONCURRENCY    MaxConcurrentReconciles for ES controller (default 16)
+//	PERF_STORE_CONCURRENCY MaxConcurrentReconciles for SecretStore controller (default 16)
+//	PERF_QPS               REST client QPS (default 500)
+//	PERF_BURST             REST client burst (default 1000)
+package fanout

--- a/pkg/perf/fanout/fanout_test.go
+++ b/pkg/perf/fanout/fanout_test.go
@@ -1,0 +1,106 @@
+// /*
+// Copyright © The ESO Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+//go:build perf
+
+package fanout
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
+	perf "github.com/external-secrets/external-secrets/pkg/perf"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Fan-out: N stores * M ExternalSecrets", func() {
+	It("reconciles all ESes across all stores", func() {
+		ctx := context.Background()
+		numStores := perf.EnvOrInt("PERF_NUM_STORES", 100)
+		esPerStore := perf.EnvOrInt("PERF_ES_PER_STORE", 100)
+		esConcurrency := perf.EnvOrInt("PERF_ES_CONCURRENCY", 16)
+		storeConcurrency := perf.EnvOrInt("PERF_STORE_CONCURRENCY", 16)
+		total := numStores * esPerStore
+		scenario := fmt.Sprintf("fanout-s%d-e%d-sc%d-ec%d", numStores, esPerStore, storeConcurrency, esConcurrency)
+
+		By(fmt.Sprintf("creating %d namespaces", numStores))
+		namespaces, err := perf.CreateNamespaces(ctx, k8sClient, numStores, "perf-fanout")
+		Expect(err).ToNot(HaveOccurred())
+
+		By(fmt.Sprintf("creating %d SecretStores", numStores))
+		Expect(perf.CreateSecretStores(ctx, k8sClient, namespaces, fakeProviderSpec())).To(Succeed())
+
+		By("waiting for all stores to reach Ready before creating ExternalSecrets")
+		_, err = perf.WaitAllStoresReady(ctx, k8sClient, namespaces, 15*time.Minute)
+		Expect(err).ToNot(HaveOccurred())
+
+		By(fmt.Sprintf("creating %d ExternalSecrets (%d per store)", total, esPerStore))
+		storeRef := esv1.SecretStoreRef{Name: "perf-store"}
+		for _, ns := range namespaces {
+			Expect(perf.CreateExternalSecrets(ctx, k8sClient, ns, esPerStore, storeRef, 2*time.Hour)).To(Succeed())
+		}
+
+		By("measuring time for all ExternalSecrets to reach Ready")
+		before := perf.Snapshot("externalsecret")
+		start := time.Now()
+
+		_, err = perf.WaitAllReadyMultiNS(ctx, k8sClient, namespaces, esPerStore, 60*time.Minute)
+		Expect(err).ToNot(HaveOccurred())
+		wallTime := time.Since(start)
+
+		after := perf.Snapshot("externalsecret")
+		_, errorsDelta, heapDelta, gcDelta := perf.DiffSnapshots(before, after)
+
+		// total ES + one Store per namespace
+		totalObjects := total + numStores
+		result := perf.PerfResult{
+			Plan:               "fanout",
+			Scenario:           scenario,
+			NumStores:          numStores,
+			NumESPerStore:      esPerStore,
+			Concurrency:        esConcurrency,
+			WallTimeSec:        wallTime.Seconds(),
+			ThroughputRPS:      float64(total) / wallTime.Seconds(),
+			ReconcileP50ms:     perf.HistogramPercentile(after.ReconcileTime, 0.50) * 1000,
+			ReconcileP90ms:     perf.HistogramPercentile(after.ReconcileTime, 0.90) * 1000,
+			ReconcileP99ms:     perf.HistogramPercentile(after.ReconcileTime, 0.99) * 1000,
+			QueueP50ms:         perf.HistogramPercentile(after.QueueDuration, 0.50) * 1000,
+			QueueP90ms:         perf.HistogramPercentile(after.QueueDuration, 0.90) * 1000,
+			HeapDeltaMB:        float64(heapDelta) / (1024 * 1024),
+			NumGCDelta:         gcDelta,
+			PauseTotalMs:       float64(after.PauseTotalNs-before.PauseTotalNs) / 1e6,
+			ErrorsDelta:        errorsDelta,
+			TotalObjects:       totalObjects,
+			HeapBytesPerObject: float64(heapDelta) / float64(totalObjects),
+			GCsPerKObject:      float64(gcDelta) / float64(totalObjects) * 1000,
+		}
+
+		AddReportEntry("perf-result", result)
+		allResults = append(allResults, result)
+
+		GinkgoWriter.Printf(
+			"\n[fanout] stores=%d es/store=%d total=%d wall=%.2fs rps=%.1f p50=%.2fms p90=%.2fms p99=%.2fms heapΔ=%.1fMB heap/obj=%.0fB gc/kobj=%.2f errors=%.0f\n",
+			numStores, esPerStore, total,
+			result.WallTimeSec, result.ThroughputRPS,
+			result.ReconcileP50ms, result.ReconcileP90ms, result.ReconcileP99ms,
+			result.HeapDeltaMB, result.HeapBytesPerObject, result.GCsPerKObject, errorsDelta,
+		)
+	})
+})

--- a/pkg/perf/fanout/fanout_test.go
+++ b/pkg/perf/fanout/fanout_test.go
@@ -51,15 +51,15 @@ var _ = Describe("Fan-out: N stores * M ExternalSecrets", func() {
 		_, err = perf.WaitAllStoresReady(ctx, k8sClient, namespaces, 15*time.Minute)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("measuring time for all ExternalSecrets to reach Ready")
+		before := perf.Snapshot("externalsecret")
+		start := time.Now()
+
 		By(fmt.Sprintf("creating %d ExternalSecrets (%d per store)", total, esPerStore))
 		storeRef := esv1.SecretStoreRef{Name: "perf-store"}
 		for _, ns := range namespaces {
 			Expect(perf.CreateExternalSecrets(ctx, k8sClient, ns, esPerStore, storeRef, 2*time.Hour)).To(Succeed())
 		}
-
-		By("measuring time for all ExternalSecrets to reach Ready")
-		before := perf.Snapshot("externalsecret")
-		start := time.Now()
 
 		_, err = perf.WaitAllReadyMultiNS(ctx, k8sClient, namespaces, esPerStore, 60*time.Minute)
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/perf/fanout/suite_test.go
+++ b/pkg/perf/fanout/suite_test.go
@@ -1,0 +1,170 @@
+// /*
+// Copyright © The ESO Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+//go:build perf
+
+package fanout
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go.uber.org/zap/zapcore"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
+	esv1alpha1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
+	genv1alpha1 "github.com/external-secrets/external-secrets/apis/generators/v1alpha1"
+	ctrlcommon "github.com/external-secrets/external-secrets/pkg/controllers/common"
+	"github.com/external-secrets/external-secrets/pkg/controllers/externalsecret"
+	"github.com/external-secrets/external-secrets/pkg/controllers/externalsecret/esmetrics"
+	ctrlmetrics "github.com/external-secrets/external-secrets/pkg/controllers/metrics"
+	"github.com/external-secrets/external-secrets/pkg/controllers/secretstore"
+	"github.com/external-secrets/external-secrets/pkg/controllers/secretstore/ssmetrics"
+	perf "github.com/external-secrets/external-secrets/pkg/perf"
+	"github.com/external-secrets/external-secrets/runtime/testing/fake"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	testEnv     *envtest.Environment
+	k8sClient   client.Client
+	cancelSuite context.CancelFunc
+
+	fakeProvider *fake.Client
+
+	allResults []perf.PerfResult
+)
+
+func TestPerf(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Fanout Perf Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.Level(zapcore.WarnLevel)))
+
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:        []string{filepath.Join("..", "..", "..", "deploy", "crds")},
+		ControlPlaneStartTimeout: 5 * time.Minute,
+	}
+
+	testEnv.ControlPlane.GetAPIServer().Configure().
+		Set("max-requests-inflight", "1000").
+		Set("max-mutating-requests-inflight", "500")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancelSuite = cancel
+
+	cfg, err := testEnv.Start()
+	Expect(err).ToNot(HaveOccurred())
+
+	// Tune the REST client for high throughput.
+	cfg.QPS = float32(perf.EnvOrInt("PERF_QPS", 500))
+	cfg.Burst = perf.EnvOrInt("PERF_BURST", 1000)
+
+	Expect(esv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(esv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(genv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:  scheme.Scheme,
+		Metrics: server.Options{BindAddress: "0"},
+		Client: client.Options{
+			Cache: &client.CacheOptions{
+				DisableFor: []client.Object{&v1.Secret{}, &v1.ConfigMap{}},
+			},
+		},
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).ToNot(HaveOccurred())
+
+	// SecretStore controller
+	Expect((&secretstore.StoreReconciler{
+		Client:          mgr.GetClient(),
+		Scheme:          mgr.GetScheme(),
+		Log:             ctrl.Log.WithName("controllers").WithName("SecretStore"),
+		RequeueInterval: time.Hour,
+	}).SetupWithManager(mgr, controller.Options{
+		MaxConcurrentReconciles: perf.EnvOrInt("PERF_STORE_CONCURRENCY", 16),
+		RateLimiter:             ctrlcommon.BuildRateLimiter(),
+	})).To(Succeed())
+
+	// ExternalSecret controller
+	secretClient, err := ctrlcommon.BuildManagedSecretClient(mgr, "")
+	Expect(err).ToNot(HaveOccurred())
+
+	Expect((&externalsecret.Reconciler{
+		Client:                             mgr.GetClient(),
+		SecretClient:                       secretClient,
+		EnableSecretAPIReadOnCacheMismatch: true,
+		RestConfig:                         cfg,
+		Scheme:                             mgr.GetScheme(),
+		Log:                                ctrl.Log.WithName("controllers").WithName("ExternalSecrets"),
+		RequeueInterval:                    time.Hour,
+		ClusterSecretStoreEnabled:          true,
+	}).SetupWithManager(ctx, mgr, controller.Options{
+		MaxConcurrentReconciles: perf.EnvOrInt("PERF_ES_CONCURRENCY", 16),
+		RateLimiter:             ctrlcommon.BuildRateLimiter(),
+	})).To(Succeed())
+
+	go func() {
+		defer GinkgoRecover()
+		Expect(mgr.Start(ctx)).To(Succeed())
+	}()
+})
+
+var _ = AfterSuite(func() {
+	cancelSuite()
+	Expect(testEnv.Stop()).To(Succeed())
+
+	if len(allResults) > 0 {
+		Expect(perf.WriteResultsJSON(allResults, ".")).To(Succeed())
+		perf.PrintResultsTable(allResults, GinkgoWriter)
+	}
+})
+
+func fakeProviderSpec() *esv1.SecretStoreProvider {
+	return &esv1.SecretStoreProvider{
+		AWS: &esv1.AWSProvider{
+			Service: esv1.AWSServiceSecretsManager,
+		},
+	}
+}
+
+func init() {
+	fakeProvider = fake.New()
+	fakeProvider.WithGetSecret([]byte("perf-value"), nil)
+	esv1.ForceRegister(fakeProvider, fakeProviderSpec(), esv1.MaintenanceStatusMaintained)
+
+	ctrlmetrics.SetUpLabelNames(false)
+	esmetrics.SetUpMetrics()
+	ssmetrics.SetUpMetrics()
+}

--- a/pkg/perf/fanout/suite_test.go
+++ b/pkg/perf/fanout/suite_test.go
@@ -143,7 +143,20 @@ var _ = BeforeSuite(func() {
 
 var _ = AfterSuite(func() {
 	cancelSuite()
-	Expect(testEnv.Stop()).To(Succeed())
+	// Work around a controller-runtime race (https://github.com/kubernetes-sigs/controller-runtime/issues/1571)
+	// where the manager has not yet released its API server connections by the time Stop() is called,
+	// causing envtest to fail tearing down the control plane. Retrying with exponential backoff gives the
+	// manager enough time to drain its connections and exit cleanly.
+	sleepTime := time.Millisecond
+	var err error
+	for range 12 {
+		if err = testEnv.Stop(); err == nil {
+			break
+		}
+		sleepTime *= 2
+		time.Sleep(sleepTime)
+	}
+	Expect(err).ToNot(HaveOccurred())
 
 	if len(allResults) > 0 {
 		Expect(perf.WriteResultsJSON(allResults, ".")).To(Succeed())

--- a/pkg/perf/metrics.go
+++ b/pkg/perf/metrics.go
@@ -1,0 +1,149 @@
+// /*
+// Copyright © The ESO Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+//go:build perf
+
+package perf
+
+import (
+	"runtime"
+
+	dto "github.com/prometheus/client_model/go"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// MetricSnapshot captures a point-in-time view of controller performance metrics.
+type MetricSnapshot struct {
+	// From controller-runtime Prometheus registry
+	ReconcileTime   *dto.Histogram // controller_runtime_reconcile_time_seconds (highest-count result for given controller)
+	QueueDuration   *dto.Histogram // workqueue_queue_duration_seconds
+	WorkDuration    *dto.Histogram // workqueue_work_duration_seconds
+	ReconcileTotal  float64        // controller_runtime_reconcile_total (all results)
+	ReconcileErrors float64        // controller_runtime_reconcile_total{result="error"}
+	// From runtime.ReadMemStats
+	HeapAllocBytes uint64
+	NumGC          uint32
+	PauseTotalNs   uint64
+}
+
+// Snapshot gathers a MetricSnapshot for the named controller.
+// controllerName must match the controller label used by controller-runtime
+// (typically the lowercased Kind, e.g. "externalsecret" or "secretstore").
+func Snapshot(controllerName string) MetricSnapshot {
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+
+	snap := MetricSnapshot{
+		HeapAllocBytes: ms.HeapAlloc,
+		NumGC:          ms.NumGC,
+		PauseTotalNs:   ms.PauseTotalNs,
+	}
+
+	mfs, err := ctrlmetrics.Registry.Gather()
+	if err != nil {
+		return snap
+	}
+
+	for _, mf := range mfs {
+		switch mf.GetName() {
+		case "controller_runtime_reconcile_time_seconds":
+			// Pick the histogram series with the most samples (usually the dominant result label).
+			var best uint64
+			for _, m := range mf.GetMetric() {
+				if !hasLabel(m, "controller", controllerName) {
+					continue
+				}
+				if h := m.GetHistogram(); h.GetSampleCount() > best {
+					best = h.GetSampleCount()
+					snap.ReconcileTime = h
+				}
+			}
+
+		case "workqueue_queue_duration_seconds":
+			for _, m := range mf.GetMetric() {
+				if hasLabel(m, "name", controllerName) {
+					snap.QueueDuration = m.GetHistogram()
+				}
+			}
+
+		case "workqueue_work_duration_seconds":
+			for _, m := range mf.GetMetric() {
+				if hasLabel(m, "name", controllerName) {
+					snap.WorkDuration = m.GetHistogram()
+				}
+			}
+
+		case "controller_runtime_reconcile_total":
+			for _, m := range mf.GetMetric() {
+				if !hasLabel(m, "controller", controllerName) {
+					continue
+				}
+				snap.ReconcileTotal += m.GetCounter().GetValue()
+				if hasLabel(m, "result", "error") {
+					snap.ReconcileErrors += m.GetCounter().GetValue()
+				}
+			}
+		}
+	}
+
+	return snap
+}
+
+// HistogramPercentile returns the approximate p-th percentile value (p in [0,1]) from a dto.Histogram
+// using linear interpolation between bucket boundaries. Returns 0 if h is nil or empty.
+func HistogramPercentile(h *dto.Histogram, p float64) float64 {
+	if h == nil || h.GetSampleCount() == 0 {
+		return 0
+	}
+	target := p * float64(h.GetSampleCount())
+	buckets := h.GetBucket()
+	var prevCount float64
+	var prevBound float64
+	for _, b := range buckets {
+		count := float64(b.GetCumulativeCount())
+		if count >= target {
+			if count == prevCount {
+				return b.GetUpperBound()
+			}
+			fraction := (target - prevCount) / (count - prevCount)
+			return prevBound + fraction*(b.GetUpperBound()-prevBound)
+		}
+		prevCount = count
+		prevBound = b.GetUpperBound()
+	}
+	// All samples are in the +Inf bucket; return the mean as a best-effort.
+	return h.GetSampleSum() / float64(h.GetSampleCount())
+}
+
+// DiffSnapshots returns the per-field deltas between two snapshots.
+func DiffSnapshots(before, after MetricSnapshot) (reconcileDelta, errorsDelta float64, heapDeltaBytes uint64, gcDelta uint32) {
+	reconcileDelta = after.ReconcileTotal - before.ReconcileTotal
+	errorsDelta = after.ReconcileErrors - before.ReconcileErrors
+	if after.HeapAllocBytes > before.HeapAllocBytes {
+		heapDeltaBytes = after.HeapAllocBytes - before.HeapAllocBytes
+	}
+	gcDelta = after.NumGC - before.NumGC
+	return
+}
+
+func hasLabel(m *dto.Metric, key, value string) bool {
+	for _, lp := range m.GetLabel() {
+		if lp.GetName() == key && lp.GetValue() == value {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/perf/metrics.go
+++ b/pkg/perf/metrics.go
@@ -60,46 +60,58 @@ func Snapshot(controllerName string) MetricSnapshot {
 	for _, mf := range mfs {
 		switch mf.GetName() {
 		case "controller_runtime_reconcile_time_seconds":
-			// Pick the histogram series with the most samples (usually the dominant result label).
-			var best uint64
-			for _, m := range mf.GetMetric() {
-				if !hasLabel(m, "controller", controllerName) {
-					continue
-				}
-				if h := m.GetHistogram(); h.GetSampleCount() > best {
-					best = h.GetSampleCount()
-					snap.ReconcileTime = h
-				}
-			}
-
+			snap.ReconcileTime = pickReconcileTime(controllerName, mf)
 		case "workqueue_queue_duration_seconds":
-			for _, m := range mf.GetMetric() {
-				if hasLabel(m, "name", controllerName) {
-					snap.QueueDuration = m.GetHistogram()
-				}
-			}
-
+			snap.QueueDuration = pickWorkqueueHist(controllerName, mf)
 		case "workqueue_work_duration_seconds":
-			for _, m := range mf.GetMetric() {
-				if hasLabel(m, "name", controllerName) {
-					snap.WorkDuration = m.GetHistogram()
-				}
-			}
-
+			snap.WorkDuration = pickWorkqueueHist(controllerName, mf)
 		case "controller_runtime_reconcile_total":
-			for _, m := range mf.GetMetric() {
-				if !hasLabel(m, "controller", controllerName) {
-					continue
-				}
-				snap.ReconcileTotal += m.GetCounter().GetValue()
-				if hasLabel(m, "result", "error") {
-					snap.ReconcileErrors += m.GetCounter().GetValue()
-				}
-			}
+			snap.ReconcileTotal, snap.ReconcileErrors = sumReconcileTotals(controllerName, mf)
 		}
 	}
 
 	return snap
+}
+
+// pickReconcileTime returns the histogram series with the most samples for the given controller.
+// This picks the dominant result label when controller-runtime emits one series per result.
+func pickReconcileTime(controllerName string, mf *dto.MetricFamily) *dto.Histogram {
+	var best uint64
+	var h *dto.Histogram
+	for _, m := range mf.GetMetric() {
+		if !hasLabel(m, "controller", controllerName) {
+			continue
+		}
+		if hist := m.GetHistogram(); hist.GetSampleCount() > best {
+			best = hist.GetSampleCount()
+			h = hist
+		}
+	}
+	return h
+}
+
+// pickWorkqueueHist returns the histogram for the workqueue metric matching the controller name.
+func pickWorkqueueHist(controllerName string, mf *dto.MetricFamily) *dto.Histogram {
+	for _, m := range mf.GetMetric() {
+		if hasLabel(m, "name", controllerName) {
+			return m.GetHistogram()
+		}
+	}
+	return nil
+}
+
+// sumReconcileTotals returns the total and error reconcile counts for the given controller.
+func sumReconcileTotals(controllerName string, mf *dto.MetricFamily) (total, errors float64) {
+	for _, m := range mf.GetMetric() {
+		if !hasLabel(m, "controller", controllerName) {
+			continue
+		}
+		total += m.GetCounter().GetValue()
+		if hasLabel(m, "result", "error") {
+			errors += m.GetCounter().GetValue()
+		}
+	}
+	return
 }
 
 // HistogramPercentile returns the approximate p-th percentile value (p in [0,1]) from a dto.Histogram

--- a/pkg/perf/resources.go
+++ b/pkg/perf/resources.go
@@ -1,0 +1,256 @@
+// /*
+// Copyright © The ESO Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+//go:build perf
+
+package perf
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
+)
+
+const createConcurrency = 64
+
+// CreateNamespaces creates n namespaces with the given prefix, up to createConcurrency at a time.
+// Returns the list of created namespace names.
+func CreateNamespaces(ctx context.Context, c client.Client, n int, prefix string) ([]string, error) {
+	names := make([]string, n)
+	for i := range names {
+		names[i] = fmt.Sprintf("%s-%05d", prefix, i)
+	}
+
+	sem := make(chan struct{}, createConcurrency)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var firstErr error
+
+	for _, name := range names {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(nsName string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}
+			if err := c.Create(ctx, ns); err != nil {
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = err
+				}
+				mu.Unlock()
+			}
+		}(name)
+	}
+	wg.Wait()
+	return names, firstErr
+}
+
+// CreateSecretStores creates one SecretStore per namespace, all referencing providerSpec.
+func CreateSecretStores(ctx context.Context, c client.Client, namespaces []string, providerSpec *esv1.SecretStoreProvider) error {
+	sem := make(chan struct{}, createConcurrency)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var firstErr error
+
+	for _, ns := range namespaces {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(namespace string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			store := &esv1.SecretStore{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "perf-store",
+					Namespace: namespace,
+				},
+				Spec: esv1.SecretStoreSpec{
+					Provider: providerSpec,
+				},
+			}
+			if err := c.Create(ctx, store); err != nil {
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = err
+				}
+				mu.Unlock()
+			}
+		}(ns)
+	}
+	wg.Wait()
+	return firstErr
+}
+
+// CreateExternalSecrets creates n ExternalSecrets in a single namespace, all referencing storeRef.
+// Each ES requests one key ("perf-key") from the store, with the given refreshInterval.
+func CreateExternalSecrets(ctx context.Context, c client.Client, namespace string, n int, storeRef esv1.SecretStoreRef, refreshInterval time.Duration) error {
+	sem := make(chan struct{}, createConcurrency)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var firstErr error
+
+	for i := range n {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(idx int) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			es := &esv1.ExternalSecret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("perf-es-%05d", idx),
+					Namespace: namespace,
+				},
+				Spec: esv1.ExternalSecretSpec{
+					SecretStoreRef:  storeRef,
+					RefreshInterval: &metav1.Duration{Duration: refreshInterval},
+					Target: esv1.ExternalSecretTarget{
+						Name: fmt.Sprintf("perf-secret-%05d", idx),
+					},
+					Data: []esv1.ExternalSecretData{
+						{
+							SecretKey: "perf-key",
+							RemoteRef: esv1.ExternalSecretDataRemoteRef{
+								Key: "perf-remote-key",
+							},
+						},
+					},
+				},
+			}
+			if err := c.Create(ctx, es); err != nil {
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = err
+				}
+				mu.Unlock()
+			}
+		}(i)
+	}
+	wg.Wait()
+	return firstErr
+}
+
+// WaitAllReady polls until n ExternalSecrets in namespace all have Ready=True, or timeout is reached.
+// Returns the elapsed time from the first call until all are ready.
+func WaitAllReady(ctx context.Context, c client.Client, namespace string, n int, timeout time.Duration) (time.Duration, error) {
+	start := time.Now()
+	deadline := start.Add(timeout)
+	for time.Now().Before(deadline) {
+		esList := &esv1.ExternalSecretList{}
+		if err := c.List(ctx, esList, client.InNamespace(namespace)); err != nil {
+			return 0, err
+		}
+		ready := 0
+		for i := range esList.Items {
+			if isESReady(&esList.Items[i]) {
+				ready++
+			}
+		}
+		if ready >= n {
+			return time.Since(start), nil
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	return 0, fmt.Errorf("timeout after %s waiting for %d ExternalSecrets to be Ready in %s", timeout, n, namespace)
+}
+
+// WaitAllStoresReady polls until every namespace in namespaces has its "perf-store" SecretStore
+// at Ready=True, or timeout is reached. Uses a single global List for efficiency.
+func WaitAllStoresReady(ctx context.Context, c client.Client, namespaces []string, timeout time.Duration) (time.Duration, error) {
+	nsSet := make(map[string]struct{}, len(namespaces))
+	for _, ns := range namespaces {
+		nsSet[ns] = struct{}{}
+	}
+	expected := len(namespaces)
+
+	start := time.Now()
+	deadline := start.Add(timeout)
+	for time.Now().Before(deadline) {
+		storeList := &esv1.SecretStoreList{}
+		if err := c.List(ctx, storeList); err != nil {
+			return 0, err
+		}
+		ready := 0
+		for i := range storeList.Items {
+			s := &storeList.Items[i]
+			if _, ok := nsSet[s.Namespace]; !ok {
+				continue
+			}
+			if isStoreReady(s) {
+				ready++
+			}
+		}
+		if ready >= expected {
+			return time.Since(start), nil
+		}
+		time.Sleep(time.Second)
+	}
+	return 0, fmt.Errorf("timeout after %s waiting for %d SecretStores to be Ready", timeout, expected)
+}
+
+// WaitAllReadyMultiNS polls until (len(namespaces) * perNS) ExternalSecrets across all listed
+// namespaces reach Ready=True. Uses a global List for efficiency at scale.
+func WaitAllReadyMultiNS(ctx context.Context, c client.Client, namespaces []string, perNS int, timeout time.Duration) (time.Duration, error) {
+	nsSet := make(map[string]struct{}, len(namespaces))
+	for _, ns := range namespaces {
+		nsSet[ns] = struct{}{}
+	}
+	expected := len(namespaces) * perNS
+
+	start := time.Now()
+	deadline := start.Add(timeout)
+	for time.Now().Before(deadline) {
+		esList := &esv1.ExternalSecretList{}
+		if err := c.List(ctx, esList); err != nil {
+			return 0, err
+		}
+		ready := 0
+		for i := range esList.Items {
+			es := &esList.Items[i]
+			if _, ok := nsSet[es.Namespace]; !ok {
+				continue
+			}
+			if isESReady(es) {
+				ready++
+			}
+		}
+		if ready >= expected {
+			return time.Since(start), nil
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return 0, fmt.Errorf("timeout after %s waiting for %d ExternalSecrets to be Ready across %d namespaces", timeout, expected, len(namespaces))
+}
+
+func isESReady(es *esv1.ExternalSecret) bool {
+	cond := esv1.GetExternalSecretCondition(es.Status, esv1.ExternalSecretReady)
+	return cond != nil && cond.Status == corev1.ConditionTrue
+}
+
+func isStoreReady(store *esv1.SecretStore) bool {
+	for _, c := range store.Status.Conditions {
+		if c.Type == esv1.SecretStoreReady && c.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/perf/results.go
+++ b/pkg/perf/results.go
@@ -1,0 +1,80 @@
+// /*
+// Copyright © The ESO Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+//go:build perf
+
+package perf
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// PerfResult holds the measurements from one perf scenario run.
+type PerfResult struct {
+	Plan           string  `json:"plan"`
+	Scenario       string  `json:"scenario"`
+	NumStores      int     `json:"num_stores"`
+	NumESPerStore  int     `json:"num_es_per_store"`
+	Concurrency    int     `json:"concurrency"`
+	WallTimeSec    float64 `json:"wall_time_sec"`
+	ThroughputRPS  float64 `json:"throughput_rps"`
+	ReconcileP50ms float64 `json:"reconcile_p50_ms"`
+	ReconcileP90ms float64 `json:"reconcile_p90_ms"`
+	ReconcileP99ms float64 `json:"reconcile_p99_ms"`
+	QueueP50ms     float64 `json:"queue_p50_ms"`
+	QueueP90ms     float64 `json:"queue_p90_ms"`
+	HeapDeltaMB    float64 `json:"heap_delta_mb"`
+	NumGCDelta     uint32  `json:"num_gc_delta"`
+	PauseTotalMs   float64 `json:"pause_total_ms"`
+	ErrorsDelta    float64 `json:"errors_delta"`
+	// Per-object metrics normalise heap and GC cost by the number of reconciled
+	// objects so that results are comparable across different N values.
+	TotalObjects       int     `json:"total_objects"`
+	HeapBytesPerObject float64 `json:"heap_bytes_per_object"`
+	GCsPerKObject      float64 `json:"gcs_per_k_object"`
+}
+
+// WriteResultsJSON writes results to perf-results-<RFC3339>.json in dir.
+func WriteResultsJSON(results []PerfResult, dir string) error {
+	name := fmt.Sprintf("perf-results-%s.json", time.Now().UTC().Format("20060102T150405Z"))
+	path := filepath.Join(dir, name)
+	data, err := json.MarshalIndent(results, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+// PrintResultsTable writes an ASCII table of results to w.
+func PrintResultsTable(results []PerfResult, w io.Writer) {
+	fmt.Fprintf(w, "\n%-30s %-8s %-8s %-8s %-10s %-10s %-10s %-10s %-10s %-10s %-12s %-10s\n",
+		"Scenario", "Stores", "ES/Store", "Workers",
+		"Wall(s)", "RPS", "P50(ms)", "P90(ms)", "P99(ms)", "HeapΔ(MB)", "Heap/Obj(B)", "GC/kObj")
+	fmt.Fprintf(w, "%s\n", "-----------------------------------------------------------"+
+		"-------------------------------------------------------------------")
+	for _, r := range results {
+		fmt.Fprintf(w, "%-30s %-8d %-8d %-8d %-10.2f %-10.1f %-10.2f %-10.2f %-10.2f %-10.2f %-12.0f %-10.2f\n",
+			r.Scenario, r.NumStores, r.NumESPerStore, r.Concurrency,
+			r.WallTimeSec, r.ThroughputRPS, r.ReconcileP50ms, r.ReconcileP90ms, r.ReconcileP99ms,
+			r.HeapDeltaMB, r.HeapBytesPerObject, r.GCsPerKObject)
+	}
+	fmt.Fprintln(w)
+}

--- a/pkg/perf/steady-es/doc.go
+++ b/pkg/perf/steady-es/doc.go
@@ -1,0 +1,33 @@
+// /*
+// Copyright © The ESO Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+//go:build perf
+
+// Package steady_es measures ExternalSecret reconciliation during steady-state operation:
+// objects are created and allowed to settle (2× refreshInterval) before any metrics are
+// captured, so the observation window reflects only routine re-reconciliation behaviour —
+// not the initial creation burst.
+//
+// Run with:
+//
+//	go test -v -tags=perf -timeout=60m ./pkg/perf/steady-es/...
+//
+// Environment variables:
+//
+//	PERF_ES_CONCURRENCY        MaxConcurrentReconciles for the ES controller (default 4)
+//	PERF_REQUEUE_INTERVAL_SECS RefreshInterval set on each ES, and the controller fallback (default 30)
+//	PERF_OBSERVATION_CYCLES    Number of refreshInterval-lengths to observe (default 3)
+package steady_es

--- a/pkg/perf/steady-es/doc.go
+++ b/pkg/perf/steady-es/doc.go
@@ -30,4 +30,6 @@
 //	PERF_ES_CONCURRENCY        MaxConcurrentReconciles for the ES controller (default 4)
 //	PERF_REQUEUE_INTERVAL_SECS RefreshInterval set on each ES, and the controller fallback (default 30)
 //	PERF_OBSERVATION_CYCLES    Number of refreshInterval-lengths to observe (default 3)
+//	PERF_QPS                   Client-side QPS for the REST client (default 500)
+//	PERF_BURST                 Client-side burst for the REST client (default 1000)
 package steady_es

--- a/pkg/perf/steady-es/steady_test.go
+++ b/pkg/perf/steady-es/steady_test.go
@@ -1,0 +1,106 @@
+// /*
+// Copyright © The ESO Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+//go:build perf
+
+package steady_es
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	perf "github.com/external-secrets/external-secrets/pkg/perf"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ExternalSecret steady-state reconciliation", func() {
+	DescribeTable("N ExternalSecrets, observe K requeue cycles after warmup",
+		func(n int) {
+			ctx := context.Background()
+			concurrency := perf.EnvOrInt("PERF_ES_CONCURRENCY", 4)
+			requeueSecs := perf.EnvOrInt("PERF_REQUEUE_INTERVAL_SECS", 30)
+			refreshInterval := time.Duration(requeueSecs) * time.Second
+			observationCycles := perf.EnvOrInt("PERF_OBSERVATION_CYCLES", 3)
+			scenario := fmt.Sprintf("steady-n%d-c%d-r%ds-k%d", n, concurrency, requeueSecs, observationCycles)
+
+			By(fmt.Sprintf("creating %d ExternalSecrets with refreshInterval=%s", n, refreshInterval))
+			Expect(perf.CreateExternalSecrets(ctx, k8sClient, testNamespace, n, storeRef, refreshInterval)).To(Succeed())
+
+			By("waiting for all to reach Ready (warmup, not measured)")
+			_, err := perf.WaitAllReady(ctx, k8sClient, testNamespace, n, 30*time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Wait 2 full refresh intervals before starting measurement.
+			// This lets the initial requeue wave drain through the controller before we start capturing metrics
+			// so the observation window reflects only routine steady-state re-reconciliations. 
+			By(fmt.Sprintf("settling: waiting 2 * refreshInterval (%s)", 2*refreshInterval))
+			time.Sleep(2 * refreshInterval)
+
+			By(fmt.Sprintf("observation window: %d * refreshInterval (%s)", observationCycles, time.Duration(observationCycles)*refreshInterval))
+			before := perf.Snapshot("externalsecret")
+			windowStart := time.Now()
+			time.Sleep(time.Duration(observationCycles) * refreshInterval)
+			after := perf.Snapshot("externalsecret")
+			wallTime := time.Since(windowStart)
+
+			reconcileDelta, errorsDelta, heapDelta, gcDelta := perf.DiffSnapshots(before, after)
+
+			result := perf.PerfResult{
+				Plan:          "steady-state",
+				Scenario:      scenario,
+				NumStores:     1,
+				NumESPerStore: n,
+				Concurrency:   concurrency,
+				WallTimeSec:   wallTime.Seconds(),
+				// ThroughputRPS reflects how many re-reconciliations the controller
+				// completed per second during the observation window, not a fixed N/t.
+				ThroughputRPS:  reconcileDelta / wallTime.Seconds(),
+				ReconcileP50ms: perf.HistogramPercentile(after.ReconcileTime, 0.50) * 1000,
+				ReconcileP90ms: perf.HistogramPercentile(after.ReconcileTime, 0.90) * 1000,
+				ReconcileP99ms: perf.HistogramPercentile(after.ReconcileTime, 0.99) * 1000,
+				QueueP50ms:     perf.HistogramPercentile(after.QueueDuration, 0.50) * 1000,
+				QueueP90ms:     perf.HistogramPercentile(after.QueueDuration, 0.90) * 1000,
+				HeapDeltaMB:    float64(heapDelta) / (1024 * 1024),
+				NumGCDelta:     gcDelta,
+				PauseTotalMs:   float64(after.PauseTotalNs-before.PauseTotalNs) / 1e6,
+				ErrorsDelta:    errorsDelta,
+				TotalObjects:   n + 1, // n ES + 1 Store
+				// HeapBytesPerObject and GCsPerKObject normalise cost by the number of
+				// managed objects so results are comparable across different N values.
+				HeapBytesPerObject: float64(heapDelta) / float64(n+1),
+				GCsPerKObject:      float64(gcDelta) / float64(n+1) * 1000,
+			}
+
+			AddReportEntry("perf-result", result)
+			allResults = append(allResults, result)
+
+			GinkgoWriter.Printf(
+				"\n[steady] n=%d concurrency=%d refreshInterval=%s observationCycles=%d wall=%.2fs rps=%.1f p50=%.2fms p90=%.2fms p99=%.2fms heap/obj=%.0fB gc/kobj=%.2f errors=%.0f\n",
+				n, concurrency, refreshInterval, observationCycles,
+				result.WallTimeSec, result.ThroughputRPS,
+				result.ReconcileP50ms, result.ReconcileP90ms, result.ReconcileP99ms,
+				result.HeapBytesPerObject, result.GCsPerKObject, errorsDelta,
+			)
+		},
+		Entry("N=100", 100),
+		Entry("N=500", 500),
+		Entry("N=1000", 1000),
+		Entry("N=5000", 5000),
+	)
+})

--- a/pkg/perf/steady-es/suite_test.go
+++ b/pkg/perf/steady-es/suite_test.go
@@ -174,7 +174,20 @@ var _ = BeforeEach(func() {
 })
 
 var _ = AfterEach(func() {
-	Expect(k8sClient.Delete(context.Background(), &v1.Namespace{
+	ctx := context.Background()
+	// envtest has no namespace or GC controller, so namespace deletion does not cascade.
+	// Explicitly remove all ExternalSecrets and SecretStores and wait for them to be gone
+	// so their reconciliations don't bleed into subsequent table entries.
+	Expect(k8sClient.DeleteAllOf(ctx, &esv1.ExternalSecret{}, client.InNamespace(testNamespace))).To(Succeed())
+	Expect(k8sClient.DeleteAllOf(ctx, &esv1.SecretStore{}, client.InNamespace(testNamespace))).To(Succeed())
+	Eventually(func() int {
+		esList := &esv1.ExternalSecretList{}
+		_ = k8sClient.List(ctx, esList, client.InNamespace(testNamespace))
+		ssList := &esv1.SecretStoreList{}
+		_ = k8sClient.List(ctx, ssList, client.InNamespace(testNamespace))
+		return len(esList.Items) + len(ssList.Items)
+	}, 60*time.Second, time.Second).Should(BeZero())
+	Expect(k8sClient.Delete(ctx, &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: testNamespace},
 	})).To(Succeed())
 })

--- a/pkg/perf/steady-es/suite_test.go
+++ b/pkg/perf/steady-es/suite_test.go
@@ -1,0 +1,197 @@
+// /*
+// Copyright © The ESO Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+//go:build perf
+
+package steady_es
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go.uber.org/zap/zapcore"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
+	genv1alpha1 "github.com/external-secrets/external-secrets/apis/generators/v1alpha1"
+	ctrlcommon "github.com/external-secrets/external-secrets/pkg/controllers/common"
+	"github.com/external-secrets/external-secrets/pkg/controllers/externalsecret"
+	"github.com/external-secrets/external-secrets/pkg/controllers/externalsecret/esmetrics"
+	ctrlmetrics "github.com/external-secrets/external-secrets/pkg/controllers/metrics"
+	perf "github.com/external-secrets/external-secrets/pkg/perf"
+	"github.com/external-secrets/external-secrets/runtime/testing/fake"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	testEnv      *envtest.Environment
+	k8sClient    client.Client
+	cancelSuite  context.CancelFunc
+	fakeProvider *fake.Client
+
+	testNamespace string
+	storeRef      esv1.SecretStoreRef
+
+	allResults []perf.PerfResult
+)
+
+func TestPerf(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Steady-State Perf Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.Level(zapcore.WarnLevel)))
+
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "deploy", "crds")},
+	}
+	testEnv.ControlPlane.GetAPIServer().Configure().
+		Set("max-requests-inflight", "1000").
+		Set("max-mutating-requests-inflight", "500")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancelSuite = cancel
+
+	cfg, err := testEnv.Start()
+	Expect(err).ToNot(HaveOccurred())
+
+	cfg.QPS = float32(perf.EnvOrInt("PERF_QPS", 500))
+	cfg.Burst = perf.EnvOrInt("PERF_BURST", 1000)
+
+	Expect(esv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(genv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme.Scheme,
+		Metrics: server.Options{BindAddress: "0"},
+		Client: client.Options{
+			Cache: &client.CacheOptions{
+				DisableFor: []client.Object{&v1.Secret{}, &v1.ConfigMap{}},
+			},
+		},
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).ToNot(HaveOccurred())
+
+	secretClient, err := ctrlcommon.BuildManagedSecretClient(mgr, "")
+	Expect(err).ToNot(HaveOccurred())
+
+	requeueInterval := time.Duration(perf.EnvOrInt("PERF_REQUEUE_INTERVAL_SECS", 30)) * time.Second
+
+	Expect((&externalsecret.Reconciler{
+		Client:                             mgr.GetClient(),
+		SecretClient:                       secretClient,
+		EnableSecretAPIReadOnCacheMismatch: true,
+		RestConfig:                         cfg,
+		Scheme:                             mgr.GetScheme(),
+		Log:                                ctrl.Log.WithName("controllers").WithName("ExternalSecrets"),
+		RequeueInterval:                    requeueInterval,
+		ClusterSecretStoreEnabled:          true,
+	}).SetupWithManager(ctx, mgr, controller.Options{
+		MaxConcurrentReconciles: perf.EnvOrInt("PERF_ES_CONCURRENCY", 4),
+		RateLimiter:             ctrlcommon.BuildRateLimiter(),
+	})).To(Succeed())
+
+	go func() {
+		defer GinkgoRecover()
+		Expect(mgr.Start(ctx)).To(Succeed())
+	}()
+})
+
+var _ = AfterSuite(func() {
+	cancelSuite()
+
+	// Work around a controller-runtime race (https://github.com/kubernetes-sigs/controller-runtime/issues/1571)
+	// where the manager has not yet released its API server connections by the time Stop() is called,
+	// causing envtest to fail tearing down the control plane. Retrying with exponential backoff gives the
+	// manager enough time to drain its connections and exit cleanly.
+	sleepTime := time.Millisecond
+	var err error
+	for range 12 {
+		if err = testEnv.Stop(); err == nil {
+			break
+		}
+		sleepTime *= 2
+		time.Sleep(sleepTime)
+	}
+	Expect(err).ToNot(HaveOccurred())
+
+	if len(allResults) > 0 {
+		Expect(perf.WriteResultsJSON(allResults, ".")).To(Succeed())
+		perf.PrintResultsTable(allResults, GinkgoWriter)
+	}
+})
+
+var _ = BeforeEach(func() {
+	ns := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "perf-steady-",
+		},
+	}
+	Expect(k8sClient.Create(context.Background(), ns)).To(Succeed())
+	testNamespace = ns.Name
+
+	store := &esv1.SecretStore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "perf-store",
+			Namespace: testNamespace,
+		},
+		Spec: esv1.SecretStoreSpec{
+			Provider: fakeProviderSpec(),
+		},
+	}
+	Expect(k8sClient.Create(context.Background(), store)).To(Succeed())
+	storeRef = esv1.SecretStoreRef{Name: store.Name}
+})
+
+var _ = AfterEach(func() {
+	Expect(k8sClient.Delete(context.Background(), &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: testNamespace},
+	})).To(Succeed())
+})
+
+func fakeProviderSpec() *esv1.SecretStoreProvider {
+	return &esv1.SecretStoreProvider{
+		AWS: &esv1.AWSProvider{
+			Service: esv1.AWSServiceSecretsManager,
+		},
+	}
+}
+
+func init() {
+	fakeProvider = fake.New()
+	fakeProvider.WithGetSecret([]byte("perf-value"), nil)
+	esv1.ForceRegister(fakeProvider, fakeProviderSpec(), esv1.MaintenanceStatusMaintained)
+
+	ctrlmetrics.SetUpLabelNames(false)
+	esmetrics.SetUpMetrics()
+}

--- a/pkg/perf/util.go
+++ b/pkg/perf/util.go
@@ -1,0 +1,35 @@
+// /*
+// Copyright © The ESO Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+//go:build perf
+
+// Package perf provides shared helpers for performance test suites.
+package perf
+
+import (
+	"os"
+	"strconv"
+)
+
+// EnvOrInt reads an integer environment variable, returning defaultVal if unset or invalid.
+func EnvOrInt(key string, defaultVal int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return defaultVal
+}


### PR DESCRIPTION
## Problem Statement

Without this, there is no way to observe the performance of our operator in a consistent manner.

This is a problem, as our future refactors will cause us to wonder what is the performance improvement of our changes.

This fixes it by introducing a whole suite of benchmark tools:

- First one is a burst ES creation tool: It creates many ES for a single SecretStore, analyzing the time to ready. This should give an idea on how the controller behaves at start time, or at a burst of creation (quite rare). This will therefore analyse if (when many secrets are used) there are non-linear behaviours when we scale the amount of secrets, revealing scalability issues
- Second one is a burst of SecretStores. As secretstores are close to no-op and their amount is generally small, this test is only useful to test if a large amount of secretstores messes the controller. I hope it would reveal bad code. This was not hard to implement when the first one was done.
- Third one is a fanout of the first two scenarios: Each SecretStore would get an amount of ES, spreading the load. The idea here would be to have a test that is a more accurate representation of the start or recovery of a multi-tenant cluster with many SecretStores/ES
- The fourth one is the settle test for ES: After the creation of many ES, we will be analyzing the runtime behaviour of ESO while the secrets are syncing due to their refresh intervals. After waiting for the initial wave of ES creation to settle, we will start measuring the runtime info after 3 syncs.

To be worth noting:
I have had issues on my machine with 50k ES, where the tests takes far more than 5x the wall time of an 10k ES test.
The non-linear behaviour is to be investigated separately.

For information: To optimize and prevent this issue, this code allow tweaking of concurrency, timeouts, client-side limits, refreshInterval of ESes, and API server configuration (QPS, ...).

What is the problem you're trying to solve?

## Related Issue

https://github.com/external-secrets/external-secrets/issues/5924

## Proposed Changes

Well, it's just an idea so far: Have a test suite we can run when we want. It's dead code if we don't maintain it though, so I REALLY ENCOURAGE US TO THINK ABOUT IT TWICE.

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] My changes have reasonable test coverage
- [X] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR introduces a comprehensive performance benchmarking suite for the External Secrets Operator, adding four perf scenarios plus supporting tooling and portability fixes.

Scenarios
- Burst ExternalSecret Creation (pkg/perf/burst-es): create many ExternalSecrets against a single SecretStore and measure time-to-ready and reconcile/queue latencies.
- Burst SecretStore Creation (pkg/perf/burst-ss): create many SecretStores (one per namespace) to measure store reconciler throughput.
- Fanout (pkg/perf/fanout): distribute ExternalSecrets across many SecretStores to simulate multi-tenant startup/recovery.
- Steady (pkg/perf/steady-es): measure steady-state reconciliation after objects settle across periodic sync cycles.

Key additions
- Ginkgo-based perf test packages (//go:build perf) with parameterized test entries (100, 500, 1000, 5000) and tunable env vars.
- Metric helpers (pkg/perf/metrics.go) to snapshot controller-runtime Prometheus histograms and runtime.MemStats, compute percentiles and deltas.
- Resource helpers (pkg/perf/resources.go) to concurrently create namespaces, SecretStores, ExternalSecrets and wait-for-ready utilities (single and multi-NS).
- Result reporting (pkg/perf/results.go) with PerfResult struct, JSON output (timestamped perf-results-*.json) and ASCII table printing.
- Makefile targets to run each perf scenario (perf-test-*) that set env vars, prepare envtest assets, run tests and tee logs.
- Utility EnvOrInt (pkg/perf/util.go) and package docs for each scenario.
- .gitignore updated to ignore perf result/log files.

Robustness/portability fixes
- Portable shell invocation and perf log ignore added.
- Increased client QPS/Burst after testEnv.Start to reduce throttling.
- Use uncached client where appropriate to avoid “cache not started” races.
- Exponential-backoff retries around testEnv.Stop to handle controller-runtime shutdown races.
- Test cleanup tightened: explicit deletion of ExternalSecrets/SecretStores and waits to avoid cross-test bleed.
- Measurement and reporting refinements and various small portability/cleanup commits.

Configurability and notes
- Tunables via env vars: PERF_ES_CONCURRENCY, PERF_STORE_CONCURRENCY, PERF_NUM_STORES, PERF_ES_PER_STORE, PERF_QPS, PERF_BURST, PERF_REQUEUE_INTERVAL_SECS, PERF_OBSERVATION_CYCLES, etc.
- Author observed non-linear scaling when increasing from 10k→50k ExternalSecrets on their machine; investigation deferred.
- Contribution checklist largely followed (signed commits, tests pass with make test); make reviewable not completed.

Primary files: pkg/perf/* (new suites, metrics, resources, results), Makefile (new perf targets), .gitignore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->