### PR TITLE
docs(core): correct CRD examples and document missing fields

### DIFF
--- a/docs/guides/decoding-strategy.md
+++ b/docs/guides/decoding-strategy.md
@@ -47,4 +47,4 @@ data:
 At this time, decoding Strategy Auto is only trying to check if the original input is valid to perform Base64 operations. As there is no reliable way to detect base64 encoded values, this means that some non-encoded secret values might end up being decoded, producing gibberish. For example, this is the case for alphanumeric values with a length divisible by 4, like `1234` or `happy/street`. 
 
 !!! note 
-    If you are using `decodeStrategy: Auto` and start to see ESO pulling completely wrong secret values into your kubernetes secret, consider changing it to `None` to investigate it.
+    If you are using `decodingStrategy: Auto` and start to see ESO pulling completely wrong secret values into your kubernetes secret, consider changing it to `None` to investigate it.

--- a/docs/snippets/full-cluster-external-secret.yaml
+++ b/docs/snippets/full-cluster-external-secret.yaml
@@ -4,8 +4,14 @@ kind: ClusterExternalSecret
 metadata:
   name: "hello-world"
 spec:
-  # The name to be used on the ExternalSecrets
+  # The name to be used on the ExternalSecrets.
+  # Defaults to the name of the ClusterExternalSecret when omitted.
   externalSecretName: "hello-world-es"
+
+  # Optional labels and annotations to set on every created ExternalSecret.
+  externalSecretMetadata:
+    labels: {}
+    annotations: {}
 
   # This is a basic label selector to select the namespaces to deploy ExternalSecrets to.
   # you can read more about them here https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements
@@ -22,8 +28,14 @@ spec:
   - matchLabels:
       cool: label
 
+  # Choose namespaces by name. This is OR'd with anything namespaceSelectors matches.
+  # Deprecated: Use namespaceSelectors instead.
+  # namespaces:
+  #   - my-namespace
+
   # How often the ClusterExternalSecret should reconcile itself
   # This will decide how often to check and make sure that the ExternalSecrets exist in the matching namespaces
+  # If omitted, the controller's default requeue interval is used.
   refreshTime: "1m"
 
   # This is the spec of the ExternalSecrets to be created
@@ -83,11 +95,12 @@ status:
     - "matching-ns-3"
     - "matching-ns-2"
 
-  # The condition can be Ready, PartiallyReady, or NotReady
-  # PartiallyReady would indicate an error in 1 or more namespaces
-  # NotReady would indicate errors in all namespaces meaning all ExternalSecrets resulted in errors
+  # The only condition type is Ready. status is "True" when all matching
+  # namespaces synced, and "False" if one or more namespaces failed (the failed
+  # ones are listed under failedNamespaces above).
   conditions:
-  - type: PartiallyReady
-    status: "True"
+  - type: Ready
+    status: "False"
+    message: "one or more namespaces failed"
     lastTransitionTime: "2022-01-12T12:33:02Z"
 {% endraw %}

--- a/docs/snippets/full-cluster-push-secret.yaml
+++ b/docs/snippets/full-cluster-push-secret.yaml
@@ -13,8 +13,14 @@ kind: ClusterPushSecret
 metadata:
   name: "hello-world"
 spec:
-  # The name to be used on the PushSecrets
+  # The name to be used on the PushSecrets.
+  # Defaults to the name of the ClusterPushSecret when omitted.
   pushSecretName: "hello-world-ps"
+
+  # Optional labels and annotations to set on every created PushSecret.
+  pushSecretMetadata:
+    labels: {}
+    annotations: {}
 
   # This is a list of basic label selector to select the namespaces to deploy PushSecrets to.
   # you can read more about them here https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements
@@ -26,6 +32,7 @@ spec:
 
   # How often the ClusterPushSecret should reconcile itself
   # This will decide how often to check and make sure that the PushSecrets exist in the matching namespaces
+  # If omitted, the controller's default requeue interval is used.
   refreshTime: "1m"
 
   # This is the spec of the PushSecrets to be created
@@ -76,18 +83,19 @@ status:
   failedNamespaces:
     - namespace: "matching-ns-1"
       # This is one of the possible messages, and likely the most common
-      reason: "external secret already exists in namespace"
+      reason: "push secret already exists in namespace"
 
   # You can find all matching and successfully deployed namespaces here
   provisionedNamespaces:
     - "matching-ns-3"
     - "matching-ns-2"
 
-  # The condition can be Ready, PartiallyReady, or NotReady
-  # PartiallyReady would indicate an error in 1 or more namespaces
-  # NotReady would indicate errors in all namespaces meaning all ExternalSecrets resulted in errors
+  # The only condition type is Ready. status is "True" when all matching
+  # namespaces synced, and "False" if one or more namespaces failed (the failed
+  # ones are listed under failedNamespaces above).
   conditions:
-  - type: PartiallyReady
-    status: "True"
+  - type: Ready
+    status: "False"
+    message: "one or more namespaces failed"
     lastTransitionTime: "2022-01-12T12:33:02Z"
 {% endraw %}

