### PR TITLE
docs(gitops-fluxcd): fix webhook race condition in Flux deployment guide

### DIFF
--- a/docs/examples/gitops-using-fluxcd.md
+++ b/docs/examples/gitops-using-fluxcd.md
@@ -38,6 +38,20 @@ Both controllers manage the resources independently, at different moments, with 
 This means that we have a wonderful race condition where sometimes the CRs (`SecretStore`,`ClusterSecretStore`...) tries
 to be deployed before than the CRDs needed to recognize them.
 
+A second, subtler race exists around the **admission webhook**. External Secrets ships a `ValidatingWebhookConfiguration`
+that is registered in the API server as soon as the HelmRelease is applied, before the webhook pod has had time to start
+serving. If a Kustomization tries to apply an `ExternalSecret` or `ClusterSecretStore` in that brief window, the API
+server performs a dry-run validation, the webhook endpoint returns `connection refused`, and the reconciliation fails with:
+
+```
+Internal error occurred: failed calling webhook "validate.externalsecret.external-secrets.io": ...
+dial tcp <ip>:443: connect: connection refused
+```
+
+Flux retries after `interval` (typically 10 minutes), so everything works on the second attempt, but the initial
+deployment always fails. The fix is a three-level dependency chain that ensures the webhook pod is healthy before
+any CR is applied.
+
 ## The solution
 
 Let's see the conditions to start working on a solution:
@@ -45,8 +59,17 @@ Let's see the conditions to start working on a solution:
 * The External Secrets operator is deployed with Helm, and admits disabling the CRDs deployment
 * The race condition only affects the deployment of `CustomResourceDefinition` and the CRs needed later
 * CRDs can be deployed directly from the Git repository of the project using a Flux `Kustomization`
-* Required CRs can be deployed using a Flux `Kustomization` too, allowing dependency between CRDs and CRs
+* The operator HelmRelease is wrapped in its own Flux `Kustomization` with `wait: true` so it only
+  reports Ready after all deployed resources (including the webhook pod) are healthy
+* Required CRs can be deployed using a Flux `Kustomization` that depends on the operator Kustomization,
+  not just the CRDs, guaranteeing the webhook is serving before any CR dry-run is attempted
 * All previous manifests can be applied with a Kubernetes `kustomization`
+
+The dependency chain is:
+
+```
+external-secrets-crds --> external-secrets-operator (wait: true) --> external-secrets-crs
+```
 
 ## Create the main kustomization
 
@@ -87,13 +110,26 @@ from our git repository using a Kustomization manifest called `deployment-crds.y
 {% include 'gitops/deployment-crds.yaml' %}
 ```
 
+Note the `wait: true` field. This ensures the Kustomization only reports Ready after all CRDs have been fully
+established in the API server, so the operator can register its validation webhooks and controllers cleanly.
+
 ## Deploy the operator
 
-The operator is deployed using a HelmRelease manifest to deploy the Helm package, but due to the special race condition,
-the deployment must be disabled in the `values` of the manifest called `deployment.yaml`, as follows:
+The operator HelmRelease is placed inside an `operator/` subdirectory and wrapped with its own Flux Kustomization.
+Create a manifest called `deployment-operator.yaml`:
 
 ```yaml
-{% include 'gitops/deployment.yaml' %}
+{% include 'gitops/deployment-operator.yaml' %}
+```
+
+The `wait: true` here is the key to solving the webhook race condition: Flux will not mark
+`external-secrets-operator` as Ready until every resource the HelmRelease created -- including the webhook
+Deployment -- has reached a healthy state. Only then will the CRs Kustomization be allowed to proceed.
+
+Inside the `operator/` subdirectory, place the HelmRelease manifest (`operator/deployment.yaml`):
+
+```yaml
+{% include 'gitops/operator/deployment.yaml' %}
 ```
 
 ## Deploy the CRs
