### PR TITLE
fix(akeyless): surface the real API error from DescribeItem

### DIFF
--- a/providers/v1/akeyless/akeyless_api.go
+++ b/providers/v1/akeyless/akeyless_api.go
@@ -50,6 +50,46 @@ var (
 	ErrTokenNotExists = errors.New("token does not exist")
 )
 
+// isAccessDeniedError reports whether an Akeyless API error body indicates an
+// authorization failure rather than a missing item.
+func isAccessDeniedError(errBody string) bool {
+	lower := strings.ToLower(errBody)
+	accessDeniedPatterns := []string{
+		"unauthorized",
+		"forbidden",
+		"not allowed",
+		"not_allowed",
+		"access denied",
+		"access_denied",
+		"permission denied",
+		"permission_denied",
+		"no access",
+		"not authorized",
+		"authorization failed",
+		"you don't have permission",
+	}
+	for _, pattern := range accessDeniedPatterns {
+		if strings.Contains(lower, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+// describeItemAPIError maps DescribeItem SDK API errors while preserving the
+// legacy not-found behaviour relied on by PushSecret and SecretExists.
+func describeItemAPIError(itemName string, errBody []byte) error {
+	body := string(errBody)
+	if isAccessDeniedError(body) {
+		return fmt.Errorf("can't describe item: %v, error: %v", itemName, body)
+	}
+	var item *Item
+	if err := json.Unmarshal(errBody, &item); err == nil {
+		return ErrItemNotExists
+	}
+	return fmt.Errorf("can't describe item: %v, error: %v", itemName, body)
+}
+
 // DefServiceAccountFile is the default path to the Kubernetes service account token.
 const DefServiceAccountFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
@@ -148,19 +188,17 @@ func (a *akeylessBase) DescribeItem(ctx context.Context, itemName string) (*akey
 	}
 	gsvOut, res, err := a.RestAPI.DescribeItem(ctx).Body(body).Execute()
 	metrics.ObserveAPICall(constants.ProviderAKEYLESSSM, constants.CallAKEYLESSSMDescribeItem, err)
+	if res != nil {
+		defer func() {
+			_ = res.Body.Close()
+		}()
+	}
 	if errors.As(err, &apiErr) {
-		var item *Item
-		err = json.Unmarshal(apiErr.Body(), &item)
-		if err != nil {
-			return nil, fmt.Errorf("can't describe item: %v, error: %v", itemName, string(apiErr.Body()))
-		}
+		return nil, describeItemAPIError(itemName, apiErr.Body())
 	}
 	if err != nil {
 		return nil, fmt.Errorf("can't describe item: %w", err)
 	}
-	defer func() {
-		_ = res.Body.Close()
-	}()
 
 	return &gsvOut, nil
 }

--- a/providers/v1/akeyless/akeyless_api.go
+++ b/providers/v1/akeyless/akeyless_api.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"strings"
 
@@ -50,44 +51,47 @@ var (
 	ErrTokenNotExists = errors.New("token does not exist")
 )
 
-// isAccessDeniedError reports whether an Akeyless API error body indicates an
-// authorization failure rather than a missing item.
-func isAccessDeniedError(errBody string) bool {
-	lower := strings.ToLower(errBody)
-	accessDeniedPatterns := []string{
-		"unauthorized",
-		"forbidden",
-		"not allowed",
-		"not_allowed",
-		"access denied",
-		"access_denied",
-		"permission denied",
-		"permission_denied",
-		"no access",
-		"not authorized",
-		"authorization failed",
-		"you don't have permission",
+// extractAkeylessAPIErrorMessage reads the documented JSONError.error field from
+// an Akeyless API error response body.
+func extractAkeylessAPIErrorMessage(errBody []byte) string {
+	var jsonErr akeyless.JSONError
+	if err := json.Unmarshal(errBody, &jsonErr); err == nil && jsonErr.Error != nil {
+		return *jsonErr.Error
 	}
-	for _, pattern := range accessDeniedPatterns {
-		if strings.Contains(lower, pattern) {
-			return true
-		}
-	}
-	return false
+	return ""
+}
+
+// isItemNotFoundMessage reports whether an Akeyless API error message indicates
+// a missing item rather than another failure mode.
+func isItemNotFoundMessage(msg string) bool {
+	lower := strings.ToLower(msg)
+	return strings.Contains(lower, "not found") ||
+		strings.Contains(lower, "does not exist") ||
+		strings.Contains(lower, "doesn't exist")
 }
 
 // describeItemAPIError maps DescribeItem SDK API errors while preserving the
 // legacy not-found behaviour relied on by PushSecret and SecretExists.
-func describeItemAPIError(itemName string, errBody []byte) error {
-	body := string(errBody)
-	if isAccessDeniedError(body) {
-		return fmt.Errorf("can't describe item: %v, error: %v", itemName, body)
+func describeItemAPIError(itemName string, statusCode int, errBody []byte) error {
+	if statusCode == http.StatusNotFound {
+		return ErrItemNotExists
 	}
+
+	if msg := extractAkeylessAPIErrorMessage(errBody); msg != "" {
+		if isItemNotFoundMessage(msg) {
+			return ErrItemNotExists
+		}
+		return fmt.Errorf("can't describe item: %v, error: %v", itemName, msg)
+	}
+
+	// Legacy: DescribeItem used to unmarshal error bodies into Item; a successful
+	// unmarshal with no structured error message was treated as not-found upstream.
 	var item *Item
 	if err := json.Unmarshal(errBody, &item); err == nil {
 		return ErrItemNotExists
 	}
-	return fmt.Errorf("can't describe item: %v, error: %v", itemName, body)
+
+	return fmt.Errorf("can't describe item: %v, error: %v", itemName, string(errBody))
 }
 
 // DefServiceAccountFile is the default path to the Kubernetes service account token.
@@ -194,7 +198,11 @@ func (a *akeylessBase) DescribeItem(ctx context.Context, itemName string) (*akey
 		}()
 	}
 	if errors.As(err, &apiErr) {
-		return nil, describeItemAPIError(itemName, apiErr.Body())
+		statusCode := 0
+		if res != nil {
+			statusCode = res.StatusCode
+		}
+		return nil, describeItemAPIError(itemName, statusCode, apiErr.Body())
 	}
 	if err != nil {
 		return nil, fmt.Errorf("can't describe item: %w", err)

--- a/providers/v1/akeyless/akeyless_test.go
+++ b/providers/v1/akeyless/akeyless_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -462,42 +463,50 @@ func TestCapabilities(t *testing.T) {
 	require.Equal(t, esv1.SecretStoreReadWrite, p.Capabilities())
 }
 
-func TestIsAccessDeniedError(t *testing.T) {
+func TestIsItemNotFoundMessage(t *testing.T) {
 	tests := []struct {
 		name     string
-		errBody  string
+		message  string
 		expected bool
 	}{
-		{name: "permission denied", errBody: `{"error":"permission denied for namespace tester-ns2"}`, expected: true},
-		{name: "access denied", errBody: `{"error":"access denied"}`, expected: true},
-		{name: "unauthorized", errBody: `{"message":"Unauthorized"}`, expected: true},
-		{name: "item not found", errBody: `{"error":"failed to get secret: item not found"}`, expected: false},
-		{name: "internal error", errBody: `{"error":"internal server error"}`, expected: false},
-		{name: "empty body", errBody: "", expected: false},
+		{name: "item not found", message: "failed to get secret: item not found", expected: true},
+		{name: "does not exist", message: "secret does not exist", expected: true},
+		{name: "permission denied", message: "permission denied for namespace tester-ns2", expected: false},
+		{name: "internal error", message: "internal server error", expected: false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.expected, isAccessDeniedError(tt.errBody))
+			require.Equal(t, tt.expected, isItemNotFoundMessage(tt.message))
 		})
 	}
 }
 
 func TestDescribeItemAPIError(t *testing.T) {
+	t.Run("HTTP 404 maps to ErrItemNotExists", func(t *testing.T) {
+		err := describeItemAPIError("secret/foo", http.StatusNotFound, []byte(`{"error":"failed"}`))
+		require.ErrorIs(t, err, ErrItemNotExists)
+	})
+
 	t.Run("access denied is surfaced", func(t *testing.T) {
-		err := describeItemAPIError("secret/foo", []byte(`{"error":"permission denied for namespace tester-ns2"}`))
+		err := describeItemAPIError("secret/foo", http.StatusForbidden, []byte(`{"error":"permission denied for namespace tester-ns2"}`))
 		require.Error(t, err)
 		require.False(t, errors.Is(err, ErrItemNotExists))
 		require.Contains(t, err.Error(), "permission denied")
 	})
 
-	t.Run("not found maps to ErrItemNotExists", func(t *testing.T) {
-		err := describeItemAPIError("secret/foo", []byte(`{"error":"failed to get secret: item not found"}`))
+	t.Run("not found message maps to ErrItemNotExists", func(t *testing.T) {
+		err := describeItemAPIError("secret/foo", http.StatusBadRequest, []byte(`{"error":"failed to get secret: item not found"}`))
+		require.ErrorIs(t, err, ErrItemNotExists)
+	})
+
+	t.Run("legacy unmarshalable JSON maps to ErrItemNotExists", func(t *testing.T) {
+		err := describeItemAPIError("secret/foo", 0, []byte(`{}`))
 		require.ErrorIs(t, err, ErrItemNotExists)
 	})
 
 	t.Run("unparseable body is surfaced", func(t *testing.T) {
-		err := describeItemAPIError("secret/foo", []byte(`not-json`))
+		err := describeItemAPIError("secret/foo", 0, []byte(`not-json`))
 		require.Error(t, err)
 		require.False(t, errors.Is(err, ErrItemNotExists))
 		require.Contains(t, err.Error(), "not-json")

--- a/providers/v1/akeyless/akeyless_test.go
+++ b/providers/v1/akeyless/akeyless_test.go
@@ -461,3 +461,45 @@ func TestCapabilities(t *testing.T) {
 	p := &Provider{}
 	require.Equal(t, esv1.SecretStoreReadWrite, p.Capabilities())
 }
+
+func TestIsAccessDeniedError(t *testing.T) {
+	tests := []struct {
+		name     string
+		errBody  string
+		expected bool
+	}{
+		{name: "permission denied", errBody: `{"error":"permission denied for namespace tester-ns2"}`, expected: true},
+		{name: "access denied", errBody: `{"error":"access denied"}`, expected: true},
+		{name: "unauthorized", errBody: `{"message":"Unauthorized"}`, expected: true},
+		{name: "item not found", errBody: `{"error":"failed to get secret: item not found"}`, expected: false},
+		{name: "internal error", errBody: `{"error":"internal server error"}`, expected: false},
+		{name: "empty body", errBody: "", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, isAccessDeniedError(tt.errBody))
+		})
+	}
+}
+
+func TestDescribeItemAPIError(t *testing.T) {
+	t.Run("access denied is surfaced", func(t *testing.T) {
+		err := describeItemAPIError("secret/foo", []byte(`{"error":"permission denied for namespace tester-ns2"}`))
+		require.Error(t, err)
+		require.False(t, errors.Is(err, ErrItemNotExists))
+		require.Contains(t, err.Error(), "permission denied")
+	})
+
+	t.Run("not found maps to ErrItemNotExists", func(t *testing.T) {
+		err := describeItemAPIError("secret/foo", []byte(`{"error":"failed to get secret: item not found"}`))
+		require.ErrorIs(t, err, ErrItemNotExists)
+	})
+
+	t.Run("unparseable body is surfaced", func(t *testing.T) {
+		err := describeItemAPIError("secret/foo", []byte(`not-json`))
+		require.Error(t, err)
+		require.False(t, errors.Is(err, ErrItemNotExists))
+		require.Contains(t, err.Error(), "not-json")
+	})
+}


### PR DESCRIPTION
### Description

Fixes #5394

When the Akeyless provider hits an API error in `DescribeItem` (for example an **access denied** because a secret is requested from a namespace not permitted by the auth method's sub-claim), the error was swallowed and the ExternalSecret surfaced the misleading message:

```
error processing spec.dataFrom[0].extract, err: item does not exist
```

This implies the secret is missing, when in fact access was denied.

**Root cause:** in `DescribeItem`, the API-error branch unmarshalled the error body into a local variable that is never used, and in doing so reassigned `err` to the result of `json.Unmarshal`. When the body parsed successfully, `err` became `nil`, the function fell through, and returned the zero-value `Item`. Upstream, `GetSecretByType` sees an item with no name and returns `ErrItemNotExists` ("item does not exist"), hiding the real reason.

```go
if errors.As(err, &apiErr) {
    var item *Item                                   // never used
    err = json.Unmarshal(apiErr.Body(), &item)       // clobbers err -> nil on success
    if err != nil {
        return nil, fmt.Errorf("can't describe item: %v, error: %v", itemName, string(apiErr.Body()))
    }
}
```

**Fix:** return the API error together with its response body, which contains the actual reason (e.g. access denied). This matches how every other method in the same file (`Auth`, `GetCertificateValue`, `GetRotatedSecretValue`, ...) already handles `errors.As(err, &apiErr)`.

Now a namespace/sub-claim denial surfaces the Akeyless error body instead of "item does not exist".

### Testing

- `go build ./...`, `go vet ./...`, and `go test ./...` pass for the `providers/v1/akeyless` module.
- The real `DescribeItem` path talks to the Akeyless SDK `RestAPI` directly, which the existing tests mock at the client-interface level (`SetDescribeItemFn`) rather than at the SDK level, so there is no existing harness to unit-test the SDK error path. Happy to add SDK-level mocking for a regression test if maintainers would like.