### PR TITLE
chore: update go version 1.26.5 - Fix  CVE-2026-39822

### DIFF
--- a/apis/go.mod
+++ b/apis/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/apis
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-bookworm@sha256:b305420a68d0f229d91eb3b3ed9e519fcf2cf5461da4bef997bf927e8c0bfd2b AS builder
+FROM golang:1.26.5-bookworm@sha256:18aedc16aa19b3fd7ded7245fc14b109e054d65d22ed53c355c899582bbb2113 AS builder
 RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.6
 
 FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets-e2e
 
-go 1.26.4
+go 1.26.5
 
 replace github.com/external-secrets/external-secrets => ../
 

--- a/generators/v1/acr/go.mod
+++ b/generators/v1/acr/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/acr
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.1

--- a/generators/v1/beyondtrustworkloadcredentials/go.mod
+++ b/generators/v1/beyondtrustworkloadcredentials/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/beyondtrustworkloadcredentials
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/cloudsmith/go.mod
+++ b/generators/v1/cloudsmith/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/cloudsmith
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/ecr/go.mod
+++ b/generators/v1/ecr/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/ecr
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.6

--- a/generators/v1/fake/go.mod
+++ b/generators/v1/fake/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/fake
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/gcr/go.mod
+++ b/generators/v1/gcr/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/gcr
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/github/go.mod
+++ b/generators/v1/github/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/github
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/gitlab/go.mod
+++ b/generators/v1/gitlab/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/gitlab
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/grafana/go.mod
+++ b/generators/v1/grafana/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/grafana
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/mfa/go.mod
+++ b/generators/v1/mfa/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/mfa
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/password/go.mod
+++ b/generators/v1/password/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/password
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/quay/go.mod
+++ b/generators/v1/quay/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/quay
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/sshkey/go.mod
+++ b/generators/v1/sshkey/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/sshkey
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/sts/go.mod
+++ b/generators/v1/sts/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/sts
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.6

--- a/generators/v1/uuid/go.mod
+++ b/generators/v1/uuid/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/uuid
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/vault/go.mod
+++ b/generators/v1/vault/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/vault
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/webhook/go.mod
+++ b/generators/v1/webhook/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/webhook
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets
 
