### PR TITLE
docs(akeyless): fix errors and expand provider documentation

### DIFF
--- a/docs/provider/akeyless.md
+++ b/docs/provider/akeyless.md
@@ -9,7 +9,7 @@ SecretStore resource specifies how to access Akeyless. This resource is namespac
 **NOTE:** Make sure the Akeyless provider is listed in the Kind=SecretStore.
 If you use a customer fragment, define the value of akeylessGWApiURL as the URL of your Akeyless Gateway in the following format: https://your.akeyless.gw:8080/v2.
 
-Akeyelss provide several Authentication Methods:
+Akeyless provides several Authentication Methods:
 
 ### Authentication with Kubernetes
 
@@ -25,22 +25,23 @@ Options for obtaining Kubernetes credentials include:
 {% include 'akeyless-secret-store-k8s-auth.yaml' %}
 ```
 
-**NOTE:** In case of a `ClusterSecretStore`, Be sure to provide `namespace` for `serviceAccountRef` and `secretRef` according to  the namespaces where the secrets reside.
+**NOTE:** In case of a `ClusterSecretStore`, be sure to provide `namespace` for `serviceAccountRef` and `secretRef` according to the namespaces where the secrets reside.
 
-### Authentication With Cloud-Identity or Api-Access-Key
+### Authentication with Cloud-Identity or Api-Access-Key
 
-Akeyless providers require an access-id, access-type and access-Type-param
-To set your SecretStore with an authentication method from Akeyless.
+Akeyless providers require an access-id, access-type and access-type-param
+to set your SecretStore with an authentication method from Akeyless.
 
 The supported auth-methods and their parameters are:
 
-| accessType  | accessTypeParam                                                                                                                                                                                                                      |
-| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `aws_iam` |   -                                                         |
-| `gcp` |      The gcp audience                                                      |
-| `azure_ad` |  azure object id  (optional)                                                          |
-| `api_key`      | The access key.                                                                                                                                     |
-| `k8s`         | The k8s configuration name |
+| accessType     | accessTypeParam                    |
+| -------------- | ---------------------------------- |
+| `aws_iam`      | -                                  |
+| `gcp`          | The GCP audience                   |
+| `azure_ad`     | Azure object ID (optional)         |
+| `api_key`      | The access key                     |
+| `access_key`   | The access key (alias for api_key) |
+| `k8s`          | The k8s configuration name         |
 
 For more information see [Akeyless Authentication Methods](https://docs.akeyless.io/docs/access-and-authentication-methods)
 
@@ -49,15 +50,7 @@ For more information see [Akeyless Authentication Methods](https://docs.akeyless
 Create a secret containing your credentials using the following example as a guide:
 
 ```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: akeyless-secret-creds
-type: Opaque
-stringData:
-  accessId: "p-XXXX"
-  accessType:  # gcp/azure_ad/api_key/k8s/aws_iam
-  accessTypeParam:  # optional: can be one of the following: gcp-audience/azure-obj-id/access-key/k8s-conf-name
+{% include 'akeyless-credentials-secret.yaml' %}
 ```
 
 #### Create the Akeyless Secret Store Provider with the Credentials Secret
@@ -66,7 +59,7 @@ stringData:
 {% include 'akeyless-secret-store.yaml' %}
 ```
 
-**NOTE:** In case of a `ClusterSecretStore`, be sure to provide `namespace` for `accessID`, `accessType` and `accessTypeParam`  according to the namespaces where the secrets reside.
+**NOTE:** In case of a `ClusterSecretStore`, be sure to provide `namespace` for `accessID`, `accessType` and `accessTypeParam` according to the namespaces where the secrets reside.
 
 #### Create the Akeyless Secret Store With CAs for TLS handshake
 
@@ -83,13 +76,22 @@ spec:
       # Instead of caBundle you can also specify a caProvider
       # this will retrieve the cert from a Secret or ConfigMap
       caProvider:
