### PR TITLE
fix(testing): check out PR head in fork e2e instead of main

### DIFF
--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -93,7 +93,7 @@ env:
   KIND_VERSION: 'v0.30.0'
   KIND_IMAGE: 'kindest/node:v1.33.4'
   AWS_REGION: "eu-central-1"
-  TARGET_SHA: ${{ github.event.client_payload.slash_command.args.named.sha }}
+  TARGET_SHA: ${{ github.event.client_payload.slash_command.args.named.sha || github.event.client_payload.pull_request.head.sha }}
   # Ephemeral tag: images are only ever loaded into kind, never pushed, so a
   # fixed tag keeps the build and test jobs in sync without passing a version.
   VERSION: "e2e"

--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -93,7 +93,12 @@ env:
   KIND_VERSION: 'v0.30.0'
   KIND_IMAGE: 'kindest/node:v1.33.4'
   AWS_REGION: "eu-central-1"
-  TARGET_SHA: ${{ github.event.client_payload.slash_command.args.named.sha || github.event.client_payload.pull_request.head.sha }}
+  # SHA under test on the fork path. Populated by a dispatcher: an explicit
+  # `/ok-to-test sha=<sha>` comment (ok-to-test.yml), or the reviewed commit_id
+  # of a PR review carrying /ok-to-test (ok-to-test-review.yml). Empty on the
+  # trusted pull_request path, where the checkout falls back to github.sha (the
+  # PR merge ref).
+  TARGET_SHA: ${{ github.event.client_payload.slash_command.args.named.sha }}
   # Ephemeral tag: images are only ever loaded into kind, never pushed, so a
   # fixed tag keeps the build and test jobs in sync without passing a version.
   VERSION: "e2e"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,10 +12,13 @@ env:
   # Common versions
   KIND_VERSION: 'v0.30.0'
   KIND_IMAGE: 'kindest/node:v1.33.4'
-  # Prefer an explicit `/ok-to-test sha=<sha>`, otherwise the PR head captured by
-  # slash-command-dispatch when the comment was made. Empty on pull_request
-  # events, where the checkout falls back to github.sha (the PR merge ref).
-  TARGET_SHA: ${{ github.event.client_payload.slash_command.args.named.sha || github.event.client_payload.pull_request.head.sha }}
+  # SHA under test on the fork path. Two dispatchers populate it: an explicit
+  # `/ok-to-test sha=<sha>` comment (ok-to-test.yml) or a PR review whose body
+  # carries /ok-to-test (ok-to-test-review.yml, pinned to the reviewed
+  # commit_id). A bare comment leaves it empty and guard-fork rejects the run
+  # rather than testing the PR head or main. Also empty on the trusted
+  # pull_request path, where the checkout falls back to github.sha.
+  TARGET_SHA: ${{ github.event.client_payload.slash_command.args.named.sha }}
   AWS_REGION: "eu-central-1"
 
 jobs:
@@ -68,11 +71,58 @@ jobs:
       ORACLE_FINGERPRINT: ${{ secrets.ORACLE_FINGERPRINT }}
       ORACLE_KEY: ${{ secrets.ORACLE_KEY }}
 
