### PR TITLE
docs(chef): add to support matrix, fix v1 types link and headings

### DIFF
--- a/docs/introduction/stability-support.md
+++ b/docs/introduction/stability-support.md
@@ -98,6 +98,7 @@ The following table describes the stability level of each provider and who's res
 | [Barbican](https://external-secrets.io/latest/provider/barbican)                                           |     alpha | [@rkferreira](https://github.com/rkferreira)                                                        |
 | [Devolutions Server](https://external-secrets.io/latest/provider/devolutions-server)                       |     alpha | [@rbstp](https://github.com/rbstp)                                                                  |
 | [Nebius MysteryBox](https://external-secrets.io/latest/provider/nebius-mysterybox)                         | alpha     | [@greenmapc](https://github.com/greenmapc)                                                          |
+| [Chef](https://external-secrets.io/latest/provider/chef)                                                   |     alpha | [@sourav977](https://github.com/sourav977)                                                          |
 
 ## Provider Feature Support
 
@@ -138,6 +139,7 @@ The following table show the support for features across different providers.
 | Barbican                  |      x       |              |                      |                         |        x         |             |                             |
 | Devolutions Server        |              |              |                      |                         |        x         |      x      |                             |
 | Nebius Mysterybox         |              |              |                      |                         |        x         |             |                             |
+| Chef                      |              |              |                      |                         |        x         |             |                             |
 
 ## Support Policy
 

--- a/docs/provider/chef.md
+++ b/docs/provider/chef.md
@@ -1,4 +1,4 @@
-## Chef
+# Chef
 
 `Chef External Secrets provider` will enable users to seamlessly integrate their Chef-based secret management with Kubernetes through the existing External Secrets framework.
 
@@ -6,7 +6,7 @@ In many enterprises, legacy applications and infrastructure are still tightly in
 
 **NOTE:** `Chef External Secrets provider` is designed only to fetch data from the Chef data bags into Kubernetes secrets, it won't update/delete any item in the data bags.
 
-### Authentication
+## Authentication
 
 Every request made to the Chef Infra server needs to be authenticated. [Authentication](https://docs.chef.io/server/auth/) is done using the Private keys of the Chef Users.  The User needs to have appropriate [Permissions](https://docs.chef.io/server/server_orgs/#permissions) to the data bags containing the data that they want to fetch using the External Secrets Operator.
 
@@ -17,7 +17,7 @@ chef-server-ctl user-create USER_NAME FIRST_NAME [MIDDLE_NAME] LAST_NAME EMAIL '
 
 More details on the above command are available here [Chef User Create Option](https://docs.chef.io/server/server_users/#user-create). The above command will return the default private key (PRIVATE_KEY_VALUE), which we will use for authentication. Additionally, a Chef User with access to specific data bags, a private key pair with an expiration date can be created with the help of the  [knife user key](https://docs.chef.io/server/auth/#knife-user-key) command.
 
-### Create a secret containing your private key
+## Create a secret containing your private key
 
 We need to store the above User's API key into a secret resource.
 Example:
@@ -25,7 +25,7 @@ Example:
 kubectl create secret generic chef-user-secret -n vivid --from-literal=user-private-key='PRIVATE_KEY_VALUE'
 ```
 
-### Creating ClusterSecretStore
+## Creating ClusterSecretStore
 
 The Chef `ClusterSecretStore` is a cluster-scoped SecretStore that can be referenced by all Chef `ExternalSecrets` from all namespaces. You can follow the below example to create a `ClusterSecretStore` resource.
 
@@ -47,7 +47,7 @@ spec:
             namespace: vivid # the namespace in which the above Secret resource resides
 ```
 
-### Creating SecretStore
+## Creating SecretStore
 
 Chef `SecretStores` are bound to a namespace and can not reference resources across namespaces. For cross-namespace SecretStores, you must use Chef `ClusterSecretStores`.
 
@@ -73,7 +73,7 @@ spec:
 
 ```
 
-### Creating ExternalSecret
+## Creating ExternalSecret
 
 The Chef `ExternalSecret` describes what data should be fetched from Chef Data bags, and how the data should be transformed and saved as a Kind=Secret.
 
@@ -82,7 +82,7 @@ You can follow the below example to create an `ExternalSecret` resource.
 {% include 'chef-external-secret.yaml' %}
 ```
 
-When the above `ClusterSecretStore` and `ExternalSecret` resources are created, the `ExternalSecret` will connect to the Chef Server using the private key and will fetch the data bags contained in the `vivid-credentials` secret resource.
+When the above `ClusterSecretStore` and `ExternalSecret` resources are created, the `ExternalSecret` will connect to the Chef Server using the private key, fetch the requested data bag items, and store them in the `vivid-credentials` Kubernetes Secret.
 
 To get all data items inside the data bag, you can use the `dataFrom` directive:
 ```yaml
@@ -110,4 +110,4 @@ spec:
 
 ```
 
-follow : [this file](https://github.com/external-secrets/external-secrets/blob/main/apis/externalsecrets/v1beta1/secretstore_chef_types.go) for more info
+follow : [this file](https://github.com/external-secrets/external-secrets/blob/main/apis/externalsecrets/v1/secretstore_chef_types.go) for more info


### PR DESCRIPTION
## Problem Statement

A documentation audit of the Chef provider found it is missing from the support documentation and the page has a few stale references. Chef is listed in the site nav but has no row in either table of `docs/introduction/stability-support.md` (the maintainer list and the feature matrix). The "more info" link at the bottom of the provider page points at the deprecated `v1beta1` types path, even though the page's examples all use `external-secrets.io/v1`. The page title is an `##` (H2), and one sentence describes the data flow backwards.

## Related Issue

None. These are documentation-only corrections.

## Proposed Changes

- Add Chef to `docs/introduction/stability-support.md`: a maintainer-table row (`alpha`, `@sourav977`, who implemented the provider in #3127) and a feature-matrix row. The provider is read-only with only store validation, so the matrix row marks store-validation and leaves the rest blank:

https://github.com/external-secrets/external-secrets/blob/b590271b5a2d6cc6103129a1b2d3ea5c8187848b/providers/v1/chef/chef.go#L356-L359

https://github.com/external-secrets/external-secrets/blob/b590271b5a2d6cc6103129a1b2d3ea5c8187848b/providers/v1/chef/chef.go#L167-L170

- Fix the "more info" link to point at the active `v1` types path (`apis/externalsecrets/v1/secretstore_chef_types.go`) instead of `v1beta1`.
- Promote the page title to `#` (H1) with `##` sections, matching the other provider pages.
- Correct the sentence that described the flow backwards: the ExternalSecret fetches data bag items from Chef and stores them in the `vivid-credentials` Kubernetes Secret.

Docs-only change; no code, CRD, or API changes.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage (docs-only; no code changed)
- [x] All tests pass with `make test` (docs-only; validated code-fence balance, that the snippet include resolves, and that the matrix table column counts match; the mkdocs build runs in CI)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated Chef provider documentation to reflect current support and usage:
- Added Chef to the stability/support page with its maintainer entry and feature-matrix row, indicating read-only provider support with store validation.
- Fixed the Chef provider docs by promoting the main title to a top-level heading, correcting the data-flow description, and updating the “more info” link to the active `v1` types path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->