### PR TITLE
feat: add emptyResultPolicy to tolerate empty or missing secret sources

### DIFF
--- a/apis/externalsecrets/v1/externalsecret_types.go
+++ b/apis/externalsecrets/v1/externalsecret_types.go
@@ -90,6 +90,22 @@ const (
 	ExternalSecretNullBytePolicyFail ExternalSecretNullBytePolicy = "Fail"
 )
 
+// ExternalSecretEmptyResultPolicy defines how ESO handles an empty or absent
+// result (signaled by esv1.NoSecretErr) from a find, extract, or single data
+// reference.
+// +kubebuilder:validation:Enum=Ignore;Fail
+type ExternalSecretEmptyResultPolicy string
+
+const (
+	// ExternalSecretEmptyResultPolicyIgnore treats an empty or absent result as
+	// contributing nothing, without failing reconciliation.
+	ExternalSecretEmptyResultPolicyIgnore ExternalSecretEmptyResultPolicy = "Ignore"
+
+	// ExternalSecretEmptyResultPolicyFail fails reconciliation when the result is
+	// empty or absent. This is the default (unset) behavior.
+	ExternalSecretEmptyResultPolicyFail ExternalSecretEmptyResultPolicy = "Fail"
+)
+
 // ExternalSecretTemplateMetadata defines metadata fields for the Secret blueprint.
 type ExternalSecretTemplateMetadata struct {
 	// +optional
@@ -313,6 +329,12 @@ type ExternalSecretDataRemoteRef struct {
 	// +optional
 	// Controls how ESO handles fetched secret data containing NUL bytes for this source.
 	NullBytePolicy ExternalSecretNullBytePolicy `json:"nullBytePolicy,omitempty"`
+
+	// +optional
+	// Controls how ESO handles an empty or absent result for this reference.
+	// Ignore skips it silently; Fail (default when unset) fails reconciliation.
+	// Only applies to providers that report absence via NoSecretErr.
+	EmptyResultPolicy ExternalSecretEmptyResultPolicy `json:"emptyResultPolicy,omitempty"`
 }
 
 // ExternalSecretMetadataPolicy defines policies for fetching metadata from provider secrets.
@@ -502,6 +524,12 @@ type ExternalSecretFind struct {
 	// +optional
 	// Controls how ESO handles fetched secret data containing NUL bytes for this find source.
 	NullBytePolicy ExternalSecretNullBytePolicy `json:"nullBytePolicy,omitempty"`
+
+	// +optional
+	// Controls how ESO handles a find that returns no secrets.
+	// Ignore skips it silently; Fail (default when unset) fails reconciliation.
+	// Only applies to providers that report absence via NoSecretErr.
+	EmptyResultPolicy ExternalSecretEmptyResultPolicy `json:"emptyResultPolicy,omitempty"`
 }
 
 // FindName defines criteria for finding secrets by name patterns.

--- a/config/crds/bases/external-secrets.io_clusterexternalsecrets.yaml
+++ b/config/crds/bases/external-secrets.io_clusterexternalsecrets.yaml
@@ -107,6 +107,15 @@ spec:
                               - Base64URL
                               - None
                               type: string
+                            emptyResultPolicy:
+                              description: |-
+                                Controls how ESO handles an empty or absent result for this reference.
+                                Ignore skips it silently; Fail (default when unset) fails reconciliation.
+                                Only applies to providers that report absence via NoSecretErr.
+                              enum:
+                              - Ignore
+                              - Fail
+                              type: string
                             key:
                               description: Key is the key used in the Provider, mandatory
                               type: string
@@ -250,6 +259,15 @@ spec:
                               - Base64URL
                               - None
                               type: string
+                            emptyResultPolicy:
+                              description: |-
+                                Controls how ESO handles an empty or absent result for this reference.
+                                Ignore skips it silently; Fail (default when unset) fails reconciliation.
+                                Only applies to providers that report absence via NoSecretErr.
+                              enum:
+                              - Ignore
+                              - Fail
+                              type: string
                             key:
                               description: Key is the key used in the Provider, mandatory
                               type: string
@@ -300,6 +318,15 @@ spec:
                               - Base64
                               - Base64URL
                               - None
+                              type: string
+                            emptyResultPolicy:
+                              description: |-
+                                Controls how ESO handles a find that returns no secrets.
+                                Ignore skips it silently; Fail (default when unset) fails reconciliation.
+                                Only applies to providers that report absence via NoSecretErr.
+                              enum:
+                              - Ignore
+                              - Fail
                               type: string
                             name:
                               description: Finds secrets based on the name.

--- a/config/crds/bases/external-secrets.io_externalsecrets.yaml
+++ b/config/crds/bases/external-secrets.io_externalsecrets.yaml
@@ -93,6 +93,15 @@ spec:
                           - Base64URL
                           - None
                           type: string
+                        emptyResultPolicy:
+                          description: |-
+                            Controls how ESO handles an empty or absent result for this reference.
+                            Ignore skips it silently; Fail (default when unset) fails reconciliation.
+                            Only applies to providers that report absence via NoSecretErr.
+                          enum:
+                          - Ignore
+                          - Fail
+                          type: string
                         key:
                           description: Key is the key used in the Provider, mandatory
                           type: string
@@ -235,6 +244,15 @@ spec:
                           - Base64URL
                           - None
                           type: string
+                        emptyResultPolicy:
+                          description: |-
+                            Controls how ESO handles an empty or absent result for this reference.
+                            Ignore skips it silently; Fail (default when unset) fails reconciliation.
+                            Only applies to providers that report absence via NoSecretErr.
+                          enum:
+                          - Ignore
+                          - Fail
+                          type: string
                         key:
                           description: Key is the key used in the Provider, mandatory
                           type: string
@@ -285,6 +303,15 @@ spec:
                           - Base64
                           - Base64URL
                           - None
+                          type: string
+                        emptyResultPolicy:
+                          description: |-
+                            Controls how ESO handles a find that returns no secrets.
+                            Ignore skips it silently; Fail (default when unset) fails reconciliation.
+                            Only applies to providers that report absence via NoSecretErr.
+                          enum:
+                          - Ignore
+                          - Fail
                           type: string
                         name:
                           description: Finds secrets based on the name.

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -103,6 +103,15 @@ spec:
                                   - Base64URL
                                   - None
                                 type: string
+                              emptyResultPolicy:
+                                description: |-
+                                  Controls how ESO handles an empty or absent result for this reference.
+                                  Ignore skips it silently; Fail (default when unset) fails reconciliation.
+                                  Only applies to providers that report absence via NoSecretErr.
+                                enum:
+                                  - Ignore
+                                  - Fail
+                                type: string
                               key:
                                 description: Key is the key used in the Provider, mandatory
                                 type: string
@@ -238,6 +247,15 @@ spec:
                                   - Base64URL
                                   - None
                                 type: string
+                              emptyResultPolicy:
+                                description: |-
+                                  Controls how ESO handles an empty or absent result for this reference.
+                                  Ignore skips it silently; Fail (default when unset) fails reconciliation.
+                                  Only applies to providers that report absence via NoSecretErr.
+                                enum:
+                                  - Ignore
+                                  - Fail
+                                type: string
                               key:
                                 description: Key is the key used in the Provider, mandatory
                                 type: string
@@ -283,6 +301,15 @@ spec:
                                   - Base64
                                   - Base64URL
                                   - None
+                                type: string
+                              emptyResultPolicy:
+                                description: |-
+                                  Controls how ESO handles a find that returns no secrets.
+                                  Ignore skips it silently; Fail (default when unset) fails reconciliation.
+                                  Only applies to providers that report absence via NoSecretErr.
+                                enum:
+                                  - Ignore
+                                  - Fail
                                 type: string
                               name:
                                 description: Finds secrets based on the name.
@@ -13101,6 +13128,15 @@ spec:
                               - Base64URL
                               - None
                             type: string
+                          emptyResultPolicy:
+                            description: |-
+                              Controls how ESO handles an empty or absent result for this reference.
+                              Ignore skips it silently; Fail (default when unset) fails reconciliation.
+                              Only applies to providers that report absence via NoSecretErr.
+                            enum:
+                              - Ignore
+                              - Fail
+                            type: string
                           key:
                             description: Key is the key used in the Provider, mandatory
                             type: string
@@ -13236,6 +13272,15 @@ spec:
                               - Base64URL
                               - None
                             type: string
+                          emptyResultPolicy:
+                            description: |-
+                              Controls how ESO handles an empty or absent result for this reference.
+                              Ignore skips it silently; Fail (default when unset) fails reconciliation.
+                              Only applies to providers that report absence via NoSecretErr.
+                            enum:
+                              - Ignore
+                              - Fail
+                            type: string
                           key:
                             description: Key is the key used in the Provider, mandatory
                             type: string
@@ -13281,6 +13326,15 @@ spec:
                               - Base64
                               - Base64URL
                               - None
+                            type: string
+                          emptyResultPolicy:
+                            description: |-
+                              Controls how ESO handles a find that returns no secrets.
+                              Ignore skips it silently; Fail (default when unset) fails reconciliation.
+                              Only applies to providers that report absence via NoSecretErr.
+                            enum:
+                              - Ignore
+                              - Fail
                             type: string
                           name:
                             description: Finds secrets based on the name.

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -4378,6 +4378,22 @@ ExternalSecretNullBytePolicy
 <p>Controls how ESO handles fetched secret data containing NUL bytes for this source.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>emptyResultPolicy</code></br>
+<em>
+<a href="#external-secrets.io/v1.ExternalSecretEmptyResultPolicy">
+ExternalSecretEmptyResultPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Controls how ESO handles an empty or absent result for this reference.
+Ignore skips it silently; Fail (default when unset) fails reconciliation.
+Only applies to providers that report absence via NoSecretErr.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="external-secrets.io/v1.ExternalSecretDecodingStrategy">ExternalSecretDecodingStrategy
@@ -4444,6 +4460,35 @@ does not go into SecretSyncedError status.</p>
 <td><p>DeletionPolicyRetain will retain the secret if all provider secrets have been deleted.
 If a provider secret does not exist the ExternalSecret gets into the
 SecretSyncedError status.</p>
+</td>
+</tr></tbody>
+</table>
+<h3 id="external-secrets.io/v1.ExternalSecretEmptyResultPolicy">ExternalSecretEmptyResultPolicy
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#external-secrets.io/v1.ExternalSecretDataRemoteRef">ExternalSecretDataRemoteRef</a>, 
+<a href="#external-secrets.io/v1.ExternalSecretFind">ExternalSecretFind</a>)
+</p>
+<p>
+<p>ExternalSecretEmptyResultPolicy defines how ESO handles an empty or absent
+result (signaled by esv1.NoSecretErr) from a find, extract, or single data
+reference.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;Fail&#34;</p></td>
+<td><p>ExternalSecretEmptyResultPolicyFail fails reconciliation when the result is
+empty or absent. This is the default (unset) behavior.</p>
+</td>
+</tr><tr><td><p>&#34;Ignore&#34;</p></td>
+<td><p>ExternalSecretEmptyResultPolicyIgnore treats an empty or absent result as
+contributing nothing, without failing reconciliation.</p>
 </td>
 </tr></tbody>
 </table>