-  # Repo owner has commented /ok-to-test on a (fork-based) pull request.
+  # A /ok-to-test *comment* must carry an explicit sha=. A bare comment has no
+  # trustworthy pinned commit (the dispatch would otherwise read the live PR
+  # head, which a later push can move), so reject it here instead of testing the
+  # wrong code. Reviews carry commit_id and arrive already pinned via
+  # ok-to-test-review.yml, so this guard never fires for them.
+  guard-fork:
+    if: github.event_name == 'repository_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # to explain a rejected /ok-to-test on the PR
+      contents: read
+    steps:
+    - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      with:
+        egress-policy: audit
+
+    - name: Accept an explicit target sha
+      if: env.TARGET_SHA != ''
+      run: echo "target sha $TARGET_SHA"
+
+    - name: Generate token
+      id: create_token
+      if: env.TARGET_SHA == ''
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+      env:
+        APP_ID: ${{ secrets.APP_ID }}
+      with:
+        app-id: ${{ env.APP_ID }}
+        private-key: ${{ secrets.PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+
+    - name: Explain the rejection on the PR
+      if: env.TARGET_SHA == ''
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
+      with:
+        token: ${{ steps.create_token.outputs.token }}
+        issue-number: ${{ github.event.client_payload.pull_request.number }}
+        body: |
+            [Bot] - :warning: A `/ok-to-test` comment needs an explicit commit: `/ok-to-test sha=<full-sha>`. Alternatively submit a PR review (Approve or Comment) whose body contains `/ok-to-test` to test the exact commit you reviewed.
+
+    - name: Fail without a target sha
+      if: env.TARGET_SHA == ''
+      run: |
+        echo "::error::/ok-to-test comment without sha=; refusing to fall back to the PR head or main"
+        exit 1
+
+  # Repo owner approved a fork PR via /ok-to-test (comment with sha= or review).
   integration-fork:
     permissions:
       id-token: write # for oidc auth with aws/gcp/azure
       contents: read  # for checkout
+    needs: guard-fork
     if: github.event_name == 'repository_dispatch'
     uses: ./.github/workflows/e2e-reusable.yml
     secrets:
@@ -118,7 +168,7 @@ jobs:
 
   # Report the fork run result back onto the originating pull request.
   report-fork:
-    if: github.event_name == 'repository_dispatch' && always()
+    if: ${{ always() && github.event_name == 'repository_dispatch' && needs.integration-fork.result != 'skipped' }}
     needs: integration-fork
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -101,6 +101,9 @@ jobs:
         app-id: ${{ env.APP_ID }}
         private-key: ${{ secrets.PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
+        repositories: ${{ github.event.repository.name }}
+        permission-issues: write
+        permission-pull-requests: write
 
     - name: Explain the rejection on the PR
       if: env.TARGET_SHA == ''
@@ -187,6 +190,9 @@ jobs:
         app-id: ${{ env.APP_ID }}
         private-key: ${{ secrets.PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
+        repositories: ${{ github.event.repository.name }}
+        permission-issues: write
+        permission-pull-requests: write
 
     - name: Update on Success
       if: needs.integration-fork.result == 'success'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -87,13 +87,23 @@ jobs:
       with:
         egress-policy: audit
 
-    - name: Accept an explicit target sha
-      if: env.TARGET_SHA != ''
-      run: echo "target sha $TARGET_SHA"
+    # Require a full 40-char commit SHA. This rejects a bare /ok-to-test (empty
+    # TARGET_SHA) and a malformed sha= (e.g. a branch name like `main`, a short
+    # SHA, or a flag), so the checkout ref is always a pinned commit. The review
+    # path supplies review.commit_id, which is always a full SHA.
+    - name: Validate the target sha
+      id: check
+      run: |
+        if printf '%s' "$TARGET_SHA" | grep -qE '^[0-9a-fA-F]{40}$'; then
+          echo "valid=true" >> "$GITHUB_OUTPUT"
+          echo "target sha $TARGET_SHA"
+        else
+          echo "valid=false" >> "$GITHUB_OUTPUT"
+        fi
 
     - name: Generate token
       id: create_token
-      if: env.TARGET_SHA == ''
+      if: steps.check.outputs.valid == 'false'
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       env:
         APP_ID: ${{ secrets.APP_ID }}
@@ -106,18 +116,18 @@ jobs:
         permission-pull-requests: write
 
     - name: Explain the rejection on the PR
-      if: env.TARGET_SHA == ''
+      if: steps.check.outputs.valid == 'false'
       uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         token: ${{ steps.create_token.outputs.token }}
         issue-number: ${{ github.event.client_payload.pull_request.number }}
         body: |
-            [Bot] - :warning: A `/ok-to-test` comment needs an explicit commit: `/ok-to-test sha=<full-sha>`. Alternatively submit a PR review (Approve or Comment) whose body contains `/ok-to-test` to test the exact commit you reviewed.
+            [Bot] - :warning: A `/ok-to-test` comment needs an explicit full commit SHA: `/ok-to-test sha=<40-char-sha>`. Alternatively submit a PR review (Approve or Comment) whose body contains `/ok-to-test` to test the exact commit you reviewed.
 
-    - name: Fail without a target sha
-      if: env.TARGET_SHA == ''
+    - name: Fail without a valid target sha
+      if: steps.check.outputs.valid == 'false'
       run: |
-        echo "::error::/ok-to-test comment without sha=; refusing to fall back to the PR head or main"
+        echo "::error::/ok-to-test needs sha=<full 40-char commit SHA>; refusing to fall back to the PR head or main"
         exit 1
 
   # Repo owner approved a fork PR via /ok-to-test (comment with sha= or review).

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,8 +12,10 @@ env:
   # Common versions
   KIND_VERSION: 'v0.30.0'
   KIND_IMAGE: 'kindest/node:v1.33.4'
-  TARGET_SHA: ${{ github.event.client_payload.slash_command.args.named.sha }}
-  GHCR_USERNAME: ${{ github.actor }}
+  # Prefer an explicit `/ok-to-test sha=<sha>`, otherwise the PR head captured by
+  # slash-command-dispatch when the comment was made. Empty on pull_request
+  # events, where the checkout falls back to github.sha (the PR merge ref).
+  TARGET_SHA: ${{ github.event.client_payload.slash_command.args.named.sha || github.event.client_payload.pull_request.head.sha }}
   AWS_REGION: "eu-central-1"
 
 jobs:

--- a/.github/workflows/ok-to-test-review.yml
+++ b/.github/workflows/ok-to-test-review.yml
@@ -52,6 +52,12 @@ jobs:
         app-id: ${{ env.APP_ID }}
         private-key: ${{ secrets.PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
+        repositories: ${{ github.event.repository.name }}
+        # contents:write to POST the repository_dispatch; metadata:read (implicit
+        # for any app token, stated for clarity) to read the reviewer's
+        # collaborator permission level.
+        permission-contents: write
+        permission-metadata: read
 
     # pull_request_review does not restrict to maintainers, and
     # author_association is not authoritative for repo write access, so verify it

--- a/.github/workflows/ok-to-test-review.yml
+++ b/.github/workflows/ok-to-test-review.yml
@@ -1,0 +1,92 @@
+# If someone with write access submits a PR review (Approve or Comment) whose
+# body contains "/ok-to-test", emit a repository_dispatch pinned to the exact
+# commit that was reviewed (github.event.review.commit_id). A review records the
+# head the reviewer actually saw, so the tested SHA cannot be moved by a later
+# push, and no PR-head lookup or sha= argument is needed.
+name: Ok To Test (review)
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+
+jobs:
+  ok-to-test-review:
+    # Only Approve or Comment reviews (never Request changes), and only when the
+    # review body mentions the command. contains() is a coarse pre-filter; the
+    # grep step below enforces a real word boundary.
+    if: >-
+      (github.event.review.state == 'approved' ||
+       github.event.review.state == 'commented') &&
+      contains(github.event.review.body, '/ok-to-test')
+    runs-on: ubuntu-latest
+    steps:
+    - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      with:
+        egress-policy: audit
+
+    # Refine the coarse contains() match: require /ok-to-test as its own token so
+    # "/ok-to-test-managed" or an incidental mention in prose does not trigger.
+    - name: Match the command in the review body
+      id: cmd
+      env:
+        REVIEW_BODY: ${{ github.event.review.body }}
+      run: |
+        if printf '%s' "$REVIEW_BODY" \
+            | grep -qiE '(^|[[:space:]])/ok-to-test([[:space:]]|$)'; then
+          echo "match=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "match=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    # App installation token, reused for the permission check and the dispatch.
+    - name: Generate token
+      id: generate_token
+      if: steps.cmd.outputs.match == 'true'
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+      env:
+        APP_ID: ${{ secrets.APP_ID }}
+      with:
+        app-id: ${{ env.APP_ID }}
+        private-key: ${{ secrets.PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+
+    # pull_request_review does not restrict to maintainers, and
+    # author_association is not authoritative for repo write access, so verify it
+    # explicitly. This is the equivalent of slash-command-dispatch's
+    # `permission: maintain` on the comment path.
+    - name: Verify the reviewer has write access
+      if: steps.cmd.outputs.match == 'true'
+      env:
+        GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+        REPO: ${{ github.repository }}
+        REVIEWER: ${{ github.event.review.user.login }}
+      run: |
+        perm=$(gh api "repos/${REPO}/collaborators/${REVIEWER}/permission" \
+          --jq '.permission')
+        echo "reviewer ${REVIEWER} permission: ${perm}"
+        case "${perm}" in
+          admin|maintain|write) : ;;
+          *) echo "::error::${REVIEWER} lacks write access (${perm})"; exit 1 ;;
+        esac
+
+    # Emit the same client_payload shape the comment path (slash-command-dispatch)
+    # produces, so e2e.yml reads TARGET_SHA from one place. jq quotes the SHA and
+    # PR number safely.
+    - name: Dispatch ok-to-test-command
+      if: steps.cmd.outputs.match == 'true'
+      env:
+        GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ github.event.review.commit_id }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        jq -cn --arg sha "$SHA" --argjson num "$PR_NUMBER" '{
+          event_type: "ok-to-test-command",
+          client_payload: {
+            slash_command: { args: { named: { sha: $sha } } },
+            pull_request: { number: $num, head: { sha: $sha } }
+          }
+        }' | gh api --method POST "repos/${REPO}/dispatches" --input -

--- a/.github/workflows/ok-to-test-review.yml
+++ b/.github/workflows/ok-to-test-review.yml
@@ -16,7 +16,7 @@ jobs:
   ok-to-test-review:
     # Only Approve or Comment reviews (never Request changes), and only when the
     # review body mentions the command. contains() is a coarse pre-filter; the
-    # grep step below enforces a real word boundary.
+    # step below enforces that /ok-to-test is the command on the first line.
     if: >-
       (github.event.review.state == 'approved' ||
        github.event.review.state == 'commented') &&
@@ -27,18 +27,23 @@ jobs:
       with:
         egress-policy: audit
 
-    # Refine the coarse contains() match: require /ok-to-test as its own token so
-    # "/ok-to-test-managed" or an incidental mention in prose does not trigger.
+    # Mirror how slash-command-dispatch parses the comment path: the command
+    # must be on the FIRST line and start with the slash command. This rejects a
+    # /ok-to-test mentioned in prose elsewhere in a longer review, and the
+    # /ok-to-test-managed prefix. Do not echo the body back: it is attacker
+    # controlled and could inject `::workflow commands::` into the log.
     - name: Match the command in the review body
       id: cmd
       env:
         REVIEW_BODY: ${{ github.event.review.body }}
       run: |
-        if printf '%s' "$REVIEW_BODY" \
-            | grep -qiE '(^|[[:space:]])/ok-to-test([[:space:]]|$)'; then
+        first=$(printf '%s' "$REVIEW_BODY" | head -n1 | tr -d '\r' \
+          | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
+        if printf '%s' "$first" | grep -qE '^/ok-to-test([[:space:]]|$)'; then
           echo "match=true" >> "$GITHUB_OUTPUT"
         else
           echo "match=false" >> "$GITHUB_OUTPUT"
+          echo "first line is not an /ok-to-test command; no e2e triggered"
         fi
 
     # App installation token, reused for the permission check and the dispatch.
@@ -73,14 +78,16 @@ jobs:
         perm=$(gh api "repos/${REPO}/collaborators/${REVIEWER}/permission" \
           --jq '.permission')
         echo "reviewer ${REVIEWER} permission: ${perm}"
+        # .permission is rolled up to admin/write/read/none (Maintain surfaces
+        # as write, Triage as read); accept write and above.
         case "${perm}" in
-          admin|maintain|write) : ;;
+          admin|write) : ;;
           *) echo "::error::${REVIEWER} lacks write access (${perm})"; exit 1 ;;
         esac
 
-    # Emit the same client_payload shape the comment path (slash-command-dispatch)
-    # produces, so e2e.yml reads TARGET_SHA from one place. jq quotes the SHA and
-    # PR number safely.
+    # Emit the client_payload fields e2e.yml consumes on the comment path:
+    # slash_command.args.named.sha (the target SHA) and pull_request.number
+    # (used by report-fork to comment the result). jq quotes both safely.
     - name: Dispatch ok-to-test-command
       if: steps.cmd.outputs.match == 'true'
       env:
@@ -93,6 +100,6 @@ jobs:
           event_type: "ok-to-test-command",
           client_payload: {
             slash_command: { args: { named: { sha: $sha } } },
-            pull_request: { number: $num, head: { sha: $sha } }
+            pull_request: { number: $num }
           }
         }' | gh api --method POST "repos/${REPO}/dispatches" --input -


### PR DESCRIPTION
## Problem Statement

The fork e2e path (triggered by `/ok-to-test` -> `repository_dispatch: ok-to-test-command`) checked out `${{ env.TARGET_SHA || github.sha }}`, where `TARGET_SHA` came only from the `/ok-to-test sha=<sha>` argument. On a `repository_dispatch` event `github.sha` is the default branch head, so a bare `/ok-to-test` (no `sha=`) built and tested `main`, and `report-fork` then posted a pass/fail comment on the pull request as if it reflected the PR. The fork's code was never tested and the PR got a misleading green (or red) check. Nothing validated that a real target commit was provided.

Beyond the false green, there is a pinning question: which commit should a `/ok-to-test` actually run? Using the live PR head (`pull_request.head.sha`, fetched by slash-command-dispatch when the dispatch job runs) is not the commit the maintainer reviewed. It is read a few seconds after the comment via `pulls.get`, so a push landing in that window is picked up, and it drifts further from the reviewed state on every later push. For a fork PR that grants secret access, the tested commit should be one a maintainer explicitly vouched for, not whatever the head happens to be at dispatch time.

## Proposed Changes

Resolve the target commit from an explicit, non-inferred source, via two paths:

Comment path (`ok-to-test.yml`, unchanged): a `/ok-to-test` comment is accepted only when it carries an explicit `/ok-to-test sha=<full-sha>`. There is no fallback to the PR head or to `main`. A new `guard-fork` job in `e2e.yml` rejects a bare comment, posts a short explanation on the PR, and fails the run before any checkout, so a comment can never silently test the wrong code.

Review path (new `ok-to-test-review.yml`): a PR review (Approve or Comment) whose body contains `/ok-to-test` triggers e2e against `github.event.review.commit_id`, the exact commit the reviewer was looking at when they submitted. GitHub records that commit_id server-side and it does not move when the author pushes more commits, so the tested SHA is precisely the reviewed one, with no `pulls.get` race and no `sha=` argument needed. The workflow verifies the reviewer has repo write access (pull_request_review is not restricted to maintainers, so this replaces slash-command-dispatch's `permission: maintain`) and then emits the same `ok-to-test-command` `repository_dispatch` payload the comment path uses, so `e2e.yml` and the existing `report-fork` comment stay single-sourced.

Also drop the unused `GHCR_USERNAME` env; the reusable pipeline only loads images into kind and never pushes them.

## Resulting behavior

| Trigger | Target SHA | Outcome |
| --- | --- | --- |
| `/ok-to-test sha=<sha>` comment (maintainer) | the `sha=` value | runs |
| bare `/ok-to-test` comment | none | rejected, bot comment explains how to retry |
| review (Approve or Comment) whose body has `/ok-to-test` | `review.commit_id` | runs, pinned to the reviewed commit |
| review by a user without write access | n/a | rejected in the write-access check |
| `changes_requested` review | n/a | ignored |

## Notes

Both `e2e.yml` and `e2e-reusable.yml` now read `TARGET_SHA` from `client_payload.slash_command.args.named.sha` only. The `|| github.sha` checkout fallback stays for the trusted `pull_request` job, where `client_payload` is empty and `github.sha` is the PR merge ref; `guard-fork` ensures the fork path never reaches that fallback with an empty SHA.

Because `issue_comment` and `pull_request_review` workflows always run from the default branch, the review path only becomes active after this merges to `main`; it cannot be exercised from within this PR. The separate `/ok-to-test-managed` flow (`e2e-managed.yml`) is unchanged; it checks out `refs/pull/<n>/merge` and is out of scope here.

## Related Issue

N/A

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
