### PR TITLE
docs: add missing generators to ClusterGenerator spec snippet

### DIFF
--- a/docs/guides/generator.md
+++ b/docs/guides/generator.md
@@ -55,20 +55,22 @@ exactly. The following Spec fields are available:
 
 ```go
 type GeneratorSpec struct {
-	ACRAccessTokenSpec        *ACRAccessTokenSpec        `json:"acrAccessTokenSpec,omitempty"`
-	CloudsmithAccessTokenSpec *CloudsmithAccessTokenSpec `json:"cloudsmithAccessTokenSpec,omitempty"`
-	ECRAuthorizationTokenSpec *ECRAuthorizationTokenSpec `json:"ecrAuthorizationTokenSpec,omitempty"`
-	FakeSpec                  *FakeSpec                  `json:"fakeSpec,omitempty"`
-	GCRAccessTokenSpec        *GCRAccessTokenSpec        `json:"gcrAccessTokenSpec,omitempty"`
-	GithubAccessTokenSpec     *GithubAccessTokenSpec     `json:"githubAccessTokenSpec,omitempty"`
-	QuayAccessTokenSpec       *QuayAccessTokenSpec       `json:"quayAccessTokenSpec,omitempty"`
-	PasswordSpec              *PasswordSpec              `json:"passwordSpec,omitempty"`
-	SSHKeySpec                *SSHKeySpec                `json:"sshKeySpec,omitempty"`
-	STSSessionTokenSpec       *STSSessionTokenSpec       `json:"stsSessionTokenSpec,omitempty"`
-	UUIDSpec                  *UUIDSpec                  `json:"uuidSpec,omitempty"`
-	VaultDynamicSecretSpec    *VaultDynamicSecretSpec    `json:"vaultDynamicSecretSpec,omitempty"`
-	WebhookSpec               *WebhookSpec               `json:"webhookSpec,omitempty"`
-	GrafanaSpec               *GrafanaSpec               `json:"grafanaSpec,omitempty"`
-	MFASpec                   *MFASpec                   `json:"mfaSpec,omitempty"`
+	ACRAccessTokenSpec                              *ACRAccessTokenSpec                              `json:"acrAccessTokenSpec,omitempty"`
+	BeyondtrustWorkloadCredentialsDynamicSecretSpec *BeyondtrustWorkloadCredentialsDynamicSecretSpec `json:"beyondtrustWorkloadCredentialsDynamicSecretSpec,omitempty"`
+	CloudsmithAccessTokenSpec                       *CloudsmithAccessTokenSpec                       `json:"cloudsmithAccessTokenSpec,omitempty"`
+	ECRAuthorizationTokenSpec                       *ECRAuthorizationTokenSpec                       `json:"ecrAuthorizationTokenSpec,omitempty"`
+	FakeSpec                                        *FakeSpec                                        `json:"fakeSpec,omitempty"`
+	GCRAccessTokenSpec                              *GCRAccessTokenSpec                              `json:"gcrAccessTokenSpec,omitempty"`
+	GithubAccessTokenSpec                           *GithubAccessTokenSpec                           `json:"githubAccessTokenSpec,omitempty"`
+	GitlabDeployTokenSpec                           *GitlabDeployTokenSpec                           `json:"gitlabDeployTokenSpec,omitempty"`
+	QuayAccessTokenSpec                             *QuayAccessTokenSpec                             `json:"quayAccessTokenSpec,omitempty"`
+	PasswordSpec                                    *PasswordSpec                                    `json:"passwordSpec,omitempty"`
+	SSHKeySpec                                      *SSHKeySpec                                      `json:"sshKeySpec,omitempty"`
+	STSSessionTokenSpec                             *STSSessionTokenSpec                             `json:"stsSessionTokenSpec,omitempty"`
+	UUIDSpec                                        *UUIDSpec                                        `json:"uuidSpec,omitempty"`
+	VaultDynamicSecretSpec                          *VaultDynamicSecretSpec                          `json:"vaultDynamicSecretSpec,omitempty"`
+	WebhookSpec                                     *WebhookSpec                                     `json:"webhookSpec,omitempty"`
+	GrafanaSpec                                     *GrafanaSpec                                     `json:"grafanaSpec,omitempty"`
+	MFASpec                                         *MFASpec                                         `json:"mfaSpec,omitempty"`
 }
 ```


### PR DESCRIPTION
## Problem Statement
as per the discussion in the PR #6265
The recently added generators are missing form the ClusterGenerator snippet.
- BeyondtrustWorkloadCredentialsDynamicSecretSpec
- GitlabDeployTokenSpec

This PR is for adding them.

## Proposed Changes
Adding the missing generators to the snippet.

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the `ClusterGenerator` docs snippet in `docs/guides/generator.md` to include the two missing generator specs: `BeyondtrustWorkloadCredentialsDynamicSecretSpec` and `GitlabDeployTokenSpec`. Also normalized the snippet’s field ordering/formatting to reflect the current spec shape.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->