### PR TITLE
feat(vault): add PushSecret custom metadata support for KV v2

### DIFF
--- a/docs/provider/hashicorp-vault.md
+++ b/docs/provider/hashicorp-vault.md
@@ -460,6 +460,29 @@ Here is an example of how to set up `PushSecret`:
 
 Note that in this example, we are generating two secrets in the target vault with the same structure but using different input formats.
 
+#### Custom metadata for PushSecret
+
+With Vault KV v2 stores, PushSecret can manage the [custom metadata](https://developer.hashicorp.com/vault/docs/secrets/kv/kv-v2#custom-metadata) of the pushed secret. Define the metadata in the `spec.data[].metadata` field of the PushSecret resource:
+
+```yaml
+{% include 'vault-pushsecret-metadata.yaml' %}
+```
+
+The `spec` supports two fields:
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `mergePolicy` | string: `Merge`, `Replace` | `Merge` (default) merges `customMetadata` into the custom metadata already present on the Vault secret, keeping existing keys that are not part of the spec. `Replace` replaces the entire custom metadata with `customMetadata`. |
+| `customMetadata` | `map[string]string` | Key/value pairs written to the `custom_metadata` of the Vault secret. |
+
+For example, if a secret currently has the custom metadata `managed-by: external-secrets, team: payments` and you push `customMetadata: {environment: dev}`, the result is:
+
+- `Merge`: `managed-by: external-secrets, team: payments, environment: dev`
+- `Replace`: `managed-by: external-secrets, environment: dev` (the `team` key is dropped)
+
+!!! note
+    If the referenced store uses a KV v1 engine, the `metadata` field is silently ignored and the secret data is still pushed.
+
 #### Check-And-Set (CAS) for PushSecret
 
 Vault KV v2 supports Check-And-Set operations to prevent unintentional overwrites when multiple clients modify the same secret. When CAS is enabled in your Vault configuration, External Secrets Operator can be configured to include the required version parameter in write operations.

--- a/docs/snippets/vault-pushsecret-metadata.yaml
+++ b/docs/snippets/vault-pushsecret-metadata.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: source-secret
+  namespace: default
+stringData:
+  source-key: "{\"foo\":\"bar\"}" # Needs to be a JSON
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: pushsecret-with-metadata
+  namespace: default
+spec:
+  refreshInterval: 1h0m0s
+  secretStoreRefs:
+    # The referenced store must use a KV v2 secrets engine;
+    # with KV v1 the metadata below is silently ignored.
+    - name: vault-secretstore
+      kind: SecretStore
+  selector:
+    secret:
+      name: source-secret
+  data:
+    - match:
+        secretKey: source-key
+        remoteRef:
+          remoteKey: vault/secret1
+      metadata:
+        apiVersion: kubernetes.external-secrets.io/v1alpha1
+        kind: PushSecretMetadata
+        spec:
+          # Merge (default): keep the custom metadata already present on the
+          #   Vault secret and merge the keys below into it.
+          # Replace: replace the entire custom metadata of the Vault secret
+          #   with the keys below.
+          mergePolicy: Merge
+          customMetadata:
+            environment: dev
+            team: payments

--- a/providers/v1/vault/client_push.go
+++ b/providers/v1/vault/client_push.go
@@ -23,141 +23,69 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"reflect"
 
 	corev1 "k8s.io/api/core/v1"
 
 	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
 	"github.com/external-secrets/external-secrets/runtime/constants"
 	"github.com/external-secrets/external-secrets/runtime/esutils"
+	"github.com/external-secrets/external-secrets/runtime/esutils/metadata"
 	"github.com/external-secrets/external-secrets/runtime/metrics"
 )
 
