### PR TITLE
docs(beyondtrustworkloadcredentials): add to nav and support matrix

### DIFF
--- a/docs/api/generator/beyondtrustworkloadcredentials.md
+++ b/docs/api/generator/beyondtrustworkloadcredentials.md
@@ -37,8 +37,9 @@ spec:
     folderPath: "my/dynamic"
 ```
 ### Generated Secret Fields
-The generator returns different fields depending on the type of dynamic secret:
-#### AWS Dynamic Secrets
+
+The generator maps the AWS-style fields returned by the BeyondTrust Workload Credentials dynamic-secret endpoint. The target Kubernetes secret always receives `accessKeyId`, `secretAccessKey`, `leaseId`, and `expiration`, plus `sessionToken` when the response includes one:
+
 ```yaml
 stringData:
   accessKeyId: ASIAIOSFODNN7EXAMPLE
@@ -47,7 +48,9 @@ stringData:
   leaseId: 84038398-ec0f-417d-9a0f-02494fd7d22c
   expiration: 2025-12-29T22:35:29Z
 ```
-All fields are automatically populated in the target Kubernetes secret.
+
+Only these fields are populated. Dynamic-secret definitions that return a different shape are not yet mapped to additional keys.
+
 ### Credential Refresh and Expiration
 **Important:** External Secrets Operator does NOT automatically handle credential expiration/TTL from BeyondTrust Workload Credentials. The refresh is controlled solely by the `refreshInterval` specified in the ExternalSecret spec.
 

--- a/docs/introduction/stability-support.md
+++ b/docs/introduction/stability-support.md
@@ -86,6 +86,7 @@ The following table describes the stability level of each provider and who's res
 | [CyberArk Secrets Manager](https://external-secrets.io/latest/provider/conjur)                             |    stable | [@davidh-cyberark](https://github.com/davidh-cyberark/) [@szh](https://github.com/szh)              |
 | [Delinea](https://external-secrets.io/latest/provider/delinea)                                             |     alpha | [@michaelsauter](https://github.com/michaelsauter/)                                                 |
 | [Beyondtrust](https://external-secrets.io/latest/provider/beyondtrust)                                     |     alpha | [@btfhernandez](https://github.com/btfhernandez/)                                                   |
+| [Beyondtrust Workload Credentials](https://external-secrets.io/latest/provider/beyondtrustworkloadcredentials) | alpha | [@sdahal-bt](https://github.com/sdahal-bt/) |
 | [SecretServer](https://external-secrets.io/latest/provider/secretserver)                                   |      beta | [@gmurugezan](https://github.com/gmurugezan)                                                    |
 | [Pulumi ESC](https://external-secrets.io/latest/provider/pulumi)                                           |     alpha | [@dirien](https://github.com/dirien)                                                                |
 | [Passbolt](https://external-secrets.io/latest/provider/passbolt)                                           |     alpha | [@stripthis](https://github.com/stripthis)                                                                                  |
@@ -126,6 +127,7 @@ The following table show the support for features across different providers.
 | CyberArk Secrets Manager  |      x       |      x       |                      |                         |        x         |             |                             |
 | Delinea                   |      x       |              |                      |                         |        x         |             |                             |
 | Beyondtrust               |      x       |              |                      |                         |        x         |             |                             |
+| Beyondtrust Workload Credentials |      x       |      x       |                      |                         |        x         |             |                             |
 | SecretServer              |      x       |              |                      |                         |        x         |      x      |              x              |
 | Pulumi ESC                |      x       |              |                      |                         |        x         |             |                             |
 | Passbolt                  |      x       |              |                      |                         |        x         |             |                             |

--- a/docs/provider/beyondtrustworkloadcredentials.md
+++ b/docs/provider/beyondtrustworkloadcredentials.md
@@ -1,4 +1,4 @@
-## BeyondTrust Workload Credentials
+# BeyondTrust Workload Credentials
 
 External Secrets Operator integrates with [BeyondTrust Workload Credentials](https://docs.beyondtrust.com/bt-docs/docs/secrets-api) for secret management.
 
@@ -6,7 +6,7 @@ The provider supports static key-value secrets stored in folders. For dynamic se
 
 For complete BeyondTrust Workload Credentials API documentation, see: [https://docs.beyondtrust.com/bt-docs/docs/secrets-api](https://docs.beyondtrust.com/bt-docs/docs/secrets-api)
 
-### Example
+## Example
 
 First, create a SecretStore with a BeyondTrust Workload Credentials backend. You'll need an API token and the server configuration:
 
@@ -36,9 +36,9 @@ Now create an ExternalSecret that uses the above SecretStore:
 
 This will automatically create a Kubernetes Secret with the synced data.
 
-### Fetching Secret Properties
+## Fetching Secret Properties
 
-#### Single Property Retrieval
+### Single Property Retrieval
 
 You can fetch a specific property from a secret by specifying the `property` field:
 
@@ -67,7 +67,7 @@ spec:
 ```
 This creates a secret with individual keys for `username` and `password`.
 