--- a/docs/snippets/full-cluster-secret-store.yaml
+++ b/docs/snippets/full-cluster-secret-store.yaml
@@ -4,7 +4,7 @@ metadata:
   name: example
   annotations:
     ## Add this annotation to disable controller warning events for unmaintained stores
-    external-secrets.io/disable-maintenance-checks: "true"
+    external-secrets.io/ignore-maintenance-checks: "true"
 spec:
   # Used to select the correct ESO controller (think: ingress.ingressClassName)
   # The ESO controller is instantiated with a specific controller name
@@ -177,6 +177,6 @@ status:
     # should prevent attempts to fetch secrets
     - type: Ready
       status: "False"
-      reason: "ConfigError"
+      reason: "ValidationFailed"
       message: "SecretStore validation failed"
       lastTransitionTime: "2019-08-12T12:33:02Z"

--- a/docs/snippets/full-pushsecret.yaml
+++ b/docs/snippets/full-pushsecret.yaml
@@ -15,19 +15,21 @@ metadata:
   namespace: default # Same of the SecretStores
 spec:
   updatePolicy: Replace # Policy to overwrite existing secrets in the provider on sync
-  deletionPolicy: Delete # the provider' secret will be deleted if the PushSecret is deleted
+  deletionPolicy: Delete # delete the provider secret when the PushSecret is deleted (default: None, which keeps it)
   refreshInterval: 1h0m0s # Refresh interval for which push secret will reconcile
   secretStoreRefs: # A list of secret stores to push secrets to
     - name: aws-parameterstore
       kind: SecretStore
+  # Exactly one of selector.secret or selector.generatorRef may be set.
   selector:
     secret:
       name: pokedex-credentials # Source Kubernetes secret to be pushed
-    # Alternatively, you can point to a generator that produces values to be pushed
-    generatorRef:
-      apiVersion: generators.external-secrets.io/v1alpha1
-      kind: ECRAuthorizationToken
-      name: prod-registry-credentials
+    # Alternatively (mutually exclusive with secret), point to a generator
+    # that produces the values to be pushed:
+    # generatorRef:
+    #   apiVersion: generators.external-secrets.io/v1alpha1
+    #   kind: ECRAuthorizationToken
+    #   name: prod-registry-credentials
   template:
     metadata:
       annotations: { }

--- a/docs/snippets/full-secret-store.yaml
+++ b/docs/snippets/full-secret-store.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: example-ns
   annotations:
     ## Add this annotation to disable controller warning events for unmaintained stores
-    external-secrets.io/disable-maintenance-checks: "true"
+    external-secrets.io/ignore-maintenance-checks: "true"
 spec:
 
   # Used to select the correct ESO controller (think: ingress.ingressClassName)
@@ -141,6 +141,6 @@ status:
   # should prevent attempts to fetch secrets
   - type: Ready
     status: "False"
-    reason: "ConfigError"
+    reason: "ValidationFailed"
     message: "SecretStore validation failed"
     lastTransitionTime: "2019-08-12T12:33:02Z"


### PR DESCRIPTION
## Problem Statement

Auditing the core CRD documentation (ExternalSecret, PushSecret, SecretStore/ClusterSecretStore, ClusterExternalSecret, ClusterPushSecret) against the controller code surfaced several documentation errors where the examples would not work if copied, plus a few user-facing fields that were missing from the examples. Each item below was verified against the source.

## Related Issue

N/A (found during a code-vs-docs review of the core controllers).

## Proposed Changes

Documentation only; no API, CRD, or controller changes. Code references are pinned to `3a13a95`.

Corrected errors:

