### PR TITLE
docs(azure): correct Azure Stack example version and note expiry limit

### DIFF
--- a/docs/provider/azure-key-vault.md
+++ b/docs/provider/azure-key-vault.md
@@ -165,7 +165,7 @@ spec:
 For Azure Stack Hub or Azure Stack Edge environments:
 
 ```yaml
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: azure-stack-backend
@@ -263,6 +263,9 @@ You can optionally attach metadata to the secret via the `spec.data[].metadata` 
 
 !!! note
     Omitting `contentType` (or setting it to an empty string) is interpreted as "don't change" rather than "clear": if the secret in Azure Key Vault already has a `ContentType` set, it will be preserved on update. There is currently no way to clear an existing `ContentType` via PushSecret — if you need to remove it, delete the secret from Azure Key Vault directly and let PushSecret recreate it.
+
+!!! note
+    `expirationDate` is applied only when the SecretStore uses the legacy SDK (the default). When `useAzureSDK: true` is set (required for `customCloudConfig`, including Azure Stack and Azure China Workload Identity), `expirationDate` is currently ignored: the secret is pushed without an expiry, and changing `expirationDate` alone does not trigger an update. If you need an expiry in those environments, set it directly on the secret in Azure Key Vault.
 
 #### Pushing to a Key
 The first step is to generate a valid private key. Supported formats include `PRIVATE KEY`, `RSA PRIVATE KEY` AND `EC PRIVATE KEY` (EC/PKCS1/PKCS8 types). After uploading your key to a Kubernetes Secret, the next step is to create a PushSecret manifest with the following configuration:


### PR DESCRIPTION
## Problem Statement

Two accuracy issues in the Azure Key Vault provider documentation (`docs/provider/azure-key-vault.md`):

1. The "Azure Stack Configuration" example declares `apiVersion: external-secrets.io/v1beta1`. The v1beta1 `SecretStore`/`ClusterSecretStore` are marked unserved and deprecated (the API server does not serve that version), and the v1beta1 `azurekv` provider has no `useAzureSDK` or `customCloudConfig` fields at all (both exist only in v1). So the example, which relies on both fields, cannot be applied as written. Every other example on the page already uses `external-secrets.io/v1`.

2. The PushSecret metadata table lists `expirationDate` as supported with no caveat, but the new SDK push path (`setKeyVaultSecretWithNewSDK`) does not set an expiry. When `useAzureSDK: true` is set, which is required for `customCloudConfig` (Azure Stack, Azure China Workload Identity), `expirationDate` is silently ignored and a change to it alone does not trigger an update. This is acknowledged in the code itself (`The new SDK doesn't support setting expiration in SetSecretParameters. This is a limitation compared to the legacy SDK` https://github.com/external-secrets/external-secrets/blob/bbc9b97b9c451a5c933a7044413a45d1d9f218fd/providers/v1/azure/keyvault/keyvault_new_sdk.go#L112-L120).

## Proposed Changes

- Change the Azure Stack example to `apiVersion: external-secrets.io/v1`.
- Add a note under "Pushing to a Secret" stating that `expirationDate` is honored only by the legacy SDK and is currently ignored when `useAzureSDK: true`, with guidance to set the expiry directly in Azure Key Vault in those environments.

Documentation only. No code or API changes.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage (n/a, docs only)
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the Azure Key Vault docs to correct two inaccuracies:

- Switched the Azure Stack `SecretStore` example from `external-secrets.io/v1beta1` to `external-secrets.io/v1`.
- Clarified that `expirationDate` in `spec.data[].metadata` only applies with the legacy SDK; it is ignored when `useAzureSDK: true`, so expiry must be set directly in Azure Key Vault in those setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->