### PR TITLE
fix(templating): preserve mixed-case in generic target paths

### DIFF
--- a/runtime/template/v2/template.go
+++ b/runtime/template/v2/template.go
@@ -94,8 +94,10 @@ func init() {
 }
 
 func applyToTarget(k string, val []byte, target string, obj client.Object) error {
-	target = strings.ToLower(target)
-	switch target {
+	// Match the well-known top-level targets case-insensitively, but keep the
+	// original case of target so nested custom-resource paths preserve
+	// mixed-case segments (e.g. spec.headers.customRequestHeaders). Issue #6458.
+	switch strings.ToLower(target) {
 	case "annotations":
 		annotations := obj.GetAnnotations()
 		if annotations == nil {
@@ -184,8 +186,9 @@ func mapScopeApply(tpl string, data map[string][]byte, target string, secret cli
 		return fmt.Errorf(errExecute, tpl, err)
 	}
 
-	target = strings.ToLower(target)
-	switch target {
+	// See applyToTarget: switch on the lowercased target but keep the original
+	// case so nested paths are not lowercased (issue #6458).
+	switch strings.ToLower(target) {
 	case "annotations", "labels", "data":
 		// normal route
 		src := make(map[string]string)

--- a/runtime/template/v2/template_test.go
+++ b/runtime/template/v2/template_test.go
@@ -1382,6 +1382,100 @@ channel: {{ .new_channel }}
 				assert.Equal(t, "test-value", slackMap["other_field"], "existing other_field should be preserved")
 			},
 		},
+		{
+			name:   "nested path preserves mixed-case segments (issue #6458)",
+			target: "spec.headers.customRequestHeaders",
+			scope:  esapi.TemplateScopeKeysAndValues,
+			tpl: map[string][]byte{
+				"header": []byte(`foo: {{ .token }}`),
+			},
+			data: map[string][]byte{
+				"token": []byte("Bearer"),
+			},
+			verify: func(t *testing.T, obj map[string]any) {
+				specMap := obj["spec"].(map[string]any)
+				headersMap := specMap["headers"].(map[string]any)
+
+				// The mixed-case segment must be preserved, not lowercased.
+				crh, ok := headersMap["customRequestHeaders"].(map[string]any)
+				require.True(t, ok, "customRequestHeaders should keep its mixed case")
+				assert.Equal(t, "Bearer", crh["foo"], "foo should be set under the mixed-case path")
+
+				// The lowercased variant must NOT exist.
+				_, lowered := headersMap["customrequestheaders"]
+				assert.False(t, lowered, "path must not be forcibly lowercased")
+			},
+		},
+		{
+			name:   "values scope nested path preserves mixed-case (issue #6458)",
+			target: "spec.headers.customRequestHeaders",
+			scope:  esapi.TemplateScopeValues,
+			tpl: map[string][]byte{
+				"foo": []byte(`{{ .token }}`),
+			},
+			data: map[string][]byte{
+				"token": []byte("Bearer"),
+			},
+			verify: func(t *testing.T, obj map[string]any) {
+				specMap := obj["spec"].(map[string]any)
+				headersMap := specMap["headers"].(map[string]any)
+
+				// applyToTarget sets the value at the final mixed-case segment.
+				assert.Equal(t, "Bearer", headersMap["customRequestHeaders"], "value should land under the mixed-case key")
+
+				// The lowercased variant must NOT exist.
+				_, lowered := headersMap["customrequestheaders"]
+				assert.False(t, lowered, "path must not be forcibly lowercased")
+			},
+		},
+		{
+			name:   "nested path preserves intermediate mixed-case segment (issue #6458)",
+			target: "spec.tlsConfig.certResolver",
+			scope:  esapi.TemplateScopeKeysAndValues,
+			tpl: map[string][]byte{
+				"resolver": []byte(`name: {{ .val }}`),
+			},
+			data: map[string][]byte{
+				"val": []byte("myResolver"),
+			},
+			verify: func(t *testing.T, obj map[string]any) {
+				specMap := obj["spec"].(map[string]any)
+
+				// Both the intermediate and the leaf segment keep their case.
+				tlsConfig, ok := specMap["tlsConfig"].(map[string]any)
+				require.True(t, ok, "intermediate tlsConfig segment should keep its case")
+				certResolver, ok := tlsConfig["certResolver"].(map[string]any)
+				require.True(t, ok, "leaf certResolver segment should keep its case")
+				assert.Equal(t, "myResolver", certResolver["name"])
+
+				// No lowercased intermediate segment should be created.
+				_, lowered := specMap["tlsconfig"]
+				assert.False(t, lowered, "intermediate segment must not be lowercased")
+			},
+		},
+		{
+			name:   "values scope preserves intermediate mixed-case segment (issue #6458)",
+			target: "spec.tlsConfig.certResolver",
+			scope:  esapi.TemplateScopeValues,
+			tpl: map[string][]byte{
+				"x": []byte(`{{ .val }}`),
+			},
+			data: map[string][]byte{
+				"val": []byte("myResolver"),
+			},
+			verify: func(t *testing.T, obj map[string]any) {
+				specMap := obj["spec"].(map[string]any)
+
+				// The intermediate segment keeps its case and the value lands on it.
+				tlsConfig, ok := specMap["tlsConfig"].(map[string]any)
+				require.True(t, ok, "intermediate tlsConfig segment should keep its case")
+				assert.Equal(t, "myResolver", tlsConfig["certResolver"])
+
+				// No lowercased intermediate segment should be created.
+				_, lowered := specMap["tlsconfig"]
+				assert.False(t, lowered, "intermediate segment must not be lowercased")
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Problem Statement

Templating into a generic custom resource (via `spec.target.manifest`) with a mixed-case `templateFrom[].target` dotted path silently lowercases the entire path, so the rendered value is written under the wrong key and dropped by the API server. For example, targeting a Traefik `Middleware` with `target: spec.headers.customRequestHeaders.foo` ends up writing `spec.headers.customrequestheaders.foo`; because Kubernetes field names are case-sensitive the field is unknown, ESO logs `unknown field "spec.headers.customrequestheaders"`, and the result collapses to `spec.headers: {}`.

## Related Issue

Fixes #6458

## Proposed Changes

The lowercasing was introduced so the well-known top-level targets (`annotations`, `labels`, `data`, `spec`) match case-insensitively. The bug is that `runtime/template/v2/template.go` reassigned `target = strings.ToLower(target)` before splitting the path into segments, so the lowercased value also flowed into the arbitrary nested-path branch where case is significant.

Both `applyToTarget` and `mapScopeApply` now switch on a lowercased copy of the target for top-level dispatch while leaving the original `target` untouched, so the nested-path branch (`strings.Split` / `applyParsedToPath`) preserves the case of every segment. The well-known targets stay case-insensitive: the `data`/`spec` cases already pass hardcoded literals to `setField`, and the existing `TestExecuteTargetCaseInsensitive` / `TestScopeKeysAndValues` continue to pass unchanged.

One deliberate behavior change is worth calling out: a nested path that capitalizes a well-known root (e.g. `Spec.foo`) is no longer collapsed to `spec.foo`. The real field is lowercase `spec`, and the case-insensitivity guarantee only ever applied to single-token targets, so this is the correct behavior rather than a regression.

Added four regression cases to `TestNestedPathTargeting` mirroring the issue: a leaf mixed-case segment and a deeper intermediate mixed-case segment, each for both the `KeysAndValues` scope (`mapScopeApply` -> `applyParsedToPath`) and the `Values` scope (`applyToTarget`). All four fail on `main` and pass with this change.

Verified on the affected package: `go build`, `go vet`, `gofmt -l` (clean), `golangci-lint run ./template/v2/...` (0 issues), and `go test ./template/v2/... -race` (all green, including the new cases and the case-insensitivity guards).

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Fixed a bug where templating into generic custom resources was converting mixed-case dotted paths to lowercase, causing values to be written to incorrect lowercase keys instead of the original mixed-case fields.

## Changes
**runtime/template/v2/template.go**
- Modified `applyToTarget` and `mapScopeApply` to perform case-insensitive matching of well-known top-level targets within switch statements while preserving the original casing of the target string for nested-path handling
- Removed `target = strings.ToLower(target)` assignments that were globally lowercasing all paths

**runtime/template/v2/template_test.go**
- Added four regression test cases to `TestNestedPathTargeting` covering mixed-case paths like `spec.headers.customRequestHeaders` and `spec.tlsConfig.certResolver` for both `TemplateScopeKeysAndValues` and `TemplateScopeValues` scopes

## Testing
All verifications passed: go build, go vet, gofmt, golangci-lint, and go test with race detector enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->