### PR TITLE
docs(aws): fix broken snippet include and add IRSA trust policy and troubleshooting

### DIFF
--- a/docs/provider/aws-access.md
+++ b/docs/provider/aws-access.md
@@ -100,10 +100,11 @@ spec:
 First, ensure your cluster has an IAM OIDC provider associated with it:
 
 ```bash
-# Get your cluster's OIDC issuer URL
+# Get your cluster's OIDC issuer URL — note: output includes https:// prefix
 aws eks describe-cluster --name <cluster-name> \
   --query "cluster.identity.oidc.issuer" \
   --output text
+# Example output: https://oidc.eks.eu-central-1.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE
 
 # Associate the OIDC provider (if not already done)
 eksctl utils associate-iam-oidc-provider \
@@ -111,7 +112,7 @@ eksctl utils associate-iam-oidc-provider \
   --approve
 ```
 
-Create an IAM role with the following trust policy. Replace the OIDC issuer URL, account ID, namespace, and service account name with your values:
+Create an IAM role with the following trust policy. The trust policy uses the OIDC issuer **without** the `https://` prefix — strip it before pasting into the `Federated` ARN and condition keys. Replace the OIDC issuer host/path, account ID, namespace, and service account name with your values:
 
 ```json
 {
@@ -134,7 +135,7 @@ Create an IAM role with the following trust policy. Replace the OIDC issuer URL,
 }
 ```
 
-The `sub` condition must match the `namespace:serviceaccount-name` of the service account referenced in your `SecretStore`. Scope this as narrowly as possible — granting access to a specific service account in a specific namespace is more secure than using a wildcard.
+The `sub` condition must be `system:serviceaccount:<namespace>:<serviceaccount-name>`, matching the service account referenced in your `SecretStore`. Scope this as narrowly as possible — a specific namespace and service account name is more secure than using a wildcard.
 
 Attach an IAM permissions policy to this role granting `secretsmanager:GetSecretValue` (and `secretsmanager:DescribeSecret`) on the secrets ESO needs to access.
 

--- a/docs/provider/aws-access.md
+++ b/docs/provider/aws-access.md
@@ -95,6 +95,51 @@ spec:
 
 **NOTE:** In case of a `ClusterSecretStore`, Be sure to provide `namespace` for `serviceAccountRef` with the namespace where the service account resides.
 
+#### Setting up the IAM Role for IRSA
+
+First, ensure your cluster has an IAM OIDC provider associated with it:
+
+```bash
+# Get your cluster's OIDC issuer URL
+aws eks describe-cluster --name <cluster-name> \
+  --query "cluster.identity.oidc.issuer" \
+  --output text
+
+# Associate the OIDC provider (if not already done)
+eksctl utils associate-iam-oidc-provider \
+  --cluster <cluster-name> \
+  --approve
+```
+
+Create an IAM role with the following trust policy. Replace the OIDC issuer URL, account ID, namespace, and service account name with your values:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.eu-central-1.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "oidc.eks.eu-central-1.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE:sub": "system:serviceaccount:default:my-serviceaccount",
+          "oidc.eks.eu-central-1.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE:aud": "sts.amazonaws.com"
+        }
+      }
+    }
+  ]
+}
+```
+
+The `sub` condition must match the `namespace:serviceaccount-name` of the service account referenced in your `SecretStore`. Scope this as narrowly as possible — granting access to a specific service account in a specific namespace is more secure than using a wildcard.
+
+Attach an IAM permissions policy to this role granting `secretsmanager:GetSecretValue` (and `secretsmanager:DescribeSecret`) on the secrets ESO needs to access.
+
+**NOTE:** AWS Secrets Manager appends a 6-character random suffix to secret ARNs (e.g. `arn:aws:secretsmanager:region:account:secret:my-secret-AbCdEf`). Use a trailing wildcard in your IAM policy resource to avoid access denied errors when the suffix is not known in advance: `arn:aws:secretsmanager:eu-central-1:123456789012:secret:my-secret-*`.
+
 ## EKS Pod Identity Setup
 
 In order to use EKS Pod Identity Agent, create a role like this:
@@ -274,4 +319,79 @@ When session tags are enabled, the role trust policy must allow `sts:TagSession`
     }
   ]
 }
+```
+
+## Troubleshooting
+
+### Checking sync status
+
+Use `kubectl describe` to inspect the status conditions and recent events on your resources:
+
+```bash
+# Check ExternalSecret status and events
+kubectl describe externalsecret <name> -n <namespace>
+
+# Check SecretStore status
+kubectl describe secretstore <name> -n <namespace>
+
+# Check ClusterSecretStore status
+kubectl describe clustersecretstore <name>
+```
+
+A healthy `ExternalSecret` shows `Ready=True` in its status conditions. When sync fails, the `message` field contains the error returned by the provider.
+
+### Common errors
+
+#### `AccessDeniedException: Not authorized to perform sts:AssumeRoleWithWebIdentity`
+
+The IRSA trust policy is missing or misconfigured. Check:
+
+1. Your cluster has an IAM OIDC provider: `aws iam list-open-id-connect-providers`
+2. The `Federated` principal in the trust policy exactly matches your cluster's OIDC provider ARN
+3. The `sub` condition matches `system:serviceaccount:<namespace>:<serviceaccount-name>` for the service account referenced in your `SecretStore`
+4. The service account has the `eks.amazonaws.com/role-arn` annotation set to the correct role ARN
+
+#### `AccessDeniedException: is not authorized to perform: secretsmanager:GetSecretValue`
+
+The role can be assumed but lacks permissions on the secret. Check:
+
+1. The IAM permissions policy is attached to the role
+2. The resource ARN in the policy covers your secret — AWS Secrets Manager appends a 6-character random suffix to ARNs. Use a trailing wildcard: `arn:aws:secretsmanager:region:account:secret:my-secret-*`
+
+#### `ResourceNotFoundException`
+
+The secret cannot be found. Verify:
+
+1. The `region` in your `SecretStore` or `ClusterSecretStore` matches the AWS region where the secret is stored
+2. The `remoteRef.key` in your `ExternalSecret` is the correct secret name or ARN
+3. The secret exists and is not scheduled for deletion (`aws secretsmanager describe-secret --secret-id <name>`)
+
+#### `ClusterSecretStore` not syncing — service account not found
+
+When using `auth.jwt.serviceAccountRef` in a `ClusterSecretStore`, the `namespace` field is required:
+
+```yaml
+auth:
+  jwt:
+    serviceAccountRef:
+      name: my-serviceaccount
+      namespace: external-secrets  # required for ClusterSecretStore
+```
+
+Without `namespace`, ESO cannot locate the service account and the store will fail to initialize.
+
+#### Secret syncs once but never updates
+
+Check the `refreshInterval` on your `ExternalSecret`. A value of `0` disables periodic re-sync — the secret is only fetched on creation:
+
+```yaml
+spec:
+  refreshInterval: 1h  # re-sync every hour; use 0 to disable
+```
+
+To trigger an immediate re-sync without waiting for the interval, annotate the `ExternalSecret`:
+
+```bash
+kubectl annotate externalsecret <name> \
+  force-sync=$(date +%s) --overwrite
 ```

