### PR TITLE
feat(keepersecurity): throttle/429 retry, shared cache, find.path, notation, real Validate

### DIFF
--- a/docs/provider/keeper-security.md
+++ b/docs/provider/keeper-security.md
@@ -41,7 +41,7 @@ Be sure the `keepersecurity` provider is listed in the `Kind=SecretStore`
 ## External Secrets
 ### Behavior
 * How a Record is equated to an ExternalSecret:
-    * `remoteRef.key` is equated to a Record's ID
+    * `remoteRef.key` is equated to a Record's ID, **or** a [Keeper Notation](https://docs.keeper.io/en/secrets-manager/secrets-manager/about/keeper-notation) expression when prefixed with `keeper://` (see [Keeper Notation](#keeper-notation) below). ID lookup is the default; record **title** lookup only happens when `getByTitleFallback` is enabled on the SecretStore.
     * `remoteRef.property` is equated to one of the following options:
         * Fields: Record's field's Label (if present), otherwise [Record's field's Type](https://docs.keeper.io/secrets-manager/secrets-manager/about/field-record-types)
         * CustomFields: Record's field's Label
@@ -49,12 +49,49 @@ Be sure the `keepersecurity` provider is listed in the `Kind=SecretStore`
         * If empty, defaults to the complete Record in JSON format
     * `remoteRef.version` is currently not supported.
 * `dataFrom`:
-    * `find.path` is currently not supported.
-    * `find.name.regexp` is equated to one of the following options:
-        * Fields: Record's field's Label (if present), otherwise Record's field's Type
-        * CustomFields: Record's field's Label
-        * Files: Record's file's Name
+    * `find.path` filters records by their **folder path** (e.g. `Production/Databases`). Matching is by prefix, so the path and everything beneath it is returned.
+    * `find.name.regexp` matches the record's **title** (regular expression).
     * `find.tags` are not supported at this time.
+
+### Keeper Notation
+
+`remoteRef.key` accepts a [Keeper Notation](https://docs.keeper.io/en/secrets-manager/secrets-manager/about/keeper-notation) expression to pull a specific field, custom field, or file out of a record. It must be prefixed with `keeper://`:
+
+```yaml
+  data:
+    - secretKey: username
+      remoteRef:
+        key: keeper://<recordUID|title>/field/login
+    - secretKey: password
+      remoteRef:
+        key: keeper://<recordUID|title>/field/password
+    - secretKey: token
+      remoteRef:
+        key: keeper://<recordUID|title>/custom_field/API Token
+```
+
+Array indexes and predicates are supported (e.g. `keeper://<uid>/field/phone[0]`, `keeper://<uid>/field/name[first]`). A key without the `keeper://` prefix is treated as a plain record key — a UID by default, or a title only when `getByTitleFallback` is enabled on the SecretStore.
+
+### Finding records by folder path
+
+`dataFrom.find.path` returns every record at (or beneath) a folder path:
+
+```yaml
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: by-folder
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: SecretStore
+    name: keeper
+  target:
+    name: by-folder
+  dataFrom:
+    - find:
+        path: "Production/Databases"   # all records in this folder and its subfolders
+```
 
 **NOTE:** For complex [types](https://docs.keeper.io/secrets-manager/secrets-manager/about/field-record-types), like name, phone, bankAccount, which does not match with a single string value, external secrets will return the complete json string. Use the json template functions to decode.
 
@@ -76,7 +113,24 @@ There are some limitations using this provider.
 
 * Keeper Secret Manager does not work with `General` Records types nor legacy non-typed records
 * Using tags `find.tags` is not supported by KSM
-* Using path `find.path` is not supported at the moment
+
+## Performance & rate-limit tuning
+
+Keeper Secrets Manager throttles per device (a `403 {"error":"throttled"}` at the application layer, and a `429 Too Many Requests` at the edge). Two built-in behaviors keep the provider within those limits at scale:
+
+* **Throttle/429 retry (on by default).** Read and write calls that hit a throttle (`403`) or `429` are retried with exponential backoff + jitter, instead of surfacing as an `ExternalSecret` sync error. Non-rate-limit errors are returned immediately.
+* **Shared record cache (opt-in).** A single `get_secret` call returns every record the application can read. Enabling the cache lets one fetch serve a whole reconcile wave of `ExternalSecrets` (and `Validate`) instead of one backend call per `ExternalSecret`, which is the main lever for large fleets.
+
+Configure via environment variables on the `external-secrets` controller:
+
+| Variable | Default | Description |
+|---|---|---|
+| `KEEPER_RECORD_CACHE_TTL_MS` | `0` (disabled) | TTL in milliseconds for the shared record/folder cache. Set e.g. `30000` to dedupe bursts; writes invalidate the cache immediately. |
+| `KEEPER_THROTTLE_RETRY_ATTEMPTS` | `4` | Max attempts (including the first) for a throttled call. |
+| `KEEPER_THROTTLE_RETRY_BASE_MS` | `500` | Base backoff in milliseconds (doubles each attempt). |
+| `KEEPER_THROTTLE_RETRY_MAX_MS` | `10000` | Backoff ceiling in milliseconds. |
+
+For very large deployments, also stagger `refreshInterval` across `ExternalSecrets` and raise the controller's `--concurrent` flag.
 
 ## Push Secrets
 

--- a/providers/v1/keepersecurity/cache.go
+++ b/providers/v1/keepersecurity/cache.go
@@ -1,0 +1,276 @@
+/*
+Copyright © The ESO Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keepersecurity
+
+import (
+	"context"
+	crand "crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"math/big"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	ksm "github.com/keeper-security/secrets-manager-go/core"
+)
+
+// Resilience knobs (env-overridable):
+//   - Throttle/429 retry is ON by default (pure resilience; only triggers on rate-limit errors).
+//   - The shared record cache is OPT-IN via KEEPER_RECORD_CACHE_TTL_MS (>0 enables it).
+func envInt(key string, def int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return def
+}
+
+// waitFn sleeps for d but returns early if ctx is cancelled. Overridable in tests.
+var waitFn = func(ctx context.Context, d time.Duration) error {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-t.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// backoff returns base*2^attempt capped, plus up to 25% jitter to avoid
+// synchronized retry waves across many ExternalSecrets.
+func backoff(attempt int) time.Duration {
+	base := time.Duration(envInt("KEEPER_THROTTLE_RETRY_BASE_MS", 500)) * time.Millisecond
+	maxd := time.Duration(envInt("KEEPER_THROTTLE_RETRY_MAX_MS", 10000)) * time.Millisecond
+	d := base << attempt
+	if d > maxd {
+		d = maxd
+	}
+	// Add up to 25% jitter to de-synchronize retries across ExternalSecrets.
+	// crypto/rand is used (not math/rand) only to satisfy weak-PRNG linters; the
+	// jitter itself is not security-sensitive.
+	if j := int64(d) / 4; j > 0 {
+		if n, err := crand.Int(crand.Reader, big.NewInt(j)); err == nil {
+			d += time.Duration(n.Int64())
+		}
+	}
+	return d
+}
+
+// isRateLimited matches both the keeperapp app-throttle (403 {"error":"throttled"})
+// and the edge nginx limit (429 Too Many Requests) — the latter is what real prod
+// clients hit first and is NOT covered by the SDK's 403-only retry.
+func isRateLimited(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := strings.ToLower(err.Error())
+	return strings.Contains(s, "throttled") ||
+		strings.Contains(s, "429") ||
+		strings.Contains(s, "too many request")
+}
+
+// retryAttempts is clamped to >=1 so a misconfigured env value can never turn the
+// retry loops into zero-attempt no-ops (which would make reads return empty and
+// writes silently skip). Note: envInt is NOT clamped because 0 is meaningful for
+// other knobs (e.g. KEEPER_RECORD_CACHE_TTL_MS=0 disables the cache).
+func retryAttempts() int {
+	if n := envInt("KEEPER_THROTTLE_RETRY_ATTEMPTS", 4); n > 0 {
+		return n
+	}
+	return 1
+}
+
+// getSecretsWithRetry wraps the SDK GetSecrets with backoff on throttle (403) / 429.
+func getSecretsWithRetry(ctx context.Context, cl SecurityClient, filter []string) ([]*ksm.Record, error) {
+	attempts := retryAttempts()
+	var last error
+	for attempt := 0; attempt < attempts; attempt++ {
+		recs, err := cl.GetSecrets(filter)
+		if err == nil {
+			return recs, nil
+		}
+		if !isRateLimited(err) {
+			return nil, err
+		}
+		last = err
+		if attempt == attempts-1 {
+			break
+		}
+		if werr := waitFn(ctx, backoff(attempt)); werr != nil {
+			return nil, werr
+		}
+	}
+	return nil, last
+}
+
+// getFoldersWithRetry wraps the SDK GetFolders with backoff on throttle (403) / 429.
+func getFoldersWithRetry(ctx context.Context, cl SecurityClient) ([]*ksm.KeeperFolder, error) {
+	attempts := retryAttempts()
+	var last error
+	for attempt := 0; attempt < attempts; attempt++ {
+		folders, err := cl.GetFolders()
+		if err == nil {
+			return folders, nil
+		}
+		if !isRateLimited(err) {
+			return nil, err
+		}
+		last = err
+		if attempt == attempts-1 {
+			break
+		}
+		if werr := waitFn(ctx, backoff(attempt)); werr != nil {
+			return nil, werr
+		}
+	}
+	return nil, last
+}
+
+// withRateLimitRetry retries a write op on throttle/429. Safe because a rate-limit
+// response means the request was rejected before processing (no partial write).
+func withRateLimitRetry(ctx context.Context, op func() error) error {
+	attempts := retryAttempts()
+	var last error
+	for attempt := 0; attempt < attempts; attempt++ {
+		err := op()
+		if err == nil || !isRateLimited(err) {
+			return err
+		}
+		last = err
+		if attempt == attempts-1 {
+			break
+		}
+		if werr := waitFn(ctx, backoff(attempt)); werr != nil {
+			return werr
+		}
+	}
+	return last
+}
+
+// ---- shared record cache (opt-in) ----
+// One get_secret returns ALL records the app can read, so a short-lived shared
+// cache collapses a reconcile wave of N ExternalSecrets into a single backend call.
+
+type recordCacheEntry struct {
+	records []*ksm.Record
+	fetched time.Time
+}
+
+type recordCache struct {
+	mu sync.Mutex
+	m  map[string]recordCacheEntry
+}
+
+var sharedRecordCache = &recordCache{m: map[string]recordCacheEntry{}}
+
+// folder cache (folders change rarely; reuses the same TTL knob)
+type folderCacheEntry struct {
+	folders []*ksm.KeeperFolder
+	fetched time.Time
+}
+
+type folderCache struct {
+	mu sync.Mutex
+	m  map[string]folderCacheEntry
+}
+
+var sharedFolderCache = &folderCache{m: map[string]folderCacheEntry{}}
+
+func (fc *folderCache) get(key string, ttl time.Duration) ([]*ksm.KeeperFolder, bool) {
+	if ttl <= 0 || key == "" {
+		return nil, false
+	}
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	e, ok := fc.m[key]
+	if !ok {
+		return nil, false
+	}
+	if time.Since(e.fetched) > ttl {
+		delete(fc.m, key) // evict instead of leaking stale entries
+		return nil, false
+	}
+	return e.folders, true
+}
+
+func (fc *folderCache) set(key string, folders []*ksm.KeeperFolder) {
+	if key == "" {
+		return
+	}
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	fc.m[key] = folderCacheEntry{folders: folders, fetched: time.Now()}
+}
+
+func cacheTTL() time.Duration {
+	return time.Duration(envInt("KEEPER_RECORD_CACHE_TTL_MS", 0)) * time.Millisecond
+}
+
+func (rc *recordCache) get(key string, ttl time.Duration) ([]*ksm.Record, bool) {
+	if ttl <= 0 || key == "" {
+		return nil, false
+	}
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+	e, ok := rc.m[key]
+	if !ok {
+		return nil, false
+	}
+	if time.Since(e.fetched) > ttl {
+		delete(rc.m, key) // evict instead of leaking stale entries
+		return nil, false
+	}
+	return e.records, true
+}
+
+func (rc *recordCache) set(key string, recs []*ksm.Record) {
+	if key == "" {
+		return
+	}
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+	rc.m[key] = recordCacheEntry{records: recs, fetched: time.Now()}
+}
+
+// invalidate drops a key so a subsequent read re-fetches (called after writes).
+func (rc *recordCache) invalidate(key string) {
+	if key == "" {
+		return
+	}
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+	delete(rc.m, key)
+}
+
+func resetRecordCache() {
+	sharedRecordCache.mu.Lock()
+	sharedRecordCache.m = map[string]recordCacheEntry{}
+	sharedRecordCache.mu.Unlock()
+	sharedFolderCache.mu.Lock()
+	sharedFolderCache.m = map[string]folderCacheEntry{}
+	sharedFolderCache.mu.Unlock()
+}
+
+func hashConfig(parts ...string) string {
+	h := sha256.Sum256([]byte(strings.Join(parts, "|")))
+	return hex.EncodeToString(h[:])
+}

--- a/providers/v1/keepersecurity/client.go
+++ b/providers/v1/keepersecurity/client.go
@@ -24,6 +24,7 @@ import (
 	"maps"
 	"regexp"
 	"strings"
+	"time"
 
 	ksm "github.com/keeper-security/secrets-manager-go/core"
 	corev1 "k8s.io/api/core/v1"
@@ -72,11 +73,81 @@ type Client struct {
 	ksmClient          SecurityClient
 	folderID           string
 	getByTitleFallback bool
+	// cacheKey identifies this store's record set in the shared cache (empty -> folderID).
+	cacheKey string
+	// cacheTTL >0 enables the shared record cache for this client (0 -> env KEEPER_RECORD_CACHE_TTL_MS).
+	cacheTTL time.Duration
+}
+
+// recordCacheTTL resolves the effective cache TTL (client field, else env).
+func (c *Client) recordCacheTTL() time.Duration {
+	if c.cacheTTL > 0 {
+		return c.cacheTTL
+	}
+	return cacheTTL()
+}
+
+// recordCacheKey identifies this store's record set in the shared cache.
+func (c *Client) recordCacheKey() string {
+	if c.cacheKey != "" {
+		return c.cacheKey
+	}
+	return c.folderID
+}
+
+// getAllRecords fetches the full record set once (with throttle/429 retry) and,
+// when caching is enabled, serves a reconcile wave of N ExternalSecrets from a
+// single backend get_secret call instead of N.
+func (c *Client) getAllRecords(ctx context.Context) ([]*ksm.Record, error) {
+	key := c.recordCacheKey()
+	ttl := c.recordCacheTTL()
+	if recs, ok := sharedRecordCache.get(key, ttl); ok {
+		return recs, nil
+	}
+	records, err := getSecretsWithRetry(ctx, c.ksmClient, []string{})
+	metrics.ObserveAPICall(constants.ProviderKeeperSecurity, constants.CallKeeperSecurityGetSecrets, err)
+	if err != nil {
+		return nil, err
+	}
+	if ttl > 0 {
+		sharedRecordCache.set(key, records)
+	}
+	return records, nil
+}
+
+// getAllFolders fetches the folder hierarchy (with throttle/429 retry), cached
+// alongside records since folders change rarely. Used for dataFrom.find.path.
+func (c *Client) getAllFolders(ctx context.Context) ([]*ksm.KeeperFolder, error) {
+	key := c.recordCacheKey()
+	ttl := c.recordCacheTTL()
+	if f, ok := sharedFolderCache.get(key, ttl); ok {
+		return f, nil
+	}
+	folders, err := getFoldersWithRetry(ctx, c.ksmClient)
+	metrics.ObserveAPICall(constants.ProviderKeeperSecurity, constants.CallKeeperSecurityGetFolders, err)
+	if err != nil {
+		return nil, err
+	}
+	if ttl > 0 {
+		sharedFolderCache.set(key, folders)
+	}
+	return folders, nil
+}
+
+// recordFolderUID returns the UID of the folder directly containing the record
+// (the subfolder if present, else the shared folder).
+func recordFolderUID(r *ksm.Record) string {
+	if uid := r.InnerFolderUid(); uid != "" {
+		return uid
+	}
+	return r.FolderUid()
 }
 
 // SecurityClient defines the interface for interacting with KeeperSecurity's API.
 type SecurityClient interface {
 	GetSecrets(filter []string) ([]*ksm.Record, error)
+	GetFolders() ([]*ksm.KeeperFolder, error)
+	FindNotation(records []*ksm.Record, notation string) ([]interface{}, error)
 	GetSecretByTitle(recordTitle string) (*ksm.Record, error)
 	GetSecretsByTitle(recordTitle string) (records []*ksm.Record, err error)
 	CreateSecretWithRecordData(recUID, folderUID string, recordData *ksm.RecordCreate) (string, error)
@@ -113,25 +184,74 @@ type Secret struct {
 	Files  []File        `json:"files"`
 }
 
-// Validate performs validation of the Keeper Security client configuration.
+// Validate checks the store is actually usable by performing a real (cache-backed)
+// read against Keeper. A transient rate-limit is reported as Unknown (ignored by
+// ESO) rather than failing the store; auth/config errors are reported as Error.
+// With the record cache enabled this is effectively free (served from cache).
 func (c *Client) Validate() (esv1.ValidationResult, error) {
+	if _, err := c.getAllRecords(context.Background()); err != nil {
+		if isRateLimited(err) {
+			return esv1.ValidationResultUnknown, err
+		}
+		return esv1.ValidationResultError, err
+	}
 	return esv1.ValidationResultReady, nil
 }
 
 // GetSecret retrieves a secret from Keeper Security by ID or name.
 // It first attempts to find the secret by ID, then falls back to name lookup.
 // The name lookup must be opted in by setting getByTitleFallback on the provider.
-func (c *Client) GetSecret(_ context.Context, ref esv1.ExternalSecretDataRemoteRef) ([]byte, error) {
-	secret, err := c.findByIDWithNameFallback(ref.Key)
+func (c *Client) GetSecret(ctx context.Context, ref esv1.ExternalSecretDataRemoteRef) ([]byte, error) {
+	// Keeper Notation (e.g. keeper://<uid|title>/field/password[0], /custom_field/..., /file/...)
+	// is resolved against the (cached) record set by the SDK — no extra backend call.
+	if isKeeperNotation(ref.Key) {
+		return c.getByNotation(ctx, ref.Key)
+	}
+	secret, err := c.findByIDWithNameFallback(ctx, ref.Key)
 	if err != nil {
 		return nil, err
 	}
 	return secret.getItem(ref)
 }
 
+// isKeeperNotation reports whether key is a Keeper Notation expression. We require
+// the explicit "keeper://" prefix so a bare record UID/title is never mistaken for
+// notation (maximum backwards-compat safety).
+func isKeeperNotation(key string) bool {
+	return strings.HasPrefix(key, "keeper://")
+}
+
+// getByNotation resolves a Keeper Notation expression against all records the
+// app can read (served from cache when enabled).
+func (c *Client) getByNotation(ctx context.Context, notation string) ([]byte, error) {
+	records, err := c.getAllRecords(ctx)
+	if err != nil {
+		return nil, err
+	}
+	values, err := c.ksmClient.FindNotation(records, notation)
+	if err != nil {
+		return nil, fmt.Errorf("keeper notation %q: %w", notation, err)
+	}
+	if len(values) == 0 {
+		return nil, fmt.Errorf("keeper notation %q returned no value", notation)
+	}
+	return notationValueToBytes(values[0])
+}
+
+func notationValueToBytes(v interface{}) ([]byte, error) {
+	switch t := v.(type) {
+	case string:
+		return []byte(t), nil
+	case []byte:
+		return t, nil
+	default:
+		return json.Marshal(v)
+	}
+}
+
 // GetSecretMap retrieves a secret from Keeper Security and returns it as a map.
-func (c *Client) GetSecretMap(_ context.Context, ref esv1.ExternalSecretDataRemoteRef) (map[string][]byte, error) {
-	secret, err := c.findByIDWithNameFallback(ref.Key)
+func (c *Client) GetSecretMap(ctx context.Context, ref esv1.ExternalSecretDataRemoteRef) (map[string][]byte, error) {
+	secret, err := c.findByIDWithNameFallback(ctx, ref.Key)
 	if err != nil {
 		return nil, err
 	}
@@ -140,17 +260,22 @@ func (c *Client) GetSecretMap(_ context.Context, ref esv1.ExternalSecretDataRemo
 
 // It first attempts to find the secret by ID, then falls back to name lookup.
 // The name lookup must be opted in by setting getByTitleFallback on the provider.
-func (c *Client) findByIDWithNameFallback(key string) (*Secret, error) {
-	record, err := c.findSecretByID(key)
+func (c *Client) findByIDWithNameFallback(ctx context.Context, key string) (*Secret, error) {
+	record, err := c.findSecretByID(ctx, key)
 	if err != nil {
 		return nil, err
 	}
 
 	if record == nil && c.getByTitleFallback {
-		records, err := c.ksmClient.GetSecretsByTitle(key)
-		metrics.ObserveAPICall(constants.ProviderKeeperSecurity, constants.CallKeeperSecurityGetSecretsByTitle, err)
-		if err != nil {
-			return nil, err
+		var records []*ksm.Record
+		ferr := withRateLimitRetry(ctx, func() error {
+			var e error
+			records, e = c.ksmClient.GetSecretsByTitle(key)
+			return e
+		})
+		metrics.ObserveAPICall(constants.ProviderKeeperSecurity, constants.CallKeeperSecurityGetSecretsByTitle, ferr)
+		if ferr != nil {
+			return nil, ferr
 		}
 
 		if len(records) > 1 {
@@ -172,39 +297,83 @@ func (c *Client) findByIDWithNameFallback(key string) (*Secret, error) {
 }
 
 // GetAllSecrets retrieves all secrets from Keeper Security that match the given criteria.
-func (c *Client) GetAllSecrets(_ context.Context, ref esv1.ExternalSecretFind) (map[string][]byte, error) {
+func (c *Client) GetAllSecrets(ctx context.Context, ref esv1.ExternalSecretFind) (map[string][]byte, error) {
 	if ref.Tags != nil {
 		return nil, errors.New(errTagsNotImplemented)
 	}
-	if ref.Path != nil {
-		return nil, errors.New(errPathNotImplemented)
-	}
-	secretData := make(map[string][]byte)
-	records, err := c.findSecrets()
-	// GetAllSecrets retrieves all secrets from Keeper Security that match the given criteria.
-	// Currently supports filtering by name pattern only.
+
+	records, err := c.findSecrets(ctx)
 	if err != nil {
 		return nil, err
 	}
+	matchPath, err := c.folderPathMatcher(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+	nameRe, err := compileFindName(ref)
+	if err != nil {
+		return nil, err
+	}
+
+	secretData := make(map[string][]byte)
 	for _, record := range records {
-		secret, err := c.getValidKeeperSecret(record)
-		if err != nil {
-			return nil, err
-		}
-		match, err := regexp.MatchString(ref.Name.RegExp, secret.Title)
-		if err != nil {
-			return nil, fmt.Errorf(errInvalidRegex, ref.Name.RegExp, err)
-		}
-		if !match {
+		if !matchPath(record) {
 			continue
 		}
-		secretData[secret.Title], err = secret.getItem(esv1.ExternalSecretDataRemoteRef{})
-		if err != nil {
-			return nil, err
+		if title, value, ok := c.findRecordValue(record, nameRe); ok {
+			secretData[title] = value
 		}
 	}
 
 	return secretData, nil
+}
+
+// folderPathMatcher returns a predicate for dataFrom.find.path; when no path is
+// set it matches every record.
+func (c *Client) folderPathMatcher(ctx context.Context, ref esv1.ExternalSecretFind) (func(*ksm.Record) bool, error) {
+	if ref.Path == nil {
+		return func(*ksm.Record) bool { return true }, nil
+	}
+	folders, err := c.getAllFolders(ctx)
+	if err != nil {
+		return nil, err
+	}
+	tree := buildFolderTree(folders)
+	path := *ref.Path
+	return func(r *ksm.Record) bool {
+		return pathMatchesPrefix(tree.pathOf(recordFolderUID(r)), path)
+	}, nil
+}
+
+// compileFindName compiles dataFrom.find.name.regexp (nil when unset).
+func compileFindName(ref esv1.ExternalSecretFind) (*regexp.Regexp, error) {
+	if ref.Name == nil || ref.Name.RegExp == "" {
+		return nil, nil
+	}
+	re, err := regexp.Compile(ref.Name.RegExp)
+	if err != nil {
+		return nil, fmt.Errorf(errInvalidRegex, ref.Name.RegExp, err)
+	}
+	return re, nil
+}
+
+// findRecordValue resolves a record to its (title, value) for find. It is
+// best-effort: records that can't be represented (or don't match the name regexp)
+// are skipped (ok=false) rather than failing the whole ExternalSecret — important
+// for find.path, which sweeps entire folders.
+func (c *Client) findRecordValue(record *ksm.Record, nameRe *regexp.Regexp) (string, []byte, bool) {
+	secret, err := c.getValidKeeperSecret(record)
+	if err != nil {
+		return "", nil, false
+	}
+	if nameRe != nil && !nameRe.MatchString(secret.Title) {
+		return "", nil, false
+	}
+	value, err := secret.getItem(esv1.ExternalSecretDataRemoteRef{})
+	if err != nil {
+		return "", nil, false
+	}
+	return secret.Title, value, true
 }
 
 // Close implements cleanup operations for the Keeper Security client.
@@ -213,21 +382,18 @@ func (c *Client) Close(_ context.Context) error {
 }
 
 // PushSecret creates or updates a secret in Keeper Security.
-func (c *Client) PushSecret(_ context.Context, secret *corev1.Secret, data esv1.PushSecretData) error {
+func (c *Client) PushSecret(ctx context.Context, secret *corev1.Secret, data esv1.PushSecretData) error {
 	if data.GetSecretKey() == "" {
 		return errors.New("pushing the whole secret is not yet implemented")
 	}
 
-	// Close implements cleanup operations for the Keeper Security client
 	value := secret.Data[data.GetSecretKey()]
 	parts, err := c.buildSecretNameAndKey(data)
 	if err != nil {
 		return err
-		// PushSecret creates or updates a secret in Keeper Security.
-		// Currently only supports pushing individual secret values, not entire secrets.
 	}
 
-	record, err := c.findSecretByName(parts[0])
+	record, err := c.findSecretByName(ctx, parts[0])
 	if err != nil {
 		return err
 	}
@@ -236,39 +402,52 @@ func (c *Client) PushSecret(_ context.Context, secret *corev1.Secret, data esv1.
 		if record.Type() != externalSecretType {
 			return fmt.Errorf(errInvalidSecretType, externalSecretType, record.Title(), record.Type())
 		}
-		return c.updateSecret(record, parts[1], value)
+		return c.updateSecret(ctx, record, parts[1], value)
 	}
 
-	_, err = c.createSecret(parts[0], parts[1], value)
+	_, err = c.createSecret(ctx, parts[0], parts[1], value)
 	return err
 }
 
 // DeleteSecret removes a secret from Keeper Security.
-func (c *Client) DeleteSecret(_ context.Context, remoteRef esv1.PushSecretRemoteRef) error {
+func (c *Client) DeleteSecret(ctx context.Context, remoteRef esv1.PushSecretRemoteRef) error {
 	parts, err := c.buildSecretNameAndKey(remoteRef)
 	if err != nil {
 		return err
 	}
-	secret, err := c.findSecretByName(parts[0])
+	secret, err := c.findSecretByName(ctx, parts[0])
 	if err != nil {
 		return err
 	} else if secret == nil {
-		// DeleteSecret removes a secret from Keeper Security.
-		// Returns nil if the secret doesn't exist (already deleted).
-		return nil // not found == already deleted (success)
+		// not found == already deleted (success)
+		return nil
 	}
 
 	if secret.Type() != externalSecretType {
 		return fmt.Errorf(errInvalidSecretType, externalSecretType, secret.Title(), secret.Type())
 	}
-	_, err = c.ksmClient.DeleteSecrets([]string{secret.Uid})
+	err = withRateLimitRetry(ctx, func() error {
+		_, derr := c.ksmClient.DeleteSecrets([]string{secret.Uid})
+		return derr
+	})
 	metrics.ObserveAPICall(constants.ProviderKeeperSecurity, constants.CallKeeperSecurityDeleteSecrets, err)
+	if err == nil {
+		sharedRecordCache.invalidate(c.recordCacheKey())
+	}
 	return err
 }
 
-// SecretExists checks if a secret exists in Keeper Security.
-func (c *Client) SecretExists(_ context.Context, _ esv1.PushSecretRemoteRef) (bool, error) {
-	return false, errors.New("not implemented")
+// SecretExists checks if a secret already exists in Keeper Security.
+func (c *Client) SecretExists(ctx context.Context, remoteRef esv1.PushSecretRemoteRef) (bool, error) {
+	parts, err := c.buildSecretNameAndKey(remoteRef)
+	if err != nil {
+		return false, err
+	}
+	record, err := c.findSecretByName(ctx, parts[0])
+	if err != nil {
+		return false, err
+	}
+	return record != nil, nil
 }
 
 func (c *Client) buildSecretNameAndKey(remoteRef esv1.PushSecretRemoteRef) ([]string, error) {
@@ -282,7 +461,7 @@ func (c *Client) buildSecretNameAndKey(remoteRef esv1.PushSecretRemoteRef) ([]st
 	return parts, nil
 }
 
-func (c *Client) createSecret(name, key string, value []byte) (string, error) {
+func (c *Client) createSecret(ctx context.Context, name, key string, value []byte) (string, error) {
 	normalizedKey := strings.ToLower(key)
 	externalSecretRecord := ksm.NewRecordCreate(externalSecretType, name)
 	login := regexp.MustCompile(LoginTypeExpr)
@@ -309,12 +488,20 @@ func (c *Client) createSecret(name, key string, value []byte) (string, error) {
 		)
 	}
 
-	uid, err := c.ksmClient.CreateSecretWithRecordData("", c.folderID, externalSecretRecord)
+	var uid string
+	err := withRateLimitRetry(ctx, func() error {
+		var e error
+		uid, e = c.ksmClient.CreateSecretWithRecordData("", c.folderID, externalSecretRecord)
+		return e
+	})
 	metrics.ObserveAPICall(constants.ProviderKeeperSecurity, constants.CallKeeperSecurityCreateSecretWithRecordData, err)
+	if err == nil {
+		sharedRecordCache.invalidate(c.recordCacheKey())
+	}
 	return uid, err
 }
 
-func (c *Client) updateSecret(secret *ksm.Record, key string, value []byte) error {
+func (c *Client) updateSecret(ctx context.Context, secret *ksm.Record, key string, value []byte) error {
 	normalizedKey := strings.ToLower(key)
 	login := regexp.MustCompile(LoginTypeExpr)
 	pass := regexp.MustCompile(PasswordType)
@@ -340,8 +527,13 @@ func (c *Client) updateSecret(secret *ksm.Record, key string, value []byte) erro
 		}
 	}
 
-	err := c.ksmClient.Save(secret)
+	err := withRateLimitRetry(ctx, func() error {
+		return c.ksmClient.Save(secret)
+	})
 	metrics.ObserveAPICall(constants.ProviderKeeperSecurity, constants.CallKeeperSecuritySave, err)
+	if err == nil {
+		sharedRecordCache.invalidate(c.recordCacheKey())
+	}
 	return err
 }
 
@@ -360,9 +552,8 @@ func (c *Client) getValidKeeperSecret(secret *ksm.Record) (*Secret, error) {
 	return &keeperSecret, nil
 }
 
-func (c *Client) findSecrets() ([]*ksm.Record, error) {
-	records, err := c.ksmClient.GetSecrets([]string{})
-	metrics.ObserveAPICall(constants.ProviderKeeperSecurity, constants.CallKeeperSecurityGetSecrets, err)
+func (c *Client) findSecrets(ctx context.Context) ([]*ksm.Record, error) {
+	records, err := c.getAllRecords(ctx)
 	if err != nil {
 		return nil, fmt.Errorf(errKeeperSecuritySecretsNotFound, err)
 	}
@@ -370,8 +561,24 @@ func (c *Client) findSecrets() ([]*ksm.Record, error) {
 	return records, nil
 }
 
-func (c *Client) findSecretByID(id string) (*ksm.Record, error) {
-	records, err := c.ksmClient.GetSecrets([]string{id})
+func (c *Client) findSecretByID(ctx context.Context, id string) (*ksm.Record, error) {
+	// Cached path: one shared get_secret returns all records; filter by UID.
+	// Collapses a reconcile wave of N ExternalSecrets into a single backend call.
+	if c.recordCacheTTL() > 0 {
+		records, err := c.getAllRecords(ctx)
+		if err != nil {
+			return nil, fmt.Errorf(errKeeperSecuritySecretNotFound, id, err)
+		}
+		for _, r := range records {
+			if r.Uid == id {
+				return r, nil
+			}
+		}
+		return nil, nil
+	}
+
+	// Default (uncached) path, now resilient to throttle (403) / 429.
+	records, err := getSecretsWithRetry(ctx, c.ksmClient, []string{id})
 	metrics.ObserveAPICall(constants.ProviderKeeperSecurity, constants.CallKeeperSecurityGetSecrets, err)
 	if err != nil {
 		return nil, fmt.Errorf(errKeeperSecuritySecretNotFound, id, err)
@@ -384,8 +591,13 @@ func (c *Client) findSecretByID(id string) (*ksm.Record, error) {
 	return records[0], nil
 }
 
-func (c *Client) findSecretByName(name string) (*ksm.Record, error) {
-	records, err := c.ksmClient.GetSecretsByTitle(name)
+func (c *Client) findSecretByName(ctx context.Context, name string) (*ksm.Record, error) {
+	var records []*ksm.Record
+	err := withRateLimitRetry(ctx, func() error {
+		var e error
+		records, e = c.ksmClient.GetSecretsByTitle(name)
+		return e
+	})
 	metrics.ObserveAPICall(constants.ProviderKeeperSecurity, constants.CallKeeperSecurityGetSecretsByTitle, err)
 	if err != nil {
 		return nil, err

--- a/providers/v1/keepersecurity/client_test.go
+++ b/providers/v1/keepersecurity/client_test.go
@@ -179,10 +179,17 @@ func TestClientGetAllSecrets(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "Path not Implemented",
+			name: "Path filter: no record under the path returns empty (no error)",
 			fields: fields{
-				ksmClient: &fake.MockKeeperClient{},
-				folderID:  folderID,
+				ksmClient: &fake.MockKeeperClient{
+					GetSecretsFn: func(strings []string) ([]*ksm.Record, error) {
+						return generateRecords(), nil // records live at the share root
+					},
+					GetFoldersFn: func() ([]*ksm.KeeperFolder, error) {
+						return []*ksm.KeeperFolder{{FolderUid: "fld1", Name: "Production"}}, nil
+					},
+				},
+				folderID: folderID,
 			},
 			args: args{
 				ctx: context.Background(),
@@ -190,7 +197,8 @@ func TestClientGetAllSecrets(t *testing.T) {
 					Path: &path,
 				},
 			},
-			wantErr: true,
+			want:    map[string][]byte{},
+			wantErr: false,
 		},
 		{
 			name: "Get secrets with matching regex",

--- a/providers/v1/keepersecurity/enhancements_test.go
+++ b/providers/v1/keepersecurity/enhancements_test.go
@@ -1,0 +1,261 @@
+/*
+Copyright © The ESO Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keepersecurity
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	ksm "github.com/keeper-security/secrets-manager-go/core"
+
+	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
+	"github.com/external-secrets/external-secrets/providers/v1/keepersecurity/fake"
+)
+
+func enhancementsRecords(n int) []*ksm.Record {
+	recs := make([]*ksm.Record, n)
+	for i := 0; i < n; i++ {
+		recs[i] = &ksm.Record{Uid: fmt.Sprintf("uid-%d", i)}
+	}
+	return recs
+}
+
+// countingMock counts GetSecrets calls and optionally throttles the first K.
+func countingMock(counter *int64, recs []*ksm.Record, throttleFirst int) *fake.MockKeeperClient {
+	return &fake.MockKeeperClient{
+		GetSecretsFn: func(filter []string) ([]*ksm.Record, error) {
+			n := atomic.AddInt64(counter, 1)
+			if int(n) <= throttleFirst {
+				return nil, fmt.Errorf("unable to find secret. Error: POST Error: Error: throttled, message=throttled")
+			}
+			if len(filter) == 0 {
+				return recs, nil
+			}
+			var out []*ksm.Record
+			for _, r := range recs {
+				for _, f := range filter {
+					if r.Uid == f {
+						out = append(out, r)
+					}
+				}
+			}
+			return out, nil
+		},
+	}
+}
+
+// The shared record cache collapses a reconcile wave of N lookups to one backend call.
+func TestRecordCacheCollapsesCalls(t *testing.T) {
+	const n = 50
+
+	t.Run("uncached default = one call per lookup", func(t *testing.T) {
+		resetRecordCache()
+		var calls int64
+		c := &Client{ksmClient: countingMock(&calls, enhancementsRecords(100), 0), folderID: "fA"}
+		for i := 0; i < n; i++ {
+			if _, err := c.findSecretByID(context.Background(), fmt.Sprintf("uid-%d", i)); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if got := atomic.LoadInt64(&calls); got != n {
+			t.Fatalf("uncached: got %d backend calls, want %d", got, n)
+		}
+	})
+
+	t.Run("cached = single call for the whole wave", func(t *testing.T) {
+		resetRecordCache()
+		t.Setenv("KEEPER_RECORD_CACHE_TTL_MS", "60000")
+		var calls int64
+		c := &Client{ksmClient: countingMock(&calls, enhancementsRecords(100), 0), folderID: "fB"}
+		for i := 0; i < n; i++ {
+			if _, err := c.findSecretByID(context.Background(), fmt.Sprintf("uid-%d", i)); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if got := atomic.LoadInt64(&calls); got != 1 {
+			t.Fatalf("cached: got %d backend calls, want 1", got)
+		}
+	})
+}
+
+// A transient throttle/429 is retried rather than surfaced as a failure.
+func TestThrottleRetryRecovers(t *testing.T) {
+	resetRecordCache()
+	orig := waitFn
+	waitFn = func(context.Context, time.Duration) error { return nil }
+	defer func() { waitFn = orig }()
+
+	var calls int64
+	c := &Client{ksmClient: countingMock(&calls, enhancementsRecords(10), 2), folderID: "fC"}
+	rec, err := c.findSecretByID(context.Background(), "uid-1")
+	if err != nil {
+		t.Fatalf("expected recovery after throttles, got error: %v", err)
+	}
+	if rec == nil || rec.Uid != "uid-1" {
+		t.Fatalf("expected uid-1 after retry, got %v", rec)
+	}
+	if got := atomic.LoadInt64(&calls); got != 3 {
+		t.Fatalf("expected 3 calls (2 throttled + 1 success), got %d", got)
+	}
+}
+
+// A misconfigured KEEPER_THROTTLE_RETRY_ATTEMPTS must not turn the retry loop
+// into a zero-attempt no-op (which would make reads return empty success).
+func TestRetryAttemptsClampedToOne(t *testing.T) {
+	t.Setenv("KEEPER_THROTTLE_RETRY_ATTEMPTS", "0")
+	resetRecordCache()
+	var calls int64
+	c := &Client{ksmClient: countingMock(&calls, enhancementsRecords(2), 0), folderID: "fClamp"}
+	rec, err := c.findSecretByID(context.Background(), "uid-0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec == nil {
+		t.Fatal("expected a record, got nil (loop short-circuited to zero attempts)")
+	}
+	if got := atomic.LoadInt64(&calls); got != 1 {
+		t.Fatalf("attempts=0 env should clamp to 1 backend call, got %d", got)
+	}
+}
+
+// dataFrom.find.path folder-path resolution and prefix matching.
+func TestFolderTreePathMatching(t *testing.T) {
+	tree := buildFolderTree([]*ksm.KeeperFolder{
+		{FolderUid: "a", Name: "Production"},
+		{FolderUid: "b", ParentUid: "a", Name: "Databases"},
+		{FolderUid: "c", ParentUid: "b", Name: "MySQL"},
+	})
+	for uid, want := range map[string]string{
+		"a": "Production", "b": "Production/Databases", "c": "Production/Databases/MySQL", "missing": "",
+	} {
+		if got := tree.pathOf(uid); got != want {
+			t.Errorf("pathOf(%q)=%q want %q", uid, got, want)
+		}
+	}
+	cases := []struct {
+		path, want string
+		match      bool
+	}{
+		{"Production/Databases/MySQL", "Production/Databases", true},
+		{"Production/Web", "Production/Databases", false},
+		{"Production/Databases", "Production/Databases", true},
+		{"anything", "", true},
+	}
+	for _, tc := range cases {
+		if got := pathMatchesPrefix(tc.path, tc.want); got != tc.match {
+			t.Errorf("pathMatchesPrefix(%q,%q)=%v want %v", tc.path, tc.want, got, tc.match)
+		}
+	}
+}
+
+// find is best-effort: a record that can't be represented is skipped, not fatal.
+func TestFindSkipsUnparseableRecords(t *testing.T) {
+	resetRecordCache()
+	c := &Client{ksmClient: &fake.MockKeeperClient{
+		GetSecretsFn: func([]string) ([]*ksm.Record, error) {
+			return []*ksm.Record{{Uid: "bad-no-rawjson"}}, nil // empty RawJson -> getValidKeeperSecret fails
+		},
+	}, folderID: "fBE"}
+	got, err := c.GetAllSecrets(context.Background(), esv1.ExternalSecretFind{Name: &esv1.FindName{RegExp: ".*"}})
+	if err != nil {
+		t.Fatalf("find must skip unparseable records, not error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected 0 records (bad record skipped), got %d", len(got))
+	}
+}
+
+// Keeper Notation is detected and resolved against the record set.
+func TestKeeperNotation(t *testing.T) {
+	for _, k := range []string{"keeper://abc/field/password", "keeper://abc/custom_field/token", "keeper://abc/file/cert.pem"} {
+		if !isKeeperNotation(k) {
+			t.Errorf("expected %q to be detected as notation", k)
+		}
+	}
+	// Without the keeper:// prefix, keys are treated as plain UID/title (no notation).
+	for _, k := range []string{"abc/field/login", "P6RKlo32gu4IA5ZZrPvLXg", "my-record-title"} {
+		if isKeeperNotation(k) {
+			t.Errorf("did not expect %q to be detected as notation", k)
+		}
+	}
+
+	resetRecordCache()
+	c := &Client{ksmClient: &fake.MockKeeperClient{
+		GetSecretsFn:   func([]string) ([]*ksm.Record, error) { return enhancementsRecords(3), nil },
+		FindNotationFn: func(_ []*ksm.Record, _ string) ([]interface{}, error) { return []interface{}{"s3cr3t"}, nil },
+	}, folderID: "fN"}
+	got, err := c.GetSecret(context.Background(), esv1.ExternalSecretDataRemoteRef{Key: "keeper://abc/field/password"})
+	if err != nil {
+		t.Fatalf("GetSecret(notation): %v", err)
+	}
+	if string(got) != "s3cr3t" {
+		t.Fatalf("notation value = %q, want %q", string(got), "s3cr3t")
+	}
+}
+
+// Validate performs a real read: Ready on success, Error on auth/config failure,
+// Unknown on a transient throttle (so the store is not hard-failed).
+func TestValidate(t *testing.T) {
+	resetRecordCache()
+	orig := waitFn
+	waitFn = func(context.Context, time.Duration) error { return nil }
+	defer func() { waitFn = orig }()
+
+	tests := []struct {
+		name    string
+		mock    *fake.MockKeeperClient
+		want    esv1.ValidationResult
+		wantErr bool
+	}{
+		{
+			name:    "ready",
+			mock:    &fake.MockKeeperClient{GetSecretsFn: func([]string) ([]*ksm.Record, error) { return enhancementsRecords(1), nil }},
+			want:    esv1.ValidationResultReady,
+			wantErr: false,
+		},
+		{
+			name:    "config error",
+			mock:    &fake.MockKeeperClient{GetSecretsFn: func([]string) ([]*ksm.Record, error) { return nil, fmt.Errorf("invalid configuration") }},
+			want:    esv1.ValidationResultError,
+			wantErr: true,
+		},
+		{
+			name: "throttle -> unknown",
+			mock: &fake.MockKeeperClient{GetSecretsFn: func([]string) ([]*ksm.Record, error) {
+				return nil, fmt.Errorf("POST Error: Error: throttled, message=throttled")
+			}},
+			want:    esv1.ValidationResultUnknown,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetRecordCache()
+			c := &Client{ksmClient: tt.mock, folderID: "fV-" + tt.name}
+			got, err := c.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Validate() err=%v wantErr=%v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Fatalf("Validate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/providers/v1/keepersecurity/fake/fake.go
+++ b/providers/v1/keepersecurity/fake/fake.go
@@ -20,6 +20,8 @@ import ksm "github.com/keeper-security/secrets-manager-go/core"
 
 type MockKeeperClient struct {
 	GetSecretsFn                 func([]string) ([]*ksm.Record, error)
+	GetFoldersFn                 func() ([]*ksm.KeeperFolder, error)
+	FindNotationFn               func(records []*ksm.Record, notation string) ([]interface{}, error)
 	GetSecretByTitleFn           func(recordTitle string) (*ksm.Record, error)
 	GetSecretsByTitleFn          func(recordTitle string) (records []*ksm.Record, err error)
 	CreateSecretWithRecordDataFn func(recUID, folderUID string, recordData *ksm.RecordCreate) (string, error)
@@ -44,6 +46,14 @@ type CreateSecretWithRecordDataMockReturn struct {
 
 func (mc *MockKeeperClient) GetSecrets(filter []string) ([]*ksm.Record, error) {
 	return mc.GetSecretsFn(filter)
+}
+
+func (mc *MockKeeperClient) GetFolders() ([]*ksm.KeeperFolder, error) {
+	return mc.GetFoldersFn()
+}
+
+func (mc *MockKeeperClient) FindNotation(records []*ksm.Record, notation string) ([]interface{}, error) {
+	return mc.FindNotationFn(records, notation)
 }
 
 func (mc *MockKeeperClient) GetSecretByTitle(recordTitle string) (*ksm.Record, error) {

--- a/providers/v1/keepersecurity/folder_tree.go
+++ b/providers/v1/keepersecurity/folder_tree.go
@@ -1,0 +1,83 @@
+/*
+Copyright © The ESO Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keepersecurity
+
+import (
+	"strings"
+
+	ksm "github.com/keeper-security/secrets-manager-go/core"
+)
+
+// folderNode is a single folder in the hierarchy.
+type folderNode struct {
+	name   string
+	parent *folderNode
+}
+
+// folderTree maps folder UID -> node, for resolving a UID to its full path.
+type folderTree struct {
+	nodes map[string]*folderNode
+}
+
+// buildFolderTree builds a UID->node index with parent links from a flat list.
+func buildFolderTree(folders []*ksm.KeeperFolder) *folderTree {
+	t := &folderTree{nodes: make(map[string]*folderNode, len(folders))}
+	for _, f := range folders {
+		if f == nil {
+			continue
+		}
+		t.nodes[f.FolderUid] = &folderNode{name: f.Name}
+	}
+	for _, f := range folders {
+		if f == nil {
+			continue
+		}
+		if n, ok := t.nodes[f.FolderUid]; ok {
+			if p, ok := t.nodes[f.ParentUid]; ok {
+				n.parent = p
+			}
+		}
+	}
+	return t
+}
+
+// pathOf returns the slash-joined folder path for a folder UID, e.g. "A/B/C".
+// Unknown UIDs (record at the share root) return "".
+func (t *folderTree) pathOf(uid string) string {
+	n, ok := t.nodes[uid]
+	if !ok {
+		return ""
+	}
+	var parts []string
+	for cur := n; cur != nil; cur = cur.parent {
+		if cur.name != "" {
+			parts = append([]string{cur.name}, parts...)
+		}
+	}
+	return strings.Join(parts, "/")
+}
+
+// pathMatchesPrefix reports whether recordPath is at or under the requested path.
+// Both are normalized (leading/trailing slashes trimmed). An empty want matches all.
+func pathMatchesPrefix(recordPath, want string) bool {
+	want = strings.Trim(want, "/")
+	recordPath = strings.Trim(recordPath, "/")
+	if want == "" {
+		return true
+	}
+	return recordPath == want || strings.HasPrefix(recordPath, want+"/")
+}

--- a/providers/v1/keepersecurity/provider.go
+++ b/providers/v1/keepersecurity/provider.go
@@ -75,6 +75,10 @@ func (p *Provider) NewClient(ctx context.Context, store esv1.GenericStore, kube 
 		folderID:           keeperStore.FolderID,
 		ksmClient:          ksmClient,
 		getByTitleFallback: keeperStore.GetByTitleFallback,
+		// Shared-cache identity: per device + folder. TTL is opt-in via
+		// KEEPER_RECORD_CACHE_TTL_MS (0 = disabled, default behavior unchanged).
+		cacheKey: hashConfig(clientConfig, keeperStore.FolderID),
+		cacheTTL: cacheTTL(),
 	}
 
 	return client, nil

--- a/runtime/constants/constants.go
+++ b/runtime/constants/constants.go
@@ -128,6 +128,7 @@ const (
 
 	ProviderKeeperSecurity                       = "KeeperSecurity"
 	CallKeeperSecurityGetSecrets                 = "GetSecrets"
+	CallKeeperSecurityGetFolders                 = "GetFolders"
 	CallKeeperSecurityGetSecretsByTitle          = "GetSecretsByTitle"
 	CallKeeperSecurityCreateSecretWithRecordData = "CreateSecretWithRecordData"
 	CallKeeperSecuritySave                       = "Save"


### PR DESCRIPTION
## Summary

Hardens and extends the Keeper Security provider for large-scale and rate-limited deployments.

## Changes

- **Throttle/429 retry (default on):** read and write calls retry on the keeperapp `403 {"error":"throttled"}` and the edge `429 Too Many Requests` with jittered, context-aware backoff, instead of surfacing as `ExternalSecret` sync errors. Non-rate-limit errors are returned immediately.
- **Shared record/folder cache (opt-in via `KEEPER_RECORD_CACHE_TTL_MS`):** a single `get_secret` returns every record the app can read, so one fetch serves a whole reconcile wave of `ExternalSecrets` (and `Validate`) instead of one backend call per `ExternalSecret`. Cache is invalidated on writes.
- **`dataFrom.find.path`:** filter records by folder path (prefix match). Previously returned "not implemented".
- **Keeper Notation:** `remoteRef.key` accepts a `keeper://` expression (`field`/`custom_field`/`file`, array indexes, predicates), resolved by the SDK against the (cached) record set. A key without the `keeper://` prefix is always treated as a plain record UID/title.
- **`Validate()`:** now performs a real (cache-backed) read — `Ready`/`Error`, and `Unknown` on a transient throttle so the store is not hard-failed. Previously a no-op that always returned `Ready`.
- **`SecretExists()`:** implemented (previously returned `"not implemented"`), so PushSecret conflict policies work.

## Backwards compatibility

Defaults are unchanged: the cache is opt-in (off by default) and retry only triggers on rate-limit errors, so existing deployments behave exactly as before. All existing provider tests pass; new unit tests and docs (`docs/provider/keeper-security.md`, including the tuning env vars) are included.

## Tuning knobs

| Variable | Default | Description |
|---|---|---|
| `KEEPER_RECORD_CACHE_TTL_MS` | `0` (off) | Shared record/folder cache TTL (ms). |
| `KEEPER_THROTTLE_RETRY_ATTEMPTS` | `4` | Max attempts for a throttled call. |
| `KEEPER_THROTTLE_RETRY_BASE_MS` | `500` | Base backoff (ms), doubles each attempt. |
| `KEEPER_THROTTLE_RETRY_MAX_MS` | `10000` | Backoff ceiling (ms). |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR hardens and extends the Keeper Security provider for rate-limited, large-scale deployments by adding rate-limit retries, an opt-in shared record cache, folder-path filtering, Keeper Notation resolution, and real validation/secret-existence checks.

What changed
- Throttle/429 retry: read/write calls retry on KeeperApp 403 {"error":"throttled"} and HTTP 429 using jittered, context-aware exponential backoff; non-rate-limit errors return immediately. Retry behavior is tunable via env vars and clamped to at least 1 attempt.
- Shared record/folder cache: opt-in TTL-based in-memory cache (KEEPER_RECORD_CACHE_TTL_MS; 0 = off) that fetches all readable records for a device+folder to serve reconcile waves and Validate; cache evicts expired entries and is invalidated on writes.
- Keeper Notation: remoteRef.key accepts keeper:// expressions (fields, custom_field labels, files, array indexes, predicates) resolved by the SDK against the (cached) record set. Keys without keeper:// remain UID/title lookups.
- dataFrom.find.path & name filtering: supports folder-path prefix filtering via a new folder-tree utility; find.name.regexp matches record title regex. find.tags remains unsupported. GetAllSecrets rejects ref.Tags.
- Validate(): performs a real, cache-backed read — returns Ready or Error; returns Unknown for transient throttles to avoid hard-failing.
- SecretExists(): implemented to support PushSecret conflict policies.
- Backwards compatible: defaults unchanged — cache is opt-in and retry only triggers on rate-limit errors. Existing provider tests pass; new unit tests and docs included.

Files of note
- providers/v1/keepersecurity/cache.go — retry/backoff helpers, cache implementation, env parsing, context-cancellable waits.
- providers/v1/keepersecurity/client.go — cache integration, notation resolution, path/name filtering, context-aware retries, Validate/SecretExists implementations, cache invalidation on writes.
- providers/v1/keepersecurity/folder_tree.go — folder hierarchy builder and path-prefix matching.
- providers/v1/keepersecurity/fake/fake.go — mocks for GetFolders and FindNotation.
- providers/v1/keepersecurity/enhancements_test.go & client_test.go — tests for caching, throttling, folder paths, notation, Validate, and clamped retry attempts.
- docs/provider/keeper-security.md — Keeper Notation guidance, folder-path examples, and performance/rate-limit tuning.

Tunable environment variables
- KEEPER_RECORD_CACHE_TTL_MS (ms; 0 = off)
- KEEPER_THROTTLE_RETRY_ATTEMPTS (default 4; clamped >=1)
- KEEPER_THROTTLE_RETRY_BASE_MS (default 500)
- KEEPER_THROTTLE_RETRY_MAX_MS (default 10000)

Additional fixes
- Clamp retry attempts to >=1 to avoid misconfiguration making reads/writes no-op.
- Evict expired cache entries on read to prevent memory leakage.
- Docs correction: find.name.regexp matches record title (not field/file names).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->