-go 1.26.4
+go 1.26.5
 
 replace (
 	github.com/external-secrets/external-secrets/apis => ./apis

--- a/providers/v1/akeyless/go.mod
+++ b/providers/v1/akeyless/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/akeyless
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.1

--- a/providers/v1/aws/go.mod
+++ b/providers/v1/aws/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/aws
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.6

--- a/providers/v1/azure/go.mod
+++ b/providers/v1/azure/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/azure
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible

--- a/providers/v1/barbican/go.mod
+++ b/providers/v1/barbican/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/barbican
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/beyondtrust/go.mod
+++ b/providers/v1/beyondtrust/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/beyondtrust
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/BeyondTrust/go-client-library-passwordsafe v1.3.0

--- a/providers/v1/beyondtrustworkloadcredentials/go.mod
+++ b/providers/v1/beyondtrustworkloadcredentials/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/beyondtrustworkloadcredentials
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/bitwarden/go.mod
+++ b/providers/v1/bitwarden/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/bitwarden
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/chef/go.mod
+++ b/providers/v1/chef/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/chef
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/cloudru/go.mod
+++ b/providers/v1/cloudru/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/cloudru
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/cloudru-tech/iam-sdk v1.0.4

--- a/providers/v1/conjur/go.mod
+++ b/providers/v1/conjur/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/conjur
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/cyberark/conjur-api-go v0.13.8

--- a/providers/v1/delinea/go.mod
+++ b/providers/v1/delinea/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/delinea
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/DelineaXPM/dsv-sdk-go/v2 v2.2.0

--- a/providers/v1/doppler/go.mod
+++ b/providers/v1/doppler/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/doppler
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/dvls/go.mod
+++ b/providers/v1/dvls/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/dvls
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/Devolutions/go-dvls v0.19.1

--- a/providers/v1/fake/go.mod
+++ b/providers/v1/fake/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/fake
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/fortanix/go.mod
+++ b/providers/v1/fortanix/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/fortanix
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/gcp/go.mod
+++ b/providers/v1/gcp/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/gcp
 
-go 1.26.4
+go 1.26.5
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0

--- a/providers/v1/github/go.mod
+++ b/providers/v1/github/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/github
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.17.0

--- a/providers/v1/gitlab/go.mod
+++ b/providers/v1/gitlab/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/gitlab
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/ibm/go.mod
+++ b/providers/v1/ibm/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/ibm
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/IBM/go-sdk-core/v5 v5.21.0

--- a/providers/v1/infisical/go.mod
+++ b/providers/v1/infisical/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/infisical
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/keepersecurity/go.mod
+++ b/providers/v1/keepersecurity/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/keepersecurity
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/kubernetes/go.mod
+++ b/providers/v1/kubernetes/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/kubernetes
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/nebius/go.mod
+++ b/providers/v1/nebius/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/nebius
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/ngrok/go.mod
+++ b/providers/v1/ngrok/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/ngrok
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/onboardbase/go.mod
+++ b/providers/v1/onboardbase/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/onboardbase
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/Onboardbase/go-cryptojs-aes-decrypt v0.0.0-20230430095000-27c0d3a9016d

--- a/providers/v1/onepassword/go.mod
+++ b/providers/v1/onepassword/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/onepassword
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/1Password/connect-sdk-go v1.5.3

--- a/providers/v1/onepasswordsdk/go.mod
+++ b/providers/v1/onepasswordsdk/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/onepasswordsdk
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/1password/onepassword-sdk-go v0.3.1

--- a/providers/v1/openbao/go.mod
+++ b/providers/v1/openbao/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/openbao
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/oracle/go.mod
+++ b/providers/v1/oracle/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/oracle
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/ovh/go.mod
+++ b/providers/v1/ovh/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/ovh
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/passbolt/go.mod
+++ b/providers/v1/passbolt/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/passbolt
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/passworddepot/go.mod
+++ b/providers/v1/passworddepot/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/passworddepot
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/previder/go.mod
+++ b/providers/v1/previder/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/previder
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/pulumi/go.mod
+++ b/providers/v1/pulumi/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/pulumi
 
-go 1.26.4
+go 1.26.5
 
 require (
 	dario.cat/mergo v1.0.2

--- a/providers/v1/scaleway/go.mod
+++ b/providers/v1/scaleway/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/scaleway
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/secretserver/go.mod
+++ b/providers/v1/secretserver/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/secretserver
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/DelineaXPM/tss-sdk-go/v3 v3.0.2

--- a/providers/v1/senhasegura/go.mod
+++ b/providers/v1/senhasegura/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/senhasegura
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/vault/go.mod
+++ b/providers/v1/vault/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/vault
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.6

--- a/providers/v1/volcengine/go.mod
+++ b/providers/v1/volcengine/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/volcengine
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/webhook/go.mod
+++ b/providers/v1/webhook/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/webhook
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358

--- a/providers/v1/yandex/go.mod
+++ b/providers/v1/yandex/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/yandex
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/runtime/go.mod
+++ b/runtime/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/runtime
 
-go 1.26.4
+go 1.26.5
 
 require (
 	dario.cat/mergo v1.0.2


### PR DESCRIPTION
## Problem Statement

The repository pinned Go `1.26.4` across the root module, all submodules, and the golang builder images. Go `1.26.4` is affected by CVE-2026-39822: on Unix, `os.Root` improperly followed a symlink in the final path component when the path ended in a trailing slash (e.g. `root.Open("symlink/")`), allowing a path to escape the root and access files outside it. The 1.26 release line is affected from 1.26.0 up to, but not including, 1.26.5.

## Related Issue

No tracking issue. Upstream fix: https://go.dev/issue/79005
Advisory: CVE-2026-39822 (fixed in Go 1.26.5 and 1.25.12).

## Proposed Changes

Bump the Go toolchain to `1.26.5`, which contains the fix:

- `go` directive updated `1.26.4` to `1.26.5` in the root module and every submodule (62 `go.mod` files).
- golang builder image bumped `1.26.4` to `1.26.5`, tag and pinned digest, in `Dockerfile.standalone`, `e2e/Dockerfile`, and `tilt.debug.dockerfile`, so the shipped binaries are built with the patched toolchain. The `@sha256` values are the multi-arch index digests for the new tags.

No dependency or `go.sum` changes: a patch-level `go` directive bump touches nothing else. CI resolves the Go version from `go.mod` via `go-version-file`, so it picks up the new version automatically.

## AI Assistance disclosure

Did you use an script, LLM, or AI assisted development tool for this contribution?

AI assistance used: Yes

If yes provide details:

Tool(s) used: Claude Code

Purpose of assistance: confirm the exact fixed Go version for CVE-2026-39822, resolve the new golang image index digests, and apply the mechanical version bump across all modules and Dockerfiles.

Parts of the contribution affected: the `go` directive in all `go.mod` files and the builder image references in the three Dockerfiles.

Human validation performed: reviewed the full diff; verified the CVE is fixed in 1.26.5 (not 1.26.4) against the Go security release notes; confirmed each new `@sha256` resolves to the golang 1.26.5 multi-arch index manifest via `docker buildx imagetools inspect`.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.