+// MergePolicy defines how metadata should be merged when pushing secrets.
+type MergePolicy string
+
+const (
+	// MergePolicyMerge indicates that metadata should be merged.
+	MergePolicyMerge MergePolicy = "Merge"
+	// MergePolicyReplace indicates that metadata should be replaced entirely.
+	MergePolicyReplace MergePolicy = "Replace"
+)
+
+const (
+	managedByKey   = "managed-by"
+	managedByValue = "external-secrets"
+)
+
+const customMetadataKey = "custom_metadata"
+
+// errNotManagedByESO is returned when touching a secret not managed by ESO.
+var errNotManagedByESO = errors.New("secret not managed by external-secrets")
+
+// isManagedByESO checks if metadata carries the ESO ownership tag
+// (managed-by=external-secrets) to prevent clobbering unmanaged secrets.
+func isManagedByESO[V any](meta map[string]V) bool {
+	return any(meta[managedByKey]) == managedByValue
+}
+
+// PushSecretMetadataSpec defines the metadata specification for pushed secrets.
+type PushSecretMetadataSpec struct {
+	CustomMetadata map[string]string `json:"customMetadata,omitempty"`
+	MergePolicy    MergePolicy       `json:"mergePolicy,omitempty"`
+}
+
 func (c *client) PushSecret(ctx context.Context, secret *corev1.Secret, data esv1.PushSecretData) error {
-	var (
-		value []byte
-		err   error
-	)
-	key := data.GetSecretKey()
-	if key == "" {
-		// Must convert secret values to string, otherwise data will be sent as base64 to Vault
-		secretStringVal := make(map[string]string)
-		for k, v := range secret.Data {
-			secretStringVal[k] = string(v)
-		}
-		value, err = esutils.JSONMarshal(secretStringVal)
-		if err != nil {
-			return fmt.Errorf("failed to serialize secret content as JSON: %w", err)
-		}
-	} else {
-		value = secret.Data[key]
-	}
-	label := map[string]any{
-		"custom_metadata": map[string]string{
-			"managed-by": "external-secrets",
-		},
-	}
-	secretVal := make(map[string]any)
-	path := c.buildPath(data.GetRemoteKey())
-	metaPath, err := c.buildMetadataPath(data.GetRemoteKey())
+	value, err := esutils.ExtractSecretData(data, secret)
 	if err != nil {
 		return err
 	}
 
-	// Retrieve the secret map from vault and convert the secret value in string form.
-	vaultSecret, err := c.readSecret(ctx, path, "")
-	// If error is not of type secret not found, we should error
+	vaultSecret, err := c.readSecret(ctx, data.GetRemoteKey(), "")
 	if err != nil && !errors.Is(err, esv1.NoSecretError{}) {
 		return err
 	}
 
-	secretExists := err == nil
-	// If the secret exists, we should check if it is managed by external-secrets
-	if secretExists {
-		metadata, err := c.readSecretMetadata(ctx, data.GetRemoteKey())
-		if err != nil {
-			return err
-		}
-		manager, ok := metadata["managed-by"]
-		if !ok || manager != "external-secrets" {
-			return errors.New("secret not managed by external-secrets")
-		}
-		// Remove the metadata map to check the reconcile difference
-		if c.store.Version == esv1.VaultKVStoreV1 {
-			delete(vaultSecret, "custom_metadata")
-		}
-		// Only compare the entire secret if we're pushing the whole secret (not a single property)
-		if data.GetProperty() == "" {
-			// Convert incoming value to map for proper JSON comparison
-			var incomingSecretMap map[string]any
-			err = json.Unmarshal(value, &incomingSecretMap)
-			if err != nil {
-				// Do not wrap the original error with %w as json.Unmarshal errors
-				// may contain sensitive secret data in the error message
-				return errors.New("error unmarshalling incoming secret value: invalid JSON format")
-			}
-			// Compare maps instead of raw bytes to handle JSON field ordering and formatting
-			if maps.Equal(vaultSecret, incomingSecretMap) {
-				return nil
-			}
-		}
+	path := c.buildPath(data.GetRemoteKey())
+	switch c.store.Version {
+	case esv1.VaultKVStoreV1:
+		return c.pushSecretKV1(ctx, path, vaultSecret, value, data)
+	case esv1.VaultKVStoreV2:
+		return c.pushSecretKV2(ctx, path, vaultSecret, value, data)
+	default:
+		return fmt.Errorf("unsupported vault KV store version: %s", c.store.Version)
 	}
-	// If a Push of a property only, we should merge and add/update the property
-	if data.GetProperty() != "" {
-		if _, ok := vaultSecret[data.GetProperty()]; ok {
-			d, ok := vaultSecret[data.GetProperty()].(string)
-			if !ok {
-				return fmt.Errorf("error converting %s to string", data.GetProperty())
-			}
-			// If the property has the same value, don't update the secret
-			if bytes.Equal([]byte(d), value) {
-				return nil
-			}
-		}
-		maps.Insert(secretVal, maps.All(vaultSecret))
-		// Secret got from vault is already on map[string]string format
-		secretVal[data.GetProperty()] = string(value)
-	} else {
-		err = json.Unmarshal(value, &secretVal)
-		if err != nil {
-			// Do not wrap the original error with %w as json.Unmarshal errors
-			// may contain sensitive secret data in the error message
-			return errors.New("error unmarshalling vault secret: invalid JSON format")
-		}
-	}
-	secretToPush := secretVal
-	// Adding custom_metadata to the secret for KV v1
-	if c.store.Version == esv1.VaultKVStoreV1 {
-		secretToPush["custom_metadata"] = label["custom_metadata"]
-	}
-	if c.store.Version == esv1.VaultKVStoreV2 {
-		secretToPush = map[string]any{
-			"data": secretVal,
-		}
-
-		// Add CAS options if required
-		if c.store.CheckAndSet != nil && c.store.CheckAndSet.Required {
-			casVersion, casErr := c.getCASVersion(ctx, data.GetRemoteKey(), secretExists)
-			if casErr != nil {
-				return fmt.Errorf("failed to get CAS version: %w", casErr)
-			}
-
-			secretToPush["options"] = map[string]any{
-				"cas": casVersion,
-			}
-		}
-	}
-	// Secret metadata should be pushed separately only for KV2
-	if c.store.Version == esv1.VaultKVStoreV2 {
-		_, err = c.logical.WriteWithContext(ctx, metaPath, label)
-		metrics.ObserveAPICall(constants.ProviderHCVault, constants.CallHCVaultWriteSecretData, err)
-		if err != nil {
-			return err
-		}
-	}
-	// Otherwise, create or update the version.
-	_, err = c.logical.WriteWithContext(ctx, path, secretToPush)
-	metrics.ObserveAPICall(constants.ProviderHCVault, constants.CallHCVaultWriteSecretData, err)
-	return err
 }
 
 func (c *client) DeleteSecret(ctx context.Context, remoteRef esv1.PushSecretRemoteRef) error {
@@ -168,27 +96,29 @@ func (c *client) DeleteSecret(ctx context.Context, remoteRef esv1.PushSecretRemo
 	}
 	// Retrieve the secret map from vault and convert the secret value in string form.
 	secretVal, err := c.readSecret(ctx, path, "")
-	// If error is not of type secret not found, we should error
+	// Deleting an already-absent secret is a no-op.
 	if err != nil && errors.Is(err, esv1.NoSecretError{}) {
 		return nil
 	}
+	// Any other read error must be propagated, not ignored.
 	if err != nil {
 		return err
 	}
-	metadata, err := c.readSecretMetadata(ctx, remoteRef.GetRemoteKey())
+	remoteMeta, err := c.readSecretMetadata(ctx, remoteRef.GetRemoteKey())
 	if err != nil {
 		return err
 	}
-	manager, ok := metadata["managed-by"]
-	if !ok || manager != "external-secrets" {
+	if !isManagedByESO(remoteMeta) {
 		return nil
 	}
 	// If Push for a Property, we need to delete the property and update the secret
 	if remoteRef.GetProperty() != "" {
 		delete(secretVal, remoteRef.GetProperty())
 		// If the only key left in the remote secret is the reference of the metadata.
-		if c.store.Version == esv1.VaultKVStoreV1 && len(secretVal) == 1 {
-			delete(secretVal, "custom_metadata")
+		if c.store.Version == esv1.VaultKVStoreV1 {
+			if _, onlyMeta := secretVal[customMetadataKey]; onlyMeta && len(secretVal) == 1 {
+				delete(secretVal, customMetadataKey)
+			}
 		}
 		if len(secretVal) > 0 {
 			secretToPush := secretVal
@@ -213,6 +143,123 @@ func (c *client) DeleteSecret(ctx context.Context, remoteRef esv1.PushSecretRemo
 		if err != nil {
 			return fmt.Errorf("could not delete secret metadata %v: %w", remoteRef.GetRemoteKey(), err)
 		}
+	}
+	return nil
+}
+
+func (c *client) pushSecretKV1(ctx context.Context, path string, vaultSecret map[string]any, value []byte, data esv1.PushSecretData) error {
+	if vaultSecret != nil {
+		// KV1 has no metadata endpoint; the ownership tag rides inside the
+		// secret data under the custom_metadata key.
+		cmMap, _ := vaultSecret[customMetadataKey].(map[string]any)
+		if !isManagedByESO(cmMap) {
+			return errNotManagedByESO
+		}
+
+		delete(vaultSecret, customMetadataKey)
+	}
+
+	mergedData, dataNeedsUpdate, err := reconcileData(vaultSecret, value, data.GetProperty())
+	if err != nil {
+		return err
+	}
+
+	if vaultSecret != nil && !dataNeedsUpdate {
+		return nil // secret exists and is already up-to-date
+	}
+
+	mergedData[customMetadataKey] = map[string]string{
+		managedByKey: managedByValue,
+	}
+
+	_, err = c.logical.WriteWithContext(ctx, path, mergedData)
+	metrics.ObserveAPICall(constants.ProviderHCVault, constants.CallHCVaultWriteSecretData, err)
+	if err != nil {
+		return fmt.Errorf("failed to write secret data: %w", err)
+	}
+
+	return nil
+}
+
+func (c *client) pushSecretKV2(ctx context.Context, path string, vaultSecret map[string]any, value []byte, data esv1.PushSecretData) error {
+	secretExists := vaultSecret != nil
+
+	metaPath, err := c.buildMetadataPath(data.GetRemoteKey())
+	if err != nil {
+		return err
+	}
+
+	mergedData, dataNeedsUpdate, err := reconcileData(vaultSecret, value, data.GetProperty())
+	if err != nil {
+		return err
+	}
+
+	var remoteMeta map[string]string
+	if secretExists {
+		remoteMeta, err = c.readSecretMetadata(ctx, data.GetRemoteKey())
+		if err != nil {
+			return err
+		}
+	}
+
+	suppliedMeta, err := metadata.ParseMetadataParameters[PushSecretMetadataSpec](data.GetMetadata())
+	if err != nil {
+		return fmt.Errorf("failed to parse push secret metadata: %w", err)
+	}
+
+	finalCustomMeta, metadataNeedsUpdate, err := reconcileKV2Metadata(secretExists, remoteMeta, suppliedMeta)
+	if err != nil {
+		return err
+	}
+
+	if !dataNeedsUpdate && !metadataNeedsUpdate {
+		return nil
+	}
+
+	// Metadata is written before data intentionally: for new secrets this establishes
+	// the "managed-by" ownership tag first. If the data write subsequently fails the
+	// reconciler will retry; because managed-by is already present it will proceed
+	// straight to updating the data without re-checking ownership.
+	if metadataNeedsUpdate {
+		if err := c.writeKV2Metadata(ctx, metaPath, finalCustomMeta); err != nil {
+			return err
+		}
+	}
+
+	if dataNeedsUpdate {
+		if err := c.writeKV2Data(ctx, path, mergedData, data.GetRemoteKey(), secretExists); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *client) writeKV2Metadata(ctx context.Context, metaPath string, finalCustomMeta map[string]string) error {
+	metaPayload := map[string]any{customMetadataKey: finalCustomMeta}
+	_, err := c.logical.WriteWithContext(ctx, metaPath, metaPayload)
+	metrics.ObserveAPICall(constants.ProviderHCVault, constants.CallHCVaultWriteSecretData, err)
+	if err != nil {
+		return fmt.Errorf("failed to write secret metadata: %w", err)
+	}
+	return nil
+}
+
+func (c *client) writeKV2Data(ctx context.Context, path string, mergedData map[string]any, remoteKey string, secretExists bool) error {
+	secretToPush := map[string]any{"data": mergedData}
+
+	if c.store.CheckAndSet != nil && c.store.CheckAndSet.Required {
+		casVersion, casErr := c.getCASVersion(ctx, remoteKey, secretExists)
+		if casErr != nil {
+			return fmt.Errorf("failed to get CAS version: %w", casErr)
+		}
+		secretToPush["options"] = map[string]any{"cas": casVersion}
+	}
+
+	_, err := c.logical.WriteWithContext(ctx, path, secretToPush)
+	metrics.ObserveAPICall(constants.ProviderHCVault, constants.CallHCVaultWriteSecretData, err)
+	if err != nil {
+		return fmt.Errorf("failed to write secret data: %w", err)
 	}
 	return nil
 }
@@ -249,7 +296,6 @@ func (c *client) getCASVersion(ctx context.Context, remoteKey string, secretExis
 }
 
 func getCurrentVersionFromMetadata(data map[string]any) (int, error) {
-	var err error
 	if currentVersion, ok := data["current_version"]; ok {
 		switch v := currentVersion.(type) {
 		case int:
@@ -257,10 +303,11 @@ func getCurrentVersionFromMetadata(data map[string]any) (int, error) {
 		case float64:
 			return int(v), nil
 		case json.Number:
-			if intVal, err := v.Int64(); err == nil {
-				return int(intVal), nil
+			intVal, err := v.Int64()
+			if err != nil {
+				return 0, fmt.Errorf("failed to convert json.Number to int: %w", err)
 			}
-			return 0, fmt.Errorf("failed to convert json.Number to int: %w", err)
+			return int(intVal), nil
 		default:
 			return 0, fmt.Errorf("unexpected type for current_version: %T", currentVersion)
 		}
@@ -270,4 +317,97 @@ func getCurrentVersionFromMetadata(data map[string]any) (int, error) {
 	// This handles edge cases with legacy secrets or incomplete metadata.
 	// Vault KV v2 secrets start at version 1, so this is the safest assumption.
 	return 1, nil
+}
+
+func reconcileData(vaultSecret map[string]any, value []byte, property string) (map[string]any, bool, error) {
+	if property == "" {
+		return reconcileWholeSecret(vaultSecret, value)
+	}
+	return reconcileSecretProperty(vaultSecret, value, property)
+}
+
+func reconcileWholeSecret(vaultSecret map[string]any, value []byte) (map[string]any, bool, error) {
+	incomingSecretMap := make(map[string]any)
+	if err := json.Unmarshal(value, &incomingSecretMap); err != nil {
+		if vaultSecret == nil {
+			return nil, false, errors.New("error unmarshalling vault secret: invalid JSON format")
+		}
+		return nil, false, errors.New("error unmarshalling incoming secret value: invalid JSON format")
+	}
+
+	needsUpdate := !reflect.DeepEqual(vaultSecret, incomingSecretMap)
+	return incomingSecretMap, needsUpdate, nil
+}
+
+func reconcileSecretProperty(vaultSecret map[string]any, value []byte, property string) (map[string]any, bool, error) {
+	secretVal := make(map[string]any)
+	needsUpdate := true
+
+	if vaultSecret != nil {
+		maps.Copy(secretVal, vaultSecret)
+
+		// Check if the specific property matches to avoid unnecessary writes
+		if existingVal, ok := vaultSecret[property]; ok {
+			d, isStr := existingVal.(string)
+			if !isStr {
+				// Refuse to overwrite a non-string remote value (e.g. a nested
+				// object) with a string; the caller must resolve the conflict.
+				return nil, false, fmt.Errorf("error converting %s to string", property)
+			}
+			if bytes.Equal([]byte(d), value) {
+				needsUpdate = false
+			}
+		}
+	}
+	secretVal[property] = string(value)
+
+	return secretVal, needsUpdate, nil
+}
+
+// reconcileKV2Metadata computes the KV v2 custom_metadata map that PushSecret
+// should end up with, and whether it differs from what Vault already has.
+func reconcileKV2Metadata(secretExists bool, remoteMeta map[string]string, suppliedMeta *metadata.PushSecretMetadata[PushSecretMetadataSpec]) (map[string]string, bool, error) {
+	desiredCustomMeta := map[string]string{managedByKey: managedByValue}
+	mergePolicy := MergePolicyMerge // Default Policy
+
+	if suppliedMeta != nil {
+		if suppliedMeta.Spec.MergePolicy != "" {
+			switch suppliedMeta.Spec.MergePolicy {
+			case MergePolicyMerge, MergePolicyReplace:
+				mergePolicy = suppliedMeta.Spec.MergePolicy
+			default:
+				return nil, false, fmt.Errorf("unsupported merge policy %q, must be one of: Merge, Replace", suppliedMeta.Spec.MergePolicy)
+			}
+		}
+		if suppliedMeta.Spec.CustomMetadata != nil {
+			maps.Copy(desiredCustomMeta, suppliedMeta.Spec.CustomMetadata)
+		}
+	}
+
+	// Re-assert after merging user-supplied custom metadata so every downstream
+	// path (the new-secret return below and all merge-policy branches) inherits
+	// the correct ownership tag from this single source.
+	desiredCustomMeta[managedByKey] = managedByValue
+
+	if !secretExists {
+		return desiredCustomMeta, true, nil
+	}
+
+	// Refuse to touch a secret ESO doesn't already own.
+	if !isManagedByESO(remoteMeta) {
+		return nil, false, errNotManagedByESO
+	}
+
+	finalCustomMeta := make(map[string]string)
+	switch mergePolicy {
+	case MergePolicyMerge:
+		maps.Copy(finalCustomMeta, remoteMeta)
+		maps.Copy(finalCustomMeta, desiredCustomMeta)
+	case MergePolicyReplace:
+		finalCustomMeta = maps.Clone(desiredCustomMeta)
+	}
+
+	needsUpdate := !maps.Equal(remoteMeta, finalCustomMeta)
+
+	return finalCustomMeta, needsUpdate, nil
 }

--- a/providers/v1/vault/client_push_test.go
+++ b/providers/v1/vault/client_push_test.go
@@ -20,23 +20,81 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
+	vault "github.com/hashicorp/vault/api"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
 	"github.com/external-secrets/external-secrets/providers/v1/vault/fake"
 	vaultutil "github.com/external-secrets/external-secrets/providers/v1/vault/util"
+	"github.com/external-secrets/external-secrets/runtime/esutils/metadata"
 	testingfake "github.com/external-secrets/external-secrets/runtime/testing/fake"
 )
 
+// capturedWrite records a single WriteWithContext call so a test case can
+// assert on both the metadata write and the data write independently -
+// fake.ExpectWriteWithContextValue skips assertions on any path containing
+// "metadata", so it cannot be used to verify metadata payloads.
+type capturedWrite struct {
+	path string
+	data map[string]any
+}
+
+// withWriteRecorder wraps a *fake.Logical so every WriteWithContext call is
+// captured before delegating to its existing WriteWithContextFn. It returns a
+// shallow copy, so the original test case's fake is left untouched, and a
+// pointer to the (initially empty) slice of recorded calls. A test case only
+// needs to provide a normal WriteWithContextFn (e.g. fake.NewWriteWithContextFn) -
+// no per-case slice variable required, however many cases need this.
+func withWriteRecorder(logical vaultutil.Logical) (vaultutil.Logical, *[]capturedWrite) {
+	fl, ok := logical.(*fake.Logical)
+	if !ok {
+		return logical, nil
+	}
+	calls := &[]capturedWrite{}
+	wrapped := *fl
+	original := fl.WriteWithContextFn
+	wrapped.WriteWithContextFn = func(ctx context.Context, path string, data map[string]any) (*vault.Secret, error) {
+		*calls = append(*calls, capturedWrite{path: path, data: data})
+		return original(ctx, path, data)
+	}
+	return &wrapped, calls
+}
+
 const (
-	fakeKey      = "fake-key"
-	fakeValue    = "fake-value"
-	managedBy    = "managed-by"
-	managedByESO = "external-secrets"
+	fakeKey   = "fake-key"
+	fakeValue = "fake-value"
 )
+
+// requireErrorMatch asserts gotErr against wantErr using the substring
+// convention shared by the push/delete/reconcile table tests:
+//   - wantErr == nil: gotErr must be nil.
+//   - wantErr != nil: gotErr must be non-nil and its message must contain
+//     wantErr's message.
+//
+// It returns true whenever the result is anything other than a clean success
+// (an error was expected, or an unexpected error occurred), letting
+// table-driven callers short-circuit assertions that only apply on success.
+func requireErrorMatch(t *testing.T, label, name, reason string, wantErr, gotErr error) bool {
+	t.Helper()
+
+	if wantErr == nil {
+		if gotErr != nil {
+			t.Errorf("\nTesting %s:\nName: %v\nReason: %v\nWant no error\nGot error: %v", label, name, reason, gotErr)
+			return true
+		}
+		return false
+	}
+
+	if gotErr == nil || !strings.Contains(gotErr.Error(), wantErr.Error()) {
+		t.Errorf("\nTesting %s:\nName: %v\nReason: %v\nWant error containing: %v\nGot error: %v", label, name, reason, wantErr, gotErr)
+	}
+	return true
+}
 
 func TestDeleteSecret(t *testing.T) {
 	type args struct {
@@ -118,7 +176,7 @@ func TestDeleteSecret(t *testing.T) {
 					ReadWithDataWithContextFn: fake.NewReadWithContextFn(map[string]any{
 						fakeKey: fakeValue,
 						"custom_metadata": map[string]any{
-							managedBy: "another-secret-tool",
+							managedByKey: "another-secret-tool",
 						},
 					}, nil),
 					WriteWithContextFn:  fake.ExpectWriteWithContextNoCall(),
@@ -139,7 +197,7 @@ func TestDeleteSecret(t *testing.T) {
 							fakeKey: fakeValue,
 						},
 						"custom_metadata": map[string]any{
-							managedBy: "another-secret-tool",
+							managedByKey: "another-secret-tool",
 						},
 					}, nil),
 					WriteWithContextFn:  fake.ExpectWriteWithContextNoCall(),
@@ -158,7 +216,7 @@ func TestDeleteSecret(t *testing.T) {
 					ReadWithDataWithContextFn: fake.NewReadWithContextFn(map[string]any{
 						fakeKey: fakeValue,
 						"custom_metadata": map[string]any{
-							managedBy: managedByESO,
+							managedByKey: managedByValue,
 						},
 					}, nil),
 					WriteWithContextFn:  fake.ExpectWriteWithContextNoCall(),
@@ -179,7 +237,7 @@ func TestDeleteSecret(t *testing.T) {
 							fakeKey: fakeValue,
 						},
 						"custom_metadata": map[string]any{
-							managedBy: managedByESO,
+							managedByKey: managedByValue,
 						},
 					}, nil),
 					WriteWithContextFn:  fake.ExpectWriteWithContextNoCall(),
@@ -198,7 +256,7 @@ func TestDeleteSecret(t *testing.T) {
 					ReadWithDataWithContextFn: fake.NewReadWithContextFn(map[string]any{
 						fakeKey: fakeValue,
 						"custom_metadata": map[string]any{
-							managedBy: managedByESO,
+							managedByKey: managedByValue,
 						},
 					}, nil),
 					WriteWithContextFn:  fake.ExpectWriteWithContextNoCall(),
@@ -219,7 +277,7 @@ func TestDeleteSecret(t *testing.T) {
 							fakeKey: fakeValue,
 						},
 						"custom_metadata": map[string]any{
-							managedBy: managedByESO,
+							managedByKey: managedByValue,
 						},
 					}, nil),
 					WriteWithContextFn:  fake.ExpectWriteWithContextNoCall(),
@@ -240,13 +298,13 @@ func TestDeleteSecret(t *testing.T) {
 						fakeKey: fakeValue,
 						"foo":   "bar",
 						"custom_metadata": map[string]any{
-							managedBy: managedByESO,
+							managedByKey: managedByValue,
 						},
 					}, nil),
 					WriteWithContextFn: fake.ExpectWriteWithContextValue(map[string]any{
 						"foo": "bar",
 						"custom_metadata": map[string]any{
-							managedBy: managedByESO,
+							managedByKey: managedByValue,
 						}}),
 					DeleteWithContextFn: fake.ExpectDeleteWithContextNoCall(),
 				},
@@ -267,7 +325,7 @@ func TestDeleteSecret(t *testing.T) {
 							"foo":   "bar",
 						},
 						"custom_metadata": map[string]any{
-							managedBy: managedByESO,
+							managedByKey: managedByValue,
 						},
 					}, nil),
 					WriteWithContextFn:  fake.ExpectWriteWithContextValue(map[string]any{"data": map[string]any{"foo": "bar"}}),
@@ -287,7 +345,7 @@ func TestDeleteSecret(t *testing.T) {
 					ReadWithDataWithContextFn: fake.NewReadWithContextFn(map[string]any{
 						"foo": "bar",
 						"custom_metadata": map[string]any{
-							managedBy: managedByESO,
+							managedByKey: managedByValue,
 						},
 					}, nil),
 					WriteWithContextFn:  fake.ExpectWriteWithContextNoCall(),
@@ -309,7 +367,7 @@ func TestDeleteSecret(t *testing.T) {
 							"foo": "bar",
 						},
 						"custom_metadata": map[string]any{
-							managedBy: managedByESO,
+							managedByKey: managedByValue,
 						},
 					}, nil),
 					WriteWithContextFn:  fake.ExpectWriteWithContextNoCall(),
@@ -333,17 +391,7 @@ func TestDeleteSecret(t *testing.T) {
 			}
 			err := client.DeleteSecret(context.Background(), ref)
 
-			// Error nil XOR tc.want.err nil
-			if ((err == nil) || (tc.want.err == nil)) && !((err == nil) && (tc.want.err == nil)) {
-				t.Errorf("\nTesting DeleteSecret:\nName: %v\nReason: %v\nWant error: %v\nGot error: %v", name, tc.reason, tc.want.err, err)
-			}
-
-			// if errors are the same type but their contents do not match
-			if err != nil && tc.want.err != nil {
-				if !strings.Contains(err.Error(), tc.want.err.Error()) {
-					t.Errorf("\nTesting DeleteSecret:\nName: %v\nReason: %v\nWant error: %v\nGot error got nil", name, tc.reason, tc.want.err)
-				}
-			}
+			requireErrorMatch(t, "DeleteSecret", name, tc.reason, tc.want.err, err)
 		})
 	}
 }
