### PR TITLE
docs(passbolt): mark referent auth in matrix and fix heading levels

### DIFF
--- a/docs/introduction/stability-support.md
+++ b/docs/introduction/stability-support.md
@@ -128,7 +128,7 @@ The following table show the support for features across different providers.
 | Beyondtrust               |              |              |                      |                         |        x         |      x      |                             |
 | SecretServer              |      x       |              |                      |                         |        x         |      x      |              x              |
 | Pulumi ESC                |      x       |              |                      |                         |        x         |             |                             |
-| Passbolt                  |      x       |              |                      |                         |        x         |             |                             |
+| Passbolt                  |      x       |              |                      |            x            |        x         |             |                             |
 | Infisical                 |      x       |              |                      |            x            |        x         |      x      |              x              |
 | Bitwarden Secrets Manager |      x       |              |                      |                         |        x         |      x      |              x              |
 | Previder                  |      x       |              |                      |                         |        x         |             |                             |

--- a/docs/provider/passbolt.md
+++ b/docs/provider/passbolt.md
@@ -2,7 +2,7 @@ External Secrets Operator integrates with [Passbolt API](https://www.passbolt.co
 
 
 
-### Creating a Passbolt secret store
+## Creating a Passbolt secret store
 
 Be sure the `passbolt` provider is listed in the `Kind=SecretStore` and auth and host are set.
 The API requires a password and private key provided in a secret.
@@ -11,7 +11,7 @@ The API requires a password and private key provided in a secret.
 {% include 'passbolt-secret-store.yaml' %}
 ```
 
-#### Custom CA certificate
+### Custom CA certificate
 
 If your Passbolt instance uses a certificate signed by a private or custom
 Certificate Authority, you can configure the CA bundle that ESO uses to
@@ -27,7 +27,7 @@ If neither `caBundle` nor `caProvider` is set, ESO uses the system root
 certificates to validate the TLS connection.
 
 
-### Creating an external secret
+## Creating an external secret
 
 To sync a Passbolt secret to a Kubernetes secret, a `Kind=ExternalSecret` is needed.
 By default the secret contains name, username, uri, password and description.
@@ -45,7 +45,7 @@ The above external secret will lead to the creation of a secret in the following
 ```
 
 
-### Finding a secret by name
+## Finding a secret by name
 
 Instead of retrieving secrets by ID you can also use `dataFrom` to search for secrets by name.
 


### PR DESCRIPTION
## Problem Statement

Two documentation fixes for the Passbolt provider. First, the support matrix leaves `referent authentication` blank, but Passbolt supports it. Second, the provider page starts at `###` (H3): its top-level sections are H3 and the Custom CA subsection is H4, with no `#`/`##` heading.

## Related Issue

None. Documentation-only corrections.

## Proposed Changes

- Support matrix (`docs/introduction/stability-support.md`): set `referent authentication` to `x` for Passbolt. `ValidateStore` does not require a namespace on a ClusterSecretStore secret ref, and the credentials are resolved with `resolvers.SecretKeyRef(..., namespace, ...)`, which resolves a namespace-less ClusterSecretStore ref against the ExternalSecret namespace:

https://github.com/external-secrets/external-secrets/blob/b590271b5a2d6cc6103129a1b2d3ea5c8187848b/providers/v1/passbolt/passbolt.go#L66-L90

This is the same referent mechanism as the OVHcloud, Infisical, and Cloud.ru rows.

- Promote the page headings one level so the page starts at `##`: the top-level sections move from `###` (H3) to `##` (H2), and the Custom CA subsection from `####` (H4) to `###` (H3).

Docs-only change; no code, CRD, or API changes.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage (docs-only; no code changed)
- [x] All tests pass with `make test` (docs-only; validated that the matrix column count matches the header and the headings parse; the mkdocs build runs in CI)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated Passbolt documentation to mark referent authentication as supported in the provider feature matrix and adjusted the Passbolt provider page heading hierarchy so the page starts at H2, with subsections promoted accordingly. No code or API changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->