### PR TITLE
docs(delinea): fix find matrix cell and clarify provider page

### DIFF
--- a/docs/introduction/stability-support.md
+++ b/docs/introduction/stability-support.md
@@ -124,7 +124,7 @@ The following table show the support for features across different providers.
 | Keeper Security           |      x       |              |                      |                         |        x         |      x      |                             |
 | Scaleway                  |      x       |      x       |                      |                         |        x         |      x      |              x              |
 | CyberArk Secrets Manager  |      x       |      x       |                      |                         |        x         |             |                             |
-| Delinea                   |      x       |              |                      |                         |        x         |             |                             |
+| Delinea                   |              |              |                      |                         |        x         |             |                             |
 | Beyondtrust               |      x       |              |                      |                         |        x         |             |                             |
 | SecretServer              |      x       |              |                      |                         |        x         |      x      |              x              |
 | Pulumi ESC                |      x       |              |                      |                         |        x         |             |                             |

--- a/docs/provider/delinea.md
+++ b/docs/provider/delinea.md
@@ -1,10 +1,10 @@
-## Delinea DevOps Secrets Vault
+# Delinea DevOps Secrets Vault
 
 External Secrets Operator integrates with [Delinea DevOps Secrets Vault](https://docs.delinea.com/online-help/products/devops-secrets-vault/current).
 
-Please note that the [Delinea Secret Server](https://delinea.com/products/secret-server) product is NOT in scope of this integration.
+Please note that the [Delinea Secret Server](https://delinea.com/products/secret-server) product is not covered by this provider. ESO integrates with Secret Server through the separate [Secret Server provider](secretserver.md).
 
-### Creating a SecretStore
+## Creating a SecretStore
 
 You need client ID, client secret and tenant to authenticate with DSV.
 Both client ID and client secret can be specified either directly in the config, or by referencing a kubernetes secret.
@@ -35,11 +35,11 @@ The `tenant` field must correspond to the host name / site name of your DevOps v
 
 If required, the URL template (`urlTemplate`) can be customized as well.
 
-### Referencing Secrets
+## Referencing Secrets
 
 Secrets can be referenced by path. Getting a specific version of a secret is not yet supported.
 
-Note that because all DSV secrets are JSON objects, you must specify `remoteRef.property`. You can access nested values or arrays using [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).
+Because all DSV secrets are JSON objects, omitting `remoteRef.property` returns the whole secret as a JSON object. To extract a single field, set `remoteRef.property`; nested values and arrays are addressable with [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).
 
 ```yaml
 apiVersion: external-secrets.io/v1

--- a/providers/v1/delinea/provider.go
+++ b/providers/v1/delinea/provider.go
@@ -42,7 +42,8 @@ var (
 	errClusterStoreRequiresNamespace = errors.New("when using a ClusterSecretStore, namespaces must be explicitly set")
 )
 
-// Provider implements the External Secrets provider for Delinea Secret Server.
+// Provider implements the External Secrets provider for Delinea DevOps
+// Secrets Vault.
 type Provider struct{}
 
 var _ esv1.Provider = &Provider{}
@@ -52,7 +53,7 @@ func (p *Provider) Capabilities() esv1.SecretStoreCapabilities {
 	return esv1.SecretStoreReadOnly
 }
 
-// NewClient creates a new Delinea Secret Server client.
+// NewClient creates a new Delinea DevOps Secrets Vault client.
 func (p *Provider) NewClient(ctx context.Context, store esv1.GenericStore, kube kubeClient.Client, namespace string) (esv1.SecretsClient, error) {
 	cfg, err := getConfig(store)
 	if err != nil {


### PR DESCRIPTION
## Problem Statement

A documentation audit of the Delinea DevOps Secrets Vault provider found one support-matrix inaccuracy and a few page issues. The support matrix marks Delinea with `find by name` = `x`, but the provider does not implement find at all: `GetAllSecrets` returns an explicit "not supported" error. The provider page says you "must" specify `remoteRef.property`, but it is optional (an empty property returns the whole secret as JSON). The page also states the Delinea Secret Server product is "not in scope", which can read as "ESO cannot integrate with Secret Server" even though there is a separate Secret Server provider. Finally, the page title is an `##` (H2), and two godoc comments in `provider.go` mislabel this provider as "Delinea Secret Server".

## Related Issue

None. These are documentation-only corrections (the two `provider.go` edits are comment-only, no behaviour change).

## Proposed Changes

- Support matrix (`docs/introduction/stability-support.md`): set `find by name` to blank for Delinea. The provider has no find support:

https://github.com/external-secrets/external-secrets/blob/b590271b5a2d6cc6103129a1b2d3ea5c8187848b/providers/v1/delinea/client.go#L104-L107

- `Referencing Secrets`: clarify that `remoteRef.property` is optional. Omitting it returns the whole secret as a JSON object; set it to extract a single field (gjson). This matches the code, which returns the raw JSON when no property is given:

https://github.com/external-secrets/external-secrets/blob/b590271b5a2d6cc6103129a1b2d3ea5c8187848b/providers/v1/delinea/client.go#L59-L68

- Clarify the Secret Server note: ESO does support Delinea Secret Server, through the separate Secret Server provider, so the page now links to it instead of implying Secret Server is unsupported.
- Promote the page title to `#` (H1) with `##` sections, matching the other provider pages.
- Fix two godoc comments in `providers/v1/delinea/provider.go` that called this the "Delinea Secret Server" provider; it is the DevOps Secrets Vault provider. Comment-only, no behaviour or CRD changes.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage (docs and comment-only; no code paths changed)
- [x] All tests pass with `make test` (verified `go build ./...` in the delinea module, code-fence balance, and that the matrix column count matches the header; the mkdocs build runs in CI)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated Delinea DevOps Secrets Vault documentation and comments to match current behavior.

- Corrected the support matrix to show Delinea does not support “find by name”.
- Clarified that `remoteRef.property` is optional and omitting it returns the full secret as JSON.
- Reworked the Secret Server note to point to the separate Secret Server provider.
- Changed the page title to `#` for consistency with other provider docs.
- Fixed godoc comments in `providers/v1/delinea/provider.go` to use “Delinea DevOps” instead of “Delinea Secret Server”.

These changes are documentation-only and do not affect behavior or CRDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->