@@ -356,7 +404,9 @@ func TestPushSecret(t *testing.T) {
 	}
 
 	type want struct {
-		err error
+		err           error
+		metadataWrite map[string]any
+		noDataWrite   bool
 	}
 	tests := map[string]struct {
 		reason string
@@ -426,7 +476,7 @@ func TestPushSecret(t *testing.T) {
 					ReadWithDataWithContextFn: fake.NewReadWithContextFn(map[string]any{
 						fakeKey: fakeValue,
 						"custom_metadata": map[string]any{
-							managedBy: managedByESO,
+							managedByKey: managedByValue,
 						},
 					}, nil),
 				},
@@ -445,7 +495,7 @@ func TestPushSecret(t *testing.T) {
 							fakeKey: fakeValue,
 						},
 						"custom_metadata": map[string]any{
-							managedBy: managedByESO,
+							managedByKey: managedByValue,
 						},
 					}, nil),
 				},
@@ -464,13 +514,13 @@ func TestPushSecret(t *testing.T) {
 					ReadWithDataWithContextFn: fake.NewReadWithContextFn(map[string]any{
 						fakeKey: fakeValue,
 						"custom_metadata": map[string]any{
-							managedBy: managedByESO,
+							managedByKey: managedByValue,
 						},
 					}, nil),
 					WriteWithContextFn: fake.ExpectWriteWithContextValue(map[string]any{
 						fakeKey: fakeValue,
 						"custom_metadata": map[string]string{
-							managedBy: managedByESO,
+							managedByKey: managedByValue,
 						},
 						"foo": fakeValue,
 					}),
@@ -492,7 +542,7 @@ func TestPushSecret(t *testing.T) {
 							fakeKey: fakeValue,
 						},
 						"custom_metadata": map[string]any{
-							managedBy: managedByESO,
+							managedByKey: managedByValue,
 						},
 					}, nil),
 					WriteWithContextFn: fake.ExpectWriteWithContextValue(map[string]any{"data": map[string]any{fakeKey: fakeValue, "foo": fakeValue}}),