@@ -4542,6 +4587,22 @@ ExternalSecretNullBytePolicy
 <td>
 <em>(Optional)</em>
 <p>Controls how ESO handles fetched secret data containing NUL bytes for this find source.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>emptyResultPolicy</code></br>
+<em>
+<a href="#external-secrets.io/v1.ExternalSecretEmptyResultPolicy">
+ExternalSecretEmptyResultPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Controls how ESO handles a find that returns no secrets.
+Ignore skips it silently; Fail (default when unset) fails reconciliation.
+Only applies to providers that report absence via NoSecretErr.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/guides/getallsecrets.md
+++ b/docs/guides/getallsecrets.md
@@ -30,6 +30,23 @@ This will match any secrets containing all of the metadata labels in the `tags` 
 ### Searching only in a given path
 Some providers support filtering out a find operation only to a given path, instead of the root path. In order to use this feature, you can pass `find.path` to filter out these secrets into only this path, instead of the root path.
 
+### Tolerating empty or missing paths
+
+By default, if a `find` (or `extract`) operation resolves to nothing - for example a Vault path that does not exist yet - the ExternalSecret fails to reconcile. When you merge several `dataFrom` entries and some paths may legitimately be absent, set `emptyResultPolicy: Ignore` on that entry so ESO treats an empty result as contributing nothing instead of failing:
+
+```yaml
+dataFrom:
+  - find:
+      path: infra/configuration
+      name: {regexp: ".*"}
+  - find:
+      path: infra/secrets
+      name: {regexp: ".*"}
+      emptyResultPolicy: Ignore   # OK if nothing exists at this path
+```
+
+`emptyResultPolicy` accepts `Fail` (the default when unset - error on empty) or `Ignore`. It only affects providers that report absence via the standard "no secret" signal (for example HashiCorp Vault); providers that return a generic error on a missing path are unaffected. The same field is available on `dataFrom.extract` and `spec.data[].remoteRef`.
+
 ### Avoiding name conflicts
 By default, kubernetes Secrets accepts only a given range of characters. `Find` operations will automatically replace any not allowed character with a `_`. So if we have a given secret `a_c` and `a/c` would lead to a naming conflict.
 

