### PR TITLE
docs(passworddepot): add to support matrix and fix heading levels

### DIFF
--- a/docs/introduction/stability-support.md
+++ b/docs/introduction/stability-support.md
@@ -98,6 +98,7 @@ The following table describes the stability level of each provider and who's res
 | [Barbican](https://external-secrets.io/latest/provider/barbican)                                           |     alpha | [@rkferreira](https://github.com/rkferreira)                                                        |
 | [Devolutions Server](https://external-secrets.io/latest/provider/devolutions-server)                       |     alpha | [@rbstp](https://github.com/rbstp)                                                                  |
 | [Nebius MysteryBox](https://external-secrets.io/latest/provider/nebius-mysterybox)                         | alpha     | [@greenmapc](https://github.com/greenmapc)                                                          |
+| [Password Depot](https://external-secrets.io/latest/provider-passworddepot)                                |     alpha | [@Sulfixx](https://github.com/Sulfixx)                                                              |
 
 ## Provider Feature Support
 
@@ -138,6 +139,7 @@ The following table show the support for features across different providers.
 | Barbican                  |      x       |              |                      |                         |        x         |             |                             |
 | Devolutions Server        |              |              |                      |                         |        x         |      x      |                             |
 | Nebius Mysterybox         |              |              |                      |                         |        x         |             |                             |
+| Password Depot            |              |              |                      |                         |                  |             |                             |
 
 ## Support Policy
 

--- a/docs/provider-passworddepot.md
+++ b/docs/provider-passworddepot.md
@@ -1,6 +1,6 @@
 External Secrets Operator integrates with [Password Depot API](https://www.password-depot.de/) to sync Password Depot to secrets held on the Kubernetes cluster.
 
-### Authentication
+## Authentication
 
 The API requires a username and password. 
 
@@ -9,7 +9,7 @@ The API requires a username and password.
 {% include 'password-depot-credentials-secret.yaml' %}
 ```
 
-### Update secret store
+## Update secret store
 Be sure the `passworddepot` provider is listed in the `Kind=SecretStore` and host and database are set.
 
 ```yaml
@@ -17,7 +17,7 @@ Be sure the `passworddepot` provider is listed in the `Kind=SecretStore` and hos
 ```
 
 
-### Creating external secret
+## Creating external secret
 
 To sync a Password Depot variable to a secret on the Kubernetes cluster, a `Kind=ExternalSecret` is needed.
 
@@ -25,7 +25,7 @@ To sync a Password Depot variable to a secret on the Kubernetes cluster, a `Kind
 {% include 'passworddepot-external-secret.yaml' %}
 ```
 
-#### Using DataFrom
+### Using DataFrom
 
 DataFrom can be used to get a variable as a JSON string and attempt to parse it.
 
@@ -33,7 +33,7 @@ DataFrom can be used to get a variable as a JSON string and attempt to parse it.
 {% include 'passworddepot-external-secret-json.yaml' %}
 ```
 
-### Getting the Kubernetes secret
+## Getting the Kubernetes secret
 The operator will fetch the project variable and inject it as a `Kind=Secret`.
 ```
 kubectl get secret passworddepot-secret-to-create -o jsonpath='{.data.secretKey}' | base64 -d


### PR DESCRIPTION
## Problem Statement

The Password Depot provider is documented and in the navigation, but it is missing entirely from the provider support matrix (neither the stability/maintainer table nor the feature matrix). The provider page also starts at `###` (H3), with no `#`/`##` heading.

## Related Issue

None. Documentation-only corrections.

## Proposed Changes

- Add Password Depot to the support matrix:
    - Stability/maintainer table: `alpha`, maintained by @Sulfixx (introduced the provider in #2799). Please correct the attribution if it should be someone else.
    - Feature matrix: the provider supports none of the matrix feature columns, so the row is intentionally all-blank. It is read-only (`Capabilities()` is `ReadOnly`; `GetAllSecrets` returns "not implemented"; `ValidateStore` is a no-op; a ClusterSecretStore requires an explicit credentials namespace, so referent auth is not supported; and `GetSecret` does not return `NoSecretErr`). It implements only `GetSecret` by key and `GetSecretMap`:

https://github.com/external-secrets/external-secrets/blob/b590271b5a2d6cc6103129a1b2d3ea5c8187848b/providers/v1/passworddepot/passworddepot.go#L56-L63

- Promote the page headings one level so the page starts at `##`: the top-level sections move from `###` (H3) to `##` (H2), and the DataFrom subsection from `####` (H4) to `###` (H3).

The matrix maintainer-table link points at the page's current URL (`/provider-passworddepot`). Note: this page lives at `docs/provider-passworddepot.md` rather than `docs/provider/passworddepot.md` like every other provider page; moving it would be a good consistency follow-up but changes the published URL, so it is left as-is here.

Docs-only change; no code, CRD, or API changes.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage (docs-only; no code changed)
- [x] All tests pass with `make test` (docs-only; validated that both matrix tables' column counts match their headers; the mkdocs build runs in CI)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the Password Depot documentation to add it to the support matrix as an alpha provider maintained by `@Sulfixx`, with no feature support indicated in the feature table. Also fixed the page heading hierarchy so the main section starts at `##` and the DataFrom subsection is promoted to `###`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->