### PR TITLE
docs(ovh): add to support matrix and fix page title

### DIFF
--- a/docs/introduction/stability-support.md
+++ b/docs/introduction/stability-support.md
@@ -98,6 +98,7 @@ The following table describes the stability level of each provider and who's res
 | [Barbican](https://external-secrets.io/latest/provider/barbican)                                           |     alpha | [@rkferreira](https://github.com/rkferreira)                                                        |
 | [Devolutions Server](https://external-secrets.io/latest/provider/devolutions-server)                       |     alpha | [@rbstp](https://github.com/rbstp)                                                                  |
 | [Nebius MysteryBox](https://external-secrets.io/latest/provider/nebius-mysterybox)                         | alpha     | [@greenmapc](https://github.com/greenmapc)                                                          |
+| [OVHcloud](https://external-secrets.io/latest/provider/ovhcloud)                                           |     alpha | [@ldesauw](https://github.com/ldesauw)                                                              |
 
 ## Provider Feature Support
 
@@ -138,6 +139,7 @@ The following table show the support for features across different providers.
 | Barbican                  |      x       |              |                      |                         |        x         |             |                             |
 | Devolutions Server        |              |              |                      |                         |        x         |      x      |                             |
 | Nebius Mysterybox         |              |              |                      |                         |        x         |             |                             |
+| OVHcloud                  |      x       |              |                      |            x            |        x         |      x      |              x              |
 
 ## Support Policy
 

--- a/docs/provider/ovhcloud.md
+++ b/docs/provider/ovhcloud.md
@@ -1,4 +1,4 @@
-## Secrets Manager
+# OVHcloud Secrets Manager
 
 External Secrets Operator integrates with [OVHcloud KMS](https://www.ovhcloud.com/en/identity-security-operations/key-management-service/).  
 


### PR DESCRIPTION
## Problem Statement

The OVHcloud provider is documented and in the navigation, but it is missing entirely from the provider support matrix (neither the stability/maintainer table nor the feature matrix). The page title is also the generic `## Secrets Manager` (H2), which does not identify the provider.

## Related Issue

None. Documentation-only corrections.

## Proposed Changes

- Add OVHcloud to the support matrix:
    - Stability/maintainer table: `alpha`, maintained by @ldesauw (introduced the provider in #6101). Please correct the attribution if it should be someone else.
    - Feature matrix: `find by name`, `referent authentication`, `store validation`, `push secret`, and `DeletionPolicy Merge/Delete` are supported; find by tags and metadataPolicy Fetch are not.

  Derived from the code: the provider is `ReadWrite` with `PushSecret`; `GetAllSecrets` matches `ref.Name.RegExp` and filters by path (no tags); and `GetSecret` returns `esv1.NoSecretErr` on a missing secret, so the ExternalSecret `deletionPolicy` works:

https://github.com/external-secrets/external-secrets/blob/b590271b5a2d6cc6103129a1b2d3ea5c8187848b/providers/v1/ovh/client_get_all_secrets.go#L40-L70

https://github.com/external-secrets/external-secrets/blob/b590271b5a2d6cc6103129a1b2d3ea5c8187848b/providers/v1/ovh/client_utils.go#L50-L60

- Fix the page title from the generic `## Secrets Manager` (H2) to `# OVHcloud Secrets Manager` (H1), so the page has a single, provider-specific top-level heading like the other provider pages.

Docs-only change; no code, CRD, or API changes.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage (docs-only; no code changed)
- [x] All tests pass with `make test` (docs-only; validated that both matrix tables' column counts match their headers; the mkdocs build runs in CI)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated OVHcloud documentation to include the provider in the support matrix with alpha stability, maintainer attribution, and feature support details for find by name, referent authentication, store validation, push secret, and DeletionPolicy Merge/Delete. Also changed the OVHcloud docs page heading to a provider-specific top-level title: “OVHcloud Secrets Manager.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->