### PR TITLE
feat(charts): add multi namespace mode for eso

### DIFF
--- a/cmd/controller/root.go
+++ b/cmd/controller/root.go
@@ -105,6 +105,7 @@ var (
 	tlsMinVersion                         string
 	enableHTTP2                           bool
 	allowGenericTargets                   bool
+	watchNamespaces                       []string
 )
 
 const (
@@ -183,10 +184,18 @@ var rootCmd = &cobra.Command{
 			LeaderElection:   enableLeaderElection,
 			LeaderElectionID: leaderElectionID,
 		}
+		// Namespaced mode takes precedence
 		if namespace != "" {
 			mgrOpts.Cache.DefaultNamespaces = map[string]cache.Config{
 				namespace: {},
 			}
+		} else if len(watchNamespaces) > 0 {
+			// Multi-namespace mode limited to specific list of namespaces
+			nsMap := make(map[string]cache.Config, len(watchNamespaces))
+			for _, ns := range watchNamespaces {
+				nsMap[ns] = cache.Config{}
+			}
+			mgrOpts.Cache.DefaultNamespaces = nsMap
 		}
 		mgr, err := ctrl.NewManager(config, mgrOpts)
 		if err != nil {
@@ -200,7 +209,7 @@ var rootCmd = &cobra.Command{
 		// if we are already caching all secrets, we don't need to use the special client.
 		secretClient := mgr.GetClient()
 		if enableManagedSecretsCache && !enableSecretsCache {
-			secretClient, err = ctrlcommon.BuildManagedSecretClient(mgr, namespace)
+			secretClient, err = ctrlcommon.BuildManagedSecretClient(mgr, namespace, watchNamespaces)
 			if err != nil {
 				setupLog.Error(err, "unable to create managed secret client")
 				os.Exit(1)
@@ -377,6 +386,10 @@ func init() {
 		"If set, HTTP/2 will be enabled for the metrics server")
 	rootCmd.Flags().
 		BoolVar(&allowGenericTargets, "unsafe-allow-generic-targets", false, "Enable support for creating generic resources (ConfigMaps, Custom Resources). WARNING: Using generic resources, please sure all policies are correctly configured.")
+	rootCmd.Flags().StringSliceVar(&watchNamespaces, "watch-namespaces", nil,
+		"Comma-separated list of namespaces to limit ESO to watch only the provided list of namespaces"+
+			" when deployed in multi-namespace mode instead of watching all the namespaces which is the default behavior",
+	)
 	fs := feature.Features()
 	for _, f := range fs {
 		rootCmd.Flags().AddFlagSet(f.Flags)

--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -251,6 +251,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | vault | object | `{"enableTokenCache":false,"tokenCacheSize":262144}` | Vault token cache configuration |
 | vault.enableTokenCache | bool | `false` | Enable Vault token cache. External secrets will reuse the Vault token without creating a new one on each request. |
 | vault.tokenCacheSize | int | `262144` | Maximum size of Vault token cache. Only used if enableTokenCache is true. |
+| watchNamespaces | list | `[]` | If set, the controller will watch only the provided namespaces, reconcile external secrets only in those namespaces, and implicitly disable cluster stores, cluster external secrets and cluster push secrets. If this feature is used and create.rbac is set to true, then a Role and RoleBinding will be deployed in each watched namespace. |
 | webhook.affinity | object | `{}` |  |
 | webhook.annotations | object | `{}` | Annotations to place on validating webhook configuration. |
 | webhook.certCheckInterval | string | `"5m"` | Specifies the time to check if the cert is valid |

--- a/deploy/charts/external-secrets/templates/deployment.yaml
+++ b/deploy/charts/external-secrets/templates/deployment.yaml
@@ -79,7 +79,10 @@ spec:
           {{- if or .Values.scopedNamespace .Values.scopedRBAC }}
           - --namespace={{ .Values.scopedNamespace | default .Release.Namespace }}
           {{- end }}
-          {{- if .Values.scopedRBAC }}
+          {{- if .Values.watchNamespaces }}
+          - --watch-namespaces={{ join "," .Values.watchNamespaces }}
+          {{- end }}
+          {{- if or .Values.scopedNamespace .Values.scopedRBAC .Values.watchNamespaces }}
           - --enable-cluster-store-reconciler=false
           - --enable-cluster-external-secret-reconciler=false
           - --enable-cluster-push-secret-reconciler=false

--- a/deploy/charts/external-secrets/templates/rbac-per-namespace.yaml
+++ b/deploy/charts/external-secrets/templates/rbac-per-namespace.yaml
@@ -1,0 +1,166 @@
+{{- if and .Values.rbac.create .Values.watchNamespaces }}
+{{- range $ns := uniq .Values.watchNamespaces }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "external-secrets.fullname" $ }}
+  namespace: {{ $ns }}
+rules:
+  - apiGroups:
+    - "external-secrets.io"
+    resources:
+    - "secretstores"
+    - "externalsecrets"
+    {{- if $.Values.processPushSecret }}
+    - "pushsecrets"
+    {{- end }}
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+  - apiGroups:
+    - "external-secrets.io"
+    resources:
+    - "externalsecrets"
+    - "externalsecrets/status"
+    {{- if $.Values.openshiftFinalizers }}
+    - "externalsecrets/finalizers"
+    {{- end }}
+    - "secretstores"
+    - "secretstores/status"
+    {{- if $.Values.openshiftFinalizers }}
+    - "secretstores/finalizers"
+    {{- end }}
+    {{- if $.Values.processPushSecret }}
+    - "pushsecrets"
+    - "pushsecrets/status"
+    {{- if $.Values.openshiftFinalizers }}
+    - "pushsecrets/finalizers"
+    {{- end }}
+    {{- end }}
+    verbs:
+    - "get"
+    - "update"
+    - "patch"
+  - apiGroups:
+    - "generators.external-secrets.io"
+    resources:
+    - "generatorstates"
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+    - "create"
+    - "update"
+    - "patch"
+    - "delete"
+    - "deletecollection"
+  - apiGroups:
+    - "generators.external-secrets.io"
+    resources:
+    - "acraccesstokens"
+    - "cloudsmithaccesstokens"
+    - "ecrauthorizationtokens"
+    - "fakes"
+    - "gcraccesstokens"
+    - "githubaccesstokens"
+    - "quayaccesstokens"
+    - "passwords"
+    - "sshkeys"
+    - "stssessiontokens"
+    - "uuids"
+    - "vaultdynamicsecrets"
+    - "webhooks"
+    - "grafanas"
+    - "mfas"
+    - "beyondtrustworkloadcredentialsdynamicsecrets"
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+  - apiGroups:
+    - ""
+    resources:
+    - "serviceaccounts"
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+  - apiGroups:
+    - ""
+    resources:
+    - "configmaps"
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+  - apiGroups:
+    - ""
+    resources:
+    - "secrets"
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+    - "create"
+    - "update"
+    - "delete"
+    - "patch"
+  {{- if $.Values.genericTargets.enabled }}
+  # Generic target permissions (ConfigMaps)
+  - apiGroups:
+    - ""
+    resources:
+    - "configmaps"
+    verbs:
+    - "create"
+    - "update"
+    - "delete"
+    - "patch"
+  {{- range $.Values.genericTargets.resources }}
+  # Custom resource permissions for non-Secret targets
+  - apiGroups:
+    - {{ .apiGroup | quote }}
+    resources:
+    {{- range .resources }}
+    - {{ . | quote }}
+    {{- end }}
+    verbs:
+    {{- range .verbs }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- if $.Values.rbac.serviceAccountTokenCreate }}
+  - apiGroups:
+    - ""
+    resources:
+    - "serviceaccounts/token"
+    verbs:
+    - "create"
+  {{- end }}
+  - apiGroups:
+    - ""
+    resources:
+    - "events"
+    verbs:
+    - "create"
+    - "patch"
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "external-secrets.fullname" $ }}
+  namespace: {{ $ns }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "external-secrets.fullname" $ }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "external-secrets.serviceAccountName" $ }}
+    namespace: {{ template "external-secrets.namespace" $ }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/external-secrets/templates/rbac.yaml
+++ b/deploy/charts/external-secrets/templates/rbac.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.rbac.create -}}
+{{- if .Values.rbac.create }}
+{{- if not .Values.watchNamespaces }}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.scopedRBAC }}
 kind: Role