- **SecretStore / ClusterSecretStore**: the example annotation to suppress unmaintained-store warnings was `external-secrets.io/disable-maintenance-checks`, but the controller only honours `external-secrets.io/ignore-maintenance-checks` ([common.go#L143](https://github.com/external-secrets/external-secrets/blob/3a13a95be34104ea8497bbae7d249cffd7ee257e/pkg/controllers/secretstore/common.go#L143)), so copying the example did nothing (the prose already used the correct annotation). Also replaced the status `reason: "ConfigError"` example with `ValidationFailed`, an actual reason the controller emits ([secretstore_types.go#L286-L289](https://github.com/external-secrets/external-secrets/blob/3a13a95be34104ea8497bbae7d249cffd7ee257e/apis/externalsecrets/v1/secretstore_types.go#L286-L289)).
- **PushSecret**: the flagship example set both `selector.secret` and `selector.generatorRef` in one selector, which violates `MaxProperties=1` on `PushSecretSelector` ([pushsecret_types.go#L141](https://github.com/external-secrets/external-secrets/blob/3a13a95be34104ea8497bbae7d249cffd7ee257e/apis/externalsecrets/v1alpha1/pushsecret_types.go#L141)) and is rejected by the API server. The example now sets `secret` and shows `generatorRef` as the commented, mutually-exclusive alternative, and notes that `deletionPolicy` defaults to `None` ([pushsecret_types.go#L104](https://github.com/external-secrets/external-secrets/blob/3a13a95be34104ea8497bbae7d249cffd7ee257e/apis/externalsecrets/v1alpha1/pushsecret_types.go#L104)).
- **ClusterExternalSecret / ClusterPushSecret**: the status examples documented condition types `PartiallyReady` and `NotReady` that the controllers never emit; the only type is `Ready` ([clusterexternalsecret_types.go#L77](https://github.com/external-secrets/external-secrets/blob/3a13a95be34104ea8497bbae7d249cffd7ee257e/apis/externalsecrets/v1/clusterexternalsecret_types.go#L77), built in [util.go#L29](https://github.com/external-secrets/external-secrets/blob/3a13a95be34104ea8497bbae7d249cffd7ee257e/pkg/controllers/clusterexternalsecret/util.go#L29)), with message "one or more namespaces failed" ([controller#L64](https://github.com/external-secrets/external-secrets/blob/3a13a95be34104ea8497bbae7d249cffd7ee257e/pkg/controllers/clusterexternalsecret/clusterexternalsecret_controller.go#L64)) on partial failure. Also corrected the ClusterPushSecret failure reason from "external secret already exists in namespace" to "push secret already exists in namespace" ([clusterpushsecret_controller.go#L152](https://github.com/external-secrets/external-secrets/blob/3a13a95be34104ea8497bbae7d249cffd7ee257e/pkg/controllers/clusterpushsecret/clusterpushsecret_controller.go#L152)).
- **decoding-strategy guide**: a note referenced `decodeStrategy`; the field is `decodingStrategy` ([externalsecret_types.go#L306](https://github.com/external-secrets/external-secrets/blob/3a13a95be34104ea8497bbae7d249cffd7ee257e/apis/externalsecrets/v1/externalsecret_types.go#L306)).

Documented previously missing fields (verified wired into the controllers):

- ClusterExternalSecret: `namespaces` ([type#L58](https://github.com/external-secrets/external-secrets/blob/3a13a95be34104ea8497bbae7d249cffd7ee257e/apis/externalsecrets/v1/clusterexternalsecret_types.go#L58); by-name, marked deprecated in favour of `namespaceSelectors`; used at [controller#L160](https://github.com/external-secrets/external-secrets/blob/3a13a95be34104ea8497bbae7d249cffd7ee257e/pkg/controllers/clusterexternalsecret/clusterexternalsecret_controller.go#L160) and [#L598](https://github.com/external-secrets/external-secrets/blob/3a13a95be34104ea8497bbae7d249cffd7ee257e/pkg/controllers/clusterexternalsecret/clusterexternalsecret_controller.go#L598)) and `externalSecretMetadata` ([type#L39](https://github.com/external-secrets/external-secrets/blob/3a13a95be34104ea8497bbae7d249cffd7ee257e/apis/externalsecrets/v1/clusterexternalsecret_types.go#L39)).
- ClusterPushSecret: `pushSecretMetadata` ([type#L382](https://github.com/external-secrets/external-secrets/blob/3a13a95be34104ea8497bbae7d249cffd7ee257e/apis/externalsecrets/v1alpha1/pushsecret_types.go#L382); applied at [controller#L212](https://github.com/external-secrets/external-secrets/blob/3a13a95be34104ea8497bbae7d249cffd7ee257e/pkg/controllers/clusterpushsecret/clusterpushsecret_controller.go#L212)).
- Both: noted that `refreshTime`, when omitted, falls back to the controller's default requeue interval ([CPS type#L371](https://github.com/external-secrets/external-secrets/blob/3a13a95be34104ea8497bbae7d249cffd7ee257e/apis/externalsecrets/v1alpha1/pushsecret_types.go#L371)).

## Format

`docs(core): correct CRD examples and document missing fields`

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Documentation corrections for core CRDs

This documentation-only PR audits and corrects CRD examples and documentation against the controller implementation:

### Key corrections:
- **SecretStore/ClusterSecretStore**: Updated annotation from `external-secrets.io/disable-maintenance-checks` to `external-secrets.io/ignore-maintenance-checks`; changed status reason from `ConfigError` to `ValidationFailed`
- **PushSecret**: Fixed selector example to show only `secret` as active configuration (removed `generatorRef` from active example to avoid invalid MaxProperties constraint); documented `deletionPolicy` and `refreshInterval` fields
- **ClusterExternalSecret/ClusterPushSecret**: Removed undocumented condition types; documented only the `Ready` condition with appropriate failure messages
- **ClusterExternalSecret**: Added `externalSecretMetadata` field documentation and `namespaces` selection option
- **ClusterPushSecret**: Added `pushSecretMetadata` field documentation
- **Decoding strategy guide**: Fixed field name from `decodeStrategy` to `decodingStrategy`

No API, CRD, or controller code changes included. All corrections verified against controller source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->