### PR TITLE
fix(bitwarden): honor name.regexp in GetAllSecrets find

### DIFF
--- a/docs/provider/bitwarden-secrets-manager.md
+++ b/docs/provider/bitwarden-secrets-manager.md
@@ -122,6 +122,10 @@ When using dataFrom like this:
         regexp: db_
 ```
 
+Bitwarden Secrets Manager only supports finding secrets by `name.regexp`.
+It has no concept of tags or paths, so setting `find.tags` or `find.path` results in an error.
+A `find` block without a `name.regexp` also errors.
+
 Note that the secrets in the map will end up something like this:
 
 ```

--- a/providers/v1/bitwarden/client.go
+++ b/providers/v1/bitwarden/client.go
@@ -30,13 +30,16 @@ import (
 
 	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
 	"github.com/external-secrets/external-secrets/runtime/esutils"
+	"github.com/external-secrets/external-secrets/runtime/find"
 )
 
 const (
 	// NoteMetadataKey defines the note for the pushed secret.
 	NoteMetadataKey = "note"
 
-	errNoProvider = "store does not have a provider"
+	errNoProvider              = "store does not have a provider"
+	errUnsupportedFindOperator = "provider does not support tags or path operators in find"
+	errNoFindOperator          = "no find operator found"
 )
 
 var (
@@ -292,29 +295,46 @@ func (p *Provider) parseYamlSecretData(data []byte) (map[string][]byte, error) {
 
 // GetAllSecrets gets multiple secrets from the provider and loads into a kubernetes secret.
 // First load all secrets from secretStore path configuration
-// Then, gets secrets from a matching name or matching custom_metadata.
-func (p *Provider) GetAllSecrets(ctx context.Context, _ esv1.ExternalSecretFind) (map[string][]byte, error) {
-	spec := p.store.GetSpec()
-	if spec == nil {
-		return nil, errors.New(errNoProvider)
+// Then, gets secrets from matching the name regexp in find against the secret's key.
+func (p *Provider) GetAllSecrets(ctx context.Context, ref esv1.ExternalSecretFind) (map[string][]byte, error) {
+	// Bitwarden does not support tags or path in their secrets.
+	// Hence we check for path or tags operator in find and return error if found.
+	if ref.Path != nil || len(ref.Tags) > 0 {
+		return nil, errors.New(errUnsupportedFindOperator)
 	}
 
-	secrets, err := p.bitwardenSdkClient.ListSecrets(ctx, spec.Provider.BitwardenSecretsManager.OrganizationID)
-	if err != nil {
-		return nil, fmt.Errorf(errFailedToGetAllSecrets, err)
-	}
-
-	result := map[string][]byte{}
-	for _, d := range secrets.Data {
-		sec, err := p.bitwardenSdkClient.GetSecret(ctx, d.ID)
+	if ref.Name != nil && ref.Name.RegExp != "" {
+		matcher, err := find.New(*ref.Name)
 		if err != nil {
-			return nil, fmt.Errorf(errFailedToGetSecret, err)
+			return nil, err
 		}
 
-		result[d.ID] = []byte(sec.Value)
+		spec := p.store.GetSpec()
+		if spec == nil {
+			return nil, errors.New(errNoProvider)
+		}
+
+		secrets, err := p.bitwardenSdkClient.ListSecrets(ctx, spec.Provider.BitwardenSecretsManager.OrganizationID)
+		if err != nil {
+			return nil, fmt.Errorf(errFailedToGetAllSecrets, err)
+		}
+
+		result := map[string][]byte{}
+		for _, d := range secrets.Data {
+			if matcher.MatchName(d.Key) {
+				sec, err := p.bitwardenSdkClient.GetSecret(ctx, d.ID)
+				if err != nil {
+					return nil, fmt.Errorf(errFailedToGetSecret, err)
+				}
+
+				result[d.ID] = []byte(sec.Value)
+			}
+		}
+
+		return result, nil
 	}
 
-	return result, nil
+	return nil, errors.New(errNoFindOperator)
 }
 
 // Validate validates the provider.

--- a/providers/v1/bitwarden/client_test.go
+++ b/providers/v1/bitwarden/client_test.go
@@ -31,8 +31,10 @@ import (
 )
 
 const (
-	remoteID = "d8f29773-3019-4973-9bbc-66327d077fe2"
-	testKey  = "this-is-a-name"
+	remoteID      = "d8f29773-3019-4973-9bbc-66327d077fe2"
+	remoteIDTwo   = "91bfaa90-c11b-4fe8-840a-3a0aae8455e3"
+	remoteIDThree = "990cf31a-f707-4233-ba3d-2e79f1f8c504"
+	testKey       = "this-is-a-name"
 )
 
 var projectID = "e8fc8f9c-2208-446e-9e89-9bc358f39b47"
@@ -238,8 +240,13 @@ func TestProviderGetAllSecrets(t *testing.T) {
 								OrganizationID: "orgid",
 							},
 							{
-								ID:             "7c0d21ec-10d9-4972-bdf8-ec52df99cc86",
+								ID:             remoteIDTwo,
 								Key:            "key2",
+								OrganizationID: "orgid",
+							},
+							{
+								ID:             remoteIDThree,
+								Key:            "notAMatch",
 								OrganizationID: "orgid",
 							},
 						},
@@ -251,7 +258,7 @@ func TestProviderGetAllSecrets(t *testing.T) {
 						Value: "value1",
 					})
 					c.GetSecretReturnsOnCallN(1, &SecretResponse{
-						ID:    "7c0d21ec-10d9-4972-bdf8-ec52df99cc86",
+						ID:    remoteIDTwo,
 						Key:   "key2",
 						Value: "value2",
 					})
@@ -259,11 +266,15 @@ func TestProviderGetAllSecrets(t *testing.T) {
 			},
 			args: args{
 				ctx: context.TODO(),
-				ref: esv1.ExternalSecretFind{},
+				ref: esv1.ExternalSecretFind{
+					Name: &esv1.FindName{
+						RegExp: "key",
+					},
+				},
 			},
 			want: map[string][]byte{
-				remoteID:                               []byte("value1"),
-				"7c0d21ec-10d9-4972-bdf8-ec52df99cc86": []byte("value2"),
+				remoteID:    []byte("value1"),
+				remoteIDTwo: []byte("value2"),
 			},
 		},
 	}


### PR DESCRIPTION
## Problem Statement

`Provider.GetAllSecrets` (Bitwarden Secrets Manager) ignored the `find` ref entirely and returned every secret in the organization. This contradicts the provider docs, which show a `find.name.regexp` example implying results are filtered by name — the code never applied that filter. `find.tags` and `find.path` were also silently accepted even though Bitwarden Secrets Manager has no concept of tags or paths.

## Related Issue

Fixes #6550 

## Proposed Changes

- `GetAllSecrets` now matches secret keys against `find.name.regexp` and only returns matches, instead of dumping the whole organization.
- `find.tags` and `find.path` now return an explicit error, since Bitwarden Secrets Manager doesn't support either.
- A `find` block without `name.regexp` now errors instead of silently returning everything.
- Updated `docs/provider/bitwarden-secrets-manager.md` to document that only `name.regexp` is supported.

**BREAKING CHANGE:** callers relying on the old behavior — an empty `find` (or one using only `tags`/`path`) returning all secrets in the org — will now get an error instead. They need to add a `name.regexp` to their `find` block.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