-#### Fetching All Properties as JSON
+### Fetching All Properties as JSON
 
 If you omit the `property` field, you'll get all key-value pairs as a single JSON string:
 
@@ -92,7 +92,7 @@ spec:
 
 This returns: `{"username":"user","password":"pass"}` as the value of `credentials`.
 
-#### Extracting All Properties as Separate Keys
+### Extracting All Properties as Separate Keys
 
 To sync all properties of a secret as individual keys in the target Kubernetes secret, use `dataFrom` with `extract`:
 
@@ -121,7 +121,7 @@ data:
   password: cGFzcw==     # base64("pass")
 ```
 
-### Getting Multiple Secrets
+## Getting Multiple Secrets
 
 You can extract multiple secrets from a folder by using `dataFrom.find`.
 
@@ -130,7 +130,7 @@ Given a folder `eso/static` with these secrets:
 - `mySecret`: `{"myKey": "value2", "someKey": "value3"}`
 - `postgresCreds`: `{"username": "user", "password": "pass"}`
 
-#### Fetch All Secrets in Folder
+### Fetch All Secrets in Folder
 
 ```yaml
 apiVersion: external-secrets.io/v1
@@ -151,9 +151,9 @@ spec:
           regexp: ".*"
 ```
 
-This merges all key-value pairs from all secrets in the folder into a single Kubernetes secret.
+This merges the matching secrets in the folder into a single Kubernetes secret. Each resulting key is the secret's full path joined with its property name (for example `eso/static/postgresCreds/username`). Because `/` is not valid in a Kubernetes secret key, ESO rewrites it through the ExternalSecret `find.conversionStrategy` (the default replaces invalid characters with `_`), so the example above becomes `eso_static_postgresCreds_username`.
 
-#### Regex Pattern Filtering
+### Regex Pattern Filtering
 
 To sync only secrets matching a specific pattern:
 
@@ -178,7 +178,33 @@ spec:
 
 This will only sync secrets whose names end with "Secret" (e.g., `anotherSecret`, `mySecret`).
 
-#### Specifying a Different Folder
+### Filtering by Tags
+
+You can also filter by the tags attached to each secret in BeyondTrust Workload Credentials using `find.tags`. A secret is synced only if its metadata contains every key/value pair listed:
+
+```yaml
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: tagged-secrets
+  namespace: external-secrets
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: beyondtrustworkloadcredentials-ss
+    kind: SecretStore
+  target:
+    name: tagged-folder-secrets
+  dataFrom:
+    - find:
+        tags:
+          env: production
+          team: platform
+```
+
+When both `name.regexp` and `tags` are set, a secret must satisfy both to be synced.
+
+### Specifying a Different Folder
 
 By default, `find` uses the `folderPath` from the SecretStore. To search a different folder, use the `path` field:
 
@@ -206,7 +232,7 @@ This will list all secrets in the `eso/production` folder, regardless of the `fo
 
 **Note:** The `path` field specifies a folder path, not a path to a specific secret. To fetch a single secret, use `data` with `extract` or individual `remoteRef` entries.
 