-        type: "Secret/ConfigMap" # Can be Secret or ConfigMap
+        type: Secret  # Can be Secret or ConfigMap
         name: "<name of secret or configmap>"
         key: "<key inside secret>"
         # namespace is mandatory for ClusterSecretStore and not relevant for SecretStore
         namespace: "my-cert-secret-namespace"
   ....
 ```
+
+### Supported Secret Types
+
+The provider supports the following Akeyless item types:
+
+- **Static Secret** -- standard key/value secret
+- **Dynamic Secret** -- ephemeral credentials generated on demand
+- **Rotated Secret** -- automatically rotated credentials
+- **Certificate** -- TLS/SSH certificates
 
 ### Creating an external secret
 
@@ -99,13 +101,55 @@ To get a secret from Akeyless and create it as a secret on the Kubernetes cluste
 {% include 'akeyless-external-secret.yaml' %}
 ```
 
+#### Fetching a specific version
+
+Use `remoteRef.version` to pin a specific secret version (integer). Omit the field or set it to `0` to get the latest version.
+
+```yaml
+data:
+  - secretKey: password
+    remoteRef:
+      key: /path/to/secret
+      version: "3"  # fetch version 3 specifically
+```
+
+#### Extracting a property from a JSON secret
+
+If the secret value is a JSON object, use `remoteRef.property` to extract a single key. Nested keys can be addressed with dot notation; literal dots in key names are escaped with a backslash (`key\.with\.dots`).
+
+```yaml
+data:
+  - secretKey: db-password
+    remoteRef:
+      key: /path/to/json-secret
+      property: password  # extracts {"password": "..."} from the JSON value
+```
 
 #### Using DataFrom
 
-DataFrom can be used to get a secret as a JSON string and attempt to parse it.
+DataFrom can be used to get a secret as a JSON string and attempt to parse it, creating one Kubernetes secret key per JSON field.
 
 ```yaml
 {% include 'akeyless-external-secret-json.yaml' %}
+```
+
+#### Finding secrets by name or tag
+
+Use `dataFrom.find` to bulk-fetch secrets matching a name pattern or tag:
+
+```yaml
+# by name regex
+dataFrom:
+  - find:
+      path: /my/path/         # optional path prefix
+      name:
+        regexp: ".*db.*"
+
+# by tag
+dataFrom:
+  - find:
+      tags:
+        env: production
 ```
 
 ### Getting the Kubernetes Secret
@@ -124,7 +168,9 @@ kubectl get secret database-credentials-json -o jsonpath='{.data}'
 
 To push a secret from Kubernetes cluster and create it as a secret to Akeyless, a `Kind=PushSecret` resource is needed.
 
+```yaml
 {% include 'akeyless-push-secret.yaml' %}
+```
 
 Then when you create a matching secret as follows:
 

--- a/docs/snippets/akeyless-credentials-secret.yaml
+++ b/docs/snippets/akeyless-credentials-secret.yaml
@@ -5,8 +5,5 @@ metadata:
 type: Opaque
 stringData:
   accessId: "p-XXXX"
-  accessType:  # k8s/aws_iam/gcp/azure_ad/api_key
-  accessTypeParam: # can be one of the following: k8s-conf-name/gcp-audience/azure-obj-id/access-key
-
-
-
+  accessType:  # one of: aws_iam / gcp / azure_ad / api_key / access_key / k8s
+  accessTypeParam:  # optional -- one of: gcp-audience / azure-obj-id / access-key / k8s-conf-name

--- a/docs/snippets/akeyless-secret-store-k8s-auth.yaml
+++ b/docs/snippets/akeyless-secret-store-k8s-auth.yaml
@@ -13,12 +13,16 @@ spec:
           k8sConfName: "my-conf-name"
 
           # Optional service account field containing the name
-          # of a kubernetes ServiceAccount
+          # of a kubernetes ServiceAccount.
+          # For ClusterSecretStore, namespace is required.
           serviceAccountRef:
             name: "my-sa"
+            # namespace: "my-namespace"  # required for ClusterSecretStore
 
           # Optional secret field containing a Kubernetes ServiceAccount JWT
-          # used for authenticating with Akeyless
+          # used for authenticating with Akeyless.
+          # For ClusterSecretStore, namespace is required.
           secretRef:
             name: "my-secret"
             key: "token"
+            # namespace: "my-namespace"  # required for ClusterSecretStore


### PR DESCRIPTION
## What this PR does

Fixes several errors and omissions in the Akeyless provider documentation found during a documentation review.

## Changes

### Bug fixes