--- a/docs/guides/getallsecrets.md
+++ b/docs/guides/getallsecrets.md
@@ -32,7 +32,7 @@ Some providers support filtering out a find operation only to a given path, inst
 
 ### Tolerating empty or missing paths
 
-By default, if a `find` (or `extract`) operation resolves to nothing - for example a Vault path that does not exist yet - the ExternalSecret fails to reconcile. When you merge several `dataFrom` entries and some paths may legitimately be absent, set `emptyResultPolicy: Ignore` on that entry so ESO treats an empty result as contributing nothing instead of failing:
+By default (with `deletionPolicy: Retain`), if a `find` (or `extract`) operation resolves to nothing - for example a Vault path that does not exist yet - the ExternalSecret fails to reconcile. When you merge several `dataFrom` entries and some paths may legitimately be absent, set `emptyResultPolicy: Ignore` on that entry so ESO treats an empty result as contributing nothing instead of failing:
 
 ```yaml
 dataFrom:

--- a/docs/snippets/full-external-secret.yaml
+++ b/docs/snippets/full-external-secret.yaml
@@ -127,6 +127,8 @@ spec:
       property: data
       conversionStrategy: Default
       decodingStrategy: Auto
+      # If the secret does not exist, skip it instead of failing (Ignore | Fail; default Fail).
+      # emptyResultPolicy: Ignore
     rewrite:
     - regexp:
         source: "exp-(.*?)-ression"
@@ -139,6 +141,8 @@ spec:
         foo: bar
       conversionStrategy: Unicode
       decodingStrategy: Base64
+      # If the path/selector matches nothing, skip it instead of failing (Ignore | Fail; default Fail).
+      # emptyResultPolicy: Ignore
     rewrite:
     - regexp:
         source: "foo"

--- a/pkg/controllers/externalsecret/externalsecret_controller_secret.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller_secret.go
@@ -277,6 +277,10 @@ func (r *Reconciler) handleFindAllSecrets(
 	// get all secrets from the store that match the selector
 	secretMap, err := client.GetAllSecrets(ctx, *remoteRef.Find)
 	if err != nil {
+		if shouldIgnoreEmptyResult(remoteRef.Find.EmptyResultPolicy, err) {
+			r.Log.V(1).Info("find returned no secrets; ignoring per emptyResultPolicy", "dataFrom", i)
+			return map[string][]byte{}, nil
+		}
 		return nil, fmt.Errorf("error getting all secrets: %w", err)
 	}
 

--- a/pkg/controllers/externalsecret/externalsecret_controller_secret.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller_secret.go
@@ -312,6 +312,14 @@ func (r *Reconciler) handleFindAllSecrets(
 	return secretMap, nil
 }
 
+// shouldIgnoreEmptyResult reports whether an empty or absent provider result,
+// signaled via esv1.NoSecretErr, should be tolerated for a reference based on
+// its emptyResultPolicy. Only an explicit Ignore tolerates the error; unset and
+// Fail preserve the historical error behavior.
+func shouldIgnoreEmptyResult(policy esv1.ExternalSecretEmptyResultPolicy, err error) bool {
+	return policy == esv1.ExternalSecretEmptyResultPolicyIgnore && errors.Is(err, esv1.NoSecretErr)
+}
+
 func validateFetchedSecretValue(policy esv1.ExternalSecretNullBytePolicy, key string, value []byte) error {
 	if policy != esv1.ExternalSecretNullBytePolicyFail || !bytes.Contains(value, []byte{0}) {
 		return nil

--- a/pkg/controllers/externalsecret/externalsecret_controller_secret.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller_secret.go
@@ -226,6 +226,10 @@ func (r *Reconciler) handleExtractSecrets(
 	// get multiple secrets from the store
 	secretMap, err := client.GetSecretMap(ctx, *remoteRef.Extract)
 	if err != nil {
+		if shouldIgnoreEmptyResult(remoteRef.Extract.EmptyResultPolicy, err) {
+			r.Log.V(1).Info("extract returned no secret; ignoring per emptyResultPolicy", "dataFrom", i)
+			return map[string][]byte{}, nil
+		}
 		return nil, err
 	}
 

--- a/pkg/controllers/externalsecret/externalsecret_controller_secret.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller_secret.go
@@ -131,6 +131,10 @@ func (r *Reconciler) handleSecretData(ctx context.Context, externalSecret *esv1.
 	// get a single secret from the store
 	secretData, err := client.GetSecret(ctx, secretRef.RemoteRef)
 	if err != nil {
+		if shouldIgnoreEmptyResult(secretRef.RemoteRef.EmptyResultPolicy, err) {
+			r.Log.V(1).Info("data secret not found; ignoring per emptyResultPolicy", "key", secretRef.RemoteRef.Key)
+			return nil
+		}
 		return err
 	}
 

--- a/pkg/controllers/externalsecret/externalsecret_controller_test.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller_test.go
@@ -2244,6 +2244,41 @@ var _ = Describe("ExternalSecret controller", Serial, func() {
 			Expect(secret.Data).To(HaveLen(1))
 		}
 	}
+	// emptyResultPolicy=Ignore must tolerate NoSecretErr independently of
+	// deletionPolicy. Same merge scenario as above but with deletionPolicy=Delete:
+	// the absent find is still skipped, the present find still syncs, no error.
+	ignoreEmptyFindDeletionPolicyDelete := func(tc *testCase) {
+		expVal := []byte("1234")
+		present := "present"
+		absent := "absent"
+		tc.externalSecret.Spec.Data = nil
+		tc.externalSecret.Spec.Target.DeletionPolicy = esv1.DeletionPolicyDelete
+		tc.externalSecret.Spec.DataFrom = []esv1.ExternalSecretDataFromRemoteRef{
+			{
+				Find: &esv1.ExternalSecretFind{
+					Path: &present,
+					Name: &esv1.FindName{RegExp: ".*"},
+				},
+			},
+			{
+				Find: &esv1.ExternalSecretFind{
+					Path:              &absent,
+					Name:              &esv1.FindName{RegExp: ".*"},
+					EmptyResultPolicy: esv1.ExternalSecretEmptyResultPolicyIgnore,
+				},
+			},
+		}
+		fakeProvider.WithGetAllSecretsFn(func(_ context.Context, ref esv1.ExternalSecretFind) (map[string][]byte, error) {
+			if ref.Path != nil && *ref.Path == present {
+				return map[string][]byte{"foo": expVal}, nil
+			}
+			return nil, esv1.NoSecretErr
+		})
+		tc.checkSecret = func(_ *esv1.ExternalSecret, secret *v1.Secret) {
+			Expect(secret.Data["foo"]).To(Equal(expVal))
+			Expect(secret.Data).To(HaveLen(1))
+		}
+	}
 	// A find that returns NoSecretErr with the policy unset (Fail) errors, as today.
 	failWhenFindEmptyAndPolicyUnset := func(tc *testCase) {
 		tc.externalSecret.Spec.Data = nil
@@ -2618,6 +2653,7 @@ var _ = Describe("ExternalSecret controller", Serial, func() {
 		Entry("should fail when extracted secret data contains null bytes and extract.nullBytePolicy=Fail", failWhenExtractedSecretContainsNullBytes),
 		Entry("should fail when found secret data contains null bytes and find.nullBytePolicy=Fail", failWhenFoundSecretContainsNullBytes),
 		Entry("should ignore an empty find and merge remaining data when emptyResultPolicy=Ignore", ignoreEmptyFindMergesRemaining),
+		Entry("should ignore an empty find under deletionPolicy=Delete when emptyResultPolicy=Ignore", ignoreEmptyFindDeletionPolicyDelete),
 		Entry("should fail on an empty find when emptyResultPolicy is unset", failWhenFindEmptyAndPolicyUnset),
 		Entry("should ignore an empty extract when emptyResultPolicy=Ignore", ignoreEmptyExtract),
 		Entry("should fail on an empty extract when emptyResultPolicy is unset", failWhenExtractEmptyAndPolicyUnset),

--- a/pkg/controllers/externalsecret/externalsecret_controller_test.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller_test.go
@@ -2211,6 +2211,55 @@ var _ = Describe("ExternalSecret controller", Serial, func() {
 			}, time.Second, interval).Should(BeTrue())
 		}
 	}
+	// A find that returns NoSecretErr with emptyResultPolicy=Ignore contributes
+	// nothing; a second find that returns data is still synced (the merge case).
+	ignoreEmptyFindMergesRemaining := func(tc *testCase) {
+		expVal := []byte("1234")
+		present := "present"
+		absent := "absent"
+		tc.externalSecret.Spec.Data = nil
+		tc.externalSecret.Spec.DataFrom = []esv1.ExternalSecretDataFromRemoteRef{
+			{
+				Find: &esv1.ExternalSecretFind{
+					Path: &present,
+					Name: &esv1.FindName{RegExp: ".*"},
+				},
+			},
+			{
+				Find: &esv1.ExternalSecretFind{
+					Path:              &absent,
+					Name:              &esv1.FindName{RegExp: ".*"},
+					EmptyResultPolicy: esv1.ExternalSecretEmptyResultPolicyIgnore,
+				},
+			},
+		}
+		fakeProvider.WithGetAllSecretsFn(func(_ context.Context, ref esv1.ExternalSecretFind) (map[string][]byte, error) {
+			if ref.Path != nil && *ref.Path == present {
+				return map[string][]byte{"foo": expVal}, nil
+			}
+			return nil, esv1.NoSecretErr
+		})
+		tc.checkSecret = func(_ *esv1.ExternalSecret, secret *v1.Secret) {
+			Expect(secret.Data["foo"]).To(Equal(expVal))
+			Expect(secret.Data).To(HaveLen(1))
+		}
+	}
+	// A find that returns NoSecretErr with the policy unset (Fail) errors, as today.
+	failWhenFindEmptyAndPolicyUnset := func(tc *testCase) {
+		tc.externalSecret.Spec.Data = nil
+		tc.externalSecret.Spec.DataFrom = []esv1.ExternalSecretDataFromRemoteRef{
+			{
+				Find: &esv1.ExternalSecretFind{
+					Name: &esv1.FindName{RegExp: ".*"},
+				},
+			},
+		}
+		fakeProvider.WithGetAllSecrets(map[string][]byte{}, esv1.NoSecretErr)
+		tc.checkCondition = func(es *esv1.ExternalSecret) bool {
+			cond := esv1.GetExternalSecretCondition(es.Status, esv1.ExternalSecretReady)
+			return cond != nil && cond.Status == v1.ConditionFalse && cond.Reason == esv1.ConditionReasonSecretSyncedError
+		}
+	}
 	useClusterSecretStore := func(tc *testCase) {
 		tc.secretStore = &esv1.ClusterSecretStore{
 			ObjectMeta: metav1.ObjectMeta{
@@ -2487,6 +2536,8 @@ var _ = Describe("ExternalSecret controller", Serial, func() {
 		Entry("should fail when fetched secret data contains null bytes and remoteRef.nullBytePolicy=Fail", failWhenFetchedSecretContainsNullBytes),
 		Entry("should fail when extracted secret data contains null bytes and extract.nullBytePolicy=Fail", failWhenExtractedSecretContainsNullBytes),
 		Entry("should fail when found secret data contains null bytes and find.nullBytePolicy=Fail", failWhenFoundSecretContainsNullBytes),
+		Entry("should ignore an empty find and merge remaining data when emptyResultPolicy=Ignore", ignoreEmptyFindMergesRemaining),
+		Entry("should fail on an empty find when emptyResultPolicy is unset", failWhenFindEmptyAndPolicyUnset),
 		Entry("should update template if ExternalSecret is updated", templateShouldRewrite),
 		Entry("should keep data with templates if MergePolicy=Merge", templateShouldMerge),
 		Entry("should refresh secret from template", refreshWithTemplate),

--- a/pkg/controllers/externalsecret/externalsecret_controller_test.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller_test.go
@@ -2294,6 +2294,53 @@ var _ = Describe("ExternalSecret controller", Serial, func() {
 			return cond != nil && cond.Status == v1.ConditionFalse && cond.Reason == esv1.ConditionReasonSecretSyncedError
 		}
 	}
+	// A single data ref whose secret is missing (NoSecretErr) with
+	// emptyResultPolicy=Ignore is skipped; reconciliation succeeds and the key is
+	// simply absent.
+	ignoreMissingSingleData := func(tc *testCase) {
+		tc.externalSecret.Spec.DataFrom = nil
+		tc.externalSecret.Spec.Data = []esv1.ExternalSecretData{
+			{
+				SecretKey: "present-key",
+				RemoteRef: esv1.ExternalSecretDataRemoteRef{Key: "present"},
+			},
+			{
+				SecretKey: "missing-key",
+				RemoteRef: esv1.ExternalSecretDataRemoteRef{
+					Key:               "missing",
+					EmptyResultPolicy: esv1.ExternalSecretEmptyResultPolicyIgnore,
+				},
+			},
+		}
+		fakeProvider.WithGetSecretFn(func(_ context.Context, ref esv1.ExternalSecretDataRemoteRef) ([]byte, error) {
+			if ref.Key == "present" {
+				return []byte("1234"), nil
+			}
+			return nil, esv1.NoSecretErr
+		})
+		tc.checkSecret = func(_ *esv1.ExternalSecret, secret *v1.Secret) {
+			Expect(secret.Data["present-key"]).To(Equal([]byte("1234")))
+			_, ok := secret.Data["missing-key"]
+			Expect(ok).To(BeFalse())
+		}
+	}
+	// A single data ref whose secret is missing with policy unset errors when
+	// deletionPolicy=Retain (current behavior).
+	failWhenSingleDataMissingAndPolicyUnset := func(tc *testCase) {
+		tc.externalSecret.Spec.DataFrom = nil
+		tc.externalSecret.Spec.Target.DeletionPolicy = esv1.DeletionPolicyRetain
+		tc.externalSecret.Spec.Data = []esv1.ExternalSecretData{
+			{
+				SecretKey: "missing-key",
+				RemoteRef: esv1.ExternalSecretDataRemoteRef{Key: "missing"},
+			},
+		}
+		fakeProvider.WithGetSecret(nil, esv1.NoSecretErr)
+		tc.checkCondition = func(es *esv1.ExternalSecret) bool {
+			cond := esv1.GetExternalSecretCondition(es.Status, esv1.ExternalSecretReady)
+			return cond != nil && cond.Status == v1.ConditionFalse && cond.Reason == esv1.ConditionReasonSecretSyncedError
+		}
+	}
 	useClusterSecretStore := func(tc *testCase) {
 		tc.secretStore = &esv1.ClusterSecretStore{
 			ObjectMeta: metav1.ObjectMeta{
@@ -2574,6 +2621,8 @@ var _ = Describe("ExternalSecret controller", Serial, func() {
 		Entry("should fail on an empty find when emptyResultPolicy is unset", failWhenFindEmptyAndPolicyUnset),
 		Entry("should ignore an empty extract when emptyResultPolicy=Ignore", ignoreEmptyExtract),
 		Entry("should fail on an empty extract when emptyResultPolicy is unset", failWhenExtractEmptyAndPolicyUnset),
+		Entry("should ignore a missing single data key when emptyResultPolicy=Ignore", ignoreMissingSingleData),
+		Entry("should fail on a missing single data key when emptyResultPolicy is unset and deletionPolicy=Retain", failWhenSingleDataMissingAndPolicyUnset),
 		Entry("should update template if ExternalSecret is updated", templateShouldRewrite),
 		Entry("should keep data with templates if MergePolicy=Merge", templateShouldMerge),
 		Entry("should refresh secret from template", refreshWithTemplate),

--- a/pkg/controllers/externalsecret/externalsecret_controller_test.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller_test.go
@@ -2260,6 +2260,40 @@ var _ = Describe("ExternalSecret controller", Serial, func() {
 			return cond != nil && cond.Status == v1.ConditionFalse && cond.Reason == esv1.ConditionReasonSecretSyncedError
 		}
 	}
+	// An extract that returns NoSecretErr with emptyResultPolicy=Ignore contributes
+	// nothing and reconciliation succeeds.
+	ignoreEmptyExtract := func(tc *testCase) {
+		tc.externalSecret.Spec.Data = nil
+		tc.externalSecret.Spec.DataFrom = []esv1.ExternalSecretDataFromRemoteRef{
+			{
+				Extract: &esv1.ExternalSecretDataRemoteRef{
+					Key:               "does/not/exist",
+					EmptyResultPolicy: esv1.ExternalSecretEmptyResultPolicyIgnore,
+				},
+			},
+		}
+		fakeProvider.WithGetSecretMap(nil, esv1.NoSecretErr)
+		tc.checkCondition = func(es *esv1.ExternalSecret) bool {
+			cond := esv1.GetExternalSecretCondition(es.Status, esv1.ExternalSecretReady)
+			return cond != nil && cond.Status == v1.ConditionTrue && cond.Reason == esv1.ConditionReasonSecretSynced
+		}
+	}
+	// An extract that returns NoSecretErr with the policy unset (Fail) errors.
+	failWhenExtractEmptyAndPolicyUnset := func(tc *testCase) {
+		tc.externalSecret.Spec.Data = nil
+		tc.externalSecret.Spec.DataFrom = []esv1.ExternalSecretDataFromRemoteRef{
+			{
+				Extract: &esv1.ExternalSecretDataRemoteRef{
+					Key: "does/not/exist",
+				},
+			},
+		}
+		fakeProvider.WithGetSecretMap(nil, esv1.NoSecretErr)
+		tc.checkCondition = func(es *esv1.ExternalSecret) bool {
+			cond := esv1.GetExternalSecretCondition(es.Status, esv1.ExternalSecretReady)
+			return cond != nil && cond.Status == v1.ConditionFalse && cond.Reason == esv1.ConditionReasonSecretSyncedError
+		}
+	}
 	useClusterSecretStore := func(tc *testCase) {
 		tc.secretStore = &esv1.ClusterSecretStore{
 			ObjectMeta: metav1.ObjectMeta{
@@ -2538,6 +2572,8 @@ var _ = Describe("ExternalSecret controller", Serial, func() {
 		Entry("should fail when found secret data contains null bytes and find.nullBytePolicy=Fail", failWhenFoundSecretContainsNullBytes),
 		Entry("should ignore an empty find and merge remaining data when emptyResultPolicy=Ignore", ignoreEmptyFindMergesRemaining),
 		Entry("should fail on an empty find when emptyResultPolicy is unset", failWhenFindEmptyAndPolicyUnset),
+		Entry("should ignore an empty extract when emptyResultPolicy=Ignore", ignoreEmptyExtract),
+		Entry("should fail on an empty extract when emptyResultPolicy is unset", failWhenExtractEmptyAndPolicyUnset),
 		Entry("should update template if ExternalSecret is updated", templateShouldRewrite),
 		Entry("should keep data with templates if MergePolicy=Merge", templateShouldMerge),
 		Entry("should refresh secret from template", refreshWithTemplate),

--- a/pkg/controllers/externalsecret/externalsecret_controller_validation_test.go
+++ b/pkg/controllers/externalsecret/externalsecret_controller_validation_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package externalsecret
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -103,6 +105,33 @@ func TestValidateFetchedSecretMap(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			assertFetchedSecretValidationError(t, validateFetchedSecretMap(tt.policy, tt.data), tt.wantErr)
+		})
+	}
+}
+
+func TestShouldIgnoreEmptyResult(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		policy esv1.ExternalSecretEmptyResultPolicy
+		err    error
+		want   bool
+	}{
+		{"ignore + NoSecretErr", esv1.ExternalSecretEmptyResultPolicyIgnore, esv1.NoSecretErr, true},
+		{"ignore + wrapped NoSecretErr", esv1.ExternalSecretEmptyResultPolicyIgnore, fmt.Errorf("getting all secrets: %w", esv1.NoSecretErr), true},
+		{"ignore + other error", esv1.ExternalSecretEmptyResultPolicyIgnore, errors.New("boom"), false},
+		{"ignore + nil error", esv1.ExternalSecretEmptyResultPolicyIgnore, nil, false},
+		{"fail + NoSecretErr", esv1.ExternalSecretEmptyResultPolicyFail, esv1.NoSecretErr, false},
+		{"unset + NoSecretErr", "", esv1.NoSecretErr, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := shouldIgnoreEmptyResult(tt.policy, tt.err); got != tt.want {
+				t.Fatalf("shouldIgnoreEmptyResult(%q, %v) = %v, want %v", tt.policy, tt.err, got, tt.want)
+			}
 		})
 	}
 }

--- a/runtime/testing/fake/fake.go
+++ b/runtime/testing/fake/fake.go
@@ -162,6 +162,14 @@ func (v *Client) WithGetAllSecrets(secData map[string][]byte, err error) *Client
 	return v
 }
 
+// WithGetAllSecretsFn installs a custom GetAllSecrets function under the client lock.
+func (v *Client) WithGetAllSecretsFn(fn func(context.Context, esv1.ExternalSecretFind) (map[string][]byte, error)) *Client {
+	v.mu.Lock()
+	v.GetAllSecretsFn = fn
+	v.mu.Unlock()
+	return v
+}
+
 // WithSetSecretFn installs a custom SetSecret function under the client lock.
 func (v *Client) WithSetSecretFn(fn func() error) *Client {
 	v.mu.Lock()

--- a/runtime/testing/fake/fake.go
+++ b/runtime/testing/fake/fake.go
@@ -122,6 +122,14 @@ func (v *Client) WithGetSecret(secData []byte, err error) *Client {
 	return v
 }
 
+// WithGetSecretFn installs a custom GetSecret function under the client lock.
+func (v *Client) WithGetSecretFn(fn func(context.Context, esv1.ExternalSecretDataRemoteRef) ([]byte, error)) *Client {
+	v.mu.Lock()
+	v.GetSecretFn = fn
+	v.mu.Unlock()
+	return v
+}
+
 // GetSecretMap implements the provider.Provider interface.
 func (v *Client) GetSecretMap(ctx context.Context, ref esv1.ExternalSecretDataRemoteRef) (map[string][]byte, error) {
 	v.mu.RLock()

--- a/tests/__snapshot__/clusterexternalsecret-v1.yaml
+++ b/tests/__snapshot__/clusterexternalsecret-v1.yaml
@@ -11,6 +11,7 @@ spec:
     - remoteRef:
         conversionStrategy: "Default"
         decodingStrategy: "None"
+        emptyResultPolicy: "Ignore" # "Ignore", "Fail"
         key: string
         metadataPolicy: "None"
         nullBytePolicy: "Ignore" # "Ignore", "Fail"
@@ -29,6 +30,7 @@ spec:
     - extract:
         conversionStrategy: "Default"
         decodingStrategy: "None"
+        emptyResultPolicy: "Ignore" # "Ignore", "Fail"
         key: string
         metadataPolicy: "None"
         nullBytePolicy: "Ignore" # "Ignore", "Fail"
@@ -37,6 +39,7 @@ spec:
       find:
         conversionStrategy: "Default"
         decodingStrategy: "None"
+        emptyResultPolicy: "Ignore" # "Ignore", "Fail"
         name:
           regexp: string
         nullBytePolicy: "Ignore" # "Ignore", "Fail"

--- a/tests/__snapshot__/externalsecret-v1.yaml
+++ b/tests/__snapshot__/externalsecret-v1.yaml
@@ -6,6 +6,7 @@ spec:
   - remoteRef:
       conversionStrategy: "Default"
       decodingStrategy: "None"
+      emptyResultPolicy: "Ignore" # "Ignore", "Fail"
       key: string
       metadataPolicy: "None"
       nullBytePolicy: "Ignore" # "Ignore", "Fail"
@@ -24,6 +25,7 @@ spec:
   - extract:
       conversionStrategy: "Default"
       decodingStrategy: "None"
+      emptyResultPolicy: "Ignore" # "Ignore", "Fail"
       key: string
       metadataPolicy: "None"
       nullBytePolicy: "Ignore" # "Ignore", "Fail"
@@ -32,6 +34,7 @@ spec:
     find:
       conversionStrategy: "Default"
       decodingStrategy: "None"
+      emptyResultPolicy: "Ignore" # "Ignore", "Fail"
       name:
         regexp: string
       nullBytePolicy: "Ignore" # "Ignore", "Fail"


### PR DESCRIPTION
<!-- PR title: feat: add emptyResultPolicy to tolerate empty or missing secret sources -->

## Problem Statement

When an `ExternalSecret` merges several `dataFrom` or `data` sources, the whole reconcile fails if any one source resolves to nothing and deletion policy is set to `Retain`. For example, merging two Vault paths:

```yaml
target:
  deletionPolicy: Retain