@@ -106,9 +142,11 @@ Now, be ready for the arcane magic. Create a Kustomization manifest called `depl
 
 There are several interesting details to see here, that finally solves the race condition:
 
-1. First one is the field `dependsOn`, which points to a previous Kustomization called `external-secrets-crds`. This
-   dependency forces this deployment to wait for the other to be ready, before start being deployed.
-2. The reference to the place where to find the CRs
+1. The `dependsOn` field now points to `external-secrets-operator` rather than `external-secrets-crds`. This
+   dependency forces this deployment to wait for the operator (including its webhook) to be fully ready before
+   any CR is applied, eliminating the webhook race condition.
+2. `retryInterval: 1m` makes Flux retry quickly if the very first reconcile still catches a brief startup window.
+3. The reference to the place where to find the CRs
    ```yaml
    path: ./infrastructure/external-secrets/crs
    sourceRef:
@@ -128,6 +166,21 @@ for example, a manifest `clusterSecretStore.yaml` to reach your Hashicorp Vault 
 
 ## Results
 
-At the end, the required files tree is shown in the following picture:
+At the end, the required files tree is:
 
-![FluxCD files tree](../pictures/screenshot_gitops_final_directory_tree.png)
+```
+./infrastructure/external-secrets/
+  kustomization.yaml
+  namespace.yaml
+  secret-token.yaml
+  repositories.yaml
+  deployment-crds.yaml
+  deployment-operator.yaml
+  operator/
+    kustomization.yaml
+    deployment.yaml
+  deployment-crs.yaml
+  crs/
+    kustomization.yaml
+    clusterSecretStore.yaml
+```

--- a/docs/snippets/gitops/deployment-crs.yaml
+++ b/docs/snippets/gitops/deployment-crs.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -6,8 +5,9 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
-    - name: external-secrets-crds
+    - name: external-secrets-operator
   interval: 10m
+  retryInterval: 1m
   path: ./infrastructure/external-secrets/crs
   prune: true
   sourceRef:

--- a/docs/snippets/gitops/deployment-operator.yaml
+++ b/docs/snippets/gitops/deployment-operator.yaml
@@ -1,14 +1,15 @@
----
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: external-secrets-crds
+  name: external-secrets-operator
   namespace: flux-system
 spec:
+  dependsOn:
+    - name: external-secrets-crds
   interval: 10m
-  path: ./config/crds/bases
+  path: ./infrastructure/external-secrets/operator
   prune: true
   wait: true
   sourceRef:
     kind: GitRepository
-    name: external-secrets
+    name: flux-system

--- a/docs/snippets/gitops/kustomization.yaml
+++ b/docs/snippets/gitops/kustomization.yaml
@@ -12,9 +12,9 @@ resources:
 # Deploy the CRDs
 - deployment-crds.yaml
 
-# Deploy the operator
-- deployment.yaml
+# Deploy the operator (wrapped in a Kustomization so wait: true gates the CRs)
+- deployment-operator.yaml
 
 # Deploy default Custom Resources from 'crs' directory
-# INFO: This depends on the CRDs deployment. Will happen after it
+# INFO: This depends on the operator deployment. Will happen after the webhook is ready
 - deployment-crs.yaml

--- a/docs/snippets/gitops/operator/deployment.yaml
+++ b/docs/snippets/gitops/operator/deployment.yaml
@@ -1,0 +1,27 @@
+# How to manage values files. Ref: https://fluxcd.io/docs/guides/helmreleases/#refer-to-values-inside-the-chart
+# How to inject values: https://fluxcd.io/docs/guides/helmreleases/#cloud-storage
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: external-secrets
+  namespace: flux-system
+spec:
+  # Override Release name to avoid the pattern Namespace-Release
+  # Ref: https://fluxcd.io/flux/components/helm/api/v2/#helm.toolkit.fluxcd.io/v2.HelmRelease
+  interval: 10m
+  releaseName: external-secrets
+  chart:
+    spec:
+      chart: external-secrets
+      version: 1.3.1
+      sourceRef:
+        kind: HelmRepository
+        name: external-secrets
+        namespace: flux-system
+  values:
+    crds:
+      create: false
+  # Ref: https://fluxcd.io/flux/components/helm/api/v2/#helm.toolkit.fluxcd.io/v2.Install
+  install:
+    createNamespace: true

