### PR TITLE
[WIP need other markdownlint-cli2 merges first] feat: Use markdownlint-cli2 locally and CI

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+files=()
+while IFS= read -r file; do
+  files+=("$file")
+done < <(git diff --cached --name-only --diff-filter=ACMR -- '*.md')
+
+if [ ${#files[@]} -eq 0 ]; then
+  exit 0
+fi
+
+printf -v markdown_files '%q ' "${files[@]}"
+make markdownlint MARKDOWNLINT_FILES="$markdown_files"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,26 @@ jobs:
       - name: Check License Headers
         uses: apache/skywalking-eyes/header@61275cc80d0798a405cb070f7d3a8aaf7cf2c2c1 # v0.8.0
 
+  markdownlint:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Setup Node.js
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: 24
+      - name: Run markdownlint-cli2
+        run: make markdownlint
+
   check-diff:
     runs-on: ubuntu-latest
     needs: detect-noop
@@ -74,6 +94,10 @@ jobs:
         id: setup-go
         with:
           go-version-file: "go.mod"
+      - name: Setup Node.js
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: 24
 
       - name: Download Go modules
         run: go mod download

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,36 @@
+{
+  "config": {
+    "MD007": false,
+    "MD013": false,
+    "MD033": false,
+    "MD046": {
+      "style": "fenced"
+    },
+    "MD060": {
+      "style": "aligned"
+    }
+  },
+  "ignores": [
+    "bin/**",
+    "docs/api/spec.md",
+
+    // Existing documents with pre-existing markdownlint violations.
+    "AGENTS.md",
+    "CLAUDE.md",
+    "CODEOWNERS.md",
+    "CONTRIBUTOR_LADDER.md",
+    "DEPRECATING.md",
+    "GOVERNANCE.md",
+    "MAINTAINERS.md",
+    "OWNERS.md",
+    "README.md",
+    "SECURITY.md",
+    "SECURITY_RESPONSE.md",
+    ".github/CODEOWNERS.md",
+    ".github/ISSUE_TEMPLATE/bug_report.md",
+    ".github/pull_request_template.md",
+    "deploy/charts/external-secrets/README.md",
+    "deploy/charts/external-secrets/templates/crds/README.md",
+    "design/**"
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ FAIL	= (echo ${TIME} ${RED}[FAIL]${CNone} && false)
 # ====================================================================================
 # Conformance
 
-reviewable: generate docs manifests helm.generate helm.schema.update helm.docs lint license.check helm.test.update test.crds.update tf.fmt ## Ensure a PR is ready for review.
+reviewable: generate docs manifests helm.generate helm.schema.update helm.docs lint markdownlint license.check helm.test.update test.crds.update tf.fmt ## Ensure a PR is ready for review.
 	@go mod tidy
 	@cd e2e/ && go mod tidy
 	@cd apis/ && go mod tidy
@@ -191,6 +191,17 @@ lint: golangci-lint ## Run golangci-lint (set LINT_TARGET to run on specific mod
 generate: ## Generate code and crds
 	@./hack/crd.generate.sh $(BUNDLE_DIR) $(CRD_DIR)
 	@$(OK) Finished generating deepcopy and crds
+
+.PHONY: markdownlint
+markdownlint: markdownlint-cli2 ## Run markdownlint-cli2 against Markdown files (set MARKDOWNLINT_FILES to override)
+	@$(INFO) markdownlint-cli2 $(MARKDOWNLINT_FILES)
+	$(MARKDOWNLINT_CLI2) $(MARKDOWNLINT_FILES)
+	@$(OK) markdownlint-cli2
+
+.PHONY: git-hooks
+git-hooks: ## Install project git hooks
+	@git config core.hooksPath .githooks
+	@$(OK) installed project git hooks
 
 # ====================================================================================
 # Local Utility
@@ -428,12 +439,15 @@ TILT ?= $(LOCALBIN)/tilt
 CTY ?= $(LOCALBIN)/cty
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
+MARKDOWNLINT_CLI2 ?= $(LOCALBIN)/markdownlint-cli2/node_modules/.bin/markdownlint-cli2
 LINT_TARGET ?= ""
+MARKDOWNLINT_FILES ?= "**/*.md"
 ## Tool Versions
 GOLANGCI_VERSION := 2.11.3
 KUBERNETES_VERSION := 1.33.x
 TILT_VERSION := 0.33.21
 CTY_VERSION := 1.1.3
+MARKDOWNLINT_CLI2_VERSION := 0.18.1
 
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
@@ -446,6 +460,14 @@ golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
 	test -s $(LOCALBIN)/golangci-lint && $(LOCALBIN)/golangci-lint version | grep -q $(GOLANGCI_VERSION) || \
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(LOCALBIN) v$(GOLANGCI_VERSION)
+
+.PHONY: markdownlint-cli2
+.PHONY: $(MARKDOWNLINT_CLI2)
+markdownlint-cli2: $(MARKDOWNLINT_CLI2) ## Download markdownlint-cli2 locally if necessary.
+$(MARKDOWNLINT_CLI2): $(LOCALBIN)
+	@mkdir -p $(LOCALBIN)/npm-cache $(LOCALBIN)/markdownlint-cli2
+	test -x $(MARKDOWNLINT_CLI2) && $(MARKDOWNLINT_CLI2) --version | grep -q "v$(MARKDOWNLINT_CLI2_VERSION)" || \
+	npm_config_cache=$(LOCALBIN)/npm-cache npm install --no-save --package-lock=false --prefix $(LOCALBIN)/markdownlint-cli2 markdownlint-cli2@$(MARKDOWNLINT_CLI2_VERSION)
 
 .PHONY: tilt
 .PHONY: $(TILT)

--- a/docs/contributing/devguide.md
+++ b/docs/contributing/devguide.md
@@ -10,6 +10,8 @@ cd external-secrets
 
 _Note: many of the `make` commands use [yq](https://github.com/mikefarah/yq), version 4.2X.X or higher._
 
+Markdown linting uses [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2), installed by `make markdownlint` with `npm`. Install Node.js and npm before running Markdown checks locally.
+
 Our helm chart is tested using `helm-unittest`. You will need it to run tests locally if you modify the helm chart.
 
 ```shell
@@ -32,8 +34,14 @@ make docker.build IMAGE_NAME=external-secrets IMAGE_TAG=latest
 Run tests and lint the code:
 ```shell
 make test
-make lint # OR
-docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.49.0 golangci-lint run
+make lint # Or run an updated version of this command: docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.49.0 golangci-lint run
+make markdownlint
+```
+
+Install the project Git hooks if you want to automatically test staged Markdown files before commit (else just run `make markdownlint`):
+
+```shell
+make git-hooks
 ```
 
 Build the documentation:


### PR DESCRIPTION
## Problem Statement

Without this, coderabbit complaints on markdown changes that are not
passing markdownlint-cli2.

This is a problem, as it makes the work inefficient and distract us
from real issues.

We want to catch those as early as possible to not "waste energy".

## Related Issue

No issue proposed.

## Proposed Changes

Add markdownlint-cli2 as a make target + as a pre-commit hook + ci test.

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Added local and CI support for `markdownlint-cli2`:

- Introduced a `markdownlint` Make target and local tool install flow for `markdownlint-cli2`
- Added a pre-commit hook to lint staged Markdown files
- Added a dedicated CI job, plus Node.js setup where needed, to run markdown linting
- Configured `markdownlint-cli2` rules and ignore paths for existing repo docs
- Updated contributing docs to reflect the new markdown lint workflow and hook setup
<!-- end of auto-generated comment: release notes by coderabbit.ai -->