@@ -512,13 +562,13 @@ func TestPushSecret(t *testing.T) {
 					ReadWithDataWithContextFn: fake.NewReadWithContextFn(map[string]any{
 						"foo": fakeValue,
 						"custom_metadata": map[string]any{
-							managedBy: managedByESO,
+							managedByKey: managedByValue,
 						},
 					}, nil),
 					WriteWithContextFn: fake.ExpectWriteWithContextValue(map[string]any{
 						"foo": "new-value",
 						"custom_metadata": map[string]string{
-							managedBy: managedByESO,
+							managedByKey: managedByValue,
 						},
 					}),
 				},
@@ -539,7 +589,7 @@ func TestPushSecret(t *testing.T) {
 							"foo": fakeValue,
 						},
 						"custom_metadata": map[string]any{
-							managedBy: managedByESO,
+							managedByKey: managedByValue,
 						},
 					}, nil),
 					WriteWithContextFn: fake.ExpectWriteWithContextValue(map[string]any{"data": map[string]any{"foo": "new-value"}}),
@@ -550,7 +600,7 @@ func TestPushSecret(t *testing.T) {
 			},
 		},
 		"PushSecretPropertyNoUpdateKV1": {
-			reason: "push secret with property only updates the property",
+			reason: "push secret is a no-op when the property value already matches the remote",
 			value:  []byte(fakeValue),
 			data:   &testingfake.PushSecretData{SecretKey: secretKey, RemoteKey: "secret", Property: "foo"},
 			args: args{
@@ -559,7 +609,7 @@ func TestPushSecret(t *testing.T) {
 					ReadWithDataWithContextFn: fake.NewReadWithContextFn(map[string]any{
 						"foo": fakeValue,
 						"custom_metadata": map[string]any{
-							managedBy: managedByESO,
+							managedByKey: managedByValue,
 						},
 					}, nil),
 					WriteWithContextFn: fake.ExpectWriteWithContextNoCall(),
@@ -570,7 +620,7 @@ func TestPushSecret(t *testing.T) {
 			},
 		},
 		"PushSecretPropertyNoUpdateKV2": {
-			reason: "push secret with property only updates the property",
+			reason: "push secret is a no-op when the property value already matches the remote",
 			value:  []byte(fakeValue),
 			data:   &testingfake.PushSecretData{SecretKey: secretKey, RemoteKey: "secret", Property: "foo"},
 			args: args{
@@ -581,7 +631,7 @@ func TestPushSecret(t *testing.T) {
 							"foo": fakeValue,
 						},
 						"custom_metadata": map[string]any{
-							managedBy: managedByESO,
+							managedByKey: managedByValue,
 						},
 					}, nil),
 					WriteWithContextFn: fake.ExpectWriteWithContextNoCall(),
@@ -589,6 +639,48 @@ func TestPushSecret(t *testing.T) {
 			},
 			want: want{
 				err: nil,
+			},
+		},
+		"PushSecretPropertyNonStringRemoteErrorsKV1": {
+			reason: "pushing a property onto a non-string remote value must error instead of silently overwriting it",
+			value:  []byte(fakeValue),
+			data:   &testingfake.PushSecretData{SecretKey: secretKey, RemoteKey: "secret", Property: "foo"},
+			args: args{
+				store: makeValidSecretStoreWithVersion(esv1.VaultKVStoreV1).Spec.Provider.Vault,
+				vLogical: &fake.Logical{
+					ReadWithDataWithContextFn: fake.NewReadWithContextFn(map[string]any{
+						"foo": map[string]any{"nested": "value"},
+						"custom_metadata": map[string]any{
+							managedByKey: managedByValue,
+						},
+					}, nil),
+					WriteWithContextFn: fake.ExpectWriteWithContextNoCall(),
+				},
+			},
+			want: want{
+				err: errors.New("error converting foo to string"),
+			},
+		},
+		"PushSecretPropertyNonStringRemoteErrorsKV2": {
+			reason: "pushing a property onto a non-string remote value must error instead of silently overwriting it",
+			value:  []byte(fakeValue),
+			data:   &testingfake.PushSecretData{SecretKey: secretKey, RemoteKey: "secret", Property: "foo"},
+			args: args{
+				store: makeValidSecretStoreWithVersion(esv1.VaultKVStoreV2).Spec.Provider.Vault,
+				vLogical: &fake.Logical{
+					ReadWithDataWithContextFn: fake.NewReadWithContextFn(map[string]any{
+						"data": map[string]any{
+							"foo": map[string]any{"nested": "value"},
+						},
+						"custom_metadata": map[string]any{
+							managedByKey: managedByValue,
+						},
+					}, nil),
+					WriteWithContextFn: fake.ExpectWriteWithContextNoCall(),
+				},
+			},
+			want: want{
+				err: errors.New("error converting foo to string"),
 			},
 		},
 		"SetSecretErrorReadingSecretKV1": {
@@ -623,7 +715,7 @@ func TestPushSecret(t *testing.T) {
 					ReadWithDataWithContextFn: fake.NewReadWithContextFn(map[string]any{
 						fakeKey: "fake-value2",
 						"custom_metadata": map[string]any{
-							managedBy: "not-external-secrets",
+							managedByKey: "not-external-secrets",
 						},
 					}, nil),
 				},
@@ -641,7 +733,7 @@ func TestPushSecret(t *testing.T) {
 						"data": map[string]any{
 							fakeKey: "fake-value2",
 							"custom_metadata": map[string]any{
-								managedBy: "not-external-secrets",
+								managedByKey: "not-external-secrets",
 							},
 						},
 					}, nil),
@@ -697,7 +789,7 @@ func TestPushSecret(t *testing.T) {
 						},
 						map[string]any{
 							"custom_metadata": map[string]any{
-								managedBy: managedByESO,
+								managedByKey: managedByValue,
 							},
 							"current_version": 3,
 						},
@@ -730,7 +822,7 @@ func TestPushSecret(t *testing.T) {
 						},
 						map[string]any{
 							"custom_metadata": map[string]any{
-								managedBy: managedByESO,
+								managedByKey: managedByValue,
 							},
 							"current_version": 2,
 						},
@@ -775,13 +867,179 @@ func TestPushSecret(t *testing.T) {
 					WriteWithContextFn: fake.ExpectWriteWithContextValue(map[string]any{
 						fakeKey: fakeValue,
 						"custom_metadata": map[string]string{
-							managedBy: managedByESO,
+							managedByKey: managedByValue,
 						},
 					}),
 				},
 			},
 			want: want{
 				err: nil,
+			},
+		},
+		"PushSecretMergePolicyMergeKV2": {
+			reason: "custom metadata merge policy keeps existing remote keys and merges in the new ones, data is left untouched since it is already up to date",
+			data: &testingfake.PushSecretData{
+				SecretKey: secretKey,
+				RemoteKey: "secret",
+				Metadata: &apiextensionsv1.JSON{Raw: []byte(`{
+					"kind": "PushSecretMetadata",
+					"apiVersion": "kubernetes.external-secrets.io/v1alpha1",
+					"spec": {
+						"mergePolicy": "Merge",
+						"customMetadata": {
+							"namespace": "test-namespace"
+						}
+					}
+				}`)},
+			},
+			args: args{
+				store: makeValidSecretStoreWithVersion(esv1.VaultKVStoreV2).Spec.Provider.Vault,
+				vLogical: &fake.Logical{
+					ReadWithDataWithContextFn: fake.NewReadWithDataAndMetadataFn(
+						map[string]any{
+							"data": map[string]any{
+								fakeKey: fakeValue,
+							},
+						},
+						map[string]any{
+							"custom_metadata": map[string]any{
+								managedByKey: managedByValue,
+								"team":       "payments",
+							},
+						},
+						nil, nil,
+					),
+					WriteWithContextFn: fake.NewWriteWithContextFn(nil, nil),
+				},
+			},
+			want: want{
+				err: nil,
+				metadataWrite: map[string]any{
+					"custom_metadata": map[string]string{
+						managedByKey: managedByValue,
+						"team":       "payments",
+						"namespace":  "test-namespace",
+					},
+				},
+				noDataWrite: true,
+			},
+		},
+		"PushSecretMergePolicyReplaceKV2": {
+			reason: "custom metadata replace policy drops remote keys that are not in the new metadata spec",
+			data: &testingfake.PushSecretData{
+				SecretKey: secretKey,
+				RemoteKey: "secret",
+				Metadata: &apiextensionsv1.JSON{Raw: []byte(`{
+					"kind": "PushSecretMetadata",
+					"apiVersion": "kubernetes.external-secrets.io/v1alpha1",
+					"spec": {
+						"mergePolicy": "Replace",
+						"customMetadata": {
+							"namespace": "test-namespace"
+						}
+					}
+				}`)},
+			},
+			args: args{
+				store: makeValidSecretStoreWithVersion(esv1.VaultKVStoreV2).Spec.Provider.Vault,
+				vLogical: &fake.Logical{
+					ReadWithDataWithContextFn: fake.NewReadWithDataAndMetadataFn(
+						map[string]any{
+							"data": map[string]any{
+								fakeKey: fakeValue,
+							},
+						},
+						map[string]any{
+							"custom_metadata": map[string]any{
+								managedByKey: managedByValue,
+								"team":       "payments",
+								"namespace":  "test-namespace",
+							},
+						},
+						nil, nil,
+					),
+					WriteWithContextFn: fake.NewWriteWithContextFn(nil, nil),
+				},
+			},
+			// "team" is intentionally absent here: it is present on the remote
+			// secret but not in the pushed spec, so it must be dropped under
+			// Replace. If the policy above were wrongly set to "Merge", "team"
+			// would survive into the write and this assertion would fail.
+			want: want{
+				err: nil,
+				metadataWrite: map[string]any{
+					"custom_metadata": map[string]string{
+						managedByKey: managedByValue,
+						"namespace":  "test-namespace",
+					},
+				},
+				noDataWrite: true,
+			},
+		},
+		"PushSecretInvalidMetadataKindKV2": {
+			reason: "a PushSecretMetadata with the wrong kind must be rejected before any write",
+			data: &testingfake.PushSecretData{
+				SecretKey: secretKey,
+				RemoteKey: "secret",
+				Metadata: &apiextensionsv1.JSON{Raw: []byte(`{
+					"kind": "NotPushSecretMetadata",
+					"apiVersion": "kubernetes.external-secrets.io/v1alpha1",
+					"spec": {
+						"mergePolicy": "Merge"
+					}
+				}`)},
+			},
+			args: args{
+				store: makeValidSecretStoreWithVersion(esv1.VaultKVStoreV2).Spec.Provider.Vault,
+				vLogical: &fake.Logical{
+					ReadWithDataWithContextFn: fake.NewReadWithContextFn(nil, nil),
+					WriteWithContextFn:        fake.ExpectWriteWithContextNoCall(),
+				},
+			},
+			want: want{
+				err: errors.New("failed to parse push secret metadata"),
+			},
+		},
+		"PushSecretDataWriteErrorSkipsMetadataKV2": {
+			reason: "when remote metadata already matches the desired state, the metadata write is skipped and only the data write executes - its failure must still surface",
+			value:  []byte("new-value"),
+			data:   &testingfake.PushSecretData{SecretKey: secretKey, RemoteKey: "secret", Property: "foo"},
+			args: args{
+				store: makeValidSecretStoreWithVersion(esv1.VaultKVStoreV2).Spec.Provider.Vault,
+				vLogical: &fake.Logical{
+					ReadWithDataWithContextFn: fake.NewReadWithContextFn(map[string]any{
+						"data": map[string]any{
+							"foo": fakeValue,
+						},
+						"custom_metadata": map[string]any{
+							managedByKey: managedByValue,
+						},
+					}, nil),
+					// A single WriteWithContext call is expected here: metadata is
+					// already up to date so that branch never runs, leaving only
+					// the data write to hit this always-erroring fake.
+					WriteWithContextFn: fake.NewWriteWithContextFn(nil, noPermission),
+				},
+			},
+			want: want{
+				err: errors.New("failed to write secret data"),
+			},
+		},
+		"PushSecretMetadataWriteErrorKV2": {
+			reason: "when the metadata write fails, its error must surface; because metadata is written before data, a new secret hits the metadata write first",
+			args: args{
+				store: makeValidSecretStoreWithVersion(esv1.VaultKVStoreV2).Spec.Provider.Vault,
+				vLogical: &fake.Logical{
+					// nil,nil => secret does not exist => metadataNeedsUpdate is
+					// unconditionally true, so the metadata write branch is entered.
+					ReadWithDataWithContextFn: fake.NewReadWithContextFn(nil, nil),
+					// Every write errors; the metadata write is the first one, so its
+					// error ("failed to write secret metadata") is what surfaces.
+					WriteWithContextFn: fake.NewWriteWithContextFn(nil, noPermission),
+				},
+			},
+			want: want{
+				err: errors.New("failed to write secret metadata"),
 			},
 		},
 		// Security regression tests: ensure json.Unmarshal errors don't leak secret data