- **Missing code fence around PushSecret include** (line 127) -- the `{% include 'akeyless-push-secret.yaml' %}` was not wrapped in a `yaml` code block, causing it to render as raw text on the site. All other includes in the file had fences.

- **Misleading `caProvider.type` example** -- the example showed `type: "Secret/ConfigMap"` as a literal value with a comment saying it can be one or the other. Changed to `type: Secret` with the comment clarifying the valid values. [See `secretstore_types.go` `CAProvider` struct](https://github.com/external-secrets/external-secrets/blob/main/apis/externalsecrets/v1/secretstore_types.go).

- **Typo** -- "Akeyelss" -> "Akeyless provides".

- **Heading capitalisation** -- "Authentication With Cloud-Identity" -> "Authentication with Cloud-Identity".

### Missing documentation

- **`access_key` alias undocumented** -- the provider accepts `access_key` as a valid alias for `api_key` ([`akeyless_api.go` line 68](https://github.com/external-secrets/external-secrets/blob/main/providers/v1/akeyless/akeyless_api.go#L68)) but the auth methods table only listed `api_key`.

- **`remoteRef.version`** -- `GetSecret` parses `ref.Version` and passes it to the Akeyless API for static and rotated secrets ([`akeyless.go` lines 270-277](https://github.com/external-secrets/external-secrets/blob/main/providers/v1/akeyless/akeyless.go#L270-L277)). Added an example.

- **`remoteRef.property`** -- `GetSecret` uses `gjson` to extract a named key (with dot-path support) from JSON secret values ([`akeyless.go` lines 288-300](https://github.com/external-secrets/external-secrets/blob/main/providers/v1/akeyless/akeyless.go#L288-L300)). Added an example.

- **`dataFrom.find` by name and tag** -- `GetAllSecrets` implements both name-regex and tag-based search ([`akeyless.go` lines 325-332](https://github.com/external-secrets/external-secrets/blob/main/providers/v1/akeyless/akeyless.go#L325-L332)), and the stability table marks both as supported for Akeyless. Added examples for both.

- **Supported secret types** -- `GetSecretByType` handles `STATIC_SECRET`, `DYNAMIC_SECRET`, `ROTATED_SECRET`, and `CERTIFICATE` ([`akeyless_api.go` lines 113-126](https://github.com/external-secrets/external-secrets/blob/main/providers/v1/akeyless/akeyless_api.go#L113-L126)). Added a brief list so users know these types are supported.

### Snippet improvements

- **`akeyless-credentials-secret.yaml`** -- the snippet existed but the doc was showing an inline YAML block instead of including it, risking drift. Switched the doc to `{% include %}` and aligned the snippet comments with the updated auth methods table.

- **`akeyless-secret-store-k8s-auth.yaml`** -- added commented-out `namespace` fields on `serviceAccountRef` and `secretRef` to reinforce the existing NOTE about ClusterSecretStore requirements.

## Related issues

- Closes none (these are doc-only fixes; the two code bugs found during review were filed separately as #6504 and #6505)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Updated Akeyless provider documentation to correct errors and document previously undocumented features.

### Documentation Corrections
- Added missing code fence around PushSecret include statement
- Fixed `caProvider.type` example to properly show `type: Secret` with valid options
- Corrected typo "Akeyelss" → "Akeyless provides"
- Fixed heading capitalization: "Authentication With Cloud-Identity" → "Authentication with Cloud-Identity"

### Documentation Additions
- Added `access_key` as documented alias for `api_key` in authentication methods
- Documented `remoteRef.version` parameter for pinning specific secret versions
- Documented `remoteRef.property` parameter for extracting named keys from JSON secrets with gjson dot-path support
- Added examples for `dataFrom.find` covering regex name-based and tag-based search
- Listed all supported Akeyless secret types: Static, Dynamic, Rotated, Certificate

### Snippet Improvements
- Replaced inline YAML with reusable `akeyless-credentials-secret.yaml` include to prevent documentation-code drift
- Updated credential snippet comments to reflect expanded authentication methods
- Added commented namespace fields to k8s-auth snippet for ClusterSecretStore requirements

### Files Changed
- `docs/provider/akeyless.md` (+70/-24)
- `docs/snippets/akeyless-credentials-secret.yaml` (+2/-5)
- `docs/snippets/akeyless-secret-store-k8s-auth.yaml` (+6/-2)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->