--- a/docs/snippets/gitops/operator/kustomization.yaml
+++ b/docs/snippets/gitops/operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- deployment.yaml


### PR DESCRIPTION
## Problem Statement

When deploying ESO with Flux, a webhook race condition causes the initial reconcile of the CRs Kustomization to fail with:

```
Internal error occurred: failed calling webhook "validate.externalsecret.external-secrets.io": ...
dial tcp <ip>:443: connect: connection refused
```

The root cause: the existing guide's `external-secrets-crs` Kustomization depends only on `external-secrets-crds` (the CRD Kustomization). The operator's `ValidatingWebhookConfiguration` is registered in the API server as soon as the HelmRelease is applied, but the webhook pod has not yet started serving at that point. When Flux performs the admission dry-run for the CRs, the API server gets `connection refused` and the whole reconcile fails. Flux retries after the full `interval` (typically 10 minutes), so things always work on the second attempt -- but the initial deployment is unnecessarily broken.

## Related Issue

Fixes #6450

## Proposed Changes

The fix is a three-level dependency chain that ensures the webhook pod is healthy before any CR is applied:

```
external-secrets-crds --> external-secrets-operator (wait: true) --> external-secrets-crs
```

Specifically:

- Add `wait: true` to `deployment-crds.yaml` so the CRD Kustomization only reports Ready after all CRDs are fully established.
- Add a new `deployment-operator.yaml` Flux Kustomization that wraps the HelmRelease (placed in an `operator/` subdirectory) with `wait: true` and `dependsOn: external-secrets-crds`. Flux waits for every resource the HelmRelease created -- including the webhook Deployment -- to become healthy before marking this Kustomization Ready.
- Update `deployment-crs.yaml` to `dependsOn: external-secrets-operator` (not `external-secrets-crds`) and add `retryInterval: 1m` for fast recovery on the rare occasion a brief startup window is still caught.
- Update the guide narrative to explain the webhook race condition and the three-level dependency chain.

## Format

```
docs(gitops-fluxcd): fix webhook race condition in Flux deployment guide
```

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR fixes a webhook race condition in the Flux deployment guide for External Secrets Operator by introducing a three-level Kustomization dependency chain that ensures the webhook pod is healthy before Custom Resources are applied.

## Problem
The existing setup registers the operator's ValidatingWebhookConfiguration before the webhook pod is serving, causing Flux admission dry-run failures and triggering long retries.

## Solution
- **CRD Kustomization** (`deployment-crds.yaml`): Add `wait: true` to ensure CRDs are established before proceeding
- **New Operator Kustomization** (`deployment-operator.yaml`): Wrap the HelmRelease with `wait: true` and depend on CRDs, ensuring the webhook Deployment is healthy
- **CR Kustomization** (`deployment-crs.yaml`): Change dependency from CRDs to operator, add `retryInterval: 1m` for faster recovery
- **Operator HelmRelease** (`operator/deployment.yaml`): New manifest deploying external-secrets with `crds.create: false`

## Files Changed
- `docs/examples/gitops-using-fluxcd.md`: Updated guide text explaining the webhook race condition and three-level dependency chain
- `docs/snippets/gitops/deployment-crds.yaml`: Added `wait: true`
- `docs/snippets/gitops/deployment-crs.yaml`: Updated dependency and added retry interval
- `docs/snippets/gitops/deployment-operator.yaml`: New Flux Kustomization for operator
- `docs/snippets/gitops/kustomization.yaml`: Updated to reference new operator Kustomization
- `docs/snippets/gitops/operator/deployment.yaml`: New HelmRelease manifest
- `docs/snippets/gitops/operator/kustomization.yaml`: New Kustomize configuration

**Fixes issue `#6450`**

<!-- end of auto-generated comment: release notes by coderabbit.ai -->