### PR TITLE
fix(barbican): return decoded scalar values from JSON payloads

### DIFF
--- a/providers/v1/barbican/client.go
+++ b/providers/v1/barbican/client.go
@@ -31,7 +31,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	esapi "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
-	"github.com/external-secrets/external-secrets/runtime/esutils"
 )
 
 const (
@@ -121,18 +120,21 @@ func (c *Client) GetSecretMap(ctx context.Context, ref esapi.ExternalSecretDataR
 		return nil, fmt.Errorf(errClientGeneric, err)
 	}
 
-	var kv map[string]any
-	if err := json.Unmarshal(payload, &kv); err != nil {
+	var rawJSON map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &rawJSON); err != nil {
 		return nil, fmt.Errorf(errClientJSONUnmarshal, err)
 	}
 
-	secretMap := make(map[string][]byte, len(kv))
-	for k := range kv {
-		byteValue, err := esutils.GetByteValueFromMap(kv, k)
-		if err != nil {
-			return nil, fmt.Errorf(errClientGeneric, err)
+	secretMap := make(map[string][]byte, len(rawJSON))
+	for k, v := range rawJSON {
+		// Numbers stay raw; decoding into float64 would drop precision on
+		// large integers.
+		var strVal string
+		if err := json.Unmarshal(v, &strVal); err == nil {
+			secretMap[k] = []byte(strVal)
+		} else {
+			secretMap[k] = v
 		}
-		secretMap[k] = byteValue
 	}
 
 	return secretMap, nil

--- a/providers/v1/barbican/client.go
+++ b/providers/v1/barbican/client.go
@@ -27,9 +27,11 @@ import (
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack/keymanager/v1/secrets"
+	"github.com/tidwall/gjson"
 	corev1 "k8s.io/api/core/v1"
 
 	esapi "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
+	"github.com/external-secrets/external-secrets/runtime/esutils"
 )
 
 const (
@@ -119,14 +121,18 @@ func (c *Client) GetSecretMap(ctx context.Context, ref esapi.ExternalSecretDataR
 		return nil, fmt.Errorf(errClientGeneric, err)
 	}
 
-	var rawJSON map[string]json.RawMessage
-	if err := json.Unmarshal(payload, &rawJSON); err != nil {
+	var kv map[string]any
+	if err := json.Unmarshal(payload, &kv); err != nil {
 		return nil, fmt.Errorf(errClientJSONUnmarshal, err)
 	}
 
-	secretMap := make(map[string][]byte, len(rawJSON))
-	for k, v := range rawJSON {
-		secretMap[k] = []byte(v)
+	secretMap := make(map[string][]byte, len(kv))
+	for k := range kv {
+		byteValue, err := esutils.GetByteValueFromMap(kv, k)
+		if err != nil {
+			return nil, fmt.Errorf(errClientGeneric, err)
+		}
+		secretMap[k] = byteValue
 	}
 
 	return secretMap, nil
@@ -163,17 +169,24 @@ func getSecretPayloadProperty(payload []byte, property string) ([]byte, error) {
 		return payload, nil
 	}
 
-	var rawJSON map[string]json.RawMessage
-	if err := json.Unmarshal(payload, &rawJSON); err != nil {
-		return nil, fmt.Errorf(errClientJSONUnmarshal, err)
+	if !json.Valid(payload) {
+		return nil, fmt.Errorf(errClientJSONUnmarshal, errors.New("payload is not valid json"))
 	}
 
-	value, ok := rawJSON[property]
-	if !ok {
+	// gjson treats '.' as a path separator, so a dotted property is tried as an
+	// escaped literal key first, then as a nested path, like the gcp provider.
+	if strings.Contains(property, ".") {
+		if escaped := gjson.GetBytes(payload, strings.ReplaceAll(property, ".", "\\.")); escaped.Exists() {
+			return []byte(escaped.String()), nil
+		}
+	}
+
+	value := gjson.GetBytes(payload, property)
+	if !value.Exists() {
 		return nil, fmt.Errorf(errClientGeneric, fmt.Errorf("property %s not found in secret payload", property))
 	}
 
-	return value, nil
+	return []byte(value.String()), nil
 }
 
 // extractUUIDFromRef extracts the UUID from a Barbican secret reference URL.

--- a/providers/v1/barbican/client_test.go
+++ b/providers/v1/barbican/client_test.go
@@ -90,7 +90,7 @@ func TestGetSecretPayloadProperty(t *testing.T) {
 			payload:      testPayload,
 			property:     "username",
 			expectError:  false,
-			expectedData: []byte(`"admin"`),
+			expectedData: []byte("admin"),
 		},
 		{
 			name:         "nested property extraction",
@@ -129,6 +129,106 @@ func TestGetSecretPayloadProperty(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetSecret(t *testing.T) {
+	const uuid = "12345678-1234-1234-1234-123456789abc"
+	payload := `{"username":"admin","port":8080,"nested":{"key":"value"},"weird.key":"literal"}`
+
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/secrets/"+uuid+"/payload", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(payload))
+	})
+
+	client := &Client{keyManager: thclient.ServiceClient(fakeServer)}
+
+	testCases := []struct {
+		name         string
+		property     string
+		expectError  bool
+		expectedData []byte
+	}{
+		{
+			name:         "no property returns full payload",
+			property:     "",
+			expectedData: []byte(payload),
+		},
+		{
+			name:         "string value is unquoted",
+			property:     "username",
+			expectedData: []byte("admin"),
+		},
+		{
+			name:         "number is returned as-is",
+			property:     "port",
+			expectedData: []byte("8080"),
+		},
+		{
+			name:         "object stays as json",
+			property:     "nested",
+			expectedData: []byte(`{"key":"value"}`),
+		},
+		{
+			name:         "nested path is followed",
+			property:     "nested.key",
+			expectedData: []byte("value"),
+		},
+		{
+			name:         "dotted key matched as a literal",
+			property:     "weird.key",
+			expectedData: []byte("literal"),
+		},
+		{
+			name:        "missing property errors",
+			property:    "nonexistent",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := client.GetSecret(context.Background(), esv1.ExternalSecretDataRemoteRef{
+				Key:      uuid,
+				Property: tc.property,
+			})
+
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, data)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedData, data)
+			}
+		})
+	}
+}
+
+func TestGetSecretMap(t *testing.T) {
+	const uuid = "abcdef00-0000-0000-0000-000000000000"
+	payload := `{"username":"admin","port":8080,"enabled":true,"nested":{"key":"value"}}`
+
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/secrets/"+uuid+"/payload", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(payload))
+	})
+
+	client := &Client{keyManager: thclient.ServiceClient(fakeServer)}
+
+	result, err := client.GetSecretMap(context.Background(), esv1.ExternalSecretDataRemoteRef{Key: uuid})
+	assert.NoError(t, err)
+	// String values used to keep their surrounding JSON quotes.
+	assert.Equal(t, []byte("admin"), result["username"])
+	assert.Equal(t, []byte("8080"), result["port"])
+	assert.Equal(t, []byte("true"), result["enabled"])
+	assert.Equal(t, []byte(`{"key":"value"}`), result["nested"])
 }
 
 func TestUnsupportedOperations(t *testing.T) {

--- a/providers/v1/barbican/client_test.go
+++ b/providers/v1/barbican/client_test.go
@@ -133,7 +133,7 @@ func TestGetSecretPayloadProperty(t *testing.T) {
 
 func TestGetSecret(t *testing.T) {
 	const uuid = "12345678-1234-1234-1234-123456789abc"
-	payload := `{"username":"admin","port":8080,"nested":{"key":"value"},"weird.key":"literal"}`
+	payload := `{"username":"admin","port":8080,"nested":{"key":"value"},"weird.key":"literal","bignum":123456789012345678}`
 
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()
@@ -166,6 +166,11 @@ func TestGetSecret(t *testing.T) {
 			name:         "number is returned as-is",
 			property:     "port",
 			expectedData: []byte("8080"),
+		},
+		{
+			name:         "large integer keeps precision",
+			property:     "bignum",
+			expectedData: []byte("123456789012345678"),
 		},
 		{
 			name:         "object stays as json",
@@ -209,7 +214,7 @@ func TestGetSecret(t *testing.T) {
 
 func TestGetSecretMap(t *testing.T) {
 	const uuid = "abcdef00-0000-0000-0000-000000000000"
-	payload := `{"username":"admin","port":8080,"enabled":true,"nested":{"key":"value"}}`
+	payload := `{"username":"admin","port":8080,"enabled":true,"nested":{"key":"value"},"bignum":123456789012345678}`
 
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()
@@ -229,6 +234,7 @@ func TestGetSecretMap(t *testing.T) {
 	assert.Equal(t, []byte("8080"), result["port"])
 	assert.Equal(t, []byte("true"), result["enabled"])
 	assert.Equal(t, []byte(`{"key":"value"}`), result["nested"])
+	assert.Equal(t, []byte("123456789012345678"), result["bignum"])
 }
 
 func TestUnsupportedOperations(t *testing.T) {

--- a/providers/v1/barbican/go.mod
+++ b/providers/v1/barbican/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/external-secrets/external-secrets/runtime v0.0.0-00010101000000-000000000000
 	github.com/gophercloud/gophercloud/v2 v2.8.0
 	github.com/stretchr/testify v1.11.1
-	github.com/tidwall/gjson v1.19.0
+	github.com/tidwall/gjson v1.18.0
 	k8s.io/api v0.35.2
 	k8s.io/apimachinery v0.35.2
 	sigs.k8s.io/controller-runtime v0.23.3

--- a/providers/v1/barbican/go.mod
+++ b/providers/v1/barbican/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/external-secrets/external-secrets/runtime v0.0.0-00010101000000-000000000000
 	github.com/gophercloud/gophercloud/v2 v2.8.0
 	github.com/stretchr/testify v1.11.1
+	github.com/tidwall/gjson v1.19.0
 	k8s.io/api v0.35.2
 	k8s.io/apimachinery v0.35.2
 	sigs.k8s.io/controller-runtime v0.23.3
@@ -66,6 +67,8 @@ require (
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/providers/v1/barbican/go.mod
+++ b/providers/v1/barbican/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/external-secrets/external-secrets/runtime v0.0.0-00010101000000-000000000000
 	github.com/gophercloud/gophercloud/v2 v2.8.0
 	github.com/stretchr/testify v1.11.1
-	github.com/tidwall/gjson v1.19.0
+	github.com/tidwall/gjson v1.18.0
 	k8s.io/api v0.36.3
 	k8s.io/apimachinery v0.36.3
 	sigs.k8s.io/controller-runtime v0.24.1

--- a/providers/v1/barbican/go.mod
+++ b/providers/v1/barbican/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/external-secrets/external-secrets/runtime v0.0.0-00010101000000-000000000000
 	github.com/gophercloud/gophercloud/v2 v2.8.0
 	github.com/stretchr/testify v1.11.1
+	github.com/tidwall/gjson v1.19.0
 	k8s.io/api v0.36.3
 	k8s.io/apimachinery v0.36.3
 	sigs.k8s.io/controller-runtime v0.24.1
@@ -48,6 +49,8 @@ require (
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/providers/v1/barbican/go.sum
+++ b/providers/v1/barbican/go.sum
@@ -164,8 +164,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/tidwall/gjson v1.19.0 h1:xwxm7n691Uf3u5OFjzngavjGTh55KX5q/9w9xHW88JU=
-github.com/tidwall/gjson v1.19.0/go.mod h1:V37/opeE/JbLUOfH0QTXiNez2l0RUjYUhpT4szFQAfc=
+github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
+github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=

--- a/providers/v1/barbican/go.sum
+++ b/providers/v1/barbican/go.sum
@@ -164,6 +164,12 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tidwall/gjson v1.19.0 h1:xwxm7n691Uf3u5OFjzngavjGTh55KX5q/9w9xHW88JU=
+github.com/tidwall/gjson v1.19.0/go.mod h1:V37/opeE/JbLUOfH0QTXiNez2l0RUjYUhpT4szFQAfc=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 h1:ilQV1hzziu+LLM3zUTJ0trRztfwgjqKnBWNtSRkbmwM=

--- a/providers/v1/barbican/go.sum
+++ b/providers/v1/barbican/go.sum
@@ -117,6 +117,12 @@ github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tidwall/gjson v1.19.0 h1:xwxm7n691Uf3u5OFjzngavjGTh55KX5q/9w9xHW88JU=
+github.com/tidwall/gjson v1.19.0/go.mod h1:V37/opeE/JbLUOfH0QTXiNez2l0RUjYUhpT4szFQAfc=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=

--- a/providers/v1/barbican/go.sum
+++ b/providers/v1/barbican/go.sum
@@ -117,8 +117,8 @@ github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/tidwall/gjson v1.19.0 h1:xwxm7n691Uf3u5OFjzngavjGTh55KX5q/9w9xHW88JU=
-github.com/tidwall/gjson v1.19.0/go.mod h1:V37/opeE/JbLUOfH0QTXiNez2l0RUjYUhpT4szFQAfc=
+github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
+github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=


### PR DESCRIPTION
## Problem Statement

For the Barbican provider, `remoteRef.property` and `dataFrom` `extract` returned the raw JSON value bytes, so string values came back with their surrounding quotes. A payload of `{"token":"abc"}` with `remoteRef: { property: token }` yielded `"abc"` (5 bytes, quotes included) instead of `abc`, and `dataFrom: [{ extract: ... }]` produced a `token` key whose value was `"abc"` for the same reason.

## Related Issue

Fixes #6532

## Proposed Changes

- `GetSecret`: read the property with `gjson` (the same way the fake and gcp providers do) instead of unmarshalling into `map[string]json.RawMessage` and returning the raw bytes. String properties now come back unquoted; everything else comes back as its JSON text, except that gjson normalises non-integer numbers (`1.50` reads back as `1.5`). Dotted property names are matched as an escaped literal first and then as a nested path, mirroring the gcp provider so top-level keys containing dots stay reachable.
- `GetSecretMap` (the `dataFrom.extract` path): unmarshal into `map[string]json.RawMessage` and unquote only the values that are JSON strings, the same shape gcp's `GetSecretMap` uses. Numbers, booleans and nested objects keep their original bytes, so large integers come through exact. A JSON `null` decodes to an empty value, matching what gcp does.
- `go.mod` / `go.sum`: `gjson` pinned to v1.18.0, matching the root module and the other providers.
- Tests: added `TestGetSecret` and `TestGetSecretMap` (string, number, object, nested-path and dotted-literal cases, plus an 18-digit integer on both paths) and corrected the existing `TestGetSecretPayloadProperty` expectation that had encoded the old quoted output.

## AI Assistance disclosure

AI assistance used: No

## Checklist

- [x] I have read the contribution guidelines
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
- [x] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [ ] I have tested my changes on a live environment to confirm they are working
