### PR TITLE
docs(openbao): add to support matrix and fix page title

### DIFF
--- a/docs/introduction/stability-support.md
+++ b/docs/introduction/stability-support.md
@@ -98,6 +98,7 @@ The following table describes the stability level of each provider and who's res
 | [Barbican](https://external-secrets.io/latest/provider/barbican)                                           |     alpha | [@rkferreira](https://github.com/rkferreira)                                                        |
 | [Devolutions Server](https://external-secrets.io/latest/provider/devolutions-server)                       |     alpha | [@rbstp](https://github.com/rbstp)                                                                  |
 | [Nebius MysteryBox](https://external-secrets.io/latest/provider/nebius-mysterybox)                         | alpha     | [@greenmapc](https://github.com/greenmapc)                                                          |
+| [OpenBao](https://external-secrets.io/latest/provider/openbao)                                             |     alpha | [@phil9909](https://github.com/phil9909)                                                            |
 
 ## Provider Feature Support
 
@@ -138,6 +139,7 @@ The following table show the support for features across different providers.
 | Barbican                  |      x       |              |                      |                         |        x         |             |                             |
 | Devolutions Server        |              |              |                      |                         |        x         |      x      |                             |
 | Nebius Mysterybox         |              |              |                      |                         |        x         |             |                             |
+| OpenBao                   |      x       |              |                      |            x            |        x         |             |                             |
 
 ## Support Policy
 

--- a/docs/provider/openbao.md
+++ b/docs/provider/openbao.md
@@ -1,4 +1,4 @@
-## OpenBao
+# OpenBao
 
 External Secrets Operator integrates with [OpenBao](https://openbao.org) for secret management by using the [HashiCorp Vault Provider](./hashicorp-vault.md).
 


### PR DESCRIPTION
## Problem Statement

The OpenBao provider is documented and in the navigation, but it is missing entirely from the provider support matrix (neither the stability/maintainer table nor the feature matrix). The page title is also an `##` (H2).

## Related Issue

None required. The matrix row reflects the provider's current read-only state (read-only feature parity is tracked in #6446).

## Proposed Changes

- Add OpenBao to the support matrix:
    - Stability/maintainer table: `alpha`, maintained by @phil9909 (introduced the provider in #6405). Please correct the attribution if it should be someone else.
    - Feature matrix: `find by name`, `referent authentication`, and `store validation` are supported; find by tags, push, and deletionPolicy are not (the provider is currently read-only).

  Derived from the code: the provider is read-only (`Capabilities()` is `ReadOnly`; `PushSecret`/`DeleteSecret` return "not supported"). `GetAllSecrets` lists keys and matches `find.name.regexp` but rejects tags. Referent authentication is supported (the auth refs use the relaxed referent validator and are resolved against the ExternalSecret namespace, with explicit referent-spec handling):

https://github.com/external-secrets/external-secrets/blob/b590271b5a2d6cc6103129a1b2d3ea5c8187848b/providers/v1/openbao/client.go#L192-L219

https://github.com/external-secrets/external-secrets/blob/b590271b5a2d6cc6103129a1b2d3ea5c8187848b/providers/v1/openbao/validate.go#L38-L75

- Promote the page title from `##` (H2) to `#` (H1), matching the other provider pages.

Docs-only change; no code, CRD, or API changes.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage (docs-only; no code changed)
- [x] All tests pass with `make test` (docs-only; validated that both matrix tables' column counts match their headers; the mkdocs build runs in CI)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated OpenBao documentation to include it in the provider support matrix and feature table, reflecting its read-only support: find by name, referent authentication, and store validation are supported, while find by tags, push, and deletionPolicy are not. Also changed the OpenBao page heading from H2 to H1 to match other provider pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->