### PR TITLE
fix(pulumi): advertise PushSecret support (ReadWrite capability)

### DIFF
--- a/docs/introduction/stability-support.md
+++ b/docs/introduction/stability-support.md
@@ -145,7 +145,7 @@ The following table show the support for features across different providers.
 | Passbolt                         |      x       |              |                      |            x            |        x         |             |                             |
 | Password Depot                   |              |              |                      |                         |                  |             |                             |
 | Previder                         |              |              |                      |            x            |        x         |             |                             |
-| Pulumi ESC                       |              |              |                      |            x            |        x         |             |                             |
+| Pulumi ESC                       |              |              |                      |            x            |        x         |      x      |                             |
 | Scaleway                         |      x       |      x       |                      |            x            |        x         |      x      |              x              |
 | SecretServer                     |              |              |                      |            x            |        x         |      x      |              x              |
 | Senhasegura DSM                  |              |              |                      |            x            |        x         |             |              x              |

--- a/providers/v1/pulumi/provider.go
+++ b/providers/v1/pulumi/provider.go
@@ -346,7 +346,7 @@ func (p *Provider) ValidateStore(store esv1.GenericStore) (admission.Warnings, e
 
 // Capabilities returns the provider's esv1.SecretStoreCapabilities.
 func (p *Provider) Capabilities() esv1.SecretStoreCapabilities {
-	return esv1.SecretStoreReadOnly
+	return esv1.SecretStoreReadWrite
 }
 
 // NewProvider creates a new Provider instance.

--- a/providers/v1/pulumi/provider_test.go
+++ b/providers/v1/pulumi/provider_test.go
@@ -59,3 +59,9 @@ func TestValidateStore(t *testing.T) {
 		})
 	}
 }
+
+func TestCapabilities(t *testing.T) {
+	// Pulumi ESC implements read (GetSecret/GetSecretMap) and per-key write
+	// (PushSecret), so it must advertise ReadWrite. See issue #6579.
+	assert.Equal(t, esv1.SecretStoreReadWrite, (&Provider{}).Capabilities())
+}

--- a/providers/v1/pulumi/pulumi.go
+++ b/providers/v1/pulumi/pulumi.go
@@ -41,7 +41,6 @@ type client struct {
 }
 
 const (
-	errPushSecretsNotSupported       = "pushing secrets is currently not supported by Pulumi"
 	errDeleteSecretsNotSupported     = "deleting secrets is currently not supported by Pulumi"
 	errUnableToGetValues             = "unable to get value for key %s: %w"
 	errGettingAllSecretsNotSupported = "getting all secrets is currently not supported by Pulumi"
@@ -141,7 +140,7 @@ func (c *client) PushSecret(ctx context.Context, secret *corev1.Secret, data esv
 }
 
 func (c *client) SecretExists(_ context.Context, _ esv1.PushSecretRemoteRef) (bool, error) {
-	return false, errors.New(errPushSecretsNotSupported)
+	return false, errors.New("not implemented")
 }
 
 func (c *client) DeleteSecret(_ context.Context, _ esv1.PushSecretRemoteRef) error {


### PR DESCRIPTION
## Problem Statement

Pulumi ESC has `PushSecret` implemented (per-key) and documented, but `Capabilities()` returns `ReadOnly`, the support matrix leaves push blank, and a stale `errPushSecretsNotSupported` constant remains. The signals contradict each other.

## Related Issue

Fixes #6579

## Proposed Changes

Declare the capability that already exists: `Capabilities()` returns `ReadWrite`, the support matrix marks push for Pulumi ESC, and the stale `errPushSecretsNotSupported` constant is removed. `SecretExists` now returns a plain "not implemented" error, so the `IfNotExists` update policy is cleanly unsupported (same as the Doppler provider) while the default push path is unaffected. Whole-secret push (empty `secretKey`) still returns `errPushWholeSecret`. Added a test asserting `Capabilities()` is `ReadWrite`.

Verified per module: `go build ./...`, `go test ./...`, `go vet ./...`, and the repo-pinned `bin/golangci-lint run`, all clean.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
