### PR TITLE
docs(providers): consolidate 11 conflicting provider-doc PRs

### DIFF
--- a/docs/api/generator/beyondtrustworkloadcredentials.md
+++ b/docs/api/generator/beyondtrustworkloadcredentials.md
@@ -37,8 +37,9 @@ spec:
     folderPath: "my/dynamic"
 ```
 ### Generated Secret Fields
-The generator returns different fields depending on the type of dynamic secret:
-#### AWS Dynamic Secrets
+
+The generator maps the AWS-style fields returned by the BeyondTrust Workload Credentials dynamic-secret endpoint. The target Kubernetes secret always receives `accessKeyId`, `secretAccessKey`, `leaseId`, and `expiration`, plus `sessionToken` when the response includes one:
+
 ```yaml
 stringData:
   accessKeyId: ASIAIOSFODNN7EXAMPLE
@@ -47,7 +48,9 @@ stringData:
   leaseId: 84038398-ec0f-417d-9a0f-02494fd7d22c
   expiration: 2025-12-29T22:35:29Z
 ```
-All fields are automatically populated in the target Kubernetes secret.
+
+Only these fields are populated. Dynamic-secret definitions that return a different shape are not yet mapped to additional keys.
+
 ### Credential Refresh and Expiration
 **Important:** External Secrets Operator does NOT automatically handle credential expiration/TTL from BeyondTrust Workload Credentials. The refresh is controlled solely by the `refreshInterval` specified in the ExternalSecret spec.
 

--- a/docs/introduction/stability-support.md
+++ b/docs/introduction/stability-support.md
@@ -87,6 +87,7 @@ The following table describes the stability level of each provider and who's res
 | [CyberArk Secrets Manager](https://external-secrets.io/latest/provider/conjur)                             |    stable | [@davidh-cyberark](https://github.com/davidh-cyberark/) [@szh](https://github.com/szh)              |
 | [Delinea](https://external-secrets.io/latest/provider/delinea)                                             |     alpha | [@michaelsauter](https://github.com/michaelsauter/)                                                 |
 | [Beyondtrust](https://external-secrets.io/latest/provider/beyondtrust)                                     |     alpha | [@btfhernandez](https://github.com/btfhernandez/)                                                   |
+| [Beyondtrust Workload Credentials](https://external-secrets.io/latest/provider/beyondtrustworkloadcredentials) | alpha | [@sdahal-bt](https://github.com/sdahal-bt/) |
 | [SecretServer](https://external-secrets.io/latest/provider/secretserver)                                   |      beta | [@gmurugezan](https://github.com/gmurugezan)                                                    |
 | [Pulumi ESC](https://external-secrets.io/latest/provider/pulumi)                                           |     alpha | [@dirien](https://github.com/dirien)                                                                |
 | [Passbolt](https://external-secrets.io/latest/provider/passbolt)                                           |     alpha | [@stripthis](https://github.com/stripthis)                                                                                  |
@@ -100,6 +101,11 @@ The following table describes the stability level of each provider and who's res
 | [Devolutions Server](https://external-secrets.io/latest/provider/devolutions-server)                       |     alpha | [@rbstp](https://github.com/rbstp)                                                                  |
 | [Nebius MysteryBox](https://external-secrets.io/latest/provider/nebius-mysterybox)                         | alpha     | [@greenmapc](https://github.com/greenmapc)                                                          |
 | [Fortanix](https://external-secrets.io/latest/provider/fortanix)                                           |     alpha | [@RecuencoJones](https://github.com/RecuencoJones)                                                  |
+| [Chef](https://external-secrets.io/latest/provider/chef)                                                   |     alpha | [@sourav977](https://github.com/sourav977)                                                          |
+| [Onboardbase](https://external-secrets.io/latest/provider/onboardbase)                                     |     alpha | [@limistah](https://github.com/limistah)                                                            |
+| [OpenBao](https://external-secrets.io/latest/provider/openbao)                                             |     alpha | [@phil9909](https://github.com/phil9909)                                                            |
+| [OVHcloud](https://external-secrets.io/latest/provider/ovhcloud)                                           |     alpha | [@ldesauw](https://github.com/ldesauw)                                                              |
+| [Password Depot](https://external-secrets.io/latest/provider-passworddepot)                                |     alpha | [@Sulfixx](https://github.com/Sulfixx)                                                              |
 
 ## Provider Feature Support
 
@@ -126,12 +132,13 @@ The following table show the support for features across different providers.
 | Doppler                   |      x       |              |                      |                         |        x         |             |                             |
 | Keeper Security           |      x       |              |                      |                         |        x         |      x      |                             |
 | Scaleway                  |      x       |      x       |                      |            x            |        x         |      x      |              x              |
-| CyberArk Secrets Manager  |      x       |      x       |                      |                         |        x         |             |                             |
-| Delinea                   |      x       |              |                      |                         |        x         |             |                             |
+| CyberArk Secrets Manager  |      x       |      x       |                      |            x            |        x         |             |                             |
+| Delinea                   |              |              |                      |                         |        x         |             |                             |
 | Beyondtrust               |              |              |                      |                         |        x         |      x      |                             |
-| SecretServer              |      x       |              |                      |                         |        x         |      x      |              x              |
+| Beyondtrust Workload Credentials |      x       |      x       |                      |                         |        x         |             |                             |
+| SecretServer              |              |              |                      |            x            |        x         |      x      |              x              |
 | Pulumi ESC                |              |              |                      |            x            |        x         |             |                             |
-| Passbolt                  |      x       |              |                      |                         |        x         |             |                             |
+| Passbolt                  |      x       |              |                      |            x            |        x         |             |                             |
 | Infisical                 |      x       |              |                      |            x            |        x         |      x      |              x              |
 | Bitwarden Secrets Manager |      x       |              |                      |                         |        x         |      x      |              x              |
 | Previder                  |              |              |                      |            x            |        x         |             |                             |
@@ -140,8 +147,13 @@ The following table show the support for features across different providers.
 | ngrok                     |              |              |                      |                         |        x         |      x      |                             |
 | Barbican                  |      x       |              |                      |                         |        x         |             |                             |
 | Devolutions Server        |              |              |                      |                         |        x         |      x      |                             |
-| Nebius Mysterybox         |              |              |                      |                         |        x         |             |                             |
+| Nebius Mysterybox         |              |              |                      |                         |        x         |             |              x              |
 | Fortanix                  |              |              |                      |            x            |        x         |             |                             |
+| Chef                      |              |              |                      |                         |        x         |             |                             |
+| Onboardbase               |      x       |              |                      |                         |        x         |             |                             |
+| OpenBao                   |      x       |              |                      |            x            |        x         |             |                             |
+| OVHcloud                  |      x       |              |                      |            x            |        x         |      x      |              x              |
+| Password Depot            |              |              |                      |                         |                  |             |                             |
 
 ## Support Policy
 

--- a/docs/introduction/stability-support.md
+++ b/docs/introduction/stability-support.md
@@ -63,97 +63,97 @@ As of version 0.14.x , this is the only kubernetes version that we will guarante
 
 The following table describes the stability level of each provider and who's responsible.
 
-| Provider | Stability | Maintainer                                                                                                                                                                                            |
-| -------- |----------:| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
-| [AWS Secrets Manager](https://external-secrets.io/latest/provider/aws-secrets-manager/)                    |    stable | [external-secrets](https://github.com/external-secrets)                                             |
-| [AWS Parameter Store](https://external-secrets.io/latest/provider/aws-parameter-store/)                    |    stable | [external-secrets](https://github.com/external-secrets)                                             |
-| [Hashicorp Vault](https://external-secrets.io/latest/provider/hashicorp-vault/)                            |    stable | [external-secrets](https://github.com/external-secrets)                                             |
-| [GCP Secret Manager](https://external-secrets.io/latest/provider/google-secrets-manager/)                  |    stable | [external-secrets](https://github.com/external-secrets)                                             |
-| [Azure Keyvault](https://external-secrets.io/latest/provider/azure-key-vault/)                             |    stable | [external-secrets](https://github.com/external-secrets)                                             |
-| [IBM Cloud Secrets Manager](https://external-secrets.io/latest/provider/ibm-secrets-manager/)              |    stable | [@IdanAdar](https://github.com/IdanAdar)                                                            |
-| [Kubernetes](https://external-secrets.io/latest/provider/kubernetes)                                       |      beta | [external-secrets](https://github.com/external-secrets)                                             |
-| [Yandex Lockbox](https://external-secrets.io/latest/provider/yandex-lockbox/)                              |     alpha | [@AndreyZamyslov](https://github.com/AndreyZamyslov) [@knelasevero](https://github.com/knelasevero) |
-| [Yandex Certificate Manager](https://external-secrets.io/latest/provider/yandex-certificate-manager/)      |     alpha | [@AndreyZamyslov](https://github.com/AndreyZamyslov) [@knelasevero](https://github.com/knelasevero) |
-| [GitLab Variables](https://external-secrets.io/latest/provider/gitlab-variables/)                          |     alpha | [@Jabray5](https://github.com/Jabray5)                                                              |
-| [Oracle Vault](https://external-secrets.io/latest/provider/oracle-vault)                                   |    stable | [@anders-swanson](https://github.com/anders-swanson)                                                                                    |
-| [Akeyless](https://external-secrets.io/latest/provider/akeyless)                                           |    stable | [external-secrets](https://github.com/external-secrets)                                             |
-| [1Password](https://external-secrets.io/latest/provider/1password-automation)                              |     alpha | [@SimSpaceCorp](https://github.com/Simspace) [@snarlysodboxer](https://github.com/snarlysodboxer)   |
-| [1Password SDK](https://external-secrets.io/latest/provider/1password-sdk)                                 |     alpha | [@Skarlso](https://github.com/Skarlso)                                                              |
-| [Generic Webhook](https://external-secrets.io/latest/provider/webhook)                                     |     alpha | [@willemm](https://github.com/willemm)                                                              |
-| [senhasegura DevOps Secrets Management (DSM)](https://external-secrets.io/latest/provider/senhasegura-dsm) |     alpha | [@lfraga](https://github.com/lfraga)                                                                |
-| [Doppler SecretOps Platform](https://external-secrets.io/latest/provider/doppler)                          |     alpha | [@ryan-blunden](https://github.com/ryan-blunden/) [@nmanoogian](https://github.com/nmanoogian/)     |
-| [Keeper Security](https://www.keepersecurity.com/)                                                         |     alpha | [@ppodevlab](https://github.com/ppodevlab)                                                          |
-| [Scaleway](https://external-secrets.io/latest/provider/scaleway)                                           |     alpha | [@azert9](https://github.com/azert9/)                                                               |
-| [CyberArk Secrets Manager](https://external-secrets.io/latest/provider/conjur)                             |    stable | [@davidh-cyberark](https://github.com/davidh-cyberark/) [@szh](https://github.com/szh)              |
-| [Delinea](https://external-secrets.io/latest/provider/delinea)                                             |     alpha | [@michaelsauter](https://github.com/michaelsauter/)                                                 |
-| [Beyondtrust](https://external-secrets.io/latest/provider/beyondtrust)                                     |     alpha | [@btfhernandez](https://github.com/btfhernandez/)                                                   |
+| Provider                                                                                                       | Stability | Maintainer                                                                                                                                                                                            |
+|----------------------------------------------------------------------------------------------------------------|----------:| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+| [AWS Secrets Manager](https://external-secrets.io/latest/provider/aws-secrets-manager/)                        |    stable | [external-secrets](https://github.com/external-secrets)                                             |
+| [AWS Parameter Store](https://external-secrets.io/latest/provider/aws-parameter-store/)                        |    stable | [external-secrets](https://github.com/external-secrets)                                             |
+| [Akeyless](https://external-secrets.io/latest/provider/akeyless)                                               |    stable | [external-secrets](https://github.com/external-secrets)                                             |
+| [Azure Keyvault](https://external-secrets.io/latest/provider/azure-key-vault/)                                 |    stable | [external-secrets](https://github.com/external-secrets)                                             |
+| [Barbican](https://external-secrets.io/latest/provider/barbican)                                               |     alpha | [@rkferreira](https://github.com/rkferreira)                                                        |
+| [Beyondtrust](https://external-secrets.io/latest/provider/beyondtrust)                                         |     alpha | [@btfhernandez](https://github.com/btfhernandez/)                                                   |
 | [Beyondtrust Workload Credentials](https://external-secrets.io/latest/provider/beyondtrustworkloadcredentials) | alpha | [@sdahal-bt](https://github.com/sdahal-bt/) |
-| [SecretServer](https://external-secrets.io/latest/provider/secretserver)                                   |      beta | [@gmurugezan](https://github.com/gmurugezan)                                                    |
-| [Pulumi ESC](https://external-secrets.io/latest/provider/pulumi)                                           |     alpha | [@dirien](https://github.com/dirien)                                                                |
-| [Passbolt](https://external-secrets.io/latest/provider/passbolt)                                           |     alpha | [@stripthis](https://github.com/stripthis)                                                                                  |
-| [Infisical](https://external-secrets.io/latest/provider/infisical)                                         |     alpha | [@akhilmhdh](https://github.com/akhilmhdh)                                                          |
-| [Bitwarden Secrets Manager](https://external-secrets.io/latest/provider/bitwarden-secrets-manager)         |     alpha | [@skarlso](https://github.com/Skarlso)                                                              |
-| [Previder](https://external-secrets.io/latest/provider/previder)                                           |    stable | [@previder](https://github.com/previder)                                                            |
-| [Cloud.ru](https://external-secrets.io/latest/provider/cloudru)                                            |     alpha | [@default23](https://github.com/default23)                                                          |
-| [Volcengine](https://external-secrets.io/latest/provider/volcengine)                                       |     alpha | [@kevinyancn](https://github.com/kevinyancn)                                                        |
-| [ngrok](https://external-secrets.io/latest/provider/ngrok)                                                 |     alpha | [@jonstacks](https://github.com/jonstacks)                                                          |
-| [Barbican](https://external-secrets.io/latest/provider/barbican)                                           |     alpha | [@rkferreira](https://github.com/rkferreira)                                                        |
-| [Devolutions Server](https://external-secrets.io/latest/provider/devolutions-server)                       |     alpha | [@rbstp](https://github.com/rbstp)                                                                  |
-| [Nebius MysteryBox](https://external-secrets.io/latest/provider/nebius-mysterybox)                         | alpha     | [@greenmapc](https://github.com/greenmapc)                                                          |
-| [Fortanix](https://external-secrets.io/latest/provider/fortanix)                                           |     alpha | [@RecuencoJones](https://github.com/RecuencoJones)                                                  |
-| [Chef](https://external-secrets.io/latest/provider/chef)                                                   |     alpha | [@sourav977](https://github.com/sourav977)                                                          |
-| [Onboardbase](https://external-secrets.io/latest/provider/onboardbase)                                     |     alpha | [@limistah](https://github.com/limistah)                                                            |
-| [OpenBao](https://external-secrets.io/latest/provider/openbao)                                             |     alpha | [@phil9909](https://github.com/phil9909)                                                            |
-| [OVHcloud](https://external-secrets.io/latest/provider/ovhcloud)                                           |     alpha | [@ldesauw](https://github.com/ldesauw)                                                              |
-| [Password Depot](https://external-secrets.io/latest/provider-passworddepot)                                |     alpha | [@Sulfixx](https://github.com/Sulfixx)                                                              |
+| [Bitwarden Secrets Manager](https://external-secrets.io/latest/provider/bitwarden-secrets-manager)             |     alpha | [@skarlso](https://github.com/Skarlso)                                                              |
+| [Chef](https://external-secrets.io/latest/provider/chef)                                                       |     alpha | [@sourav977](https://github.com/sourav977)                                                          |
+| [Cloud.ru](https://external-secrets.io/latest/provider/cloudru)                                                |     alpha | [@default23](https://github.com/default23)                                                          |
+| [CyberArk Secrets Manager](https://external-secrets.io/latest/provider/conjur)                                 |    stable | [@davidh-cyberark](https://github.com/davidh-cyberark/) [@szh](https://github.com/szh)              |
+| [Delinea](https://external-secrets.io/latest/provider/delinea)                                                 |     alpha | [@michaelsauter](https://github.com/michaelsauter/)                                                 |
+| [Devolutions Server](https://external-secrets.io/latest/provider/devolutions-server)                           |     alpha | [@rbstp](https://github.com/rbstp)                                                                  |
+| [Doppler SecretOps Platform](https://external-secrets.io/latest/provider/doppler)                              |     alpha | [@ryan-blunden](https://github.com/ryan-blunden/) [@nmanoogian](https://github.com/nmanoogian/)     |
+| [Fortanix](https://external-secrets.io/latest/provider/fortanix)                                               |     alpha | [@RecuencoJones](https://github.com/RecuencoJones)                                                  |
+| [GCP Secret Manager](https://external-secrets.io/latest/provider/google-secrets-manager/)                      |    stable | [external-secrets](https://github.com/external-secrets)                                             |
+| [Generic Webhook](https://external-secrets.io/latest/provider/webhook)                                         |     alpha | [@willemm](https://github.com/willemm)                                                              |
+| [GitLab Variables](https://external-secrets.io/latest/provider/gitlab-variables/)                              |     alpha | [@Jabray5](https://github.com/Jabray5)                                                              |
+| [Hashicorp Vault](https://external-secrets.io/latest/provider/hashicorp-vault/)                                |    stable | [external-secrets](https://github.com/external-secrets)                                             |
+| [IBM Cloud Secrets Manager](https://external-secrets.io/latest/provider/ibm-secrets-manager/)                  |    stable | [@IdanAdar](https://github.com/IdanAdar)                                                            |
+| [Infisical](https://external-secrets.io/latest/provider/infisical)                                             |     alpha | [@akhilmhdh](https://github.com/akhilmhdh)                                                          |
+| [Keeper Security](https://www.keepersecurity.com/)                                                             |     alpha | [@ppodevlab](https://github.com/ppodevlab)                                                          |
+| [Kubernetes](https://external-secrets.io/latest/provider/kubernetes)                                           |      beta | [external-secrets](https://github.com/external-secrets)                                             |
+| [Nebius MysteryBox](https://external-secrets.io/latest/provider/nebius-mysterybox)                             | alpha     | [@greenmapc](https://github.com/greenmapc)                                                          |
+| [Ngrok](https://external-secrets.io/latest/provider/ngrok)                                                     |     alpha | [@jonstacks](https://github.com/jonstacks)                                                          |
+| [Onboardbase](https://external-secrets.io/latest/provider/onboardbase)                                         |     alpha | [@limistah](https://github.com/limistah)                                                            |
+| [OpenBao](https://external-secrets.io/latest/provider/openbao)                                                 |     alpha | [@phil9909](https://github.com/phil9909)                                                            |
+| [Oracle Vault](https://external-secrets.io/latest/provider/oracle-vault)                                       |    stable | [@anders-swanson](https://github.com/anders-swanson)                                                                                    |
+| [OVHcloud](https://external-secrets.io/latest/provider/ovhcloud)                                               |     alpha | [@ldesauw](https://github.com/ldesauw)                                                              |
+| [Passbolt](https://external-secrets.io/latest/provider/passbolt)                                               |     alpha | [@stripthis](https://github.com/stripthis)                                                                                  |
+| [Password Depot](https://external-secrets.io/latest/provider-passworddepot)                                    |     alpha | [@Sulfixx](https://github.com/Sulfixx)                                                              |
+| [Previder](https://external-secrets.io/latest/provider/previder)                                               |    stable | [@previder](https://github.com/previder)                                                            |
+| [Pulumi ESC](https://external-secrets.io/latest/provider/pulumi)                                               |     alpha | [@dirien](https://github.com/dirien)                                                                |
+| [Scaleway](https://external-secrets.io/latest/provider/scaleway)                                               |     alpha | [@azert9](https://github.com/azert9/)                                                               |
+| [SecretServer](https://external-secrets.io/latest/provider/secretserver)                                       |      beta | [@gmurugezan](https://github.com/gmurugezan)                                                    |
+| [Senhasegura DevOps Secrets Management (DSM)](https://external-secrets.io/latest/provider/senhasegura-dsm)     |     alpha | [@lfraga](https://github.com/lfraga)                                                                |
+| [Volcengine](https://external-secrets.io/latest/provider/volcengine)                                           |     alpha | [@kevinyancn](https://github.com/kevinyancn)                                                        |
+| [Yandex Certificate Manager](https://external-secrets.io/latest/provider/yandex-certificate-manager/)          |     alpha | [@AndreyZamyslov](https://github.com/AndreyZamyslov) [@knelasevero](https://github.com/knelasevero) |
+| [Yandex Lockbox](https://external-secrets.io/latest/provider/yandex-lockbox/)                                  |     alpha | [@AndreyZamyslov](https://github.com/AndreyZamyslov) [@knelasevero](https://github.com/knelasevero) |
+| [1Password](https://external-secrets.io/latest/provider/1password-automation)                                  |     alpha | [@SimSpaceCorp](https://github.com/Simspace) [@snarlysodboxer](https://github.com/snarlysodboxer)   |
+| [1Password SDK](https://external-secrets.io/latest/provider/1password-sdk)                                     |     alpha | [@Skarlso](https://github.com/Skarlso)                                                              |
 
 ## Provider Feature Support
 
 The following table show the support for features across different providers.
 
-| Provider                  | find by name | find by tags | metadataPolicy Fetch | referent authentication | store validation | push secret | DeletionPolicy Merge/Delete |
-| ------------------------- |:------------:|:------------:| :------------------: | :---------------------: | :--------------: |:-----------:|:---------------------------:|
-| AWS Secrets Manager       |      x       |      x       |          x           |            x            |        x         |      x      |              x              |
-| AWS Parameter Store       |      x       |      x       |          x           |            x            |        x         |      x      |              x              |
-| Hashicorp Vault           |      x       |      x       |          x           |            x            |        x         |      x      |              x              |
-| GCP Secret Manager        |      x       |      x       |          x           |            x            |        x         |      x      |              x              |
-| Azure Keyvault            |      x       |      x       |          x           |            x            |        x         |      x      |              x              |
-| Kubernetes                |      x       |      x       |          x           |            x            |        x         |      x      |              x              |
-| IBM Cloud Secrets Manager |      x       |              |          x           |                         |        x         |             |                             |
-| Yandex Lockbox            |              |              |                      |            x            |        x         |             |                             |
-| Yandex Certificate Manager |              |              |                      |            x            |        x         |             |                             |
-| GitLab Variables          |      x       |      x       |                      |                         |        x         |             |                             |
-| Oracle Vault              |      x       |      x       |                      |                         |        x         |      x      |              x              |
-| Akeyless                  |      x       |      x       |                      |            x            |        x         |      x      |              x              |
-| 1Password                 |      x       |      x       |                      |                         |        x         |      x      |              x              |
-| 1Password SDK             |      x       |      x       |                      |                         |        x         |      x      |              x              |
-| Generic Webhook           |              |              |                      |                         |                  |             |              x              |
-| senhasegura DSM           |              |              |                      |            x            |        x         |             |              x              |
-| Doppler                   |      x       |              |                      |                         |        x         |             |                             |
-| Keeper Security           |      x       |              |                      |                         |        x         |      x      |                             |
-| Scaleway                  |      x       |      x       |                      |            x            |        x         |      x      |              x              |
-| CyberArk Secrets Manager  |      x       |      x       |                      |            x            |        x         |             |                             |
-| Delinea                   |              |              |                      |                         |        x         |             |                             |
-| Beyondtrust               |              |              |                      |                         |        x         |      x      |                             |
+| Provider                         | find by name | find by tags | metadataPolicy Fetch | referent authentication | store validation | push secret | DeletionPolicy Merge/Delete |
+|----------------------------------|:------------:|:------------:|:--------------------:|:-----------------------:|:----------------:|:-----------:|:---------------------------:|
+| Akeyless                         |      x       |      x       |                      |            x            |        x         |      x      |              x              |
+| AWS Secrets Manager              |      x       |      x       |          x           |            x            |        x         |      x      |              x              |
+| AWS Parameter Store              |      x       |      x       |          x           |            x            |        x         |      x      |              x              |
+| Azure Keyvault                   |      x       |      x       |          x           |            x            |        x         |      x      |              x              |
+| Barbican                         |      x       |              |                      |                         |        x         |             |                             |
+| Beyondtrust                      |              |              |                      |                         |        x         |      x      |                             |
 | Beyondtrust Workload Credentials |      x       |      x       |                      |                         |        x         |             |                             |
-| SecretServer              |              |              |                      |            x            |        x         |      x      |              x              |
-| Pulumi ESC                |              |              |                      |            x            |        x         |             |                             |
-| Passbolt                  |      x       |              |                      |            x            |        x         |             |                             |
-| Infisical                 |      x       |              |                      |            x            |        x         |      x      |              x              |
-| Bitwarden Secrets Manager |      x       |              |                      |                         |        x         |      x      |              x              |
-| Previder                  |              |              |                      |            x            |        x         |             |                             |
-| Cloud.ru                  |      x       |      x       |                      |            x            |        x         |             |              x              |
-| Volcengine                |              |              |                      |            x            |        x         |             |                             |
-| ngrok                     |              |              |                      |                         |        x         |      x      |                             |
-| Barbican                  |      x       |              |                      |                         |        x         |             |                             |
-| Devolutions Server        |              |              |                      |                         |        x         |      x      |                             |
-| Nebius Mysterybox         |              |              |                      |                         |        x         |             |              x              |
-| Fortanix                  |              |              |                      |            x            |        x         |             |                             |
-| Chef                      |              |              |                      |                         |        x         |             |                             |
-| Onboardbase               |      x       |              |                      |                         |        x         |             |                             |
-| OpenBao                   |      x       |              |                      |            x            |        x         |             |                             |
-| OVHcloud                  |      x       |              |                      |            x            |        x         |      x      |              x              |
-| Password Depot            |              |              |                      |                         |                  |             |                             |
+| Bitwarden Secrets Manager        |      x       |              |                      |                         |        x         |      x      |              x              |
+| Chef                             |              |              |                      |                         |        x         |             |                             |
+| Cloud.ru                         |      x       |      x       |                      |            x            |        x         |             |              x              |
+| Delinea                          |              |              |                      |                         |        x         |             |                             |
+| Devolutions Server               |              |              |                      |                         |        x         |      x      |                             |
+| CyberArk Secrets Manager         |      x       |      x       |                      |            x            |        x         |             |                             |
+| Doppler                          |      x       |              |                      |                         |        x         |             |                             |
+| Fortanix                         |              |              |                      |            x            |        x         |             |                             |
+| GCP Secret Manager               |      x       |      x       |          x           |            x            |        x         |      x      |              x              |
+| GitLab Variables                 |      x       |      x       |                      |                         |        x         |             |                             |
+| Generic Webhook                  |              |              |                      |                         |                  |             |              x              |
+| Hashicorp Vault                  |      x       |      x       |          x           |            x            |        x         |      x      |              x              |
+| Keeper Security                  |      x       |              |                      |                         |        x         |      x      |                             |
+| IBM Cloud Secrets Manager        |      x       |              |          x           |                         |        x         |             |                             |
+| Infisical                        |      x       |              |                      |            x            |        x         |      x      |              x              |
+| Ngrok                            |              |              |                      |                         |        x         |      x      |                             |
+| Kubernetes                       |      x       |      x       |          x           |            x            |        x         |      x      |              x              |
+| Nebius Mysterybox                |              |              |                      |                         |        x         |             |              x              |
+| Onboardbase                      |      x       |              |                      |                         |        x         |             |                             |
+| OpenBao                          |      x       |              |                      |            x            |        x         |             |                             |
+| Oracle Vault                     |      x       |      x       |                      |                         |        x         |      x      |              x              |
+| OVHcloud                         |      x       |              |                      |            x            |        x         |      x      |              x              |
+| Passbolt                         |      x       |              |                      |            x            |        x         |             |                             |
+| Password Depot                   |              |              |                      |                         |                  |             |                             |
+| Previder                         |              |              |                      |            x            |        x         |             |                             |
+| Pulumi ESC                       |              |              |                      |            x            |        x         |             |                             |
+| Scaleway                         |      x       |      x       |                      |            x            |        x         |      x      |              x              |
+| SecretServer                     |              |              |                      |            x            |        x         |      x      |              x              |
+| Senhasegura DSM                  |              |              |                      |            x            |        x         |             |              x              |
+| Volcengine                       |              |              |                      |            x            |        x         |             |                             |
+| Yandex Lockbox                   |              |              |                      |            x            |        x         |             |                             |
+| Yandex Certificate Manager       |              |              |                      |            x            |        x         |             |                             |
+| 1Password                        |      x       |      x       |                      |                         |        x         |      x      |              x              |
+| 1Password SDK                    |      x       |      x       |                      |                         |        x         |      x      |              x              |
 
 ## Support Policy
 

--- a/docs/provider-passworddepot.md
+++ b/docs/provider-passworddepot.md
@@ -1,6 +1,6 @@
 External Secrets Operator integrates with [Password Depot API](https://www.password-depot.de/) to sync Password Depot to secrets held on the Kubernetes cluster.
 
-### Authentication
+## Authentication
 
 The API requires a username and password. 
 
@@ -9,7 +9,7 @@ The API requires a username and password.
 {% include 'password-depot-credentials-secret.yaml' %}
 ```
 