@@ -216,20 +217,6 @@ rules:
     - "update"
     - "delete"
   {{- end }}
-  {{- if .Values.metrics.listen.auth.enabled }}
-  - apiGroups:
-    - "authentication.k8s.io"
-    resources: 
-    - "tokenreviews"
-    verbs:
-    - "create"
-  - apiGroups:
-    - "authorization.k8s.io"
-    resources: 
-    - "subjectaccessreviews"
-    verbs:
-    - "create"
-  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.scopedRBAC }}
@@ -389,6 +376,30 @@ subjects:
   - name: {{ include "external-secrets.serviceAccountName" . }}
     namespace: {{ template "external-secrets.namespace" . }}
     kind: ServiceAccount
+{{- if .Values.rbac.servicebindings.create }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "external-secrets.fullname" . }}-servicebindings
+  labels:
+    servicebinding.io/controller: "true"
+    {{- include "external-secrets.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+    - "external-secrets.io"
+    resources:
+    - "externalsecrets"
+    {{- if .Values.processPushSecret }}
+    - "pushsecrets"
+    {{- end }}
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+{{- end }}
+{{- end }}
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -439,27 +450,43 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "external-secrets.serviceAccountName" . }}
     namespace: {{ template "external-secrets.namespace" . }}
-{{- if .Values.rbac.servicebindings.create }}
+
+{{- if .Values.metrics.listen.auth.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "external-secrets.fullname" . }}-servicebindings
+  name: {{ include "external-secrets.fullname" . }}-metrics-auth
   labels:
-    servicebinding.io/controller: "true"
     {{- include "external-secrets.labels" . | nindent 4 }}
 rules:
   - apiGroups:
-    - "external-secrets.io"
+    - "authentication.k8s.io"
     resources:
-    - "externalsecrets"
-    {{- if .Values.processPushSecret }}
-    - "pushsecrets"
-    {{- end }}
+    - "tokenreviews"
     verbs:
-    - "get"
-    - "list"
-    - "watch"
+    - "create"
+  - apiGroups:
+    - "authorization.k8s.io"
+    resources:
+    - "subjectaccessreviews"
+    verbs:
+    - "create"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "external-secrets.fullname" . }}-metrics-auth
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "external-secrets.fullname" . }}-metrics-auth
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "external-secrets.serviceAccountName" . }}
+    namespace: {{ template "external-secrets.namespace" . }}
 {{- end }}
 {{- end }}
 {{- if .Values.systemAuthDelegator }}

--- a/deploy/charts/external-secrets/values.schema.json
+++ b/deploy/charts/external-secrets/values.schema.json
@@ -938,6 +938,9 @@
                 }
             }
         },
+        "watchNamespaces": {
+            "type": "array"
+        },
         "webhook": {
             "type": "object",
             "properties": {

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -112,6 +112,12 @@ scopedNamespace: ""
 # controllers. Scoped to scopedNamespace if set, otherwise to .Release.Namespace.
 scopedRBAC: false
 
+# -- If set, the controller will watch only the provided namespaces, reconcile external secrets
+# only in those namespaces, and implicitly disable cluster stores, cluster external secrets
+# and cluster push secrets. If this feature is used and create.rbac is set to true, then a Role and RoleBinding will be
+# deployed in each watched namespace.
+watchNamespaces: []
+
 # -- If true the OpenShift finalizer permissions will be added to RBAC
 openshiftFinalizers: true
 

--- a/pkg/controllers/common/common.go
+++ b/pkg/controllers/common/common.go
@@ -36,7 +36,7 @@ import (
 )
 
 // BuildManagedSecretClient creates a new client that only sees secrets with the "managed" label.
-func BuildManagedSecretClient(mgr ctrl.Manager, namespace string) (client.Client, error) {
+func BuildManagedSecretClient(mgr ctrl.Manager, namespace string, watchNamespaces []string) (client.Client, error) {
 	// secrets we manage will have the `reconcile.external-secrets.io/managed=true` label
 	managedLabelReq, _ := labels.NewRequirement(esv1.LabelManaged, selection.Equals, []string{esv1.LabelManagedValue})
 	managedLabelSelector := labels.NewSelector().Add(*managedLabelReq)
@@ -60,6 +60,12 @@ func BuildManagedSecretClient(mgr ctrl.Manager, namespace string) (client.Client
 		secretCacheOpts.DefaultNamespaces = map[string]cache.Config{
 			namespace: {},
 		}
+	} else if len(watchNamespaces) > 0 {
+		nsMap := make(map[string]cache.Config, len(watchNamespaces))
+		for _, ns := range watchNamespaces {
+			nsMap[ns] = cache.Config{}
+		}
+		secretCacheOpts.DefaultNamespaces = nsMap
 	}
 
 	secretCache, err := cache.New(mgr.GetConfig(), secretCacheOpts)

--- a/pkg/controllers/externalsecret/suite_test.go
+++ b/pkg/controllers/externalsecret/suite_test.go
@@ -106,7 +106,7 @@ var _ = BeforeSuite(func() {
 
 	// by default, we use a separate cached client for secrets that are managed by the controller
 	// so we should test under the same conditions
-	secretClient, err := ctrlcommon.BuildManagedSecretClient(k8sManager, "")
+	secretClient, err := ctrlcommon.BuildManagedSecretClient(k8sManager, "", []string{})
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&Reconciler{


### PR DESCRIPTION
## Related Issue

Closes : #6490

## Summary

This PR adds a new deployment mode to External Secrets Operator called `Multi-namespace mode`. 

## Proposed Changes

Add a new watchNamespaces configuration option that allows ESO to be deployed with a fixed list of namespaces to watch. This effectively introduces a `Multi-namespace mode` (can be called also `Tenant mode` in **multi-tenant Kubernetes clusters**, where :

- A single ESO instance can manage multiple namespaces (e.g. all namespaces belonging to a given tenant)
- No cluster-wide RBAC is required — only namespace-scoped Role and RoleBinding resources are created, one per watched namespace
- All cluster-scoped ESO resources are implicitly disabled (ClusterSecretStore, ClusterExternalSecret, ClusterPushSecret reconcilers are turned off), consistent with the existing namespaced mode behavior

## Example Usage

```yaml
# values.yaml
watchNamespaces:
  - tenant-a-ns1
  - tenant-a-ns2
  - tenant-a-ns3

rbac:
  create: true
```

This deploys a single ESO instance that manages exactly those three namespaces, with a `Role` and `RoleBinding` created in each, and no cluster-wide permissions required. Also all ESO cluster wide resources will be disabled.

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] My changes have reasonable test coverage
- [X] All tests pass with `make test`
- [X] I ensured my PR is ready for review with `make reviewable`