### PR TITLE
docs(nebius): mark DeletionPolicy supported and fix page title

### DIFF
--- a/docs/introduction/stability-support.md
+++ b/docs/introduction/stability-support.md
@@ -137,7 +137,7 @@ The following table show the support for features across different providers.
 | ngrok                     |              |              |                      |                         |        x         |      x      |                             |
 | Barbican                  |      x       |              |                      |                         |        x         |             |                             |
 | Devolutions Server        |              |              |                      |                         |        x         |      x      |                             |
-| Nebius Mysterybox         |              |              |                      |                         |        x         |             |                             |
+| Nebius Mysterybox         |              |              |                      |                         |        x         |             |              x              |
 
 ## Support Policy
 

--- a/docs/provider/nebius-mysterybox.md
+++ b/docs/provider/nebius-mysterybox.md
@@ -1,4 +1,4 @@
-## Nebius MysteryBox
+# Nebius MysteryBox
 
 External Secrets Operator integrates with [Nebius MysteryBox](https://docs.nebius.com/mysterybox/overview).
 


### PR DESCRIPTION
## Problem Statement

The support matrix leaves the `DeletionPolicy Merge/Delete` cell blank for Nebius MysteryBox, but the provider supports it: `GetSecret` wraps `NoSecretErr` when the secret (or version) is not found, and the ExternalSecret controller matches that with `errors.Is` when applying `deletionPolicy`. The Cloud.ru provider, which is also read-only and returns `NoSecretErr` the same way, is already marked in that column. Separately, the page title is an `##` (H2).

## Related Issue

None. Documentation-only corrections.

## Proposed Changes

- Support matrix (`docs/introduction/stability-support.md`): set `DeletionPolicy Merge/Delete` to `x` for Nebius MysteryBox. Both `GetSecret` paths (full secret and by-key) return a `NoSecretErr`-wrapped error on a `NotFound` response:

https://github.com/external-secrets/external-secrets/blob/b590271b5a2d6cc6103129a1b2d3ea5c8187848b/providers/v1/nebius/mysterybox/secrets_client.go#L138-L170

The ExternalSecret controller honours that for `deletionPolicy` via `errors.Is`:

https://github.com/external-secrets/external-secrets/blob/b590271b5a2d6cc6103129a1b2d3ea5c8187848b/pkg/controllers/externalsecret/externalsecret_controller_secret.go#L98-L114

- Promote the page title from `##` (H2) to `#` (H1), matching the other provider pages.

Docs-only change; no code, CRD, or API changes.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage (docs-only; no code changed)
- [x] All tests pass with `make test` (docs-only; validated the matrix column count matches the header; the mkdocs build runs in CI)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated Nebius MysteryBox docs to reflect current behavior: marked `DeletionPolicy Merge/Delete` as supported in the provider feature matrix and promoted the provider page title from H2 to H1 for consistency with other provider docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->