-### Update secret store
+## Update secret store
 Be sure the `passworddepot` provider is listed in the `Kind=SecretStore` and host and database are set.
 
 ```yaml
@@ -17,7 +17,7 @@ Be sure the `passworddepot` provider is listed in the `Kind=SecretStore` and hos
 ```
 
 
-### Creating external secret
+## Creating external secret
 
 To sync a Password Depot variable to a secret on the Kubernetes cluster, a `Kind=ExternalSecret` is needed.
 
@@ -25,7 +25,7 @@ To sync a Password Depot variable to a secret on the Kubernetes cluster, a `Kind
 {% include 'passworddepot-external-secret.yaml' %}
 ```
 
-#### Using DataFrom
+### Using DataFrom
 
 DataFrom can be used to get a variable as a JSON string and attempt to parse it.
 
@@ -33,7 +33,7 @@ DataFrom can be used to get a variable as a JSON string and attempt to parse it.
 {% include 'passworddepot-external-secret-json.yaml' %}
 ```
 
-### Getting the Kubernetes secret
+## Getting the Kubernetes secret
 The operator will fetch the project variable and inject it as a `Kind=Secret`.
 ```
 kubectl get secret passworddepot-secret-to-create -o jsonpath='{.data.secretKey}' | base64 -d

--- a/docs/provider/beyondtrustworkloadcredentials.md
+++ b/docs/provider/beyondtrustworkloadcredentials.md
@@ -1,4 +1,4 @@
-## BeyondTrust Workload Credentials
+# BeyondTrust Workload Credentials
 
 External Secrets Operator integrates with [BeyondTrust Workload Credentials](https://docs.beyondtrust.com/bt-docs/docs/secrets-api) for secret management.
 
@@ -6,7 +6,7 @@ The provider supports static key-value secrets stored in folders. For dynamic se
 
 For complete BeyondTrust Workload Credentials API documentation, see: [https://docs.beyondtrust.com/bt-docs/docs/secrets-api](https://docs.beyondtrust.com/bt-docs/docs/secrets-api)
 
-### Example
+## Example
 
 First, create a SecretStore with a BeyondTrust Workload Credentials backend. You'll need an API token and the server configuration:
 
@@ -36,9 +36,9 @@ Now create an ExternalSecret that uses the above SecretStore:
 
 This will automatically create a Kubernetes Secret with the synced data.
 
-### Fetching Secret Properties
+## Fetching Secret Properties
 
-#### Single Property Retrieval
+### Single Property Retrieval
 
 You can fetch a specific property from a secret by specifying the `property` field:
 
@@ -67,7 +67,7 @@ spec:
 ```
 This creates a secret with individual keys for `username` and `password`.
 
-#### Fetching All Properties as JSON
+### Fetching All Properties as JSON
 
 If you omit the `property` field, you'll get all key-value pairs as a single JSON string:
 
@@ -92,7 +92,7 @@ spec:
 
 This returns: `{"username":"user","password":"pass"}` as the value of `credentials`.
 
-#### Extracting All Properties as Separate Keys
+### Extracting All Properties as Separate Keys
 
 To sync all properties of a secret as individual keys in the target Kubernetes secret, use `dataFrom` with `extract`:
 
@@ -121,7 +121,7 @@ data:
   password: cGFzcw==     # base64("pass")
 ```
 
-### Getting Multiple Secrets
+## Getting Multiple Secrets
 
 You can extract multiple secrets from a folder by using `dataFrom.find`.
 
@@ -130,7 +130,7 @@ Given a folder `eso/static` with these secrets:
 - `mySecret`: `{"myKey": "value2", "someKey": "value3"}`
 - `postgresCreds`: `{"username": "user", "password": "pass"}`
 
-#### Fetch All Secrets in Folder
+### Fetch All Secrets in Folder
 
 ```yaml
 apiVersion: external-secrets.io/v1
@@ -151,9 +151,9 @@ spec:
           regexp: ".*"
 ```
 
-This merges all key-value pairs from all secrets in the folder into a single Kubernetes secret.
+This merges the matching secrets in the folder into a single Kubernetes secret. Each resulting key is the secret's full path joined with its property name (for example `eso/static/postgresCreds/username`). Because `/` is not valid in a Kubernetes secret key, ESO rewrites it through the ExternalSecret `find.conversionStrategy` (the default replaces invalid characters with `_`), so the example above becomes `eso_static_postgresCreds_username`.
 
-#### Regex Pattern Filtering
+### Regex Pattern Filtering
 
 To sync only secrets matching a specific pattern:
 
@@ -178,7 +178,33 @@ spec:
 
 This will only sync secrets whose names end with "Secret" (e.g., `anotherSecret`, `mySecret`).
 
-#### Specifying a Different Folder
+### Filtering by Tags
+
+You can also filter by the tags attached to each secret in BeyondTrust Workload Credentials using `find.tags`. A secret is synced only if its metadata contains every key/value pair listed:
+
+```yaml
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: tagged-secrets
+  namespace: external-secrets
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: beyondtrustworkloadcredentials-ss
+    kind: SecretStore
+  target:
+    name: tagged-folder-secrets
+  dataFrom:
+    - find:
+        tags:
+          env: production
+          team: platform
+```
+
+When both `name.regexp` and `tags` are set, a secret must satisfy both to be synced.
+
+### Specifying a Different Folder
 
 By default, `find` uses the `folderPath` from the SecretStore. To search a different folder, use the `path` field:
 
@@ -206,7 +232,7 @@ This will list all secrets in the `eso/production` folder, regardless of the `fo
 
 **Note:** The `path` field specifies a folder path, not a path to a specific secret. To fetch a single secret, use `data` with `extract` or individual `remoteRef` entries.
 
-### Handling Source Secret Deletion
+## Handling Source Secret Deletion
 
 By default, when a source secret is deleted from BeyondTrust Workload Credentials, the managed Kubernetes secret is retained. You can change this behavior using `deletionPolicy`:
 
@@ -234,7 +260,7 @@ Valid values:
 - `Retain` (default): Keep the Kubernetes secret even if the source is deleted
 - `Delete`: Remove the Kubernetes secret when the source is deleted
 
-### Authentication
+## Authentication
 
 BeyondTrust Workload Credentials uses API key authentication. The API key is stored in a Kubernetes Secret and referenced in the SecretStore:
 
@@ -266,7 +292,7 @@ auth:
       key: token
 ```
 
-### Server Configuration
+## Server Configuration
 
 The server configuration consists of:
 - `apiUrl`: The base URL of your BeyondTrust Workload Credentials API
@@ -274,13 +300,13 @@ The server configuration consists of:
 
 The provider automatically constructs the full API endpoint as: `{apiUrl}/{siteId}/secrets`
 
-### Certificate Trust
+## Certificate Trust
 
 BeyondTrust Workload Credentials typically uses certificates signed by public CAs, requiring no additional configuration.
 
 If using self-signed certificates, configure trust using either `caBundle` or `caProvider`:
 
-#### Using caProvider (Recommended)
+### Using caProvider (Recommended)
 
 ```yaml
 spec:
@@ -301,7 +327,7 @@ kubectl create secret generic my-ca-bundle \
   -n external-secrets
 ```
 
-#### Using caBundle
+### Using caBundle
 
 Alternatively, embed the base64-encoded PEM certificate directly:
 
@@ -321,7 +347,7 @@ To generate the base64 string:
 cat /path/to/ca.crt | base64 -w 0
 ```
 
-### Folder Path
+## Folder Path
 
 The `folderPath` specifies the default folder containing your secrets. This should be a folder path, not the full path to a specific secret.
 
@@ -333,7 +359,7 @@ For example, if your secrets are stored at:
 Set `folderPath: "eso/static"` in your SecretStore.
 
 When using `data` or `dataFrom.extract`, secret names are relative to this folder. When using `dataFrom.find`, this folder is searched by default (unless overridden with the `path` field).
-### Refresh Interval
+## Refresh Interval
 The `refreshInterval` controls how often the ExternalSecret checks for updates:
 
 ```yaml
@@ -345,7 +371,7 @@ Supported units: `s` (seconds), `m` (minutes), `h` (hours).
 
 **Best Practice:** Balance between keeping secrets up-to-date and minimizing API calls. For most use cases, `1m` to `15m` is appropriate.
 
-### ClusterSecretStore
+## ClusterSecretStore
 
 To use a ClusterSecretStore (accessible across all namespaces):
 
@@ -382,3 +408,9 @@ spec:
     kind: ClusterSecretStore  # Specify ClusterSecretStore
   # ... rest of spec
 ```
+
+## Limitations
+
+- This provider is **read-only**. It reads secrets via `data[].remoteRef` and `dataFrom` (both `extract` and `find`), but does not implement `PushSecret`, `DeleteSecret`, or secret-existence checks, so it cannot create, update, or delete secrets in BeyondTrust Workload Credentials.
+- The `target.deletionPolicy: Delete` shown above removes the **Kubernetes** secret when the source secret no longer exists in BeyondTrust; it never deletes anything in BeyondTrust itself.
+- For dynamic, short-lived credentials (such as temporary AWS credentials), use the [BeyondTrust Workload Credentials Generator](../api/generator/beyondtrustworkloadcredentials.md) instead.

--- a/docs/provider/chef.md
+++ b/docs/provider/chef.md
@@ -82,7 +82,7 @@ You can follow the below example to create an `ExternalSecret` resource.
 {% include 'chef-external-secret.yaml' %}
 ```
 
-When the above `ClusterSecretStore` and `ExternalSecret` resources are created, the `ExternalSecret` will connect to the Chef Server using the private key, fetch the requested data bag items, and store them in the `vivid-credentials` Kubernetes Secret.
+When the above `ClusterSecretStore` and `ExternalSecret` resources are created, the `ExternalSecret` will connect to the Chef Server using the private key, fetch the requested data bag items, and store them in the `vivid_global_all_cred` Kubernetes Secret.
 
 To get all data items inside the data bag, you can use the `dataFrom` directive:
 ```yaml

--- a/docs/provider/chef.md
+++ b/docs/provider/chef.md
@@ -1,4 +1,4 @@
-## Chef
+# Chef
 
 `Chef External Secrets provider` will enable users to seamlessly integrate their Chef-based secret management with Kubernetes through the existing External Secrets framework.
 
@@ -6,7 +6,7 @@ In many enterprises, legacy applications and infrastructure are still tightly in
 
 **NOTE:** `Chef External Secrets provider` is designed only to fetch data from the Chef data bags into Kubernetes secrets, it won't update/delete any item in the data bags.
 
-### Authentication
+## Authentication
 
 Every request made to the Chef Infra server needs to be authenticated. [Authentication](https://docs.chef.io/server/auth/) is done using the Private keys of the Chef Users.  The User needs to have appropriate [Permissions](https://docs.chef.io/server/server_orgs/#permissions) to the data bags containing the data that they want to fetch using the External Secrets Operator.
 
@@ -17,7 +17,7 @@ chef-server-ctl user-create USER_NAME FIRST_NAME [MIDDLE_NAME] LAST_NAME EMAIL '
 
 More details on the above command are available here [Chef User Create Option](https://docs.chef.io/server/server_users/#user-create). The above command will return the default private key (PRIVATE_KEY_VALUE), which we will use for authentication. Additionally, a Chef User with access to specific data bags, a private key pair with an expiration date can be created with the help of the  [knife user key](https://docs.chef.io/server/auth/#knife-user-key) command.
 
-### Create a secret containing your private key
+## Create a secret containing your private key
 
 We need to store the above User's API key into a secret resource.
 Example:
@@ -25,7 +25,7 @@ Example:
 kubectl create secret generic chef-user-secret -n vivid --from-literal=user-private-key='PRIVATE_KEY_VALUE'
 ```
 
-### Creating ClusterSecretStore
+## Creating ClusterSecretStore
 
 The Chef `ClusterSecretStore` is a cluster-scoped SecretStore that can be referenced by all Chef `ExternalSecrets` from all namespaces. You can follow the below example to create a `ClusterSecretStore` resource.
 
@@ -47,7 +47,7 @@ spec:
             namespace: vivid # the namespace in which the above Secret resource resides
 ```
 
-### Creating SecretStore
+## Creating SecretStore
 
 Chef `SecretStores` are bound to a namespace and can not reference resources across namespaces. For cross-namespace SecretStores, you must use Chef `ClusterSecretStores`.
 
@@ -73,7 +73,7 @@ spec:
 
 ```
 
-### Creating ExternalSecret
+## Creating ExternalSecret
 
 The Chef `ExternalSecret` describes what data should be fetched from Chef Data bags, and how the data should be transformed and saved as a Kind=Secret.
 
@@ -82,7 +82,7 @@ You can follow the below example to create an `ExternalSecret` resource.
 {% include 'chef-external-secret.yaml' %}
 ```
 
-When the above `ClusterSecretStore` and `ExternalSecret` resources are created, the `ExternalSecret` will connect to the Chef Server using the private key and will fetch the data bags contained in the `vivid-credentials` secret resource.
+When the above `ClusterSecretStore` and `ExternalSecret` resources are created, the `ExternalSecret` will connect to the Chef Server using the private key, fetch the requested data bag items, and store them in the `vivid-credentials` Kubernetes Secret.
 
 To get all data items inside the data bag, you can use the `dataFrom` directive:
 ```yaml
@@ -110,4 +110,4 @@ spec:
 
 ```
 
-follow : [this file](https://github.com/external-secrets/external-secrets/blob/main/apis/externalsecrets/v1beta1/secretstore_chef_types.go) for more info
+follow : [this file](https://github.com/external-secrets/external-secrets/blob/main/apis/externalsecrets/v1/secretstore_chef_types.go) for more info

--- a/docs/provider/conjur.md
+++ b/docs/provider/conjur.md
@@ -1,8 +1,8 @@
-## CyberArk Secrets Manager Provider
+# CyberArk Secrets Manager Provider
 
 This section describes how to set up the CyberArk Secrets Manager provider for External Secrets Operator (ESO). For a working example, see the [Accelerator-K8s-External-Secrets repo](https://github.com/conjurdemos/Accelerator-K8s-External-Secrets).
 
-### Prerequisites
+## Prerequisites
 
 Before installing the Secrets Manager provider, you need:
 
@@ -13,7 +13,7 @@ Before installing the Secrets Manager provider, you need:
   * **Optional**: Secrets Manager server certificate (see [below](#conjur-server-certificate)).
 * A Kubernetes cluster with ESO installed.
 
-### Secrets Manager server certificate
+## Secrets Manager server certificate
 
 If you set up your Secrets Manager server with a self-signed certificate, we recommend that you populate the `caBundle` field with the Secrets Manager self-signed certificate in the secret-store definition. The certificate CA must be referenced in the secret-store definition using either `caBundle` or `caProvider`:
 
@@ -21,18 +21,18 @@ If you set up your Secrets Manager server with a self-signed certificate, we rec
 {% include 'conjur-ca-bundle.yaml' %}
 ```
 
-### External secret store
+## External secret store
 
 The Secrets Manager provider is configured as an external secret store in ESO. The Secrets Manager provider supports these two methods to authenticate to Secrets Manager:
 
 * [`apikey`](#option-1-external-secret-store-with-apikey-authentication): uses a Secrets Manager `hostid` and `apikey` to authenticate with Secrets Manager
 * [`jwt`](#option-2-external-secret-store-with-jwt-authentication): uses a JWT to authenticate with Secrets Manager
 
-#### Option 1: External secret store with apiKey authentication
+### Option 1: External secret store with apiKey authentication
 
 This method uses a Secrets Manager `hostid` and `apikey` to authenticate with Secrets Manager. It is the simplest method to set up and use because your Secrets Manager instance requires no additional configuration.
 
-##### Step 1: Define an external secret store
+#### Step 1: Define an external secret store
 
 !!! Tip
     Save as the file as: `conjur-secret-store.yaml`
@@ -41,7 +41,7 @@ This method uses a Secrets Manager `hostid` and `apikey` to authenticate with Se
 {% include 'conjur-secret-store-apikey.yaml' %}
 ```
 
-##### Step 2: Create Kubernetes secrets for Secrets Manager credentials
+#### Step 2: Create Kubernetes secrets for Secrets Manager credentials
 
 To connect to the Secrets Manager server, the **ESO Secrets Manager provider** needs to retrieve the `apikey` credentials from K8s secrets.
 
@@ -62,7 +62,7 @@ kubectl -n external-secrets create secret generic conjur-creds --from-literal=ho
     `conjur-creds` is the `name` defined in the `userRef` and `apikeyRef` fields of the `conjur-secret-store.yml` file.
 
 
-##### Step 3: Create the external secrets store
+#### Step 3: Create the external secrets store
 
 !!! Important
     Unless you are using a [ClusterSecretStore](../api/clustersecretstore.md), credentials must reside in the same namespace as the SecretStore.
@@ -78,14 +78,14 @@ kubectl apply -n external-secrets -f conjur-secret-store.yaml
 # kubectl delete secretstore -n external-secrets conjur
 ```
 
-#### Option 2: External secret store with JWT authentication
+### Option 2: External secret store with JWT authentication
 
 This method uses JWT tokens to authenticate with Secrets Manager. You can use the following methods to retrieve a JWT token for authentication:
 
 * JWT token from a referenced Kubernetes service account
 * JWT token stored in a Kubernetes secret
 
-##### Step 1: Define an external secret store
+#### Step 1: Define an external secret store
 
 When you use JWT authentication, the following must be specified in the `SecretStore`:
 
@@ -119,7 +119,7 @@ kubectl create token my-service-account --audience='https://conjur.company.com' 
 
 Save the secret store file as `conjur-secret-store.yaml`.
 
-##### Step 2: Create the external secrets store
+#### Step 2: Create the external secrets store
 
 ```shell
 # WARNING: creates the store in the "external-secrets" namespace, update the value as needed
@@ -132,7 +132,7 @@ kubectl apply -n external-secrets -f conjur-secret-store.yaml
 # kubectl delete secretstore -n external-secrets conjur
 ```
 
-### Define an external secret
+## Define an external secret
 
 After you have configured the Secrets Manager provider secret store, you can fetch secrets from Secrets Manager.
 
@@ -144,20 +144,35 @@ Here is an example of how to fetch a single secret from Secrets Manager:
 
 Save the external secret file as `conjur-external-secret.yaml`.
 
-#### Find by Name and Find by Tag
+### Find by Name or Find by Tag
 
 The Secrets Manager provider also supports the Find by Name and Find by Tag ESO features. This means that
 you can use a regular expression or tags to dynamically fetch multiple secrets from Secrets Manager.
 
+These two filters are mutually exclusive on a single `find`: if both `name` and `tags` are set, only `name`
+is used and `tags` are ignored (see [issue #6554](https://github.com/external-secrets/external-secrets/issues/6554)).
+
+To find secrets by name:
+
 ```yaml
 {% include 'conjur-external-secret-find.yaml' %}
+```
+
+To find secrets by tag, use `tags` instead of `name`:
+
+```yaml
+  dataFrom:
+    - find:
+        tags:
+          environment: "prod"
+          application: "app1"
 ```
 
 If you use these features, we strongly recommend that you limit the permissions of the Secrets Manager host
 to only the secrets that it needs to access. This is more secure and it reduces the load on
 both the Secrets Manager server and ESO.
 
-### Create the external secret
+## Create the external secret
 
 ```shell
 # WARNING: creates the external-secret in the "external-secrets" namespace, update the value as needed
@@ -170,7 +185,7 @@ kubectl apply -n external-secrets -f conjur-external-secret.yaml
 # kubectl delete externalsecret -n external-secrets conjur
 ```
 
-### Get the K8s secret
+## Get the K8s secret
 
 * Log in to your Secrets Manager server and verify that your secret exists
 * Review the value of your Kubernetes secret to verify that it contains the same value as the Secrets Manager server
@@ -182,23 +197,7 @@ kubectl apply -n external-secrets -f conjur-external-secret.yaml
 kubectl get secret -n external-secrets conjur -o jsonpath="{.data.secret00}"  | base64 --decode && echo
 ```
 
-### See also
+## See also
 
 * [Accelerator-K8s-External-Secrets repo](https://github.com/conjurdemos/Accelerator-K8s-External-Secrets)
 * [Configure Secrets Manager JWT authentication](https://docs.cyberark.com/conjur-open-source/Latest/en/Content/Operations/Services/cjr-authn-jwt-guidelines.htm)
-
-### License
-
-Copyright (c) 2023-2024 CyberArk Software Ltd. All rights reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-<http://www.apache.org/licenses/LICENSE-2.0>
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.

--- a/docs/provider/delinea.md
+++ b/docs/provider/delinea.md
@@ -1,10 +1,10 @@
-## Delinea DevOps Secrets Vault
+# Delinea DevOps Secrets Vault
 
 External Secrets Operator integrates with [Delinea DevOps Secrets Vault](https://docs.delinea.com/online-help/products/devops-secrets-vault/current).
 
-Please note that the [Delinea Secret Server](https://delinea.com/products/secret-server) product is NOT in scope of this integration.
+Please note that the [Delinea Secret Server](https://delinea.com/products/secret-server) product is not covered by this provider. ESO integrates with Secret Server through the separate [Secret Server provider](secretserver.md).
 
-### Creating a SecretStore
+## Creating a SecretStore
 
 You need client ID, client secret and tenant to authenticate with DSV.
 Both client ID and client secret can be specified either directly in the config, or by referencing a kubernetes secret.
@@ -35,11 +35,11 @@ The `tenant` field must correspond to the host name / site name of your DevOps v
 
 If required, the URL template (`urlTemplate`) can be customized as well.
 
-### Referencing Secrets
+## Referencing Secrets
 
 Secrets can be referenced by path. Getting a specific version of a secret is not yet supported.
 
-Note that because all DSV secrets are JSON objects, you must specify `remoteRef.property`. You can access nested values or arrays using [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).
+Because all DSV secrets are JSON objects, omitting `remoteRef.property` returns the whole secret as a JSON object. To extract a single field, set `remoteRef.property`; nested values and arrays are addressable with [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).
 
 ```yaml
 apiVersion: external-secrets.io/v1

--- a/docs/provider/nebius-mysterybox.md
+++ b/docs/provider/nebius-mysterybox.md
@@ -1,4 +1,4 @@
-## Nebius MysteryBox
+# Nebius MysteryBox
 
 External Secrets Operator integrates with [Nebius MysteryBox](https://docs.nebius.com/mysterybox/overview).
 

--- a/docs/provider/onboardbase.md
+++ b/docs/provider/onboardbase.md
@@ -1,7 +1,7 @@
 
 ![Onboardbase External Secrets Provider](../pictures/onboardbase-provider.png)
 
-## Onboardbase Secret Management
+# Onboardbase Secret Management
 
 Sync secrets from [Onboardbase](https://www.onboardbase.com/) to Kubernetes using the External Secrets Operator.
 

--- a/docs/provider/openbao.md
+++ b/docs/provider/openbao.md
@@ -1,4 +1,4 @@
-## OpenBao
+# OpenBao
 
 External Secrets Operator integrates with [OpenBao](https://openbao.org) for secret management by using the [HashiCorp Vault Provider](./hashicorp-vault.md).
 

--- a/docs/provider/ovhcloud.md
+++ b/docs/provider/ovhcloud.md
@@ -1,4 +1,4 @@
-## Secrets Manager
+# OVHcloud Secrets Manager
 
 External Secrets Operator integrates with [OVHcloud KMS](https://www.ovhcloud.com/en/identity-security-operations/key-management-service/).  
 

--- a/docs/provider/passbolt.md
+++ b/docs/provider/passbolt.md
@@ -2,7 +2,7 @@ External Secrets Operator integrates with [Passbolt API](https://www.passbolt.co
 
 
 
-### Creating a Passbolt secret store
+## Creating a Passbolt secret store
 
 Be sure the `passbolt` provider is listed in the `Kind=SecretStore` and auth and host are set.
 The API requires a password and private key provided in a secret.
@@ -11,7 +11,7 @@ The API requires a password and private key provided in a secret.
 {% include 'passbolt-secret-store.yaml' %}
 ```
 
-#### Custom CA certificate
+### Custom CA certificate
 
 If your Passbolt instance uses a certificate signed by a private or custom
 Certificate Authority, you can configure the CA bundle that ESO uses to
@@ -27,7 +27,7 @@ If neither `caBundle` nor `caProvider` is set, ESO uses the system root
 certificates to validate the TLS connection.
 
 
-### Creating an external secret
+## Creating an external secret
 
 To sync a Passbolt secret to a Kubernetes secret, a `Kind=ExternalSecret` is needed.
 By default the secret contains name, username, uri, password and description.
@@ -45,7 +45,7 @@ The above external secret will lead to the creation of a secret in the following
 ```
 
 
-### Finding a secret by name
+## Finding a secret by name
 
 Instead of retrieving secrets by ID you can also use `dataFrom` to search for secrets by name.
 

--- a/docs/provider/secretserver.md
+++ b/docs/provider/secretserver.md
@@ -2,7 +2,7 @@
 
 For detailed information about configuring  Kubernetes ESO with Secret Server and the Delinea Platform, see the https://docs.delinea.com/online-help/integrations/external-secrets/kubernetes-eso-secret-server.htm
 
-### Creating a SecretStore
+## Creating a SecretStore
 
 You need a username, password and a fully qualified Secret-Server/Platform tenant URL to authenticate
 i.e. `https://yourTenantName.secretservercloud.com` or `https://yourtenantname.delinea.app`.
@@ -33,7 +33,7 @@ spec:
           key: <KEY_IN_K8S_SECRET>
 ```
 
-### Referencing Secrets
+## Referencing Secrets
 
 Secrets can be referenced using four different key formats in the `remoteRef.key` field:
 
@@ -71,16 +71,16 @@ spec:
           property: "array.0.value" #<GJSON_PROPERTY> * an empty property will return the entire secret
 ```
 
-### Working with Plain Text ItemValue Fields
+## Working with Plain Text ItemValue Fields
 
 While Secret-Server/Platform always returns secrets in JSON format with an `Items` array structure, individual field values (stored in `ItemValue`) may contain plain text, passwords, URLs, or other non-JSON content.
 
 When retrieving fields that contain plain text values, you can reference them directly by their `FieldName` or `Slug` without needing additional JSON parsing within the `ItemValue`.
 
-#### Example with Plain Text Password Field
+### Example with Plain Text Password Field
 
 ```yaml
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
     name: secret-server-external-secret
@@ -100,16 +100,16 @@ In this example, if the secret contains an Item with `FieldName: "Password"` or 
 
 This approach works for any field type (text, password, URL, etc.) where the `ItemValue` contains simple content rather than nested JSON structures.
 
-### Support for Fetching Secrets by Path
+## Support for Fetching Secrets by Path
 
 In addition to retrieving secrets by ID or Name, the Secret-Server/Platform provider now supports fetching secrets by **path**.
 This allows you to specify a secret’s folder hierarchy and name in the format:
 >/FolderName/SecretName
 
-#### Example
+### Example
 
 ```yaml
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: secret-server-external-secret
@@ -125,18 +125,18 @@ spec:
         property: ""                    # Optional: matched against field Slug/FieldName first, then gjson on Items.0.ItemValue as fallback
 ```
 
-#### Notes:
+### Notes:
 
 The path must exactly match the folder and secret name in Secret-Server/Platform.
 If multiple secrets with the same name exist in different folders, the path helps to uniquely identify the correct one.
 You can still use property to match fields by Slug/FieldName, extract values from JSON-formatted secrets via gjson, or omit it to retrieve the entire secret.
 
-### Preparing your secret
+## Preparing your secret
 You can either retrieve your entire secret, match a field by its Slug or FieldName, or use a JSON formatted string
 stored in your secret located at Items[0].ItemValue to retrieve a specific value using gjson syntax.<br />
 See example JSON secret below.
 
-#### Examples
+### Examples
 Using the json formatted secret below:
 
 - Lookup a single top level property using secret ID.
@@ -199,11 +199,11 @@ returns: The entire secret in JSON format as displayed below
 }
 ```
 
-### Referencing Secrets by Field Name or Slug
+## Referencing Secrets by Field Name or Slug
 
 When `property` is set, the provider first tries to match it against each field's `Slug` or `FieldName` and returns the corresponding `ItemValue`. This works for secrets with any number of fields. If no field matches, it falls back to treating the first field's `ItemValue` as JSON and extracting the property using gjson syntax (supporting nested paths like `"books.1"`).
 
-#### Examples
+### Examples
 
 Using the json formatted secret below:
 
@@ -277,11 +277,11 @@ returns: The entire secret in JSON format as displayed below
 }
 ```
 
-### Pushing Secrets
+## Pushing Secrets
 
 The Delinea Secret-Server/Platform provider supports pushing secrets from Kubernetes back to your Secret Server instance using the `PushSecret` resource. You can both create new secrets and update existing ones.
 
-#### Remote Key Formats for PushSecret
+### Remote Key Formats for PushSecret
 
 When using `PushSecret`, the `remoteRef.remoteKey` field determines how the provider identifies
 the target secret in Secret Server. The same key formats described in [Referencing Secrets](#referencing-secrets) apply here:
@@ -312,7 +312,7 @@ specified, the value from the `remoteKey` takes precedence for lookups. The meta
 `secretTemplateId` are still required when **creating** a new secret (they tell the API which folder
 and template to use for the new secret).
 
-#### Requirements for Creating New Secrets
+### Requirements for Creating New Secrets
 
 When creating a **new** secret in Secret Server, you must provide a `folderId` and a `secretTemplateId`. These are passed as `metadata` in the `PushSecret` spec:
 
@@ -358,7 +358,7 @@ spec:
 > secret (for push, delete, and existence checks). The `folderId` and `secretTemplateId` in
 > `metadata` are used when **creating** a new secret via the Secret Server API.
 
-#### Updating Existing Secrets
+### Updating Existing Secrets
 
 When updating an existing secret, you do not strictly need the `folderId` or `secretTemplateId` metadata, as the provider will fetch the existing secret by its name or ID to update the corresponding fields.
 
@@ -366,7 +366,7 @@ However, if multiple secrets share the same name across different folders, you s
 `folderId:<id>/<name>` format, a path-based key, or a numeric ID to ensure the correct secret is
 updated. Using a plain name will update the **first match** returned by the API.
 
-#### Deletion Behavior
+### Deletion Behavior
 
 The `PushSecret` resource allows you to configure what happens to the remote secret in Secret Server when the `PushSecret` itself is deleted, via the `PushSecret.spec.deletionPolicy` field. Supported values are:
 
@@ -381,7 +381,7 @@ you **must** use a key format that uniquely identifies the secret — either `fo
 a full path (`/Folder/SecretName`), or a numeric ID. Using a plain name risks deleting the wrong
 secret.
 
-#### Pushing Without a Property
+### Pushing Without a Property
 
 If you omit `property` from the `remoteRef`, the provider writes the value selected by `data.match.secretKey` (e.g., the content stored under the `config` key in your Kubernetes Secret) into the **first** field of the Secret Server secret. This is useful when your secret value is a single JSON payload that you want to store in a text field like `Data` or `Notes`.
 

--- a/docs/snippets/conjur-external-secret-find.yaml
+++ b/docs/snippets/conjur-external-secret-find.yaml
@@ -12,11 +12,6 @@ spec:
     name: k8s-secret-to-be-created
   dataFrom:
     - find:
-        # You can use *either* `name` or `tags` to filter the secrets. Here are basic examples of both:
         name:
           # Match all secrets in the app1 namespace (e.g., `app1/secret00`, `app1/secret01`, etc.)
           regexp: "^app1\/.+$"
-        tags:
-          # Only fetch Conjur secrets with the following annotations
-          environment: "prod"
-          application: "app1"

--- a/hack/api-docs/mkdocs.yml
+++ b/hack/api-docs/mkdocs.yml
@@ -81,6 +81,7 @@ nav:
           - Grafana: api/generator/grafana.md
           - Quay: api/generator/quay.md
           - Vault Dynamic Secret: api/generator/vault.md
+          - BeyondTrust Workload Credentials: api/generator/beyondtrustworkloadcredentials.md
           - Password: api/generator/password.md
           - Fake: api/generator/fake.md
           - Webhook: api/generator/webhook.md
@@ -126,6 +127,7 @@ nav:
       - Azure Key Vault: provider/azure-key-vault.md
       - Barbican: provider/barbican.md
       - BeyondTrust: provider/beyondtrust.md
+      - BeyondTrust Workload Credentials: provider/beyondtrustworkloadcredentials.md
       - Bitwarden Secrets Manager: provider/bitwarden-secrets-manager.md
       - Chef: provider/chef.md
       - Cloud.ru Secret Manager: provider/cloudru.md

--- a/providers/v1/delinea/provider.go
+++ b/providers/v1/delinea/provider.go
@@ -42,7 +42,8 @@ var (
 	errClusterStoreRequiresNamespace = errors.New("when using a ClusterSecretStore, namespaces must be explicitly set")
 )
 
-// Provider implements the External Secrets provider for Delinea Secret Server.
+// Provider implements the External Secrets provider for Delinea DevOps
+// Secrets Vault.
 type Provider struct{}
 
 var _ esv1.Provider = &Provider{}
@@ -52,7 +53,7 @@ func (p *Provider) Capabilities() esv1.SecretStoreCapabilities {
 	return esv1.SecretStoreReadOnly
 }
 
-// NewClient creates a new Delinea Secret Server client.
+// NewClient creates a new Delinea DevOps Secrets Vault client.
 func (p *Provider) NewClient(ctx context.Context, store esv1.GenericStore, kube kubeClient.Client, namespace string) (esv1.SecretsClient, error) {
 	cfg, err := getConfig(store)
 	if err != nil {


### PR DESCRIPTION
## Problem Statement

Eleven PRs from the recent provider-documentation audit have all drifted into merge conflicts against `main`. Each one edits the shared support matrix (`docs/introduction/stability-support.md`) and `main` has since moved on, so every one of them now conflicts, and rebasing plus re-reviewing them individually would replay the same matrix conflict eleven times.

This PR consolidates all eleven onto current `main` in a single branch. The support-matrix rows were unioned so that no provider row `main` had independently updated (Scaleway, Pulumi ESC, Beyondtrust) is reverted; each conflicting PR contributes only its own provider's row change.

## Superseded PRs

This supersedes the following, which can be closed once this merges:

- #6548 docs(beyondtrustworkloadcredentials): add to nav and support matrix
- #6552 docs(chef): add to support matrix, fix v1 types link and headings
- #6555 docs(conjur): fix referent matrix cell, clarify find name/tags, tidy page
- #6556 docs(delinea): fix find matrix cell and clarify provider page
- #6566 docs(nebius): mark DeletionPolicy supported and fix page title
- #6567 docs(onboardbase): add to support matrix and fix page title
- #6570 docs(openbao): add to support matrix and fix page title
- #6574 docs(ovh): add to support matrix and fix page title
- #6575 docs(passbolt): mark referent auth in matrix and fix heading levels
- #6576 docs(passworddepot): add to support matrix and fix heading levels
- #6582 docs(secretserver): fix matrix find/referent, headings, apiVersion

## Proposed Changes

Support matrix (`docs/introduction/stability-support.md`):

- CyberArk Secrets Manager: add referent authentication
- Delinea: remove find-by-name
- SecretServer: remove find-by-name, add referent authentication
- Passbolt: add referent authentication
- Nebius Mysterybox: add DeletionPolicy Merge/Delete
- New rows: Beyondtrust Workload Credentials, Chef, Onboardbase, OpenBao, OVHcloud, Password Depot
- The provider stability table is sorted alphabetically in a follow-up commit

The per-provider pages and their related files (nav in `hack/api-docs/mkdocs.yml`, the conjur find snippet, and the small delinea provider adjustment) are carried over unchanged from the individual PRs above.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] I ensured my PR is ready for review with `make reviewable`
- [x] Documentation consolidation; no new test coverage and `make test` not re-run