@@ -820,7 +1078,7 @@ func TestPushSecret(t *testing.T) {
 					ReadWithDataWithContextFn: fake.NewReadWithContextFn(map[string]any{
 						fakeKey: fakeValue,
 						"custom_metadata": map[string]any{
-							managedBy: managedByESO,
+							managedByKey: managedByValue,
 						},
 					}, nil),
 				},
@@ -840,7 +1098,7 @@ func TestPushSecret(t *testing.T) {
 							fakeKey: fakeValue,
 						},
 						"custom_metadata": map[string]any{
-							managedBy: managedByESO,
+							managedByKey: managedByValue,
 						},
 					}, nil),
 				},
@@ -857,8 +1115,13 @@ func TestPushSecret(t *testing.T) {
 			if tc.data != nil {
 				data = *tc.data
 			}
+			vLogical := tc.args.vLogical
+			var writes *[]capturedWrite
+			if tc.want.metadataWrite != nil || tc.want.noDataWrite {
+				vLogical, writes = withWriteRecorder(vLogical)
+			}
 			client := &client{
-				logical: tc.args.vLogical,
+				logical: vLogical,
 				store:   tc.args.store,
 			}
 			s := tc.secret
@@ -871,17 +1134,7 @@ func TestPushSecret(t *testing.T) {
 			}
 			err := client.PushSecret(context.Background(), s, data)
 
-			// Error nil XOR tc.want.err nil
-			if ((err == nil) || (tc.want.err == nil)) && !((err == nil) && (tc.want.err == nil)) {
-				t.Errorf("\nTesting SetSecret:\nName: %v\nReason: %v\nWant error: %v\nGot error: %v", name, tc.reason, tc.want.err, err)
-			}
-
-			// if errors are the same type but their contents do not match
-			if err != nil && tc.want.err != nil {
-				if !strings.Contains(err.Error(), tc.want.err.Error()) {
-					t.Errorf("\nTesting SetSecret:\nName: %v\nReason: %v\nWant error: %v\nGot error got nil", name, tc.reason, tc.want.err)
-				}
-			}
+			requireErrorMatch(t, "PushSecret", name, tc.reason, tc.want.err, err)
 
 			// Security regression: ensure error messages don't leak secret data
 			if err != nil && tc.value != nil {
@@ -889,6 +1142,167 @@ func TestPushSecret(t *testing.T) {
 				if strings.Contains(err.Error(), secretData) {
 					t.Errorf("\nSECURITY REGRESSION: Error message contains secret data!\nName: %v\nSecret data: %v\nError: %v", name, secretData, err)
 				}
+			}
+
+			// Custom metadata merge policies write to the metadata path, which
+			// fake.ExpectWriteWithContextValue does not validate. Cases that set
+			// want.metadataWrite record every write and assert on the metadata one directly.
+			if tc.want.metadataWrite != nil {
+				found := false
+				for _, call := range *writes {
+					if !strings.Contains(call.path, "metadata") {
+						continue
+					}
+					found = true
+					if !reflect.DeepEqual(call.data, tc.want.metadataWrite) {
+						t.Errorf("\nTesting PushSecret metadata write:\nName: %v\nReason: %v\nWant: %#v\nGot: %#v", name, tc.reason, tc.want.metadataWrite, call.data)
+					}
+				}
+				if !found {
+					t.Errorf("\nTesting PushSecret metadata write:\nName: %v\nReason: %v\nWant a metadata write, but none was recorded", name, tc.reason)
+				}
+			}
+
+			// Metadata-only updates must not touch the data path. Any captured
+			// write whose path is not the metadata path is a data write that
+			// should have been skipped because the remote data already matched.
+			if tc.want.noDataWrite {
+				for _, call := range *writes {
+					if !strings.Contains(call.path, "metadata") {
+						t.Errorf("\nTesting PushSecret:\nName: %v\nReason: %v\nWant no data write, but a write to %q was recorded: %#v", name, tc.reason, call.path, call.data)
+					}
+				}
+			}
+		})
+	}
+}
+
+// pushSecretMetadata builds a valid PushSecretMetadata envelope with the given
+// merge policy and custom metadata, mirroring what metadata.ParseMetadataParameters
+// would return after parsing a user-supplied PushSecretMetadata resource.
+func pushSecretMetadata(policy MergePolicy, customMetadata map[string]string) *metadata.PushSecretMetadata[PushSecretMetadataSpec] {
+	return &metadata.PushSecretMetadata[PushSecretMetadataSpec]{
+		Kind:       metadata.Kind,
+		APIVersion: metadata.APIVersion,
+		Spec: PushSecretMetadataSpec{
+			MergePolicy:    policy,
+			CustomMetadata: customMetadata,
+		},
+	}
+}
+
+func TestReconcileKV2Metadata(t *testing.T) {
+	type want struct {
+		meta   map[string]string
+		update bool
+		err    error
+	}
+	tests := map[string]struct {
+		reason       string
+		secretExists bool
+		remoteMeta   map[string]string
+		suppliedMeta *metadata.PushSecretMetadata[PushSecretMetadataSpec]
+		want         want
+	}{
+		"NewSecretManagedByOnly": {
+			reason:       "a brand new secret has no remote metadata to merge with, so only the ownership tag is written",
+			secretExists: false,
+			want:         want{meta: map[string]string{managedByKey: managedByValue}, update: true},
+		},
+		"NewSecretMergesSuppliedCustomMetadata": {
+			reason:       "custom metadata supplied on a new secret is merged alongside the ownership tag",
+			secretExists: false,
+			suppliedMeta: pushSecretMetadata("", map[string]string{"team": "payments"}),
+			want:         want{meta: map[string]string{managedByKey: managedByValue, "team": "payments"}, update: true},
+		},
+		"NewSecretCannotOverrideManagedBy": {
+			reason:       "managed-by is reserved and always re-asserted after merging user-supplied metadata",
+			secretExists: false,
+			suppliedMeta: pushSecretMetadata("", map[string]string{managedByKey: "someone-else"}),
+			want:         want{meta: map[string]string{managedByKey: managedByValue}, update: true},
+		},
+		"NewSecretUnsupportedMergePolicyErrors": {
+			reason:       "merge policy is validated before the secretExists branch, so it applies even to new secrets",
+			secretExists: false,
+			suppliedMeta: pushSecretMetadata("NotSupportedMergePolicy", nil),
+			want:         want{err: errors.New("unsupported merge policy")},
+		},
+		"ExistingSecretNotManagedByESOErrors": {
+			reason:       "ESO must not take ownership of, or mutate metadata on, a secret it doesn't manage",
+			secretExists: true,
+			remoteMeta:   map[string]string{managedByKey: "someone-else"},
+			want:         want{err: errors.New("secret not managed by external-secrets")},
+		},
+		"ExistingSecretNoRemoteMetadataErrors": {
+			reason:       "a missing managed-by key must be treated the same as an unmanaged secret",
+			secretExists: true,
+			remoteMeta:   nil,
+			want:         want{err: errors.New("secret not managed by external-secrets")},
+		},
+		"ExistingSecretAlreadyUpToDateNeedsNoUpdate": {
+			reason:       "when the desired metadata matches the remote metadata exactly, no write is required",
+			secretExists: true,
+			remoteMeta:   map[string]string{managedByKey: managedByValue},
+			want:         want{meta: map[string]string{managedByKey: managedByValue}, update: false},
+		},
+		"ExistingSecretDefaultMergePolicyMergesCustomMetadata": {
+			reason:       "a nil suppliedMeta.Spec.MergePolicy defaults to Merge",
+			secretExists: true,
+			remoteMeta:   map[string]string{managedByKey: managedByValue, "team": "payments"},
+			suppliedMeta: pushSecretMetadata("", map[string]string{"namespace": "test-namespace"}),
+			want:         want{meta: map[string]string{managedByKey: managedByValue, "team": "payments", "namespace": "test-namespace"}, update: true},
+		},
+		"ExistingSecretMergePolicyReplaceDropsKeysNotInSpec": {
+			reason:       "Replace should discard remote keys that are not part of the new custom metadata",
+			secretExists: true,
+			remoteMeta:   map[string]string{managedByKey: managedByValue, "team": "payments"},
+			suppliedMeta: pushSecretMetadata(MergePolicyReplace, map[string]string{"namespace": "test-namespace"}),
+			want:         want{meta: map[string]string{managedByKey: managedByValue, "namespace": "test-namespace"}, update: true},
+		},
+		"ExistingSecretMergePolicyMergeWithNoChangesNeedsNoUpdate": {
+			reason:       "when the merged result is identical to the remote metadata, no write is required",
+			secretExists: true,
+			remoteMeta:   map[string]string{managedByKey: managedByValue, "team": "payments"},
+			suppliedMeta: pushSecretMetadata(MergePolicyMerge, map[string]string{"team": "payments"}),
+			want:         want{meta: map[string]string{managedByKey: managedByValue, "team": "payments"}, update: false},
+		},
+		"ExistingSecretCannotOverrideManagedByViaMerge": {
+			reason:       "managed-by is reserved and always re-asserted after merging into an existing secret's metadata",
+			secretExists: true,
+			remoteMeta:   map[string]string{managedByKey: managedByValue, "team": "payments"},
+			suppliedMeta: pushSecretMetadata(MergePolicyMerge, map[string]string{managedByKey: "someone-else", "namespace": "test-namespace"}),
+			want:         want{meta: map[string]string{managedByKey: managedByValue, "team": "payments", "namespace": "test-namespace"}, update: true},
+		},
+		"ExistingSecretCannotOverrideManagedByViaReplace": {
+			reason:       "managed-by is reserved and always re-asserted after replacing an existing secret's metadata",
+			secretExists: true,
+			remoteMeta:   map[string]string{managedByKey: managedByValue, "team": "payments"},
+			suppliedMeta: pushSecretMetadata(MergePolicyReplace, map[string]string{managedByKey: "someone-else", "namespace": "test-namespace"}),
+			want:         want{meta: map[string]string{managedByKey: managedByValue, "namespace": "test-namespace"}, update: true},
+		},
+		"ExistingSecretUnsupportedMergePolicyErrors": {
+			reason:       "an invalid merge policy must be rejected even for an already-managed secret",
+			secretExists: true,
+			remoteMeta:   map[string]string{managedByKey: managedByValue},
+			suppliedMeta: pushSecretMetadata("NotSupportedMergePolicy", nil),
+			want:         want{err: errors.New("unsupported merge policy")},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			gotMeta, gotUpdate, err := reconcileKV2Metadata(tc.secretExists, tc.remoteMeta, tc.suppliedMeta)
+
+			if requireErrorMatch(t, "reconcileKV2Metadata", name, tc.reason, tc.want.err, err) {
+				return
+			}
+
+			if !reflect.DeepEqual(tc.want.meta, gotMeta) {
+				t.Errorf("\nName: %v\nReason: %v\nWant metadata: %#v\nGot metadata: %#v", name, tc.reason, tc.want.meta, gotMeta)
+			}
+
+			if gotUpdate != tc.want.update {
+				t.Errorf("\nName: %v\nReason: %v\nWant update: %v\nGot update: %v", name, tc.reason, tc.want.update, gotUpdate)
 			}
 		})
 	}


### PR DESCRIPTION
## Problem Statement

When pushing secrets to Vault KV v2 through ESO, there is no way to also push or manage custom metadata (tags, ownership info, environment labels) alongside the secret payload. Users are left managing that metadata out of band (Terraform, manual Vault API calls), which splits the secret's lifecycle across two tools and drifts easily.

## Related Issue

Fixes #6588

## Proposed Changes

Honor the `metadata` field on `PushSecret` for the Vault provider, scoped to KV v2 only (KV v1 is unchanged), following the conventions already used by the GCP and Kubernetes providers:

- Push user-defined `customMetadata` to the KV v2 metadata endpoint (`/metadata/...`).
- Honor a `mergePolicy` (`Merge` or `Replace`) on the Vault-specific `PushSecretMetadataSpec`, carried via the standard `PushSecretMetadata` envelope. Defaults to `Merge`.
- Always keep the `managed-by: external-secrets` tag regardless of merge policy, and reject writes to secrets not owned by external-secrets instead of overwriting them.
- Reconcile secret data and metadata separately, so Vault is only called for the piece that actually changed.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`