### PR TITLE
docs(aws-secrets-manager): add JSON key extraction examples

### DIFF
--- a/docs/provider/aws-secrets-manager.md
+++ b/docs/provider/aws-secrets-manager.md
@@ -295,3 +295,84 @@ spec:
 ```
 
 --8<-- "snippets/provider-aws-access.md"
+
+
+## Extracting keys from JSON secrets
+
+Most production secrets stored in AWS Secrets Manager are JSON objects, not plain strings:
+
+```json
+{
+  "username": "admin",
+  "password": "s3cr3t",
+  "host": "mydb.cluster-xyz.us-east-1.rds.amazonaws.com",
+  "port": "5432",
+  "dbname": "myapp"
+}
+```
+
+### Fetch a single key with `remoteRef.property`
+
+Use `remoteRef.property` to extract one key from a JSON secret:
+
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: db-password
+  namespace: myapp
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secrets-manager
+    kind: SecretStore
+  target:
+    name: db-password
+    creationPolicy: Owner
+  data:
+    - secretKey: password
+      remoteRef:
+        key: myapp/prod/database
+        property: password
+```
+
+### Fetch all keys at once with `dataFrom`
+
+Maps every JSON key directly into the Kubernetes Secret:
+
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: db-credentials
+  namespace: myapp
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secrets-manager
+    kind: SecretStore
+  target:
+    name: db-credentials
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        key: myapp/prod/database
+```
+
+This produces a Secret with keys `username`, `password`, `host`, `port`, and `dbname`.
+
+### Rename keys with `rewrite`
+
+```yaml
+  dataFrom:
+    - extract:
+        key: myapp/prod/database
+      rewrite:
+        - regexp:
+            source: "(.+)"
+            target: "DB_$1"
+```
+
+This produces `DB_username`, `DB_password`, `DB_host`, etc.
+
+> **Tip:** If your secret is a plain string (not JSON), omit `property` — the entire value is stored under the `secretKey` you specify.


### PR DESCRIPTION
Add a dedicated section explaining how to extract individual keys from JSON-structured AWS Secrets Manager secrets using:
- remoteRef.property for single-key extraction
- dataFrom with extract for all-keys extraction
- dataFrom with rewrite for key renaming/prefixing

Partially addresses #2158

## Problem Statement

JSON-structured secrets are the dominant real-world pattern in AWS Secrets Manager, but the current docs only show how to fetch a plain string secret. This leaves users without clear guidance on extracting individual keys.


## Related Issue

Partially addresses #2158

## Proposed Changes

Added a new "Extracting keys from JSON secrets" section covering:
- `remoteRef.property` for single-key extraction
- `dataFrom` with `extract` for all-keys extraction  
- `dataFrom` with `rewrite` for key renaming/prefixing

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Documentation: AWS Secrets Manager JSON Key Extraction

Added a new "Extracting keys from JSON secrets" section to the AWS Secrets Manager provider documentation.

The section covers three methods for extracting keys from JSON-structured secrets:

1. **`remoteRef.property`** — Extract a single key from a JSON secret
2. **`dataFrom` with `extract`** — Extract all keys from a JSON secret at once
3. **`dataFrom` with `rewrite`** — Rename or prefix extracted keys using regex-based rules

Each method includes a practical YAML example demonstrating its usage, along with a tip for handling plain-string secrets.

**Changes:** +81 lines added to `docs/provider/aws-secrets-manager.md`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->