### PR TITLE
fix(build): use buildx --load and non-registry image tag

### DIFF
--- a/hack/api-docs/Makefile
+++ b/hack/api-docs/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 DOCKER ?= docker
-MKDOCS_IMAGE ?= github.com/external-secrets-mkdocs:latest
+MKDOCS_IMAGE ?= eso-mkdocs:latest
 MKDOCS ?= mkdocs
 MIKE ?= mike
 DOCS_VERSION ?= main
@@ -47,7 +47,7 @@ all: build
 
 .PHONY: image
 image:
-	$(DOCKER) build -t $(MKDOCS_IMAGE) -f Dockerfile .
+	$(DOCKER) buildx build --load -t $(MKDOCS_IMAGE) -f Dockerfile .
 
 VERSION_TO_UPDATE ?= $(shell echo $(MAJOR_VERSION).$(MINOR_VERSION).x)
 


### PR DESCRIPTION
## Problem Statement

`make docs` (and `make reviewable`, which calls it) fails on macOS when Orbstack is the active Docker engine. The `hack/api-docs` `image` target builds a local mkdocs image, then immediately runs it -- but on Orbstack the built image is not visible to the local store that `docker run` consults. The tag `github.com/external-secrets-mkdocs:latest` is also a valid OCI registry reference, so the local miss escalates to a remote pull from `github.com`, which does not exist, producing a confusing "not found" error instead of a clear "no such local image".

## Related Issue

Fixes #6414

## Proposed Changes

Two changes to `hack/api-docs/Makefile` that make the image build engine-agnostic:

1. Switch the `image` target from `docker build` to `docker buildx build --load`. The `--load` flag explicitly writes the built image into the local store, making it available to the subsequent `docker run` regardless of which engine or BuildKit backend is active.

2. Rename the default image tag from `github.com/external-secrets-mkdocs:latest` to `eso-mkdocs:latest`. The old name is shaped like an OCI registry reference (host `github.com`), so the Docker daemon treats a local miss as a pull attempt. A plain name like `eso-mkdocs:latest` has no registry prefix, so a local miss fails immediately with a clear "image not found" error and no remote call.

Both variables (`DOCKER` and `MKDOCS_IMAGE`) remain overridable via environment for CI and other workflows that need custom values.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage (build-tooling change only, no code paths to test)
- [x] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable` (this PR *fixes* `make reviewable` on Orbstack; verified under Docker Desktop where the existing behavior already worked)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix: Use buildx --load and non-registry image tag for docs builds

**Problem:** On macOS with Orbstack, `make docs` and `make reviewable` fail because the built mkdocs image isn't visible to `docker run`. The registry-shaped tag `github.com/external-secrets-mkdocs:latest` triggers remote pull attempts on local misses.

**Solution:** 
- Changed `MKDOCS_IMAGE` default from `github.com/external-secrets-mkdocs:latest` to `eso-mkdocs:latest` to avoid registry-shaped tags
- Updated the `image` target to use `docker buildx build --load` instead of `docker build` to ensure the built image is written to the local store and available to subsequent `docker run` commands

Both `DOCKER` and `MKDOCS_IMAGE` remain overridable via environment variables for CI and custom workflows. Verified on both Orbstack and Docker Desktop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->