### PR TITLE
docs(gcp): use external-secrets.io/v1 in SecretStore examples

### DIFF
--- a/docs/provider/google-secrets-manager.md
+++ b/docs/provider/google-secrets-manager.md
@@ -212,7 +212,7 @@ Once the Core Controller Pod can access the Secret Manager secret(s) through GKE
 Alternatively, with projectID auto-detection (GKE only):
 
 ```yaml
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: gcp-secret-store
@@ -235,7 +235,7 @@ In practice:
 This allows portable `SecretStore` configurations on GKE without hard-coding the project when the above conditions hold:
 
 ```yaml
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: gcp-secret-store
@@ -547,7 +547,7 @@ GCP Secret Manager Regional Secrets are available to be used with both ExternalS
 In order to achieve so, add a `location` to your SecretStore definition:
 
 ```yaml
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: gcp-secret-store
@@ -574,7 +574,7 @@ By default, when you request a secret without specifying a version, the provider
 #### Configuration Example
 
 ```yaml
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: gcp-secret-store


### PR DESCRIPTION
## Problem Statement

The Google Secret Manager provider page uses `external-secrets.io/v1beta1` in four inline `SecretStore` examples, while the page's other inline `SecretStore` example and all of its `gcpsm-*` snippets already use `external-secrets.io/v1`. This is an internal inconsistency, and `v1` is the current API version.

## Related Issue

None. Documentation-only consistency fix.

## Proposed Changes

- Change the four inline `SecretStore` examples from `apiVersion: external-secrets.io/v1beta1` to `apiVersion: external-secrets.io/v1` (the projectID auto-detection example, the portable `SecretStore` example, the regional secrets example, and the secret version selection policy example), so all `SecretStore` examples on the page use the same current API version as the snippets.

The `PushSecret` examples are intentionally left on `external-secrets.io/v1alpha1`, which is the version that resource is served under.

Docs-only change; no code, CRD, or API changes.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage (docs-only; no code changed)
- [x] All tests pass with `make test` (docs-only; the GCPSMProvider type is identical under v1 and v1beta1, so every field used in these examples is valid under v1; the mkdocs build runs in CI)