-### Handling Source Secret Deletion
+## Handling Source Secret Deletion
 
 By default, when a source secret is deleted from BeyondTrust Workload Credentials, the managed Kubernetes secret is retained. You can change this behavior using `deletionPolicy`:
 
@@ -234,7 +260,7 @@ Valid values:
 - `Retain` (default): Keep the Kubernetes secret even if the source is deleted
 - `Delete`: Remove the Kubernetes secret when the source is deleted
 
-### Authentication
+## Authentication
 
 BeyondTrust Workload Credentials uses API key authentication. The API key is stored in a Kubernetes Secret and referenced in the SecretStore:
 
@@ -266,7 +292,7 @@ auth:
       key: token
 ```
 
-### Server Configuration
+## Server Configuration
 
 The server configuration consists of:
 - `apiUrl`: The base URL of your BeyondTrust Workload Credentials API
@@ -274,13 +300,13 @@ The server configuration consists of:
 
 The provider automatically constructs the full API endpoint as: `{apiUrl}/{siteId}/secrets`
 
-### Certificate Trust
+## Certificate Trust
 
 BeyondTrust Workload Credentials typically uses certificates signed by public CAs, requiring no additional configuration.
 
 If using self-signed certificates, configure trust using either `caBundle` or `caProvider`:
 
-#### Using caProvider (Recommended)
+### Using caProvider (Recommended)
 
 ```yaml
 spec:
@@ -301,7 +327,7 @@ kubectl create secret generic my-ca-bundle \
   -n external-secrets
 ```
 
-#### Using caBundle
+### Using caBundle
 
 Alternatively, embed the base64-encoded PEM certificate directly:
 
@@ -321,7 +347,7 @@ To generate the base64 string:
 cat /path/to/ca.crt | base64 -w 0
 ```
 
-### Folder Path
+## Folder Path
 
 The `folderPath` specifies the default folder containing your secrets. This should be a folder path, not the full path to a specific secret.
 
@@ -333,7 +359,7 @@ For example, if your secrets are stored at:
 Set `folderPath: "eso/static"` in your SecretStore.
 
 When using `data` or `dataFrom.extract`, secret names are relative to this folder. When using `dataFrom.find`, this folder is searched by default (unless overridden with the `path` field).
-### Refresh Interval
+## Refresh Interval
 The `refreshInterval` controls how often the ExternalSecret checks for updates:
 
 ```yaml
@@ -345,7 +371,7 @@ Supported units: `s` (seconds), `m` (minutes), `h` (hours).
 
 **Best Practice:** Balance between keeping secrets up-to-date and minimizing API calls. For most use cases, `1m` to `15m` is appropriate.
 
-### ClusterSecretStore
+## ClusterSecretStore
 
 To use a ClusterSecretStore (accessible across all namespaces):
 
@@ -382,3 +408,9 @@ spec:
     kind: ClusterSecretStore  # Specify ClusterSecretStore
   # ... rest of spec
 ```
+
+## Limitations
+
+- This provider is **read-only**. It reads secrets via `data[].remoteRef` and `dataFrom` (both `extract` and `find`), but does not implement `PushSecret`, `DeleteSecret`, or secret-existence checks, so it cannot create, update, or delete secrets in BeyondTrust Workload Credentials.
+- The `target.deletionPolicy: Delete` shown above removes the **Kubernetes** secret when the source secret no longer exists in BeyondTrust; it never deletes anything in BeyondTrust itself.
+- For dynamic, short-lived credentials (such as temporary AWS credentials), use the [BeyondTrust Workload Credentials Generator](../api/generator/beyondtrustworkloadcredentials.md) instead.

--- a/hack/api-docs/mkdocs.yml
+++ b/hack/api-docs/mkdocs.yml
@@ -81,6 +81,7 @@ nav:
           - Grafana: api/generator/grafana.md
           - Quay: api/generator/quay.md
           - Vault Dynamic Secret: api/generator/vault.md
+          - BeyondTrust Workload Credentials: api/generator/beyondtrustworkloadcredentials.md
           - Password: api/generator/password.md
           - Fake: api/generator/fake.md
           - Webhook: api/generator/webhook.md