--- a/docs/provider/aws-parameter-store.md
+++ b/docs/provider/aws-parameter-store.md
@@ -180,4 +180,4 @@ You should see something similar to the following output:
 }
 ```
 
---8<-- "snippets/provider-aws-access.md"
+--8<-- "provider/aws-access.md"

--- a/docs/provider/aws-secrets-manager.md
+++ b/docs/provider/aws-secrets-manager.md
@@ -294,4 +294,4 @@ spec:
       version: "uuid/123e4567-e89b-12d3-a456-426614174000"
 ```
 
---8<-- "snippets/provider-aws-access.md"
+--8<-- "provider/aws-access.md"


### PR DESCRIPTION
## Problem Statement

Two separate issues with the AWS provider documentation:

1. **Broken snippet include (bug):** `docs/snippets/provider-aws-access.md` was deleted in #5783 when it was renamed to `docs/provider/aws-access.md`. However, the `--8<-- "snippets/provider-aws-access.md"` includes in both `aws-secrets-manager.md` and `aws-parameter-store.md` were not updated. Both pages have had a broken include since that merge — the AWS authentication section is missing from the bottom of each page.

2. **Missing IRSA setup content:** The "EKS Service Account credentials" section shows the `ServiceAccount` annotation and `SecretStore` config but omits the IAM role trust policy — the most common missing piece when IRSA fails.

## Related Issue

Fixes broken snippet reference introduced by #5783.

## Proposed Changes

- Fix `aws-secrets-manager.md` and `aws-parameter-store.md` to reference `--8<-- "provider/aws-access.md"` (the correct path after the rename)
- Expand the IRSA section in `aws-access.md` with a complete IAM role setup: OIDC provider association commands, trust policy JSON with `sub`/`aud` conditions scoped to a specific namespace and service account, and a note about the Secrets Manager ARN random suffix that causes common IAM policy mismatches
- Add a `## Troubleshooting` section to `aws-access.md` covering the five most common AWS auth failure modes with exact error messages and their fixes

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Documentation Updates for AWS Provider

Fixed broken snippet includes in AWS provider docs that referenced a deleted file. Updated references in aws-secrets-manager.md and aws-parameter-store.md to point to provider/aws-access.md.

Expanded the EKS Service Account (IRSA) section in provider/aws-access.md with:
- Full IAM role setup including commands to associate the OIDC provider.
- Example sts:AssumeRoleWithWebIdentity trust policy scoped with exact sub format (system:serviceaccount:<namespace>:<serviceaccount-name>) and aud condition.
- Clarification that the AWS CLI returns the OIDC issuer URL prefixed with https://, which must be stripped when constructing the trust policy.
- Note about Secrets Manager secret ARN random suffixes and using a trailing wildcard to avoid IAM policy mismatches.

Added a Troubleshooting section listing five common AWS auth/sync failure modes with exact errors and fixes: AssumeRoleWithWebIdentity access denied, secretsmanager:GetSecretValue access denied, ResourceNotFoundException causes, missing namespace on ClusterSecretStore serviceAccountRef, and secret-refresh/resync issues (including how to force an immediate re-sync).

Lines changed: +121/-0 (documentation-only)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->