### PR TITLE
docs(onboardbase): add to support matrix and fix page title

### DIFF
--- a/docs/introduction/stability-support.md
+++ b/docs/introduction/stability-support.md
@@ -98,6 +98,7 @@ The following table describes the stability level of each provider and who's res
 | [Barbican](https://external-secrets.io/latest/provider/barbican)                                           |     alpha | [@rkferreira](https://github.com/rkferreira)                                                        |
 | [Devolutions Server](https://external-secrets.io/latest/provider/devolutions-server)                       |     alpha | [@rbstp](https://github.com/rbstp)                                                                  |
 | [Nebius MysteryBox](https://external-secrets.io/latest/provider/nebius-mysterybox)                         | alpha     | [@greenmapc](https://github.com/greenmapc)                                                          |
+| [Onboardbase](https://external-secrets.io/latest/provider/onboardbase)                                     |     alpha | [@limistah](https://github.com/limistah)                                                            |
 
 ## Provider Feature Support
 
@@ -138,6 +139,7 @@ The following table show the support for features across different providers.
 | Barbican                  |      x       |              |                      |                         |        x         |             |                             |
 | Devolutions Server        |              |              |                      |                         |        x         |      x      |                             |
 | Nebius Mysterybox         |              |              |                      |                         |        x         |             |                             |
+| Onboardbase               |      x       |              |                      |                         |        x         |             |                             |
 
 ## Support Policy
 

--- a/docs/provider/onboardbase.md
+++ b/docs/provider/onboardbase.md
@@ -1,7 +1,7 @@
 
 ![Onboardbase External Secrets Provider](../pictures/onboardbase-provider.png)
 
-## Onboardbase Secret Management
+# Onboardbase Secret Management
 
 Sync secrets from [Onboardbase](https://www.onboardbase.com/) to Kubernetes using the External Secrets Operator.
 


### PR DESCRIPTION
## Problem Statement

The Onboardbase provider is documented and in the navigation, but it is missing entirely from the provider support matrix (neither the stability/maintainer table nor the feature matrix). The page title is also an `##` (H2).

## Related Issue

None. Documentation-only corrections.

## Proposed Changes

- Add Onboardbase to the support matrix:
    - Stability/maintainer table: `alpha`, maintained by @limistah (original provider author, PR #2697). Please correct the attribution if it should be someone else.
    - Feature matrix: `find by name` and `store validation` are supported; find by tags, push, and deletionPolicy are not.

  The feature values are derived from the code. The provider is read-only (`Capabilities()` is `ReadOnly`), `GetAllSecrets` matches by name regexp and path prefix but rejects tags, and `ValidateStore` validates the auth selectors with the strict (non-referent) validator:

https://github.com/external-secrets/external-secrets/blob/b590271b5a2d6cc6103129a1b2d3ea5c8187848b/providers/v1/onboardbase/client.go#L201-L227

https://github.com/external-secrets/external-secrets/blob/b590271b5a2d6cc6103129a1b2d3ea5c8187848b/providers/v1/onboardbase/provider.go#L84-L98

- Promote the page title from `##` (H2) to `#` (H1), matching the other provider pages.

Docs-only change; no code, CRD, or API changes.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage (docs-only; no code changed)
- [x] All tests pass with `make test` (docs-only; validated that both matrix tables' column counts match their headers; the mkdocs build runs in CI)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the Onboardbase documentation to:
- add Onboardbase to the provider stability/support matrix with `alpha` status and maintainer `@limistah`
- add its feature support entries, showing support for “find by name” and “store validation” while leaving other features unsupported
- change the Onboardbase provider page heading from H2 to H1 to match other provider pages

No code, CRD, or API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->