### PR TITLE
fix(onepassword): support PushSecret IfNotExists

### DIFF
--- a/providers/v1/onepassword/onepassword.go
+++ b/providers/v1/onepassword/onepassword.go
@@ -240,8 +240,30 @@ func (provider *ProviderOnePassword) DeleteSecret(_ context.Context, ref esv1.Pu
 }
 
 // SecretExists checks if a secret exists in 1Password.
-func (provider *ProviderOnePassword) SecretExists(_ context.Context, _ esv1.PushSecretRemoteRef) (bool, error) {
-	return false, errors.New("not implemented")
+func (provider *ProviderOnePassword) SecretExists(_ context.Context, ref esv1.PushSecretRemoteRef) (bool, error) {
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+
+	item, err := provider.findItem(ref.GetRemoteKey())
+	if errors.Is(err, ErrKeyNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	property := ref.GetProperty()
+	if property == "" {
+		return true, nil
+	}
+
+	for _, field := range item.Fields {
+		if field.Label == property {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 const (

--- a/providers/v1/onepassword/onepassword_test.go
+++ b/providers/v1/onepassword/onepassword_test.go
@@ -393,6 +393,100 @@ func TestFindItem(t *testing.T) {
 	}
 }
 
+func TestProviderOnePasswordSecretExists(t *testing.T) {
+	connectErr := errors.New("1Password Connect unavailable")
+	testCases := []struct {
+		name        string
+		provider    *ProviderOnePassword
+		ref         fakeRef
+		expected    bool
+		expectedErr error
+	}{
+		{
+			name: "item does not exist",
+			provider: &ProviderOnePassword{
+				vaults: map[string]int{myVault: 1},
+				client: fake.NewMockClient().
+					AddPredictableVault(myVault),
+			},
+			ref: fakeRef{key: myItem},
+		},
+		{
+			name: "item exists without requested property",
+			provider: &ProviderOnePassword{
+				vaults: map[string]int{myVault: 1},
+				client: fake.NewMockClient().
+					AddPredictableVault(myVault).
+					AddPredictableItemWithField(myVault, myItem, key1, value1),
+			},
+			ref:      fakeRef{key: myItem},
+			expected: true,
+		},
+		{
+			name: "requested field exists",
+			provider: &ProviderOnePassword{
+				vaults: map[string]int{myVault: 1},
+				client: fake.NewMockClient().
+					AddPredictableVault(myVault).
+					AddPredictableItemWithField(myVault, myItem, key1, value1),
+			},
+			ref:      fakeRef{key: myItem, prop: key1},
+			expected: true,
+		},
+		{
+			name: "requested field does not exist",
+			provider: &ProviderOnePassword{
+				vaults: map[string]int{myVault: 1},
+				client: fake.NewMockClient().
+					AddPredictableVault(myVault).
+					AddPredictableItemWithField(myVault, myItem, key1, value1),
+			},
+			ref: fakeRef{key: myItem, prop: key2},
+		},
+		{
+			name: "duplicate items return an error",
+			provider: &ProviderOnePassword{
+				vaults: map[string]int{myVault: 1},
+				client: fake.NewMockClient().
+					AddPredictableVault(myVault).
+					AddPredictableItemWithField(myVault, myItem, key1, value1).
+					AppendItem(myVaultID, onepassword.Item{
+						ID:    "duplicate-item-id",
+						Title: myItem,
+						Vault: onepassword.ItemVault{ID: myVaultID},
+					}),
+			},
+			ref:         fakeRef{key: myItem},
+			expectedErr: ErrExpectedOneItem,
+		},
+		{
+			name: "Connect lookup errors are propagated",
+			provider: &ProviderOnePassword{
+				vaults: map[string]int{myVault: 1},
+				client: &mockClient{
+					getVaultFunc: func(string) (*onepassword.Vault, error) {
+						return nil, connectErr
+					},
+				},
+			},
+			ref:         fakeRef{key: myItem},
+			expectedErr: connectErr,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			exists, err := tc.provider.SecretExists(context.Background(), tc.ref)
+			if exists != tc.expected {
+				t.Errorf("expected exists=%v, got %v", tc.expected, exists)
+			}
+			if !errors.Is(err, tc.expectedErr) {
+				t.Errorf("expected error %v, got %v", tc.expectedErr, err)
+			}
+		})
+	}
+}
+
 func TestValidateStore(t *testing.T) {
 	type testCase struct {
 		checkNote    string
@@ -2447,10 +2541,16 @@ func TestProviderOnePasswordPushSecret(t *testing.T) {
 // mockClient implements connect.Client interface for testing.
 type mockClient struct {
 	getItemsFunc func(vaultQuery string) ([]onepassword.Item, error)
+	getVaultFunc func(vaultQuery string) (*onepassword.Vault, error)
 }
 
-func (m *mockClient) GetVaults() ([]onepassword.Vault, error)                   { return nil, nil }
-func (m *mockClient) GetVault(uuid string) (*onepassword.Vault, error)          { return nil, nil }
+func (m *mockClient) GetVaults() ([]onepassword.Vault, error) { return nil, nil }
+func (m *mockClient) GetVault(uuid string) (*onepassword.Vault, error) {
+	if m.getVaultFunc != nil {
+		return m.getVaultFunc(uuid)
+	}
+	return nil, nil
+}
 func (m *mockClient) GetVaultByUUID(uuid string) (*onepassword.Vault, error)    { return nil, nil }
 func (m *mockClient) GetVaultByTitle(title string) (*onepassword.Vault, error)  { return nil, nil }
 func (m *mockClient) GetVaultsByTitle(uuid string) ([]onepassword.Vault, error) { return nil, nil }


### PR DESCRIPTION
## Problem Statement

The 1Password Connect provider's `SecretExists` method returned `not implemented`, causing PushSecret reconciliation to fail whenever `spec.updatePolicy: IfNotExists` was selected.

## Related Issue

Fixes #6645

## Proposed Changes

- Implement `ProviderOnePassword.SecretExists` using the existing `findItem` lookup.
- Treat `ErrKeyNotFound` as an absent item.
- Return item existence when no property is requested.
- Match requested properties against 1Password field labels.
- Preserve lookup errors, including duplicate-item and Connect failures.
- Add focused unit coverage for all of these cases.

## AI Assistance disclosure

AI assistance used: Yes

Tool(s) used: OpenAI Codex

Purpose of assistance: Repository discovery, implementation, test authoring, and local validation.

Parts of the contribution affected: `providers/v1/onepassword/onepassword.go` and `providers/v1/onepassword/onepassword_test.go`.

Human validation performed: The contributor reviewed the implementation and test results, then deployed the branch-built controller to a local kind cluster connected to a real 1Password Connect server and test vault.

## Live Validation

- Created a `PushSecret` with `updatePolicy: IfNotExists` and verified that the initial Kubernetes Secret value was created in 1Password.
- Changed the Kubernetes source value and triggered another reconciliation.
- Verified that the existing 1Password field retained its original value and the `PushSecret` remained `Ready=True` with reason `Synced`.

<details>
<summary>Live test example</summary>

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: source-secret
  namespace: eso-onepassword-live
stringData:
  source-key: created-first
---
apiVersion: external-secrets.io/v1alpha1
kind: PushSecret
metadata:
  name: onepassword-ifnotexists-test
  namespace: eso-onepassword-live
spec:
  updatePolicy: IfNotExists
  deletionPolicy: None
  refreshInterval: 10s
  secretStoreRefs:
    - name: onepassword-live
      kind: SecretStore
  selector:
    secret:
      name: source-secret
  data:
    - match:
        secretKey: source-key
        remoteRef:
          remoteKey: eso-ifnotexists-6645-test
          property: password
      metadata:
        apiVersion: kubernetes.external-secrets.io/v1alpha1
        kind: PushSecretMetadata
        spec:
          vault: ESO Connect Test
```

After the first reconciliation created the 1Password field with value `created-first`, the Kubernetes source was changed and reconciliation was triggered again:

```shell
kubectl -n eso-onepassword-live patch secret source-secret \
  --type merge \
  -p '{"stringData":{"source-key":"must-not-overwrite-v2"}}'

kubectl -n eso-onepassword-live annotate pushsecret onepassword-ifnotexists-test \
  force-reconcile="$(date +%s)" \
  --overwrite
```

Observed result:

```text
Kubernetes source value: must-not-overwrite-v2
1Password value before reconciliation: created-first
1Password value after reconciliation:  created-first

Ready=True
Reason=Synced
Message=PushSecret synced successfully. Existing secrets in providers unchanged.
```

</details>

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
- [x] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [x] I have tested my changes on a live environment to confirm they are working
