### PR TITLE
docs(conjur): fix referent matrix cell, clarify find name/tags, tidy page

### DIFF
--- a/docs/introduction/stability-support.md
+++ b/docs/introduction/stability-support.md
@@ -123,7 +123,7 @@ The following table show the support for features across different providers.
 | Doppler                   |      x       |              |                      |                         |        x         |             |                             |
 | Keeper Security           |      x       |              |                      |                         |        x         |      x      |                             |
 | Scaleway                  |      x       |      x       |                      |                         |        x         |      x      |              x              |
-| CyberArk Secrets Manager  |      x       |      x       |                      |                         |        x         |             |                             |
+| CyberArk Secrets Manager  |      x       |      x       |                      |            x            |        x         |             |                             |
 | Delinea                   |      x       |              |                      |                         |        x         |             |                             |
 | Beyondtrust               |      x       |              |                      |                         |        x         |             |                             |
 | SecretServer              |      x       |              |                      |                         |        x         |      x      |              x              |

--- a/docs/provider/conjur.md
+++ b/docs/provider/conjur.md
@@ -1,8 +1,8 @@
-## CyberArk Secrets Manager Provider
+# CyberArk Secrets Manager Provider
 
 This section describes how to set up the CyberArk Secrets Manager provider for External Secrets Operator (ESO). For a working example, see the [Accelerator-K8s-External-Secrets repo](https://github.com/conjurdemos/Accelerator-K8s-External-Secrets).
 
-### Prerequisites
+## Prerequisites
 
 Before installing the Secrets Manager provider, you need:
 
@@ -13,7 +13,7 @@ Before installing the Secrets Manager provider, you need:
   * **Optional**: Secrets Manager server certificate (see [below](#conjur-server-certificate)).
 * A Kubernetes cluster with ESO installed.
 
-### Secrets Manager server certificate
+## Secrets Manager server certificate
 
 If you set up your Secrets Manager server with a self-signed certificate, we recommend that you populate the `caBundle` field with the Secrets Manager self-signed certificate in the secret-store definition. The certificate CA must be referenced in the secret-store definition using either `caBundle` or `caProvider`:
 
@@ -21,18 +21,18 @@ If you set up your Secrets Manager server with a self-signed certificate, we rec
 {% include 'conjur-ca-bundle.yaml' %}
 ```
 
-### External secret store
+## External secret store
 
 The Secrets Manager provider is configured as an external secret store in ESO. The Secrets Manager provider supports these two methods to authenticate to Secrets Manager:
 
 * [`apikey`](#option-1-external-secret-store-with-apikey-authentication): uses a Secrets Manager `hostid` and `apikey` to authenticate with Secrets Manager
 * [`jwt`](#option-2-external-secret-store-with-jwt-authentication): uses a JWT to authenticate with Secrets Manager
 
-#### Option 1: External secret store with apiKey authentication
+### Option 1: External secret store with apiKey authentication
 
 This method uses a Secrets Manager `hostid` and `apikey` to authenticate with Secrets Manager. It is the simplest method to set up and use because your Secrets Manager instance requires no additional configuration.
 
-##### Step 1: Define an external secret store
+#### Step 1: Define an external secret store
 
 !!! Tip
     Save as the file as: `conjur-secret-store.yaml`
@@ -41,7 +41,7 @@ This method uses a Secrets Manager `hostid` and `apikey` to authenticate with Se
 {% include 'conjur-secret-store-apikey.yaml' %}
 ```
 
-##### Step 2: Create Kubernetes secrets for Secrets Manager credentials
+#### Step 2: Create Kubernetes secrets for Secrets Manager credentials
 
 To connect to the Secrets Manager server, the **ESO Secrets Manager provider** needs to retrieve the `apikey` credentials from K8s secrets.
 
@@ -62,7 +62,7 @@ kubectl -n external-secrets create secret generic conjur-creds --from-literal=ho
     `conjur-creds` is the `name` defined in the `userRef` and `apikeyRef` fields of the `conjur-secret-store.yml` file.
 
 
-##### Step 3: Create the external secrets store
+#### Step 3: Create the external secrets store
 
 !!! Important
     Unless you are using a [ClusterSecretStore](../api/clustersecretstore.md), credentials must reside in the same namespace as the SecretStore.
@@ -78,14 +78,14 @@ kubectl apply -n external-secrets -f conjur-secret-store.yaml
 # kubectl delete secretstore -n external-secrets conjur
 ```
 
-#### Option 2: External secret store with JWT authentication
+### Option 2: External secret store with JWT authentication
 
 This method uses JWT tokens to authenticate with Secrets Manager. You can use the following methods to retrieve a JWT token for authentication:
 
 * JWT token from a referenced Kubernetes service account
 * JWT token stored in a Kubernetes secret
 
-##### Step 1: Define an external secret store
+#### Step 1: Define an external secret store
 
 When you use JWT authentication, the following must be specified in the `SecretStore`:
 
@@ -119,7 +119,7 @@ kubectl create token my-service-account --audience='https://conjur.company.com' 
 
 Save the secret store file as `conjur-secret-store.yaml`.
 
-##### Step 2: Create the external secrets store
+#### Step 2: Create the external secrets store
 
 ```shell
 # WARNING: creates the store in the "external-secrets" namespace, update the value as needed
@@ -132,7 +132,7 @@ kubectl apply -n external-secrets -f conjur-secret-store.yaml
 # kubectl delete secretstore -n external-secrets conjur
 ```
 
-### Define an external secret
+## Define an external secret
 
 After you have configured the Secrets Manager provider secret store, you can fetch secrets from Secrets Manager.
 
@@ -144,20 +144,35 @@ Here is an example of how to fetch a single secret from Secrets Manager:
 
 Save the external secret file as `conjur-external-secret.yaml`.
 
-#### Find by Name and Find by Tag
+### Find by Name or Find by Tag
 
 The Secrets Manager provider also supports the Find by Name and Find by Tag ESO features. This means that
 you can use a regular expression or tags to dynamically fetch multiple secrets from Secrets Manager.
 
+These two filters are mutually exclusive on a single `find`: if both `name` and `tags` are set, only `name`
+is used and `tags` are ignored (see [issue #6554](https://github.com/external-secrets/external-secrets/issues/6554)).
+
+To find secrets by name:
+
 ```yaml
 {% include 'conjur-external-secret-find.yaml' %}
+```
+
+To find secrets by tag, use `tags` instead of `name`:
+
+```yaml
+  dataFrom:
+    - find:
+        tags:
+          environment: "prod"
+          application: "app1"
 ```
 
 If you use these features, we strongly recommend that you limit the permissions of the Secrets Manager host
 to only the secrets that it needs to access. This is more secure and it reduces the load on
 both the Secrets Manager server and ESO.
 
-### Create the external secret
+## Create the external secret
 
 ```shell
 # WARNING: creates the external-secret in the "external-secrets" namespace, update the value as needed
@@ -170,7 +185,7 @@ kubectl apply -n external-secrets -f conjur-external-secret.yaml
 # kubectl delete externalsecret -n external-secrets conjur
 ```
 
-### Get the K8s secret
+## Get the K8s secret
 
 * Log in to your Secrets Manager server and verify that your secret exists
 * Review the value of your Kubernetes secret to verify that it contains the same value as the Secrets Manager server
@@ -182,23 +197,7 @@ kubectl apply -n external-secrets -f conjur-external-secret.yaml
 kubectl get secret -n external-secrets conjur -o jsonpath="{.data.secret00}"  | base64 --decode && echo
 ```
 
-### See also
+## See also
 
 * [Accelerator-K8s-External-Secrets repo](https://github.com/conjurdemos/Accelerator-K8s-External-Secrets)
 * [Configure Secrets Manager JWT authentication](https://docs.cyberark.com/conjur-open-source/Latest/en/Content/Operations/Services/cjr-authn-jwt-guidelines.htm)
-
-### License
-
-Copyright (c) 2023-2024 CyberArk Software Ltd. All rights reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-<http://www.apache.org/licenses/LICENSE-2.0>
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.

--- a/docs/snippets/conjur-external-secret-find.yaml
+++ b/docs/snippets/conjur-external-secret-find.yaml
@@ -12,11 +12,6 @@ spec:
     name: k8s-secret-to-be-created
   dataFrom:
     - find:
-        # You can use *either* `name` or `tags` to filter the secrets. Here are basic examples of both:
         name:
           # Match all secrets in the app1 namespace (e.g., `app1/secret00`, `app1/secret01`, etc.)
           regexp: "^app1\/.+$"
-        tags:
-          # Only fetch Conjur secrets with the following annotations
-          environment: "prod"
-          application: "app1"


### PR DESCRIPTION
## Problem Statement

A documentation audit of the CyberArk Conjur (Secrets Manager) provider found one support-matrix inaccuracy and a misleading `find` example, plus some page cleanup. The support matrix marks Conjur with `referent authentication` blank, but the provider supports it: `ValidateStore` uses the referent validators and the client resolves credentials with the ExternalSecret's namespace. The `find` snippet showed `name` and `tags` together in one `find`, which reads like an AND-filter, but the provider applies only one (name takes precedence and tags are ignored, tracked in #6554). The page title is an `##` (H2) with deeper sections, and the page carries a full Apache license blob that no other provider page has.

## Related Issue

Documents the behaviour tracked in #6554 (`find` name and tags are mutually exclusive). The rest are doc-only corrections.

## Proposed Changes

- Support matrix (`docs/introduction/stability-support.md`): set `referent authentication` to `x` for Conjur. `ValidateStore` uses `ValidateReferentSecretSelector` / `ValidateReferentServiceAccountSelector`, and the client resolves the credential refs against the ExternalSecret namespace via `resolvers.SecretKeyRef`, which is the referent-auth mechanism (Cloud.ru, which uses the same pattern, is already marked `x`):

https://github.com/external-secrets/external-secrets/blob/b590271b5a2d6cc6103129a1b2d3ea5c8187848b/providers/v1/conjur/validate.go#L73-L78

https://github.com/external-secrets/external-secrets/blob/b590271b5a2d6cc6103129a1b2d3ea5c8187848b/providers/v1/conjur/client.go#L124-L142

- `find` docs: state that `name` and `tags` are mutually exclusive on a single `find` (name takes precedence, tags ignored, see #6554), make the shared snippet a clean find-by-name example, and add a separate find-by-tags example. The provider code that branches name-or-tags:

https://github.com/external-secrets/external-secrets/blob/b590271b5a2d6cc6103129a1b2d3ea5c8187848b/providers/v1/conjur/client_get.go#L90-L95

- Promote the page title to `#` (H1) with `##`/`###`/`####` sections, matching the other provider pages.
- Remove the embedded Apache license section at the bottom of the page; the repository is already Apache-licensed and no other provider page repeats it.

Docs-only change; no code, CRD, or API changes.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage (docs-only; no code changed)
- [x] All tests pass with `make test` (docs-only; validated code-fence balance, that every snippet include resolves, the edited snippet parses as YAML, and the matrix table column counts match; the mkdocs build runs in CI)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the CyberArk Conjur provider docs to reflect current behavior: marked referent authentication as supported in the support matrix, clarified that `find.name` and `find.tags` are mutually exclusive with `name` taking precedence, added separate examples for finding by name and by tags, reorganized headings to use a proper H1/section hierarchy, and removed the embedded Apache license block.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->