dataFrom:
  - find: { path: my-app/secrets, name: {regexp: ".*"} }
  - find: { path: region/us-east-2/my-app/secrets, name: {regexp: ".*"} }
```

If `infra/secrets` does not exist yet, ESO errors instead of syncing what `infra/configuration` returned. The existing tolerance for a "nothing found" result is gated on `deletionPolicy != Retain`, and since `Retain` is the default, a provider that signals absence via `NoSecretErr` (e.g. Vault, whose `LIST` on a missing prefix returns `nil`) falls through to a hard error. Operators have no way to say "it's OK if nothing exists at this path." 

Additionally, the current behavior also emits Kubernetes events that - when using a pattern like this at scale - could cause a significant amount of event churn within the cluster.

## Related Issue

None

## Proposed Changes

Add an opt-in, per-source `emptyResultPolicy` enum (`Ignore | Fail`) to the v1 `ExternalSecret` API, available on `dataFrom[].find`, `dataFrom[].extract`, and `spec.data[].remoteRef`:

- `Fail` (default when unset) preserves today's behavior exactly.
- `Ignore` treats an empty/absent result as contributing nothing, without failing reconciliation.

Implementation:

- New enum `ExternalSecretEmptyResultPolicy`, modeled on the adjacent `NullBytePolicy`; no `kubebuilder:default`, so unset == `Fail` (fully backward compatible). v1 only (storage version).
- A small pure helper `shouldIgnoreEmptyResult(policy, err)` gates tolerance on `policy == Ignore && errors.Is(err, NoSecretErr)`. The three handlers (`handleFindAllSecrets`, `handleExtractSecrets`, `handleSecretData`) intercept `NoSecretErr` before it reaches the reconcile loop, so `Ignore` is decoupled from `deletionPolicy` and emits a `V(1)` log instead of a "missing provider secret" warning event.
- Provider-agnostic: any provider that signals absence via `NoSecretErr` benefits. Providers that return a generic error on a missing path are unaffected (documented as a limitation).

Docs, the API reference, and CRD snapshots are regenerated; guide + example snippet updated.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