@@ -125,6 +126,7 @@ nav:
       - Azure Key Vault: provider/azure-key-vault.md
       - Barbican: provider/barbican.md
       - BeyondTrust: provider/beyondtrust.md
+      - BeyondTrust Workload Credentials: provider/beyondtrustworkloadcredentials.md
       - Bitwarden Secrets Manager: provider/bitwarden-secrets-manager.md
       - Chef: provider/chef.md
       - Cloud.ru Secret Manager: provider/cloudru.md


### PR DESCRIPTION
## Problem Statement

The BeyondTrust Workload Credentials provider and its dynamic-secret generator were added in #5999, but neither documentation page was wired into the site. `docs/provider/beyondtrustworkloadcredentials.md` and `docs/api/generator/beyondtrustworkloadcredentials.md` exist on disk yet are absent from the mkdocs `nav`, so they are unreachable from the site navigation, and the provider has no row in the capability support matrix. Several page-level issues compound this: the provider page omits tag-based `find` (which the code implements), describes the `find` output keys inaccurately, has no read-only/limitations note, and uses an `##` page title; the generator page implies it returns different fields depending on the dynamic-secret type when the implementation only maps a fixed AWS-style field set.

## Related Issue

There is no tracking issue for the navigation and matrix gaps; both originate in #5999. The generator field-mapping limitation that this PR documents is tracked for enhancement in #6547.

## Proposed Changes

Navigation and support matrix:

- Add both pages to the mkdocs `nav` (`hack/api-docs/mkdocs.yml`): the provider under Provider, the generator under Generators.
- Add a `Beyondtrust Workload Credentials` row to the feature matrix and a maintainer-table entry in `docs/introduction/stability-support.md`. The provider is read-only with `find` by name and by tags, which the matrix row reflects (find-by-name, find-by-tags, store-validation):

https://github.com/external-secrets/external-secrets/blob/49ea8572cf2f1b71bedfb7004be983b4b213713d/providers/v1/beyondtrustworkloadcredentials/provider.go#L196-L199

https://github.com/external-secrets/external-secrets/blob/49ea8572cf2f1b71bedfb7004be983b4b213713d/providers/v1/beyondtrustworkloadcredentials/client.go#L164-L208

Provider page:

- Document tag-based filtering (`dataFrom.find.tags`), supported by the code but previously omitted.
- Clarify that `find` result keys are the secret's full path joined with its property name, and are rewritten by the ExternalSecret `find.conversionStrategy` (so `/` becomes `_`).
- Add a Limitations section: the provider is read-only (no `PushSecret` / `DeleteSecret`), and `target.deletionPolicy: Delete` removes only the Kubernetes secret, never anything in BeyondTrust.
- Promote the page title to `#` with `##` sections, matching the sibling BeyondTrust page.

Generator page:

- Correct the "Generated Secret Fields" section: the generator maps a fixed set of AWS-style fields, so dynamic-secret definitions returning a different shape are not mapped to additional keys:

https://github.com/external-secrets/external-secrets/blob/49ea8572cf2f1b71bedfb7004be983b4b213713d/generators/v1/beyondtrustworkloadcredentials/beyondtrustworkloadcredentials.go#L154-L172

Docs-only change; no code, CRD, or API changes.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage (docs-only; no code changed)
- [x] All tests pass with `make test` (docs-only; validated that the mkdocs YAML parses, every snippet include resolves, the edited YAML examples parse, and the matrix table column counts match; the mkdocs build runs in CI)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added BeyondTrust Workload Credentials to the MkDocs navigation, support matrix, and maintainer table so the provider and generator docs are reachable and properly listed.

Updated the provider docs to cover tag-based filtering, `find.conversionStrategy` key rewriting, and limitations around read-only behavior and `deletionPolicy: Delete`. Also promoted the page title to a top-level heading and reorganized sections for clarity.

Clarified the generator docs to state that it maps a fixed AWS-style field set and does not add extra keys for other dynamic-secret shapes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->