### PR TITLE
fix(oracle): return NoSecretErr when a secret is missing

### DIFF
--- a/providers/v1/oracle/fake/fake.go
+++ b/providers/v1/oracle/fake/fake.go
@@ -63,7 +63,7 @@ func (mc *OracleMockClient) GetSecretBundleByName(ctx context.Context, request s
 				SecretBundle: bundle,
 			}, nil
 		}
-		return secrets.GetSecretBundleByNameResponse{}, &ServiceError{Code: 404}
+		return secrets.GetSecretBundleByNameResponse{}, &ServiceError{Code: 404, ServiceCode: "NotAuthorizedOrNotFound"}
 	}
 	return mc.getSecret(ctx, request)
 }
@@ -77,7 +77,8 @@ func (mc *OracleMockClient) WithValue(_ secrets.GetSecretBundleByNameRequest, ou
 }
 
 type ServiceError struct {
-	Code int
+	Code        int
+	ServiceCode string
 }
 
 func (s *ServiceError) Error() string {
@@ -92,7 +93,7 @@ func (s *ServiceError) GetMessage() string {
 }
 
 func (s *ServiceError) GetCode() string {
-	return ""
+	return s.ServiceCode
 }
 
 func (s *ServiceError) GetOpcRequestID() string {

--- a/providers/v1/oracle/oracle.go
+++ b/providers/v1/oracle/oracle.go
@@ -63,6 +63,11 @@ const (
 	errMissingKey                 = "missing Key in secret: %s"
 	errUnexpectedContent          = "unexpected secret bundle content"
 	errSettingOCIEnvVariables     = "unable to set OCI SDK environment variable %s: %w"
+
+	// codeNotAuthorizedOrNotFound is the OCI SDK service error code returned when
+	// the caller is not authorized to access a resource or the resource does not
+	// exist. OCI does not distinguish the two to avoid leaking existence.
+	codeNotAuthorizedOrNotFound = "NotAuthorizedOrNotFound"
 )
 
 const (
@@ -497,7 +502,7 @@ func (vms *VaultManagementService) Validate() (esv1.ValidationResult, error) {
 			switch code {
 			case "NotAuthenticated":
 				return esv1.ValidationResultError, sanitizeOCISDKErr(err)
-			case "NotAuthorizedOrNotFound":
+			case codeNotAuthorizedOrNotFound:
 				// User authentication was successful, but user might not have a permission like:
 				//
 				// Allow group external_secrets to read vaults in tenancy
@@ -703,7 +708,9 @@ func (vms *VaultManagementService) configureRetryPolicy(
 // sentinel NoSecretErr so the ExternalSecret controller can honor
 // spec.target.deletionPolicy, and sanitizes every other OCI SDK error.
 func sanitizeGetSecretErr(err error) error {
-	if serviceErr, ok := err.(common.ServiceError); ok && serviceErr.GetHTTPStatusCode() == 404 {
+	if svcErr, ok := common.IsServiceError(err); ok &&
+		svcErr.GetHTTPStatusCode() == 404 &&
+		svcErr.GetCode() == codeNotAuthorizedOrNotFound {
 		return esv1.NoSecretErr
 	}
 	return sanitizeOCISDKErr(err)

--- a/providers/v1/oracle/oracle.go
+++ b/providers/v1/oracle/oracle.go
@@ -238,7 +238,7 @@ func (vms *VaultManagementService) GetSecret(ctx context.Context, ref esv1.Exter
 		Stage:      secrets.GetSecretBundleByNameStageEnum(ref.Version),
 	})
 	if err != nil {
-		return nil, sanitizeOCISDKErr(err)
+		return nil, sanitizeGetSecretErr(err)
 	}
 
 	payload, err := decodeBundle(sec)
@@ -273,7 +273,7 @@ func decodeBundle(sec secrets.GetSecretBundleByNameResponse) ([]byte, error) {
 func (vms *VaultManagementService) GetSecretMap(ctx context.Context, ref esv1.ExternalSecretDataRemoteRef) (map[string][]byte, error) {
 	data, err := vms.GetSecret(ctx, ref)
 	if err != nil {
-		return nil, sanitizeOCISDKErr(err)
+		return nil, err
 	}
 	kv := make(map[string]string)
 	err = json.Unmarshal(data, &kv)
@@ -697,6 +697,16 @@ func (vms *VaultManagementService) configureRetryPolicy(
 	})
 
 	return err
+}
+
+// sanitizeGetSecretErr maps an OCI "not found" (HTTP 404) response to the ESO
+// sentinel NoSecretErr so the ExternalSecret controller can honor
+// spec.target.deletionPolicy, and sanitizes every other OCI SDK error.
+func sanitizeGetSecretErr(err error) error {
+	if serviceErr, ok := err.(common.ServiceError); ok && serviceErr.GetHTTPStatusCode() == 404 {
+		return esv1.NoSecretErr
+	}
+	return sanitizeOCISDKErr(err)
 }
 
 func sanitizeOCISDKErr(err error) error {

--- a/providers/v1/oracle/oracle_test.go
+++ b/providers/v1/oracle/oracle_test.go
@@ -160,7 +160,7 @@ func TestOracleVaultGetSecret(t *testing.T) {
 
 func TestOracleVaultGetSecretNotFound(t *testing.T) {
 	set404 := func(smtc *vaultTestCase) {
-		smtc.apiErr = &fakeoracle.ServiceError{Code: 404}
+		smtc.apiErr = &fakeoracle.ServiceError{Code: 404, ServiceCode: "NotAuthorizedOrNotFound"}
 	}
 
 	sm := VaultManagementService{}
@@ -175,6 +175,19 @@ func TestOracleVaultGetSecretNotFound(t *testing.T) {
 	sm.Client = tc.mockClient
 	if _, err := sm.GetSecretMap(context.Background(), *tc.ref); !errors.Is(err, esv1.NoSecretErr) {
 		t.Errorf("GetSecretMap on a 404 should return NoSecretErr, got: %v", err)
+	}
+
+	// A 404 with a different service code (for example a transient routing 404)
+	// must not be treated as a missing secret, matching how Validate() switches
+	// on GetCode().
+	setOther404 := func(smtc *vaultTestCase) {
+		smtc.apiErr = &fakeoracle.ServiceError{Code: 404, ServiceCode: "SomeOtherCode"}
+	}
+
+	tc = makeValidVaultTestCaseCustom(setOther404)
+	sm.Client = tc.mockClient
+	if _, err := sm.GetSecret(context.Background(), *tc.ref); errors.Is(err, esv1.NoSecretErr) {
+		t.Errorf("GetSecret on a 404 with a non NotAuthorizedOrNotFound code should not return NoSecretErr, got: %v", err)
 	}
 }
 

--- a/providers/v1/oracle/oracle_test.go
+++ b/providers/v1/oracle/oracle_test.go
@@ -158,6 +158,26 @@ func TestOracleVaultGetSecret(t *testing.T) {
 	}
 }
 
+func TestOracleVaultGetSecretNotFound(t *testing.T) {
+	set404 := func(smtc *vaultTestCase) {
+		smtc.apiErr = &fakeoracle.ServiceError{Code: 404}
+	}
+
+	sm := VaultManagementService{}
+
+	tc := makeValidVaultTestCaseCustom(set404)
+	sm.Client = tc.mockClient
+	if _, err := sm.GetSecret(context.Background(), *tc.ref); !errors.Is(err, esv1.NoSecretErr) {
+		t.Errorf("GetSecret on a 404 should return NoSecretErr, got: %v", err)
+	}
+
+	tc = makeValidVaultTestCaseCustom(set404)
+	sm.Client = tc.mockClient
+	if _, err := sm.GetSecretMap(context.Background(), *tc.ref); !errors.Is(err, esv1.NoSecretErr) {
+		t.Errorf("GetSecretMap on a 404 should return NoSecretErr, got: %v", err)
+	}
+}
+
 func TestGetSecretMap(t *testing.T) {
 	// good case: default version & deserialization
 	setDeserialization := func(smtc *vaultTestCase) {


### PR DESCRIPTION
## Problem Statement

The Oracle (OCI Vault) provider returns the sanitized SDK error when a secret isn't found, so the ExternalSecret controller never sees `esv1.NoSecretErr` and `spec.target.deletionPolicy` (Merge/Delete) doesn't fire. That means a secret deleted in OCI Vault stays behind in the Kubernetes Secret, even though the support matrix lists Oracle DeletionPolicy Merge/Delete as supported.

This maps an OCI 404 to `esv1.NoSecretErr` in `GetSecret`/`GetSecretMap`, reusing the same `ServiceError` status-code check that `getSecretBundleWithCode` already uses, and leaves `sanitizeOCISDKErr` in place for every other error. I extended `oracle_test.go` with a 404 case that asserts both methods return `NoSecretErr`; it fails before the change and passes after.

## Related Issue

Fixes #6572

## Proposed Changes

On a not-found (HTTP 404) response, return the ESO sentinel `NoSecretErr` so the controller can honor deletionPolicy, matching how the other providers behave.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
