### PR TITLE
feat(scaleway): Allow to push secrets in JSON format

### DIFF
--- a/docs/provider/scaleway.md
+++ b/docs/provider/scaleway.md
@@ -97,7 +97,8 @@ With `property` set, the pushed value is merged into the remote secret's JSON ob
 property is created or updated, other properties are preserved. Keys containing dots (e.g. `tls.crt`)
 are stored as literal top-level keys, unless the remote JSON already contains a matching nested
 structure (e.g. `{"tls":{"crt":...}}`), in which case the nested value is updated in place.
-If the remote value is not a JSON object, it is replaced by one.
+If the existing remote value is not a JSON object, the push fails: the provider refuses to
+overwrite a value it did not write. Delete or migrate the remote secret first.
 With `deletionPolicy: Delete`, deleting a pushed property removes only that key (as a new version);
 the remote secret itself is deleted when the last property is removed.
 
@@ -140,5 +141,8 @@ applied by the controller before the push.
 ```
 
 Note: Scaleway limits a secret's payload to 64KiB; the JSON object holding all pushed
-properties (or the whole serialized Secret) must stay under that limit.
+properties (or the whole serialized Secret) must stay under that limit. Values pushed with
+`property` (or via a whole-secret push) must be valid UTF-8 — binary values cannot be stored
+inside a JSON object and are rejected; push them as a single raw secret (a `data` entry
+without `property`) instead.
 

--- a/docs/provider/scaleway.md
+++ b/docs/provider/scaleway.md
@@ -30,7 +30,7 @@ spec:
 
 Secrets can be referenced by name, id or path, using the prefixes `"name:"`, `"id:"` and `"path:"` respectively.
 
-A PushSecret resource can only use a name reference.
+A PushSecret resource can use name or path references.
 
 ```yaml
 apiVersion: external-secrets.io/v1
@@ -87,4 +87,58 @@ spec:
       key: id:<SECRET_UUID>
       property: last # Anderson
 ```
+
+## PushSecret
+
+The provider supports `PushSecret` with name (`name:<NAME>`) and path (`path:/<PATH>/<NAME>`) references.
+Secret versions are immutable in Scaleway: every update creates a new version and disables the previous one.
+
+With `property` set, the pushed value is merged into the remote secret's JSON object — only that
+property is created or updated, other properties are preserved. Keys containing dots (e.g. `tls.crt`)
+are stored as literal top-level keys, unless the remote JSON already contains a matching nested
+structure (e.g. `{"tls":{"crt":...}}`), in which case the nested value is updated in place.
+If the remote value is not a JSON object, it is replaced by one.
+With `deletionPolicy: Delete`, deleting a pushed property removes only that key (as a new version);
+the remote secret itself is deleted when the last property is removed.
+
+```yaml
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: push-tls
+spec:
+  refreshInterval: 1h
+  secretStoreRefs:
+    - kind: SecretStore
+      name: secret-store
+  selector:
+    secret:
+      name: my-tls-secret
+  data:
+    - match:
+        secretKey: tls.crt
+        remoteRef:
+          remoteKey: "path:/certificates/my-cert"
+          property: tls.crt
+    - match:
+        secretKey: tls.key
+        remoteRef:
+          remoteKey: "path:/certificates/my-cert"
+          property: tls.key
+```
+
+Without `secretKey` (or with `spec.dataTo`), the whole Kubernetes Secret is serialized as a JSON
+object of its keys and pushed as the remote secret's value. `dataTo` filtering (`match.regexp`) is
+applied by the controller before the push.
+
+```yaml
+  dataTo:
+    - remoteKey: "path:/certificates/my-cert-bundle"
+      storeRef:
+        kind: SecretStore
+        name: secret-store
+```
+
+Note: Scaleway limits a secret's payload to 64KiB; the JSON object holding all pushed
+properties (or the whole serialized Secret) must stay under that limit.
 

--- a/docs/provider/scaleway.md
+++ b/docs/provider/scaleway.md
@@ -30,6 +30,9 @@ spec:
 
 Secrets can be referenced by name, id or path, using the prefixes `"name:"`, `"id:"` and `"path:"` respectively.
 
+Secret names are only unique within a path, so a `name:<NAME>` reference addresses the secret at the
+root path (`/`). A secret stored under a sub-path must be referenced with `path:/<PATH>/<NAME>` or `id:<SECRET_UUID>`.
+
 A PushSecret resource can use name or path references.
 
 ```yaml

--- a/providers/v1/scaleway/client.go
+++ b/providers/v1/scaleway/client.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	smapi "github.com/scaleway/scaleway-sdk-go/api/secret/v1beta1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -120,6 +121,9 @@ func pushPayload(secret *corev1.Secret, data esv1.PushSecretData) ([]byte, error
 
 	values := make(map[string]string, len(secret.Data))
 	for k, v := range secret.Data {
+		if !utf8.Valid(v) {
+			return nil, fmt.Errorf("value of key %q is not valid UTF-8: binary values cannot be serialized into the JSON object of a whole-secret push", k)
+		}
 		values[k] = string(v)
 	}
 	payload, err := json.Marshal(values)
@@ -133,6 +137,12 @@ func (c *client) PushSecret(ctx context.Context, secret *corev1.Secret, data esv
 	value, err := pushPayload(secret, data)
 	if err != nil {
 		return err
+	}
+
+	// Fail before any remote mutation: a JSON string cannot carry arbitrary
+	// bytes, so a binary value cannot become a JSON property.
+	if property := data.GetProperty(); property != "" && !utf8.Valid(value) {
+		return fmt.Errorf("value for property %q is not valid UTF-8: binary values cannot be stored as a JSON property, push them without property instead", property)
 	}
 
 	scwRef, err := decodeScwSecretRef(data.GetRemoteKey())
@@ -641,11 +651,14 @@ func jsonPropertyPath(doc, property string) string {
 }
 
 // setJSONProperty returns doc with property set to value as a JSON string.
-// A non-object doc (including none at all) is replaced by a fresh object:
-// PushSecret owns the remote value under updatePolicy Replace semantics.
+// An existing value that is not a JSON object is refused: the provider cannot
+// know whether it may overwrite a value it did not write.
 func setJSONProperty(existing []byte, property string, value []byte) ([]byte, error) {
 	doc := "{}"
-	if gjson.ValidBytes(existing) && gjson.ParseBytes(existing).IsObject() {
+	if len(existing) > 0 {
+		if !gjson.ValidBytes(existing) || !gjson.ParseBytes(existing).IsObject() {
+			return nil, fmt.Errorf("remote secret value is not a JSON object; refusing to overwrite it with property %q", property)
+		}
 		doc = string(existing)
 	}
 	merged, err := sjson.Set(doc, jsonPropertyPath(doc, property), string(value))

--- a/providers/v1/scaleway/client.go
+++ b/providers/v1/scaleway/client.go
@@ -29,6 +29,7 @@ import (
 	smapi "github.com/scaleway/scaleway-sdk-go/api/secret/v1beta1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 	corev1 "k8s.io/api/core/v1"
 
 	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
@@ -204,6 +205,13 @@ func (c *client) PushSecret(ctx context.Context, secret *corev1.Secret, data esv
 		}
 
 		secretID = secret.ID
+	}
+
+	if property := data.GetProperty(); property != "" {
+		value, err = setJSONProperty(existingValue, property, value)
+		if err != nil {
+			return err
+		}
 	}
 
 	if existingValue != nil && bytes.Equal(existingValue, value) {
@@ -490,14 +498,34 @@ func jsonToSecretData(value json.RawMessage) []byte {
 	return []byte(strings.TrimSpace(string(value)))
 }
 
-func extractJSONProperty(secretData []byte, property string) ([]byte, error) {
-	result := gjson.Get(string(secretData), property)
-
-	if !result.Exists() && strings.Contains(property, ".") {
-		// fall back to a literal dotted key (e.g. "tls.crt"), the shape
-		// produced when pushing a property containing dots
-		result = gjson.Get(string(secretData), strings.ReplaceAll(property, ".", "\\."))
+// jsonPropertyPath returns the gjson/sjson path to use for property on doc:
+// the property itself when it has no dot or already resolves as a nested
+// path, the dot-escaped literal key otherwise. Literal keys are how pushed
+// Kubernetes keys like "tls.crt" are stored.
+func jsonPropertyPath(doc, property string) string {
+	if !strings.Contains(property, ".") || gjson.Get(doc, property).Exists() {
+		return property
 	}
+	return strings.ReplaceAll(property, ".", "\\.")
+}
+
+// setJSONProperty returns doc with property set to value as a JSON string.
+// A non-object doc (including none at all) is replaced by a fresh object:
+// PushSecret owns the remote value under updatePolicy Replace semantics.
+func setJSONProperty(existing []byte, property string, value []byte) ([]byte, error) {
+	doc := "{}"
+	if gjson.ValidBytes(existing) && gjson.ParseBytes(existing).IsObject() {
+		doc = string(existing)
+	}
+	merged, err := sjson.Set(doc, jsonPropertyPath(doc, property), string(value))
+	if err != nil {
+		return nil, fmt.Errorf("failed to set property %q: %w", property, err)
+	}
+	return []byte(merged), nil
+}
+
+func extractJSONProperty(secretData []byte, property string) ([]byte, error) {
+	result := gjson.Get(string(secretData), jsonPropertyPath(string(secretData), property))
 
 	if !result.Exists() {
 		return nil, esv1.NoSecretError{}

--- a/providers/v1/scaleway/client.go
+++ b/providers/v1/scaleway/client.go
@@ -347,26 +347,34 @@ func (c *client) SecretExists(ctx context.Context, remoteRef esv1.PushSecretRemo
 		return false, err
 	}
 
-	listSecretReq := &smapi.ListSecretsRequest{
-		ProjectID: &c.projectID,
-		Page:      scw.Int32Ptr(1),
-		PageSize:  scw.Uint32Ptr(1),
-	}
-
 	var secretID string
+	var listSecretReq *smapi.ListSecretsRequest
 
 	switch scwRef.RefType {
 	case refTypeID:
+		if scwRef.Value == "" {
+			return false, errors.New("empty id in secret reference")
+		}
 		secretID = scwRef.Value
 	case refTypeName:
-		listSecretReq.Name = &scwRef.Value
+		listSecretReq = &smapi.ListSecretsRequest{
+			ProjectID: &c.projectID,
+			Page:      scw.Int32Ptr(1),
+			PageSize:  scw.Uint32Ptr(1),
+			Name:      &scwRef.Value,
+		}
 	case refTypePath:
 		name, path, ok := splitNameAndPath(scwRef.Value)
 		if !ok {
 			return false, errors.New("ref is not a path")
 		}
-		listSecretReq.Name = &name
-		listSecretReq.Path = &path
+		listSecretReq = &smapi.ListSecretsRequest{
+			ProjectID: &c.projectID,
+			Page:      scw.Int32Ptr(1),
+			PageSize:  scw.Uint32Ptr(1),
+			Name:      &name,
+			Path:      &path,
+		}
 	default:
 		return false, errors.New("secrets can only be referenced by id, name or path")
 	}

--- a/providers/v1/scaleway/client.go
+++ b/providers/v1/scaleway/client.go
@@ -225,7 +225,7 @@ func (c *client) PushSecret(ctx context.Context, secret *corev1.Secret, data esv
 	createSecretVersionResponse, err := c.api.CreateSecretVersion(&smapi.CreateSecretVersionRequest{
 		SecretID:        secretID,
 		Data:            value,
-		DisablePrevious: scw.BoolPtr(true),
+		DisablePrevious: new(true),
 	}, scw.WithContext(ctx))
 	if err != nil {
 		return err
@@ -330,7 +330,7 @@ func (c *client) deleteSecretProperty(ctx context.Context, secretID, property st
 	createSecretVersionResponse, err := c.api.CreateSecretVersion(&smapi.CreateSecretVersionRequest{
 		SecretID:        secretID,
 		Data:            []byte(updated),
-		DisablePrevious: scw.BoolPtr(true),
+		DisablePrevious: new(true),
 	}, scw.WithContext(ctx))
 	if err != nil {
 		return err

--- a/providers/v1/scaleway/client.go
+++ b/providers/v1/scaleway/client.go
@@ -483,6 +483,12 @@ func jsonToSecretData(value json.RawMessage) []byte {
 func extractJSONProperty(secretData []byte, property string) ([]byte, error) {
 	result := gjson.Get(string(secretData), property)
 
+	if !result.Exists() && strings.Contains(property, ".") {
+		// fall back to a literal dotted key (e.g. "tls.crt"), the shape
+		// produced when pushing a property containing dots
+		result = gjson.Get(string(secretData), strings.ReplaceAll(property, ".", "\\."))
+	}
+
 	if !result.Exists() {
 		return nil, esv1.NoSecretError{}
 	}

--- a/providers/v1/scaleway/client.go
+++ b/providers/v1/scaleway/client.go
@@ -272,6 +272,10 @@ func (c *client) DeleteSecret(ctx context.Context, remoteRef esv1.PushSecretRemo
 		return nil
 	}
 
+	if property := remoteRef.GetProperty(); property != "" {
+		return c.deleteSecretProperty(ctx, listSecrets.Secrets[0].ID, property)
+	}
+
 	request := smapi.DeleteSecretRequest{
 		SecretID: listSecrets.Secrets[0].ID,
 	}
@@ -280,6 +284,59 @@ func (c *client) DeleteSecret(ctx context.Context, remoteRef esv1.PushSecretRemo
 	if err != nil {
 		return err
 	}
+
+	return nil
+}
+
+// deleteSecretProperty removes property from the secret's JSON object value.
+// Versions are immutable, so the removal is a new version (previous one
+// disabled); the whole secret is deleted once the last property is removed.
+// A missing version, a non-object value, or an absent property is a no-op.
+func (c *client) deleteSecretProperty(ctx context.Context, secretID, property string) error {
+	secretVersion, err := c.api.GetSecretVersion(&smapi.GetSecretVersionRequest{
+		SecretID: secretID,
+		Revision: "latest",
+	}, scw.WithContext(ctx))
+	if err != nil {
+		var errNotFound *scw.ResourceNotFoundError
+		if errors.As(err, &errNotFound) {
+			return nil
+		}
+		return err
+	}
+
+	existing, err := c.accessSpecificSecretVersion(ctx, secretID, secretVersion.Revision)
+	if err != nil {
+		return err
+	}
+
+	doc := string(existing)
+	if !gjson.Valid(doc) || !gjson.Parse(doc).IsObject() {
+		return nil
+	}
+	path := jsonPropertyPath(doc, property)
+	if !gjson.Get(doc, path).Exists() {
+		return nil
+	}
+	updated, err := sjson.Delete(doc, path)
+	if err != nil {
+		return fmt.Errorf("failed to delete property %q: %w", property, err)
+	}
+
+	if len(gjson.Parse(updated).Map()) == 0 {
+		return c.api.DeleteSecret(&smapi.DeleteSecretRequest{SecretID: secretID}, scw.WithContext(ctx))
+	}
+
+	createSecretVersionResponse, err := c.api.CreateSecretVersion(&smapi.CreateSecretVersionRequest{
+		SecretID:        secretID,
+		Data:            []byte(updated),
+		DisablePrevious: scw.BoolPtr(true),
+	}, scw.WithContext(ctx))
+	if err != nil {
+		return err
+	}
+
+	c.cache.Put(secretID, createSecretVersionResponse.Revision, []byte(updated))
 
 	return nil
 }

--- a/providers/v1/scaleway/client.go
+++ b/providers/v1/scaleway/client.go
@@ -341,8 +341,74 @@ func (c *client) deleteSecretProperty(ctx context.Context, secretID, property st
 	return nil
 }
 
-func (c *client) SecretExists(_ context.Context, _ esv1.PushSecretRemoteRef) (bool, error) {
-	return false, errors.New("not implemented")
+func (c *client) SecretExists(ctx context.Context, remoteRef esv1.PushSecretRemoteRef) (bool, error) {
+	scwRef, err := decodeScwSecretRef(remoteRef.GetRemoteKey())
+	if err != nil {
+		return false, err
+	}
+
+	listSecretReq := &smapi.ListSecretsRequest{
+		ProjectID: &c.projectID,
+		Page:      scw.Int32Ptr(1),
+		PageSize:  scw.Uint32Ptr(1),
+	}
+
+	var secretID string
+
+	switch scwRef.RefType {
+	case refTypeID:
+		secretID = scwRef.Value
+	case refTypeName:
+		listSecretReq.Name = &scwRef.Value
+	case refTypePath:
+		name, path, ok := splitNameAndPath(scwRef.Value)
+		if !ok {
+			return false, errors.New("ref is not a path")
+		}
+		listSecretReq.Name = &name
+		listSecretReq.Path = &path
+	default:
+		return false, errors.New("secrets can only be referenced by id, name or path")
+	}
+
+	if secretID == "" {
+		listSecrets, err := c.api.ListSecrets(listSecretReq, scw.WithContext(ctx))
+		if err != nil {
+			return false, err
+		}
+		if len(listSecrets.Secrets) == 0 {
+			return false, nil
+		}
+		secretID = listSecrets.Secrets[0].ID
+	}
+
+	secretVersion, err := c.api.GetSecretVersion(&smapi.GetSecretVersionRequest{
+		SecretID: secretID,
+		Revision: "latest",
+	}, scw.WithContext(ctx))
+	if err != nil {
+		var errNotFound *scw.ResourceNotFoundError
+		if errors.As(err, &errNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	property := remoteRef.GetProperty()
+	if property == "" {
+		return true, nil
+	}
+
+	data, err := c.accessSpecificSecretVersion(ctx, secretID, secretVersion.Revision)
+	if err != nil {
+		return false, err
+	}
+
+	doc := string(data)
+	if !gjson.Valid(doc) || !gjson.Parse(doc).IsObject() {
+		return false, nil
+	}
+	return gjson.Get(doc, jsonPropertyPath(doc, property)).Exists(), nil
 }
 
 func (c *client) Validate() (esv1.ValidationResult, error) {

--- a/providers/v1/scaleway/client.go
+++ b/providers/v1/scaleway/client.go
@@ -133,6 +133,51 @@ func pushPayload(secret *corev1.Secret, data esv1.PushSecretData) ([]byte, error
 	return payload, nil
 }
 
+// listSecretsRequest returns a single-result ListSecrets filter for a name: or
+// path: reference. Other reference types cannot address a secret for writing.
+func (c *client) listSecretsRequest(scwRef *scwSecretRef) (*smapi.ListSecretsRequest, error) {
+	request := &smapi.ListSecretsRequest{
+		ProjectID: &c.projectID,
+		Page:      scw.Int32Ptr(1),
+		PageSize:  scw.Uint32Ptr(1),
+	}
+
+	switch scwRef.RefType {
+	case refTypeName:
+		request.Name = &scwRef.Value
+	case refTypePath:
+		name, path, ok := splitNameAndPath(scwRef.Value)
+		if !ok {
+			return nil, errors.New("ref is not a path")
+		}
+		request.Name = &name
+		request.Path = &path
+	default:
+		return nil, errors.New("secrets can only be referenced by name or path")
+	}
+
+	return request, nil
+}
+
+// findSecret resolves a name: or path: reference to the secret's ID.
+// found is false when no secret matches the reference.
+func (c *client) findSecret(ctx context.Context, scwRef *scwSecretRef) (id string, found bool, err error) {
+	request, err := c.listSecretsRequest(scwRef)
+	if err != nil {
+		return "", false, err
+	}
+
+	response, err := c.api.ListSecrets(request, scw.WithContext(ctx))
+	if err != nil {
+		return "", false, err
+	}
+	if len(response.Secrets) == 0 {
+		return "", false, nil
+	}
+
+	return response.Secrets[0].ID, true, nil
+}
+
 func (c *client) PushSecret(ctx context.Context, secret *corev1.Secret, data esv1.PushSecretData) error {
 	value, err := pushPayload(secret, data)
 	if err != nil {
@@ -150,44 +195,14 @@ func (c *client) PushSecret(ctx context.Context, secret *corev1.Secret, data esv
 		return err
 	}
 
-	listSecretReq := &smapi.ListSecretsRequest{
-		ProjectID: &c.projectID,
-		Page:      scw.Int32Ptr(1),
-		PageSize:  scw.Uint32Ptr(1),
-	}
-	var secretName string
-	secretPath := "/"
-
-	switch scwRef.RefType {
-	case refTypeName:
-		listSecretReq.Name = &scwRef.Value
-		secretName = scwRef.Value
-	case refTypePath:
-		name, path, ok := splitNameAndPath(scwRef.Value)
-		if !ok {
-			return errors.New("ref is not a path")
-		}
-		listSecretReq.Name = &name
-		listSecretReq.Path = &path
-		secretName = name
-		secretPath = path
-	default:
-		return errors.New("secrets can only be pushed by name or path")
-	}
-
-	var secretID string
 	var existingValue []byte
 
-	// list secret by ref
-	listSecrets, err := c.api.ListSecrets(listSecretReq, scw.WithContext(ctx))
+	secretID, found, err := c.findSecret(ctx, scwRef)
 	if err != nil {
 		return err
 	}
 
-	// secret exists
-	if len(listSecrets.Secrets) > 0 {
-		secretID = listSecrets.Secrets[0].ID
-
+	if found {
 		// get the latest version
 		secretVersion, err := c.api.GetSecretVersion(&smapi.GetSecretVersionRequest{
 			SecretID: secretID,
@@ -205,6 +220,13 @@ func (c *client) PushSecret(ctx context.Context, secret *corev1.Secret, data esv
 			}
 		}
 	} else {
+		secretName := scwRef.Value
+		secretPath := "/"
+		if scwRef.RefType == refTypePath {
+			// already validated by findSecret
+			secretName, secretPath, _ = splitNameAndPath(scwRef.Value)
+		}
+
 		secret, err := c.api.CreateSecret(&smapi.CreateSecretRequest{
 			ProjectID: c.projectID,
 			Name:      secretName,
@@ -252,42 +274,20 @@ func (c *client) DeleteSecret(ctx context.Context, remoteRef esv1.PushSecretRemo
 		return err
 	}
 
-	listSecretReq := &smapi.ListSecretsRequest{
-		ProjectID: &c.projectID,
-		Page:      scw.Int32Ptr(1),
-		PageSize:  scw.Uint32Ptr(1),
-	}
-
-	switch scwRef.RefType {
-	case refTypeName:
-		listSecretReq.Name = &scwRef.Value
-	case refTypePath:
-		name, path, ok := splitNameAndPath(scwRef.Value)
-		if !ok {
-			return errors.New("ref is not a path")
-		}
-		listSecretReq.Name = &name
-		listSecretReq.Path = &path
-
-	default:
-		return errors.New("secrets can only be deleted by name or path")
-	}
-
-	listSecrets, err := c.api.ListSecrets(listSecretReq, scw.WithContext(ctx))
+	secretID, found, err := c.findSecret(ctx, scwRef)
 	if err != nil {
 		return err
 	}
-
-	if len(listSecrets.Secrets) == 0 {
+	if !found {
 		return nil
 	}
 
 	if property := remoteRef.GetProperty(); property != "" {
-		return c.deleteSecretProperty(ctx, listSecrets.Secrets[0].ID, property)
+		return c.deleteSecretProperty(ctx, secretID, property)
 	}
 
 	request := smapi.DeleteSecretRequest{
-		SecretID: listSecrets.Secrets[0].ID,
+		SecretID: secretID,
 	}
 
 	err = c.api.DeleteSecret(&request, scw.WithContext(ctx))
@@ -358,48 +358,28 @@ func (c *client) SecretExists(ctx context.Context, remoteRef esv1.PushSecretRemo
 	}
 
 	var secretID string
-	var listSecretReq *smapi.ListSecretsRequest
-
-	switch scwRef.RefType {
-	case refTypeID:
+	if scwRef.RefType == refTypeID {
 		if scwRef.Value == "" {
 			return false, errors.New("empty id in secret reference")
 		}
 		secretID = scwRef.Value
-	case refTypeName:
-		listSecretReq = &smapi.ListSecretsRequest{
-			ProjectID: &c.projectID,
-			Page:      scw.Int32Ptr(1),
-			PageSize:  scw.Uint32Ptr(1),
-			Name:      &scwRef.Value,
-		}
-	case refTypePath:
-		name, path, ok := splitNameAndPath(scwRef.Value)
-		if !ok {
-			return false, errors.New("ref is not a path")
-		}
-		listSecretReq = &smapi.ListSecretsRequest{
-			ProjectID: &c.projectID,
-			Page:      scw.Int32Ptr(1),
-			PageSize:  scw.Uint32Ptr(1),
-			Name:      &name,
-			Path:      &path,
-		}
-	default:
-		return false, errors.New("secrets can only be referenced by id, name or path")
-	}
-
-	if secretID == "" {
-		listSecrets, err := c.api.ListSecrets(listSecretReq, scw.WithContext(ctx))
+	} else {
+		id, found, err := c.findSecret(ctx, scwRef)
 		if err != nil {
 			return false, err
 		}
-		if len(listSecrets.Secrets) == 0 {
+		if !found {
 			return false, nil
 		}
-		secretID = listSecrets.Secrets[0].ID
+		secretID = id
 	}
 
+	return c.secretVersionExists(ctx, secretID, remoteRef.GetProperty())
+}
+
+// secretVersionExists reports whether the secret has a latest version and,
+// when property is set, whether that property exists in its JSON value.
+func (c *client) secretVersionExists(ctx context.Context, secretID, property string) (bool, error) {
 	secretVersion, err := c.api.GetSecretVersion(&smapi.GetSecretVersionRequest{
 		SecretID: secretID,
 		Revision: "latest",
@@ -412,7 +392,6 @@ func (c *client) SecretExists(ctx context.Context, remoteRef esv1.PushSecretRemo
 		return false, err
 	}
 
-	property := remoteRef.GetProperty()
 	if property == "" {
 		return true, nil
 	}
@@ -556,14 +535,7 @@ func (c *client) accessSecretVersion(ctx context.Context, secretRef *scwSecretRe
 	}
 
 	// otherwise, we do a GetSecret() first to avoid transferring the secret value if it is cached
-	request := &smapi.ListSecretsRequest{
-		ProjectID: &c.projectID,
-		Page:      scw.Int32Ptr(1),
-		PageSize:  scw.Uint32Ptr(1),
-	}
-
-	switch secretRef.RefType {
-	case refTypeID:
+	if secretRef.RefType == refTypeID {
 		request := smapi.GetSecretVersionRequest{
 			SecretID: secretRef.Value,
 			Revision: versionSpec,
@@ -573,19 +545,11 @@ func (c *client) accessSecretVersion(ctx context.Context, secretRef *scwSecretRe
 			return nil, err
 		}
 		return c.accessSpecificSecretVersion(ctx, response.SecretID, response.Revision)
-	case refTypeName:
-		request.Name = &secretRef.Value
+	}
 
-	case refTypePath:
-		name, path, ok := splitNameAndPath(secretRef.Value)
-		if !ok {
-			return nil, errors.New("ref is not a path")
-		}
-
-		request.Name = &name
-		request.Path = &path
-	default:
-		return nil, fmt.Errorf("invalid secret reference: %q", secretRef.Value)
+	request, err := c.listSecretsRequest(secretRef)
+	if err != nil {
+		return nil, err
 	}
 
 	response, err := c.api.ListSecrets(request, scw.WithContext(ctx))

--- a/providers/v1/scaleway/client.go
+++ b/providers/v1/scaleway/client.go
@@ -104,12 +104,36 @@ func (c *client) GetSecret(ctx context.Context, ref esv1.ExternalSecretDataRemot
 	return value, nil
 }
 
-func (c *client) PushSecret(ctx context.Context, secret *corev1.Secret, data esv1.PushSecretData) error {
-	if data.GetSecretKey() == "" {
-		return errors.New("pushing the whole secret is not yet implemented")
+// pushPayload resolves the bytes to push: the selected key's value when
+// secretKey is set, otherwise the whole secret serialized as a JSON object of
+// its string values (dataTo / whole-secret push). The PushSecret controller
+// has already filtered and rewritten secret.Data for dataTo entries.
+func pushPayload(secret *corev1.Secret, data esv1.PushSecretData) ([]byte, error) {
+	if key := data.GetSecretKey(); key != "" {
+		value, ok := secret.Data[key]
+		if !ok {
+			return nil, fmt.Errorf("secret key %q not found in the source secret", key)
+		}
+		return value, nil
 	}
 
-	value := secret.Data[data.GetSecretKey()]
+	values := make(map[string]string, len(secret.Data))
+	for k, v := range secret.Data {
+		values[k] = string(v)
+	}
+	payload, err := json.Marshal(values)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal secret data: %w", err)
+	}
+	return payload, nil
+}
+
+func (c *client) PushSecret(ctx context.Context, secret *corev1.Secret, data esv1.PushSecretData) error {
+	value, err := pushPayload(secret, data)
+	if err != nil {
+		return err
+	}
+
 	scwRef, err := decodeScwSecretRef(data.GetRemoteKey())
 	if err != nil {
 		return err
@@ -141,7 +165,7 @@ func (c *client) PushSecret(ctx context.Context, secret *corev1.Secret, data esv
 	}
 
 	var secretID string
-	existingSecretVersion := int64(-1)
+	var existingValue []byte
 
 	// list secret by ref
 	listSecrets, err := c.api.ListSecrets(listSecretReq, scw.WithContext(ctx))
@@ -159,23 +183,14 @@ func (c *client) PushSecret(ctx context.Context, secret *corev1.Secret, data esv
 			Revision: "latest",
 		}, scw.WithContext(ctx))
 		if err != nil {
-			var errNotNound *scw.ResourceNotFoundError
-			if !errors.As(err, &errNotNound) {
+			var errNotFound *scw.ResourceNotFoundError
+			if !errors.As(err, &errNotFound) {
 				return err
 			}
 		} else {
-			existingSecretVersion = int64(secretVersion.Revision)
-		}
-
-		if existingSecretVersion != -1 {
-			data, err := c.accessSpecificSecretVersion(ctx, secretID, secretVersion.Revision)
+			existingValue, err = c.accessSpecificSecretVersion(ctx, secretID, secretVersion.Revision)
 			if err != nil {
 				return err
-			}
-
-			if bytes.Equal(data, value) {
-				// No change to push.
-				return nil
 			}
 		}
 	} else {
@@ -191,29 +206,24 @@ func (c *client) PushSecret(ctx context.Context, secret *corev1.Secret, data esv
 		secretID = secret.ID
 	}
 
-	// Finally, we push the new secret version.
-
-	createSecretVersionRequest := smapi.CreateSecretVersionRequest{
-		SecretID: secretID,
-		Data:     value,
+	if existingValue != nil && bytes.Equal(existingValue, value) {
+		// No change to push.
+		return nil
 	}
 
-	createSecretVersionResponse, err := c.api.CreateSecretVersion(&createSecretVersionRequest, scw.WithContext(ctx))
+	// Finally, we push the new secret version. DisablePrevious atomically
+	// disables the previous version in the same call (a no-op if there is
+	// none or it is already disabled).
+	createSecretVersionResponse, err := c.api.CreateSecretVersion(&smapi.CreateSecretVersionRequest{
+		SecretID:        secretID,
+		Data:            value,
+		DisablePrevious: scw.BoolPtr(true),
+	}, scw.WithContext(ctx))
 	if err != nil {
 		return err
 	}
 
 	c.cache.Put(secretID, createSecretVersionResponse.Revision, value)
-
-	if existingSecretVersion != -1 {
-		_, err := c.api.DisableSecretVersion(&smapi.DisableSecretVersionRequest{
-			SecretID: secretID,
-			Revision: fmt.Sprintf("%d", existingSecretVersion),
-		})
-		if err != nil {
-			return err
-		}
-	}
 
 	return nil
 }

--- a/providers/v1/scaleway/client.go
+++ b/providers/v1/scaleway/client.go
@@ -133,6 +133,51 @@ func pushPayload(secret *corev1.Secret, data esv1.PushSecretData) ([]byte, error
 	return payload, nil
 }
 
+// listSecretsRequest returns a single-result ListSecrets filter for a name: or
+// path: reference. Other reference types cannot address a secret for writing.
+func (c *client) listSecretsRequest(scwRef *scwSecretRef) (*smapi.ListSecretsRequest, error) {
+	request := &smapi.ListSecretsRequest{
+		ProjectID: &c.projectID,
+		Page:      scw.Int32Ptr(1),
+		PageSize:  scw.Uint32Ptr(1),
+	}
+
+	switch scwRef.RefType {
+	case refTypeName:
+		request.Name = &scwRef.Value
+	case refTypePath:
+		name, path, ok := splitNameAndPath(scwRef.Value)
+		if !ok {
+			return nil, errors.New("ref is not a path")
+		}
+		request.Name = &name
+		request.Path = &path
+	default:
+		return nil, errors.New("secrets can only be referenced by name or path")
+	}
+
+	return request, nil
+}
+
+// findSecret resolves a name: or path: reference to the secret's ID.
+// found is false when no secret matches the reference.
+func (c *client) findSecret(ctx context.Context, scwRef *scwSecretRef) (id string, found bool, err error) {
+	request, err := c.listSecretsRequest(scwRef)
+	if err != nil {
+		return "", false, err
+	}
+
+	response, err := c.api.ListSecrets(request, scw.WithContext(ctx))
+	if err != nil {
+		return "", false, err
+	}
+	if len(response.Secrets) == 0 {
+		return "", false, nil
+	}
+
+	return response.Secrets[0].ID, true, nil
+}
+
 func (c *client) PushSecret(ctx context.Context, secret *corev1.Secret, data esv1.PushSecretData) error {
 	value, err := pushPayload(secret, data)
 	if err != nil {
@@ -150,44 +195,14 @@ func (c *client) PushSecret(ctx context.Context, secret *corev1.Secret, data esv
 		return err
 	}
 
-	listSecretReq := &smapi.ListSecretsRequest{
-		ProjectID: &c.projectID,
-		Page:      scw.Int32Ptr(1),
-		PageSize:  scw.Uint32Ptr(1),
-	}
-	var secretName string
-	secretPath := "/"
-
-	switch scwRef.RefType {
-	case refTypeName:
-		listSecretReq.Name = &scwRef.Value
-		secretName = scwRef.Value
-	case refTypePath:
-		name, path, ok := splitNameAndPath(scwRef.Value)
-		if !ok {
-			return errors.New("ref is not a path")
-		}
-		listSecretReq.Name = &name
-		listSecretReq.Path = &path
-		secretName = name
-		secretPath = path
-	default:
-		return errors.New("secrets can only be pushed by name or path")
-	}
-
-	var secretID string
 	var existingValue []byte
 
-	// list secret by ref
-	listSecrets, err := c.api.ListSecrets(listSecretReq, scw.WithContext(ctx))
+	secretID, found, err := c.findSecret(ctx, scwRef)
 	if err != nil {
 		return err
 	}
 
-	// secret exists
-	if len(listSecrets.Secrets) > 0 {
-		secretID = listSecrets.Secrets[0].ID
-
+	if found {
 		// get the latest version
 		secretVersion, err := c.api.GetSecretVersion(&smapi.GetSecretVersionRequest{
 			SecretID: secretID,
@@ -204,6 +219,13 @@ func (c *client) PushSecret(ctx context.Context, secret *corev1.Secret, data esv
 			}
 		}
 	} else {
+		secretName := scwRef.Value
+		secretPath := "/"
+		if scwRef.RefType == refTypePath {
+			// already validated by findSecret
+			secretName, secretPath, _ = splitNameAndPath(scwRef.Value)
+		}
+
 		secret, err := c.api.CreateSecret(&smapi.CreateSecretRequest{
 			ProjectID: c.projectID,
 			Name:      secretName,
@@ -251,42 +273,20 @@ func (c *client) DeleteSecret(ctx context.Context, remoteRef esv1.PushSecretRemo
 		return err
 	}
 
-	listSecretReq := &smapi.ListSecretsRequest{
-		ProjectID: &c.projectID,
-		Page:      scw.Int32Ptr(1),
-		PageSize:  scw.Uint32Ptr(1),
-	}
-
-	switch scwRef.RefType {
-	case refTypeName:
-		listSecretReq.Name = &scwRef.Value
-	case refTypePath:
-		name, path, ok := splitNameAndPath(scwRef.Value)
-		if !ok {
-			return errors.New("ref is not a path")
-		}
-		listSecretReq.Name = &name
-		listSecretReq.Path = &path
-
-	default:
-		return errors.New("secrets can only be deleted by name or path")
-	}
-
-	listSecrets, err := c.api.ListSecrets(listSecretReq, scw.WithContext(ctx))
+	secretID, found, err := c.findSecret(ctx, scwRef)
 	if err != nil {
 		return err
 	}
-
-	if len(listSecrets.Secrets) == 0 {
+	if !found {
 		return nil
 	}
 
 	if property := remoteRef.GetProperty(); property != "" {
-		return c.deleteSecretProperty(ctx, listSecrets.Secrets[0].ID, property)
+		return c.deleteSecretProperty(ctx, secretID, property)
 	}
 
 	request := smapi.DeleteSecretRequest{
-		SecretID: listSecrets.Secrets[0].ID,
+		SecretID: secretID,
 	}
 
 	err = c.api.DeleteSecret(&request, scw.WithContext(ctx))
@@ -357,48 +357,28 @@ func (c *client) SecretExists(ctx context.Context, remoteRef esv1.PushSecretRemo
 	}
 
 	var secretID string
-	var listSecretReq *smapi.ListSecretsRequest
-
-	switch scwRef.RefType {
-	case refTypeID:
+	if scwRef.RefType == refTypeID {
 		if scwRef.Value == "" {
 			return false, errors.New("empty id in secret reference")
 		}
 		secretID = scwRef.Value
-	case refTypeName:
-		listSecretReq = &smapi.ListSecretsRequest{
-			ProjectID: &c.projectID,
-			Page:      scw.Int32Ptr(1),
-			PageSize:  scw.Uint32Ptr(1),
-			Name:      &scwRef.Value,
-		}
-	case refTypePath:
-		name, path, ok := splitNameAndPath(scwRef.Value)
-		if !ok {
-			return false, errors.New("ref is not a path")
-		}
-		listSecretReq = &smapi.ListSecretsRequest{
-			ProjectID: &c.projectID,
-			Page:      scw.Int32Ptr(1),
-			PageSize:  scw.Uint32Ptr(1),
-			Name:      &name,
-			Path:      &path,
-		}
-	default:
-		return false, errors.New("secrets can only be referenced by id, name or path")
-	}
-
-	if secretID == "" {
-		listSecrets, err := c.api.ListSecrets(listSecretReq, scw.WithContext(ctx))
+	} else {
+		id, found, err := c.findSecret(ctx, scwRef)
 		if err != nil {
 			return false, err
 		}
-		if len(listSecrets.Secrets) == 0 {
+		if !found {
 			return false, nil
 		}
-		secretID = listSecrets.Secrets[0].ID
+		secretID = id
 	}
 
+	return c.secretVersionExists(ctx, secretID, remoteRef.GetProperty())
+}
+
+// secretVersionExists reports whether the secret has a latest version and,
+// when property is set, whether that property exists in its JSON value.
+func (c *client) secretVersionExists(ctx context.Context, secretID, property string) (bool, error) {
 	secretVersion, err := c.api.GetSecretVersion(&smapi.GetSecretVersionRequest{
 		SecretID: secretID,
 		Revision: "latest",
@@ -411,7 +391,6 @@ func (c *client) SecretExists(ctx context.Context, remoteRef esv1.PushSecretRemo
 		return false, err
 	}
 
-	property := remoteRef.GetProperty()
 	if property == "" {
 		return true, nil
 	}
@@ -555,14 +534,7 @@ func (c *client) accessSecretVersion(ctx context.Context, secretRef *scwSecretRe
 	}
 
 	// otherwise, we do a GetSecret() first to avoid transferring the secret value if it is cached
-	request := &smapi.ListSecretsRequest{
-		ProjectID: &c.projectID,
-		Page:      scw.Int32Ptr(1),
-		PageSize:  scw.Uint32Ptr(1),
-	}
-
-	switch secretRef.RefType {
-	case refTypeID:
+	if secretRef.RefType == refTypeID {
 		request := smapi.GetSecretVersionRequest{
 			SecretID: secretRef.Value,
 			Revision: versionSpec,
@@ -572,19 +544,11 @@ func (c *client) accessSecretVersion(ctx context.Context, secretRef *scwSecretRe
 			return nil, err
 		}
 		return c.accessSpecificSecretVersion(ctx, response.SecretID, response.Revision)
-	case refTypeName:
-		request.Name = &secretRef.Value
+	}
 
-	case refTypePath:
-		name, path, ok := splitNameAndPath(secretRef.Value)
-		if !ok {
-			return nil, errors.New("ref is not a path")
-		}
-
-		request.Name = &name
-		request.Path = &path
-	default:
-		return nil, fmt.Errorf("invalid secret reference: %q", secretRef.Value)
+	request, err := c.listSecretsRequest(secretRef)
+	if err != nil {
+		return nil, err
 	}
 
 	response, err := c.api.ListSecrets(request, scw.WithContext(ctx))

--- a/providers/v1/scaleway/client.go
+++ b/providers/v1/scaleway/client.go
@@ -482,6 +482,12 @@ func jsonToSecretData(value json.RawMessage) []byte {
 func extractJSONProperty(secretData []byte, property string) ([]byte, error) {
 	result := gjson.Get(string(secretData), property)
 
+	if !result.Exists() && strings.Contains(property, ".") {
+		// fall back to a literal dotted key (e.g. "tls.crt"), the shape
+		// produced when pushing a property containing dots
+		result = gjson.Get(string(secretData), strings.ReplaceAll(property, ".", "\\."))
+	}
+
 	if !result.Exists() {
 		return nil, esv1.NoSecretError{}
 	}

--- a/providers/v1/scaleway/client.go
+++ b/providers/v1/scaleway/client.go
@@ -271,6 +271,10 @@ func (c *client) DeleteSecret(ctx context.Context, remoteRef esv1.PushSecretRemo
 		return nil
 	}
 
+	if property := remoteRef.GetProperty(); property != "" {
+		return c.deleteSecretProperty(ctx, listSecrets.Secrets[0].ID, property)
+	}
+
 	request := smapi.DeleteSecretRequest{
 		SecretID: listSecrets.Secrets[0].ID,
 	}
@@ -279,6 +283,59 @@ func (c *client) DeleteSecret(ctx context.Context, remoteRef esv1.PushSecretRemo
 	if err != nil {
 		return err
 	}
+
+	return nil
+}
+
+// deleteSecretProperty removes property from the secret's JSON object value.
+// Versions are immutable, so the removal is a new version (previous one
+// disabled); the whole secret is deleted once the last property is removed.
+// A missing version, a non-object value, or an absent property is a no-op.
+func (c *client) deleteSecretProperty(ctx context.Context, secretID, property string) error {
+	secretVersion, err := c.api.GetSecretVersion(&smapi.GetSecretVersionRequest{
+		SecretID: secretID,
+		Revision: "latest",
+	}, scw.WithContext(ctx))
+	if err != nil {
+		var errNotFound *scw.ResourceNotFoundError
+		if errors.As(err, &errNotFound) {
+			return nil
+		}
+		return err
+	}
+
+	existing, err := c.accessSpecificSecretVersion(ctx, secretID, secretVersion.Revision)
+	if err != nil {
+		return err
+	}
+
+	doc := string(existing)
+	if !gjson.Valid(doc) || !gjson.Parse(doc).IsObject() {
+		return nil
+	}
+	path := jsonPropertyPath(doc, property)
+	if !gjson.Get(doc, path).Exists() {
+		return nil
+	}
+	updated, err := sjson.Delete(doc, path)
+	if err != nil {
+		return fmt.Errorf("failed to delete property %q: %w", property, err)
+	}
+
+	if len(gjson.Parse(updated).Map()) == 0 {
+		return c.api.DeleteSecret(&smapi.DeleteSecretRequest{SecretID: secretID}, scw.WithContext(ctx))
+	}
+
+	createSecretVersionResponse, err := c.api.CreateSecretVersion(&smapi.CreateSecretVersionRequest{
+		SecretID:        secretID,
+		Data:            []byte(updated),
+		DisablePrevious: scw.BoolPtr(true),
+	}, scw.WithContext(ctx))
+	if err != nil {
+		return err
+	}
+
+	c.cache.Put(secretID, createSecretVersionResponse.Revision, []byte(updated))
 
 	return nil
 }

--- a/providers/v1/scaleway/client.go
+++ b/providers/v1/scaleway/client.go
@@ -34,6 +34,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
+	"github.com/external-secrets/external-secrets/runtime/esutils"
 	"github.com/external-secrets/external-secrets/runtime/find"
 )
 
@@ -126,7 +127,7 @@ func pushPayload(secret *corev1.Secret, data esv1.PushSecretData) ([]byte, error
 		}
 		values[k] = string(v)
 	}
-	payload, err := json.Marshal(values)
+	payload, err := esutils.JSONMarshal(values)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal secret data: %w", err)
 	}
@@ -627,7 +628,13 @@ func setJSONProperty(existing []byte, property string, value []byte) ([]byte, er
 		}
 		doc = string(existing)
 	}
-	merged, err := sjson.Set(doc, jsonPropertyPath(doc, property), string(value))
+	// sjson falls back to encoding/json (which escapes <, > and &) for strings
+	// with quotes or non-ASCII characters: encode the value ourselves.
+	encoded, err := esutils.JSONMarshal(string(value))
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal property %q: %w", property, err)
+	}
+	merged, err := sjson.SetRaw(doc, jsonPropertyPath(doc, property), string(encoded))
 	if err != nil {
 		return nil, fmt.Errorf("failed to set property %q: %w", property, err)
 	}

--- a/providers/v1/scaleway/client.go
+++ b/providers/v1/scaleway/client.go
@@ -311,8 +311,7 @@ func (c *client) deleteSecretProperty(ctx context.Context, secretID, property st
 		Revision: "latest",
 	}, scw.WithContext(ctx))
 	if err != nil {
-		var errNotFound *scw.ResourceNotFoundError
-		if errors.As(err, &errNotFound) {
+		if _, ok := errors.AsType[*scw.ResourceNotFoundError](err); ok {
 			return nil
 		}
 		return err
@@ -388,8 +387,7 @@ func (c *client) secretVersionExists(ctx context.Context, secretID, property str
 		Revision: "latest",
 	}, scw.WithContext(ctx))
 	if err != nil {
-		var errNotFound *scw.ResourceNotFoundError
-		if errors.As(err, &errNotFound) {
+		if _, ok := errors.AsType[*scw.ResourceNotFoundError](err); ok {
 			return false, nil
 		}
 		return false, err

--- a/providers/v1/scaleway/client.go
+++ b/providers/v1/scaleway/client.go
@@ -144,7 +144,10 @@ func (c *client) listSecretsRequest(scwRef *scwSecretRef) (*smapi.ListSecretsReq
 
 	switch scwRef.RefType {
 	case refTypeName:
+		// Secret names are only unique within a path: a name: reference
+		// addresses the secret at the root path, like the one PushSecret creates.
 		request.Name = &scwRef.Value
+		request.Path = new("/")
 	case refTypePath:
 		name, path, ok := splitNameAndPath(scwRef.Value)
 		if !ok {

--- a/providers/v1/scaleway/client.go
+++ b/providers/v1/scaleway/client.go
@@ -224,7 +224,7 @@ func (c *client) PushSecret(ctx context.Context, secret *corev1.Secret, data esv
 	createSecretVersionResponse, err := c.api.CreateSecretVersion(&smapi.CreateSecretVersionRequest{
 		SecretID:        secretID,
 		Data:            value,
-		DisablePrevious: scw.BoolPtr(true),
+		DisablePrevious: new(true),
 	}, scw.WithContext(ctx))
 	if err != nil {
 		return err
@@ -329,7 +329,7 @@ func (c *client) deleteSecretProperty(ctx context.Context, secretID, property st
 	createSecretVersionResponse, err := c.api.CreateSecretVersion(&smapi.CreateSecretVersionRequest{
 		SecretID:        secretID,
 		Data:            []byte(updated),
-		DisablePrevious: scw.BoolPtr(true),
+		DisablePrevious: new(true),
 	}, scw.WithContext(ctx))
 	if err != nil {
 		return err

--- a/providers/v1/scaleway/client.go
+++ b/providers/v1/scaleway/client.go
@@ -340,8 +340,74 @@ func (c *client) deleteSecretProperty(ctx context.Context, secretID, property st
 	return nil
 }
 
-func (c *client) SecretExists(_ context.Context, _ esv1.PushSecretRemoteRef) (bool, error) {
-	return false, errors.New("not implemented")
+func (c *client) SecretExists(ctx context.Context, remoteRef esv1.PushSecretRemoteRef) (bool, error) {
+	scwRef, err := decodeScwSecretRef(remoteRef.GetRemoteKey())
+	if err != nil {
+		return false, err
+	}
+
+	listSecretReq := &smapi.ListSecretsRequest{
+		ProjectID: &c.projectID,
+		Page:      scw.Int32Ptr(1),
+		PageSize:  scw.Uint32Ptr(1),
+	}
+
+	var secretID string
+
+	switch scwRef.RefType {
+	case refTypeID:
+		secretID = scwRef.Value
+	case refTypeName:
+		listSecretReq.Name = &scwRef.Value
+	case refTypePath:
+		name, path, ok := splitNameAndPath(scwRef.Value)
+		if !ok {
+			return false, errors.New("ref is not a path")
+		}
+		listSecretReq.Name = &name
+		listSecretReq.Path = &path
+	default:
+		return false, errors.New("secrets can only be referenced by id, name or path")
+	}
+
+	if secretID == "" {
+		listSecrets, err := c.api.ListSecrets(listSecretReq, scw.WithContext(ctx))
+		if err != nil {
+			return false, err
+		}
+		if len(listSecrets.Secrets) == 0 {
+			return false, nil
+		}
+		secretID = listSecrets.Secrets[0].ID
+	}
+
+	secretVersion, err := c.api.GetSecretVersion(&smapi.GetSecretVersionRequest{
+		SecretID: secretID,
+		Revision: "latest",
+	}, scw.WithContext(ctx))
+	if err != nil {
+		var errNotFound *scw.ResourceNotFoundError
+		if errors.As(err, &errNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	property := remoteRef.GetProperty()
+	if property == "" {
+		return true, nil
+	}
+
+	data, err := c.accessSpecificSecretVersion(ctx, secretID, secretVersion.Revision)
+	if err != nil {
+		return false, err
+	}
+
+	doc := string(data)
+	if !gjson.Valid(doc) || !gjson.Parse(doc).IsObject() {
+		return false, nil
+	}
+	return gjson.Get(doc, jsonPropertyPath(doc, property)).Exists(), nil
 }
 
 func (c *client) Validate() (esv1.ValidationResult, error) {

--- a/providers/v1/scaleway/client.go
+++ b/providers/v1/scaleway/client.go
@@ -346,26 +346,34 @@ func (c *client) SecretExists(ctx context.Context, remoteRef esv1.PushSecretRemo
 		return false, err
 	}
 
-	listSecretReq := &smapi.ListSecretsRequest{
-		ProjectID: &c.projectID,
-		Page:      scw.Int32Ptr(1),
-		PageSize:  scw.Uint32Ptr(1),
-	}
-
 	var secretID string
+	var listSecretReq *smapi.ListSecretsRequest
 
 	switch scwRef.RefType {
 	case refTypeID:
+		if scwRef.Value == "" {
+			return false, errors.New("empty id in secret reference")
+		}
 		secretID = scwRef.Value
 	case refTypeName:
-		listSecretReq.Name = &scwRef.Value
+		listSecretReq = &smapi.ListSecretsRequest{
+			ProjectID: &c.projectID,
+			Page:      scw.Int32Ptr(1),
+			PageSize:  scw.Uint32Ptr(1),
+			Name:      &scwRef.Value,
+		}
 	case refTypePath:
 		name, path, ok := splitNameAndPath(scwRef.Value)
 		if !ok {
 			return false, errors.New("ref is not a path")
 		}
-		listSecretReq.Name = &name
-		listSecretReq.Path = &path
+		listSecretReq = &smapi.ListSecretsRequest{
+			ProjectID: &c.projectID,
+			Page:      scw.Int32Ptr(1),
+			PageSize:  scw.Uint32Ptr(1),
+			Name:      &name,
+			Path:      &path,
+		}
 	default:
 		return false, errors.New("secrets can only be referenced by id, name or path")
 	}

--- a/providers/v1/scaleway/client.go
+++ b/providers/v1/scaleway/client.go
@@ -29,6 +29,7 @@ import (
 	smapi "github.com/scaleway/scaleway-sdk-go/api/secret/v1beta1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 	corev1 "k8s.io/api/core/v1"
 
 	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
@@ -203,6 +204,13 @@ func (c *client) PushSecret(ctx context.Context, secret *corev1.Secret, data esv
 		}
 
 		secretID = secret.ID
+	}
+
+	if property := data.GetProperty(); property != "" {
+		value, err = setJSONProperty(existingValue, property, value)
+		if err != nil {
+			return err
+		}
 	}
 
 	if existingValue != nil && bytes.Equal(existingValue, value) {
@@ -489,14 +497,34 @@ func jsonToSecretData(value json.RawMessage) []byte {
 	return []byte(strings.TrimSpace(string(value)))
 }
 
-func extractJSONProperty(secretData []byte, property string) ([]byte, error) {
-	result := gjson.Get(string(secretData), property)
-
-	if !result.Exists() && strings.Contains(property, ".") {
-		// fall back to a literal dotted key (e.g. "tls.crt"), the shape
-		// produced when pushing a property containing dots
-		result = gjson.Get(string(secretData), strings.ReplaceAll(property, ".", "\\."))
+// jsonPropertyPath returns the gjson/sjson path to use for property on doc:
+// the property itself when it has no dot or already resolves as a nested
+// path, the dot-escaped literal key otherwise. Literal keys are how pushed
+// Kubernetes keys like "tls.crt" are stored.
+func jsonPropertyPath(doc, property string) string {
+	if !strings.Contains(property, ".") || gjson.Get(doc, property).Exists() {
+		return property
 	}
+	return strings.ReplaceAll(property, ".", "\\.")
+}
+
+// setJSONProperty returns doc with property set to value as a JSON string.
+// A non-object doc (including none at all) is replaced by a fresh object:
+// PushSecret owns the remote value under updatePolicy Replace semantics.
+func setJSONProperty(existing []byte, property string, value []byte) ([]byte, error) {
+	doc := "{}"
+	if gjson.ValidBytes(existing) && gjson.ParseBytes(existing).IsObject() {
+		doc = string(existing)
+	}
+	merged, err := sjson.Set(doc, jsonPropertyPath(doc, property), string(value))
+	if err != nil {
+		return nil, fmt.Errorf("failed to set property %q: %w", property, err)
+	}
+	return []byte(merged), nil
+}
+
+func extractJSONProperty(secretData []byte, property string) ([]byte, error) {
+	result := gjson.Get(string(secretData), jsonPropertyPath(string(secretData), property))
 
 	if !result.Exists() {
 		return nil, esv1.NoSecretError{}

--- a/providers/v1/scaleway/client.go
+++ b/providers/v1/scaleway/client.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	smapi "github.com/scaleway/scaleway-sdk-go/api/secret/v1beta1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -120,6 +121,9 @@ func pushPayload(secret *corev1.Secret, data esv1.PushSecretData) ([]byte, error
 
 	values := make(map[string]string, len(secret.Data))
 	for k, v := range secret.Data {
+		if !utf8.Valid(v) {
+			return nil, fmt.Errorf("value of key %q is not valid UTF-8: binary values cannot be serialized into the JSON object of a whole-secret push", k)
+		}
 		values[k] = string(v)
 	}
 	payload, err := json.Marshal(values)
@@ -133,6 +137,12 @@ func (c *client) PushSecret(ctx context.Context, secret *corev1.Secret, data esv
 	value, err := pushPayload(secret, data)
 	if err != nil {
 		return err
+	}
+
+	// Fail before any remote mutation: a JSON string cannot carry arbitrary
+	// bytes, so a binary value cannot become a JSON property.
+	if property := data.GetProperty(); property != "" && !utf8.Valid(value) {
+		return fmt.Errorf("value for property %q is not valid UTF-8: binary values cannot be stored as a JSON property, push them without property instead", property)
 	}
 
 	scwRef, err := decodeScwSecretRef(data.GetRemoteKey())
@@ -640,11 +650,14 @@ func jsonPropertyPath(doc, property string) string {
 }
 
 // setJSONProperty returns doc with property set to value as a JSON string.
-// A non-object doc (including none at all) is replaced by a fresh object:
-// PushSecret owns the remote value under updatePolicy Replace semantics.
+// An existing value that is not a JSON object is refused: the provider cannot
+// know whether it may overwrite a value it did not write.
 func setJSONProperty(existing []byte, property string, value []byte) ([]byte, error) {
 	doc := "{}"
-	if gjson.ValidBytes(existing) && gjson.ParseBytes(existing).IsObject() {
+	if len(existing) > 0 {
+		if !gjson.ValidBytes(existing) || !gjson.ParseBytes(existing).IsObject() {
+			return nil, fmt.Errorf("remote secret value is not a JSON object; refusing to overwrite it with property %q", property)
+		}
 		doc = string(existing)
 	}
 	merged, err := sjson.Set(doc, jsonPropertyPath(doc, property), string(value))

--- a/providers/v1/scaleway/client.go
+++ b/providers/v1/scaleway/client.go
@@ -104,12 +104,36 @@ func (c *client) GetSecret(ctx context.Context, ref esv1.ExternalSecretDataRemot
 	return value, nil
 }
 
-func (c *client) PushSecret(ctx context.Context, secret *corev1.Secret, data esv1.PushSecretData) error {
-	if data.GetSecretKey() == "" {
-		return errors.New("pushing the whole secret is not yet implemented")
+// pushPayload resolves the bytes to push: the selected key's value when
+// secretKey is set, otherwise the whole secret serialized as a JSON object of
+// its string values (dataTo / whole-secret push). The PushSecret controller
+// has already filtered and rewritten secret.Data for dataTo entries.
+func pushPayload(secret *corev1.Secret, data esv1.PushSecretData) ([]byte, error) {
+	if key := data.GetSecretKey(); key != "" {
+		value, ok := secret.Data[key]
+		if !ok {
+			return nil, fmt.Errorf("secret key %q not found in the source secret", key)
+		}
+		return value, nil
 	}
 
-	value := secret.Data[data.GetSecretKey()]
+	values := make(map[string]string, len(secret.Data))
+	for k, v := range secret.Data {
+		values[k] = string(v)
+	}
+	payload, err := json.Marshal(values)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal secret data: %w", err)
+	}
+	return payload, nil
+}
+
+func (c *client) PushSecret(ctx context.Context, secret *corev1.Secret, data esv1.PushSecretData) error {
+	value, err := pushPayload(secret, data)
+	if err != nil {
+		return err
+	}
+
 	scwRef, err := decodeScwSecretRef(data.GetRemoteKey())
 	if err != nil {
 		return err
@@ -141,7 +165,7 @@ func (c *client) PushSecret(ctx context.Context, secret *corev1.Secret, data esv
 	}
 
 	var secretID string
-	existingSecretVersion := int64(-1)
+	var existingValue []byte
 
 	// list secret by ref
 	listSecrets, err := c.api.ListSecrets(listSecretReq, scw.WithContext(ctx))
@@ -163,18 +187,9 @@ func (c *client) PushSecret(ctx context.Context, secret *corev1.Secret, data esv
 				return err
 			}
 		} else {
-			existingSecretVersion = int64(secretVersion.Revision)
-		}
-
-		if existingSecretVersion != -1 {
-			data, err := c.accessSpecificSecretVersion(ctx, secretID, secretVersion.Revision)
+			existingValue, err = c.accessSpecificSecretVersion(ctx, secretID, secretVersion.Revision)
 			if err != nil {
 				return err
-			}
-
-			if bytes.Equal(data, value) {
-				// No change to push.
-				return nil
 			}
 		}
 	} else {
@@ -190,29 +205,24 @@ func (c *client) PushSecret(ctx context.Context, secret *corev1.Secret, data esv
 		secretID = secret.ID
 	}
 
-	// Finally, we push the new secret version.
-
-	createSecretVersionRequest := smapi.CreateSecretVersionRequest{
-		SecretID: secretID,
-		Data:     value,
+	if existingValue != nil && bytes.Equal(existingValue, value) {
+		// No change to push.
+		return nil
 	}
 
-	createSecretVersionResponse, err := c.api.CreateSecretVersion(&createSecretVersionRequest, scw.WithContext(ctx))
+	// Finally, we push the new secret version. DisablePrevious atomically
+	// disables the previous version in the same call (a no-op if there is
+	// none or it is already disabled).
+	createSecretVersionResponse, err := c.api.CreateSecretVersion(&smapi.CreateSecretVersionRequest{
+		SecretID:        secretID,
+		Data:            value,
+		DisablePrevious: scw.BoolPtr(true),
+	}, scw.WithContext(ctx))
 	if err != nil {
 		return err
 	}
 
 	c.cache.Put(secretID, createSecretVersionResponse.Revision, value)
-
-	if existingSecretVersion != -1 {
-		_, err := c.api.DisableSecretVersion(&smapi.DisableSecretVersionRequest{
-			SecretID: secretID,
-			Revision: fmt.Sprintf("%d", existingSecretVersion),
-		})
-		if err != nil {
-			return err
-		}
-	}
 
 	return nil
 }

--- a/providers/v1/scaleway/client_test.go
+++ b/providers/v1/scaleway/client_test.go
@@ -454,7 +454,7 @@ func TestPushSecret(t *testing.T) {
 		assert.JSONEq(t, `{"bundle":"{\"user\":\"alice\"}"}`, string(db.secret(secretName).versions[0].data))
 	})
 
-	t.Run("property push replaces a raw non-object value", func(t *testing.T) {
+	t.Run("property push onto a raw non-object value is refused", func(t *testing.T) {
 		ctx := context.Background()
 		c := newTestClient()
 		secretName := "property-over-raw"
@@ -462,9 +462,48 @@ func TestPushSecret(t *testing.T) {
 
 		pushErr := c.PushSecret(ctx, secret([]byte("alice")), pushSecretDataWithProperty("name:"+secretName, "username"))
 
-		assert.NoError(t, pushErr)
+		assert.ErrorContains(t, pushErr, "not a JSON object")
 		fs := db.secret(secretName)
-		assert.JSONEq(t, `{"username":"alice"}`, string(fs.versions[len(fs.versions)-1].data))
+		assert.Len(t, fs.versions, 1, "no version must be created")
+		assert.Equal(t, []byte("raw bytes"), fs.versions[0].data, "remote value must be untouched")
+	})
+
+	t.Run("property push with a binary value is refused", func(t *testing.T) {
+		ctx := context.Background()
+		c := newTestClient()
+		secretName := "property-binary"
+
+		pushErr := c.PushSecret(ctx, secret([]byte{0xff, 0xfe, 0x00, 0x01}), pushSecretDataWithProperty("name:"+secretName, "keystore"))
+
+		assert.ErrorContains(t, pushErr, "not valid UTF-8")
+		assert.Nil(t, db.secret(secretName), "no secret must be created")
+	})
+
+	t.Run("whole secret push with a binary value is refused", func(t *testing.T) {
+		ctx := context.Background()
+		c := newTestClient()
+		secretName := "whole-secret-binary"
+		wholeSecret := &corev1.Secret{Data: map[string][]byte{
+			"ok":       []byte("text"),
+			"keystore": {0xff, 0xfe, 0x00, 0x01},
+		}}
+
+		pushErr := c.PushSecret(ctx, wholeSecret, testingfake.PushSecretData{RemoteKey: "name:" + secretName})
+
+		assert.ErrorContains(t, pushErr, "not valid UTF-8")
+		assert.Nil(t, db.secret(secretName), "no secret must be created")
+	})
+
+	t.Run("raw push without property accepts binary values", func(t *testing.T) {
+		ctx := context.Background()
+		c := newTestClient()
+		secretName := "raw-binary-ok"
+		binary := []byte{0xff, 0xfe, 0x00, 0x01}
+
+		pushErr := c.PushSecret(ctx, secret(binary), pushSecretData("name:"+secretName))
+
+		assert.NoError(t, pushErr)
+		assert.Equal(t, binary, db.secret(secretName).versions[0].data)
 	})
 
 	t.Run("property push without change does not create a version", func(t *testing.T) {

--- a/providers/v1/scaleway/client_test.go
+++ b/providers/v1/scaleway/client_test.go
@@ -103,6 +103,10 @@ var db = buildDB(&fakeSecretAPI{
 				},
 			},
 		},
+		{
+			name:     "exists-no-version",
+			versions: []*fakeSecretVersion{},
+		},
 	},
 })
 
@@ -638,6 +642,66 @@ func TestDeleteSecretProperty(t *testing.T) {
 
 		assert.NoError(t, err)
 	})
+}
+
+func TestSecretExists(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient()
+
+	testCases := map[string]struct {
+		ref    testingfake.PushSecretData
+		exists bool
+		err    bool
+	}{
+		"existing secret by name": {
+			ref:    testingfake.PushSecretData{RemoteKey: "name:secret-1"},
+			exists: true,
+		},
+		"existing secret by id": {
+			ref:    testingfake.PushSecretData{RemoteKey: "id:" + db.secret("secret-1").id},
+			exists: true,
+		},
+		"existing secret by path": {
+			ref:    testingfake.PushSecretData{RemoteKey: "path:/subpath/nested-secret"},
+			exists: true,
+		},
+		"missing secret": {
+			ref: testingfake.PushSecretData{RemoteKey: "name:not-a-secret"},
+		},
+		"secret without version": {
+			ref: testingfake.PushSecretData{RemoteKey: "name:exists-no-version"},
+		},
+		"existing property": {
+			ref:    testingfake.PushSecretData{RemoteKey: "name:json-dotted-keys", Property: "username"},
+			exists: true,
+		},
+		"existing literal dotted property": {
+			ref:    testingfake.PushSecretData{RemoteKey: "name:json-dotted-keys", Property: "tls.crt"},
+			exists: true,
+		},
+		"missing property": {
+			ref: testingfake.PushSecretData{RemoteKey: "name:json-dotted-keys", Property: "nope"},
+		},
+		"property on non-object value": {
+			ref: testingfake.PushSecretData{RemoteKey: "name:nested-secret", Property: "username"},
+		},
+		"invalid ref": {
+			ref: testingfake.PushSecretData{RemoteKey: "no-colon"},
+			err: true,
+		},
+	}
+
+	for tcName, tc := range testCases {
+		t.Run(tcName, func(t *testing.T) {
+			exists, err := c.SecretExists(ctx, tc.ref)
+			if tc.err {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.exists, exists)
+		})
+	}
 }
 
 func TestDeleteSecret(t *testing.T) {

--- a/providers/v1/scaleway/client_test.go
+++ b/providers/v1/scaleway/client_test.go
@@ -86,6 +86,14 @@ var db = buildDB(&fakeSecretAPI{
 			},
 		},
 		{
+			name: "json-dotted-keys",
+			versions: []*fakeSecretVersion{
+				{revision: 1, data: []byte(
+					`{"tls.crt":"CERT","username":"alice","a.b":"literal","a":{"b":"nested"}}`,
+				)},
+			},
+		},
+		{
 			name: "nested-secret",
 			path: "/subpath",
 			versions: []*fakeSecretVersion{
@@ -158,6 +166,22 @@ func TestGetSecret(t *testing.T) {
 				Version:  "latest",
 			},
 			response: []byte("9"),
+		},
+		"literal dotted key is found without escaping": {
+			ref: esv1.ExternalSecretDataRemoteRef{
+				Key:      "id:" + db.secret("json-dotted-keys").id,
+				Property: "tls.crt",
+				Version:  "latest",
+			},
+			response: []byte("CERT"),
+		},
+		"nested path still wins over literal fallback": {
+			ref: esv1.ExternalSecretDataRemoteRef{
+				Key:      "id:" + db.secret("json-dotted-keys").id,
+				Property: "a.b",
+				Version:  "latest",
+			},
+			response: []byte("nested"),
 		},
 		"secret in path": {
 			ref: esv1.ExternalSecretDataRemoteRef{

--- a/providers/v1/scaleway/client_test.go
+++ b/providers/v1/scaleway/client_test.go
@@ -242,6 +242,13 @@ func TestPushSecret(t *testing.T) {
 			RemoteKey: remoteKey,
 		}
 	}
+	pushSecretDataWithProperty := func(remoteKey, property string) testingfake.PushSecretData {
+		return testingfake.PushSecretData{
+			SecretKey: secretKey,
+			RemoteKey: remoteKey,
+			Property:  property,
+		}
+	}
 	secret := func(value []byte) *corev1.Secret {
 		return &corev1.Secret{
 			Data: map[string][]byte{secretKey: value},
@@ -367,6 +374,104 @@ func TestPushSecret(t *testing.T) {
 		assert.NoError(t, c.PushSecret(ctx, wholeSecret, testingfake.PushSecretData{RemoteKey: "name:" + secretName}))
 		assert.NoError(t, c.PushSecret(ctx, wholeSecret, testingfake.PushSecretData{RemoteKey: "name:" + secretName}))
 
+		assert.Len(t, db.secret(secretName).versions, 1)
+	})
+
+	t.Run("property push to new secret creates a JSON object", func(t *testing.T) {
+		ctx := context.Background()
+		c := newTestClient()
+		secretName := "property-new-secret"
+
+		pushErr := c.PushSecret(ctx, secret([]byte("alice")), pushSecretDataWithProperty("name:"+secretName, "username"))
+
+		assert.NoError(t, pushErr)
+		assert.Len(t, db.secret(secretName).versions, 1)
+		assert.JSONEq(t, `{"username":"alice"}`, string(db.secret(secretName).versions[0].data))
+	})
+
+	t.Run("property push merges with existing object and disables previous version", func(t *testing.T) {
+		ctx := context.Background()
+		c := newTestClient()
+		secretName := "property-merge-secret"
+		assert.NoError(t, c.PushSecret(ctx, secret([]byte("alice")), pushSecretDataWithProperty("name:"+secretName, "username")))
+
+		pushErr := c.PushSecret(ctx, secret([]byte("s3cr3t")), pushSecretDataWithProperty("name:"+secretName, "password"))
+
+		assert.NoError(t, pushErr)
+		fs := db.secret(secretName)
+		assert.Len(t, fs.versions, 2)
+		assert.JSONEq(t, `{"username":"alice","password":"s3cr3t"}`, string(fs.versions[1].data))
+		assert.Equal(t, "disabled", fs.versions[0].status)
+	})
+
+	t.Run("property push with dotted key stays a literal top-level key", func(t *testing.T) {
+		ctx := context.Background()
+		c := newTestClient()
+		secretName := "property-dotted-secret"
+		assert.NoError(t, c.PushSecret(ctx, secret([]byte("CERT")), pushSecretDataWithProperty("name:"+secretName, "tls.crt")))
+
+		pushErr := c.PushSecret(ctx, secret([]byte("KEY")), pushSecretDataWithProperty("name:"+secretName, "tls.key"))
+
+		assert.NoError(t, pushErr)
+		fs := db.secret(secretName)
+		assert.JSONEq(t, `{"tls.crt":"CERT","tls.key":"KEY"}`, string(fs.versions[len(fs.versions)-1].data))
+
+		got, getErr := c.GetSecret(ctx, esv1.ExternalSecretDataRemoteRef{
+			Key: "name:" + secretName, Property: "tls.crt", Version: "latest",
+		})
+		assert.NoError(t, getErr)
+		assert.Equal(t, []byte("CERT"), got)
+	})
+
+	t.Run("property push updates an existing nested path in place", func(t *testing.T) {
+		ctx := context.Background()
+		c := newTestClient()
+		secretName := "property-nested-update"
+		// seed with nested JSON via a raw push — do NOT reuse the shared
+		// "json-nested" fixture, later tests read it and db is global
+		assert.NoError(t, c.PushSecret(ctx, secret([]byte(`{"root":{"intermediate":{"leaf":"9"}}}`)), pushSecretData("name:"+secretName)))
+
+		pushErr := c.PushSecret(ctx, secret([]byte("10")), pushSecretDataWithProperty("name:"+secretName, "root.intermediate.leaf"))
+
+		assert.NoError(t, pushErr)
+		fs := db.secret(secretName)
+		assert.JSONEq(t, `{"root":{"intermediate":{"leaf":"10"}}}`, string(fs.versions[len(fs.versions)-1].data))
+	})
+
+	t.Run("whole secret push with property nests the object as a JSON string", func(t *testing.T) {
+		ctx := context.Background()
+		c := newTestClient()
+		secretName := "whole-secret-with-property"
+		wholeSecret := &corev1.Secret{Data: map[string][]byte{"user": []byte("alice")}}
+
+		pushErr := c.PushSecret(ctx, wholeSecret, testingfake.PushSecretData{RemoteKey: "name:" + secretName, Property: "bundle"})
+
+		assert.NoError(t, pushErr)
+		assert.JSONEq(t, `{"bundle":"{\"user\":\"alice\"}"}`, string(db.secret(secretName).versions[0].data))
+	})
+
+	t.Run("property push replaces a raw non-object value", func(t *testing.T) {
+		ctx := context.Background()
+		c := newTestClient()
+		secretName := "property-over-raw"
+		assert.NoError(t, c.PushSecret(ctx, secret([]byte("raw bytes")), pushSecretData("name:"+secretName)))
+
+		pushErr := c.PushSecret(ctx, secret([]byte("alice")), pushSecretDataWithProperty("name:"+secretName, "username"))
+
+		assert.NoError(t, pushErr)
+		fs := db.secret(secretName)
+		assert.JSONEq(t, `{"username":"alice"}`, string(fs.versions[len(fs.versions)-1].data))
+	})
+
+	t.Run("property push without change does not create a version", func(t *testing.T) {
+		ctx := context.Background()
+		c := newTestClient()
+		secretName := "property-idempotent"
+		assert.NoError(t, c.PushSecret(ctx, secret([]byte("alice")), pushSecretDataWithProperty("name:"+secretName, "username")))
+
+		pushErr := c.PushSecret(ctx, secret([]byte("alice")), pushSecretDataWithProperty("name:"+secretName, "username"))
+
+		assert.NoError(t, pushErr)
 		assert.Len(t, db.secret(secretName).versions, 1)
 	})
 

--- a/providers/v1/scaleway/client_test.go
+++ b/providers/v1/scaleway/client_test.go
@@ -569,6 +569,77 @@ func TestGetAllSecrets(t *testing.T) {
 	}
 }
 
+func TestDeleteSecretProperty(t *testing.T) {
+	ctx := context.Background()
+	seed := func(t *testing.T, name string, data []byte) *fakeSecret {
+		t.Helper()
+		c := newTestClient()
+		assert.NoError(t, c.PushSecret(ctx, &corev1.Secret{Data: map[string][]byte{"k": data}},
+			testingfake.PushSecretData{SecretKey: "k", RemoteKey: "name:" + name}))
+		return db.secret(name)
+	}
+
+	t.Run("removes only the property and disables the previous version", func(t *testing.T) {
+		c := newTestClient()
+		fs := seed(t, "delete-prop-partial", []byte(`{"username":"alice","password":"s3cr3t"}`))
+
+		err := c.DeleteSecret(ctx, testingfake.PushSecretData{RemoteKey: "name:" + fs.name, Property: "password"})
+
+		assert.NoError(t, err)
+		assert.Len(t, fs.versions, 2)
+		assert.JSONEq(t, `{"username":"alice"}`, string(fs.versions[1].data))
+		assert.Equal(t, "disabled", fs.versions[0].status)
+	})
+
+	t.Run("removes a literal dotted key", func(t *testing.T) {
+		c := newTestClient()
+		fs := seed(t, "delete-prop-dotted", []byte(`{"tls.crt":"CERT","username":"alice"}`))
+
+		err := c.DeleteSecret(ctx, testingfake.PushSecretData{RemoteKey: "name:" + fs.name, Property: "tls.crt"})
+
+		assert.NoError(t, err)
+		assert.JSONEq(t, `{"username":"alice"}`, string(fs.versions[len(fs.versions)-1].data))
+	})
+
+	t.Run("deletes the whole secret when the last property is removed", func(t *testing.T) {
+		c := newTestClient()
+		fs := seed(t, "delete-prop-last", []byte(`{"username":"alice"}`))
+
+		err := c.DeleteSecret(ctx, testingfake.PushSecretData{RemoteKey: "name:" + fs.name, Property: "username"})
+
+		assert.NoError(t, err)
+		assert.Nil(t, db.secret(fs.name))
+	})
+
+	t.Run("missing property is a no-op", func(t *testing.T) {
+		c := newTestClient()
+		fs := seed(t, "delete-prop-missing", []byte(`{"username":"alice"}`))
+
+		err := c.DeleteSecret(ctx, testingfake.PushSecretData{RemoteKey: "name:" + fs.name, Property: "nope"})
+
+		assert.NoError(t, err)
+		assert.Len(t, fs.versions, 1)
+	})
+
+	t.Run("raw non-object value is a no-op", func(t *testing.T) {
+		c := newTestClient()
+		fs := seed(t, "delete-prop-raw", []byte("raw bytes"))
+
+		err := c.DeleteSecret(ctx, testingfake.PushSecretData{RemoteKey: "name:" + fs.name, Property: "username"})
+
+		assert.NoError(t, err)
+		assert.Len(t, fs.versions, 1)
+	})
+
+	t.Run("missing secret is a no-op", func(t *testing.T) {
+		c := newTestClient()
+
+		err := c.DeleteSecret(ctx, testingfake.PushSecretData{RemoteKey: "name:not-a-secret", Property: "username"})
+
+		assert.NoError(t, err)
+	})
+}
+
 func TestDeleteSecret(t *testing.T) {
 	ctx := context.Background()
 	c := newTestClient()

--- a/providers/v1/scaleway/client_test.go
+++ b/providers/v1/scaleway/client_test.go
@@ -363,7 +363,7 @@ func TestGetAllSecrets(t *testing.T) {
 	}{
 		"find secrets by name": {
 			ref: esv1.ExternalSecretFind{
-				Name: &esv1.FindName{RegExp: "secret-.*"},
+				Name: &esv1.FindName{RegExp: "^secret-\\d$"},
 			},
 			response: map[string][]byte{
 				db.secret("secret-1").name: db.secret("secret-1").mustGetVersion("latest_enabled").data,

--- a/providers/v1/scaleway/client_test.go
+++ b/providers/v1/scaleway/client_test.go
@@ -689,6 +689,10 @@ func TestSecretExists(t *testing.T) {
 			ref: testingfake.PushSecretData{RemoteKey: "no-colon"},
 			err: true,
 		},
+		"empty id is an error": {
+			ref: testingfake.PushSecretData{RemoteKey: "id:"},
+			err: true,
+		},
 	}
 
 	for tcName, tc := range testCases {

--- a/providers/v1/scaleway/client_test.go
+++ b/providers/v1/scaleway/client_test.go
@@ -341,6 +341,43 @@ func TestPushSecret(t *testing.T) {
 		assert.Equal(t, 2, len(fs.versions))
 		assert.Equal(t, "disabled", fs.versions[0].status)
 	})
+
+	t.Run("whole secret is pushed as a JSON object", func(t *testing.T) {
+		ctx := context.Background()
+		c := newTestClient()
+		secretName := "whole-secret-test"
+		wholeSecret := &corev1.Secret{Data: map[string][]byte{
+			"username": []byte("alice"),
+			"password": []byte("s3cr3t"),
+		}}
+
+		pushErr := c.PushSecret(ctx, wholeSecret, testingfake.PushSecretData{RemoteKey: "name:" + secretName})
+
+		assert.NoError(t, pushErr)
+		assert.Len(t, db.secret(secretName).versions, 1)
+		assert.JSONEq(t, `{"username":"alice","password":"s3cr3t"}`, string(db.secret(secretName).versions[0].data))
+	})
+
+	t.Run("whole secret push without change does not create a version", func(t *testing.T) {
+		ctx := context.Background()
+		c := newTestClient()
+		secretName := "whole-secret-idempotent"
+		wholeSecret := &corev1.Secret{Data: map[string][]byte{"a": []byte("1"), "b": []byte("2")}}
+
+		assert.NoError(t, c.PushSecret(ctx, wholeSecret, testingfake.PushSecretData{RemoteKey: "name:" + secretName}))
+		assert.NoError(t, c.PushSecret(ctx, wholeSecret, testingfake.PushSecretData{RemoteKey: "name:" + secretName}))
+
+		assert.Len(t, db.secret(secretName).versions, 1)
+	})
+
+	t.Run("missing secret key is an error", func(t *testing.T) {
+		ctx := context.Background()
+		c := newTestClient()
+
+		pushErr := c.PushSecret(ctx, secret([]byte("x")), testingfake.PushSecretData{SecretKey: "other-key", RemoteKey: "name:missing-key-test"})
+
+		assert.Error(t, pushErr)
+	})
 }
 
 func TestGetSecretMap(t *testing.T) {

--- a/providers/v1/scaleway/client_test.go
+++ b/providers/v1/scaleway/client_test.go
@@ -280,7 +280,8 @@ func TestPushSecret(t *testing.T) {
 
 	t.Run("to secret created by us", func(t *testing.T) {
 		ctx := context.Background()
-		c := newTestClient()
+		api := buildDB(&fakeSecretAPI{})
+		c := &client{api: api, cache: newCache()}
 		data := []byte("some secret data a11d416b-9169-4f4a-8c27-d2959b22e189")
 		secretName := "secret-update-test"
 		assert.NoError(t, c.PushSecret(ctx, secret([]byte("original data")), pushSecretData(fmt.Sprintf("name:%s", secretName))))
@@ -288,8 +289,8 @@ func TestPushSecret(t *testing.T) {
 		pushErr := c.PushSecret(ctx, secret(data), pushSecretData(fmt.Sprintf("name:%s", secretName)))
 
 		assert.NoError(t, pushErr)
-		assert.Len(t, db.secret(secretName).versions, 2)
-		assert.Equal(t, data, db.secret(secretName).versions[1].data)
+		assert.Len(t, api.secret(secretName).versions, 2)
+		assert.Equal(t, data, api.secret(secretName).versions[1].data)
 	})
 
 	t.Run("to secret partially created by us with no version", func(t *testing.T) {
@@ -644,17 +645,21 @@ func TestGetAllSecrets(t *testing.T) {
 
 func TestDeleteSecretProperty(t *testing.T) {
 	ctx := context.Background()
-	seed := func(t *testing.T, name string, data []byte) *fakeSecret {
-		t.Helper()
-		c := newTestClient()
-		assert.NoError(t, c.PushSecret(ctx, &corev1.Secret{Data: map[string][]byte{"k": data}},
-			testingfake.PushSecretData{SecretKey: "k", RemoteKey: "name:" + name}))
-		return db.secret(name)
+	seed := func(name string, data []byte) (esv1.SecretsClient, *fakeSecretAPI, *fakeSecret) {
+		api := buildDB(&fakeSecretAPI{
+			secrets: []*fakeSecret{
+				{
+					name:     name,
+					versions: []*fakeSecretVersion{{revision: 1, data: data}},
+				},
+			},
+		})
+		fs := api.secret(name)
+		return &client{api: api, cache: newCache()}, api, fs
 	}
 
 	t.Run("removes only the property and disables the previous version", func(t *testing.T) {
-		c := newTestClient()
-		fs := seed(t, "delete-prop-partial", []byte(`{"username":"alice","password":"s3cr3t"}`))
+		c, _, fs := seed("delete-prop-partial", []byte(`{"username":"alice","password":"s3cr3t"}`))
 
 		err := c.DeleteSecret(ctx, testingfake.PushSecretData{RemoteKey: "name:" + fs.name, Property: "password"})
 
@@ -665,8 +670,7 @@ func TestDeleteSecretProperty(t *testing.T) {
 	})
 
 	t.Run("removes a literal dotted key", func(t *testing.T) {
-		c := newTestClient()
-		fs := seed(t, "delete-prop-dotted", []byte(`{"tls.crt":"CERT","username":"alice"}`))
+		c, _, fs := seed("delete-prop-dotted", []byte(`{"tls.crt":"CERT","username":"alice"}`))
 
 		err := c.DeleteSecret(ctx, testingfake.PushSecretData{RemoteKey: "name:" + fs.name, Property: "tls.crt"})
 
@@ -675,18 +679,16 @@ func TestDeleteSecretProperty(t *testing.T) {
 	})
 
 	t.Run("deletes the whole secret when the last property is removed", func(t *testing.T) {
-		c := newTestClient()
-		fs := seed(t, "delete-prop-last", []byte(`{"username":"alice"}`))
+		c, api, fs := seed("delete-prop-last", []byte(`{"username":"alice"}`))
 
 		err := c.DeleteSecret(ctx, testingfake.PushSecretData{RemoteKey: "name:" + fs.name, Property: "username"})
 
 		assert.NoError(t, err)
-		assert.Nil(t, db.secret(fs.name))
+		assert.Nil(t, api.secret(fs.name))
 	})
 
 	t.Run("missing property is a no-op", func(t *testing.T) {
-		c := newTestClient()
-		fs := seed(t, "delete-prop-missing", []byte(`{"username":"alice"}`))
+		c, _, fs := seed("delete-prop-missing", []byte(`{"username":"alice"}`))
 
 		err := c.DeleteSecret(ctx, testingfake.PushSecretData{RemoteKey: "name:" + fs.name, Property: "nope"})
 
@@ -695,8 +697,7 @@ func TestDeleteSecretProperty(t *testing.T) {
 	})
 
 	t.Run("raw non-object value is a no-op", func(t *testing.T) {
-		c := newTestClient()
-		fs := seed(t, "delete-prop-raw", []byte("raw bytes"))
+		c, _, fs := seed("delete-prop-raw", []byte("raw bytes"))
 
 		err := c.DeleteSecret(ctx, testingfake.PushSecretData{RemoteKey: "name:" + fs.name, Property: "username"})
 
@@ -814,10 +815,23 @@ func TestNameRefTargetsRootPath(t *testing.T) {
 
 func TestDeleteSecret(t *testing.T) {
 	ctx := context.Background()
-	c := newTestClient()
+	api := buildDB(&fakeSecretAPI{
+		secrets: []*fakeSecret{
+			{
+				name:     "secret-1",
+				versions: []*fakeSecretVersion{{revision: 1}},
+			},
+			{
+				name:     "nested-secret",
+				path:     "/subpath",
+				versions: []*fakeSecretVersion{{revision: 1}},
+			},
+		},
+	})
+	c := &client{api: api, cache: newCache()}
 
-	secret := db.secrets[0]
-	byPath := db.secret("nested-secret")
+	secret := api.secret("secret-1")
+	byPath := api.secret("nested-secret")
 
 	testCases := map[string]struct {
 		ref testingfake.PushSecretData

--- a/providers/v1/scaleway/client_test.go
+++ b/providers/v1/scaleway/client_test.go
@@ -376,6 +376,18 @@ func TestPushSecret(t *testing.T) {
 		assert.JSONEq(t, `{"username":"alice","password":"s3cr3t"}`, string(db.secret(secretName).versions[0].data))
 	})
 
+	t.Run("whole secret push does not HTML-escape values", func(t *testing.T) {
+		ctx := context.Background()
+		c := newTestClient()
+		secretName := "whole-secret-html"
+		wholeSecret := &corev1.Secret{Data: map[string][]byte{"markup": []byte(`<a href="x">&</a>`)}}
+
+		pushErr := c.PushSecret(ctx, wholeSecret, testingfake.PushSecretData{RemoteKey: "name:" + secretName})
+
+		assert.NoError(t, pushErr)
+		assert.Equal(t, `{"markup":"<a href=\"x\">&</a>"}`, string(db.secret(secretName).versions[0].data))
+	})
+
 	t.Run("whole secret push without change does not create a version", func(t *testing.T) {
 		ctx := context.Background()
 		c := newTestClient()
@@ -432,6 +444,17 @@ func TestPushSecret(t *testing.T) {
 		})
 		assert.NoError(t, getErr)
 		assert.Equal(t, []byte("CERT"), got)
+	})
+
+	t.Run("property push does not HTML-escape values", func(t *testing.T) {
+		ctx := context.Background()
+		c := newTestClient()
+		secretName := "property-html"
+
+		pushErr := c.PushSecret(ctx, secret([]byte(`<a href="x">&</a>`)), pushSecretDataWithProperty("name:"+secretName, "markup"))
+
+		assert.NoError(t, pushErr)
+		assert.Equal(t, `{"markup":"<a href=\"x\">&</a>"}`, string(db.secret(secretName).versions[0].data))
 	})
 
 	t.Run("property push updates an existing nested path in place", func(t *testing.T) {

--- a/providers/v1/scaleway/client_test.go
+++ b/providers/v1/scaleway/client_test.go
@@ -194,6 +194,13 @@ func TestGetSecret(t *testing.T) {
 			},
 			response: []byte("secret data"),
 		},
+		"name ref does not match a secret under a sub-path": {
+			ref: esv1.ExternalSecretDataRemoteRef{
+				Key:     "name:nested-secret",
+				Version: "latest",
+			},
+			err: esv1.NoSecretErr,
+		},
 		"non existing secret id should yield NoSecretErr": {
 			ref: esv1.ExternalSecretDataRemoteRef{
 				Key: "id:730aa98d-ec0c-4426-8202-b11aeec8ea1e",
@@ -722,7 +729,10 @@ func TestSecretExists(t *testing.T) {
 			ref: testingfake.PushSecretData{RemoteKey: "name:json-dotted-keys", Property: "nope"},
 		},
 		"property on non-object value": {
-			ref: testingfake.PushSecretData{RemoteKey: "name:nested-secret", Property: "username"},
+			ref: testingfake.PushSecretData{RemoteKey: "path:/subpath/nested-secret", Property: "username"},
+		},
+		"name ref does not match a secret under a sub-path": {
+			ref: testingfake.PushSecretData{RemoteKey: "name:nested-secret"},
 		},
 		"invalid ref": {
 			ref: testingfake.PushSecretData{RemoteKey: "no-colon"},
@@ -745,6 +755,38 @@ func TestSecretExists(t *testing.T) {
 			assert.Equal(t, tc.exists, exists)
 		})
 	}
+}
+
+func TestNameRefTargetsRootPath(t *testing.T) {
+	ctx := context.Background()
+	// Isolated fake: the shared db indexes fixtures by name and cannot hold
+	// two secrets with the same name under different paths.
+	api := buildDB(&fakeSecretAPI{
+		secrets: []*fakeSecret{
+			{
+				name:     "same-name",
+				path:     "/subpath",
+				versions: []*fakeSecretVersion{{revision: 1, data: []byte("under subpath")}},
+			},
+		},
+	})
+	underSubPath := api.secrets[0]
+	c := &client{api: api, cache: newCache()}
+
+	pushErr := c.PushSecret(ctx,
+		&corev1.Secret{Data: map[string][]byte{"k": []byte("at root")}},
+		testingfake.PushSecretData{SecretKey: "k", RemoteKey: "name:same-name"})
+
+	assert.NoError(t, pushErr)
+	assert.Len(t, api.secrets, 2, "a secret must be created at the root path")
+	assert.Equal(t, "/", api.secrets[1].path)
+	assert.Equal(t, []byte("at root"), api.secrets[1].versions[0].data)
+	assert.Len(t, underSubPath.versions, 1, "the sub-path secret must be untouched")
+
+	deleteErr := c.DeleteSecret(ctx, testingfake.PushSecretData{RemoteKey: "name:same-name"})
+
+	assert.NoError(t, deleteErr)
+	assert.Equal(t, []*fakeSecret{underSubPath}, api.secrets, "only the root secret must be deleted")
 }
 
 func TestDeleteSecret(t *testing.T) {

--- a/providers/v1/scaleway/fake_secret_api_test.go
+++ b/providers/v1/scaleway/fake_secret_api_test.go
@@ -391,9 +391,17 @@ func (f *fakeSecretAPI) CreateSecretVersion(request *smapi.CreateSecretVersionRe
 		}
 	}
 
+	if request.DisablePrevious != nil && *request.DisablePrevious && len(secret.versions) > 0 {
+		previous := secret.versions[len(secret.versions)-1]
+		if previous.status == "enabled" {
+			previous.status = "disabled"
+		}
+	}
+
 	newVersion := &fakeSecretVersion{
 		revision: len(secret.versions) + 1,
 		data:     request.Data,
+		status:   "enabled",
 	}
 
 	secret.versions = append(secret.versions, newVersion)
@@ -414,6 +422,8 @@ func (f *fakeSecretAPI) DeleteSecret(request *smapi.DeleteSecretRequest, _ ...sc
 		}
 	}
 	delete(f._secretsByID, secret.id)
+	delete(f._secretsByName, secret.name)
+	f.secrets = slices.DeleteFunc(f.secrets, func(s *fakeSecret) bool { return s.id == secret.id })
 
 	return nil
 }

--- a/providers/v1/scaleway/fake_secret_api_test.go
+++ b/providers/v1/scaleway/fake_secret_api_test.go
@@ -27,6 +27,11 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/scw"
 )
 
+const (
+	statusEnabled  = "enabled"
+	statusDisabled = "disabled"
+)
+
 type fakeSecretVersion struct {
 	revision     int
 	data         []byte
@@ -74,7 +79,7 @@ func buildDB(f *fakeSecretAPI) *fakeSecretAPI {
 			}
 
 			if version.status == "" {
-				version.status = "enabled"
+				version.status = statusEnabled
 			}
 		}
 
@@ -106,7 +111,7 @@ func (s *fakeSecret) getVersion(revision string) (*fakeSecretVersion, bool) {
 
 	if revision == "latest_enabled" {
 		for i := len(s.versions) - 1; i >= 0; i-- {
-			if s.versions[i].status == "enabled" {
+			if s.versions[i].status == statusEnabled {
 				return s.versions[i], true
 			}
 		}
@@ -247,7 +252,7 @@ func (f *fakeSecretAPI) DisableSecretVersion(request *smapi.DisableSecretVersion
 		}
 	}
 
-	version.status = "disabled"
+	version.status = statusDisabled
 
 	return &smapi.SecretVersion{
 		SecretID: secret.id,
@@ -393,15 +398,15 @@ func (f *fakeSecretAPI) CreateSecretVersion(request *smapi.CreateSecretVersionRe
 
 	if request.DisablePrevious != nil && *request.DisablePrevious && len(secret.versions) > 0 {
 		previous := secret.versions[len(secret.versions)-1]
-		if previous.status == "enabled" {
-			previous.status = "disabled"
+		if previous.status == statusEnabled {
+			previous.status = statusDisabled
 		}
 	}
 
 	newVersion := &fakeSecretVersion{
 		revision: len(secret.versions) + 1,
 		data:     request.Data,
-		status:   "enabled",
+		status:   statusEnabled,
 	}
 
 	secret.versions = append(secret.versions, newVersion)

--- a/providers/v1/scaleway/fake_secret_api_test.go
+++ b/providers/v1/scaleway/fake_secret_api_test.go
@@ -27,6 +27,11 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/scw"
 )
 
+const (
+	statusEnabled  = "enabled"
+	statusDisabled = "disabled"
+)
+
 type fakeSecretVersion struct {
 	revision     int
 	data         []byte
@@ -74,7 +79,7 @@ func buildDB(f *fakeSecretAPI) *fakeSecretAPI {
 			}
 
 			if version.status == "" {
-				version.status = "enabled"
+				version.status = statusEnabled
 			}
 		}
 
@@ -106,7 +111,7 @@ func (s *fakeSecret) getVersion(revision string) (*fakeSecretVersion, bool) {
 
 	if revision == "latest_enabled" {
 		for _, version := range slices.Backward(s.versions) {
-			if version.status == "enabled" {
+			if version.status == statusEnabled {
 				return version, true
 			}
 		}
@@ -247,7 +252,7 @@ func (f *fakeSecretAPI) DisableSecretVersion(request *smapi.DisableSecretVersion
 		}
 	}
 
-	version.status = "disabled"
+	version.status = statusDisabled
 
 	return &smapi.SecretVersion{
 		SecretID: secret.id,
@@ -393,15 +398,15 @@ func (f *fakeSecretAPI) CreateSecretVersion(request *smapi.CreateSecretVersionRe
 
 	if request.DisablePrevious != nil && *request.DisablePrevious && len(secret.versions) > 0 {
 		previous := secret.versions[len(secret.versions)-1]
-		if previous.status == "enabled" {
-			previous.status = "disabled"
+		if previous.status == statusEnabled {
+			previous.status = statusDisabled
 		}
 	}
 
 	newVersion := &fakeSecretVersion{
 		revision: len(secret.versions) + 1,
 		data:     request.Data,
-		status:   "enabled",
+		status:   statusEnabled,
 	}
 
 	secret.versions = append(secret.versions, newVersion)

--- a/providers/v1/scaleway/go.mod
+++ b/providers/v1/scaleway/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.35
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/gjson v1.18.0
+	github.com/tidwall/sjson v1.2.5
 	k8s.io/api v0.35.2
 	sigs.k8s.io/controller-runtime v0.23.3
 )
@@ -68,7 +69,6 @@ require (
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/tidwall/match v1.2.0 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
-	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/providers/v1/scaleway/go.mod
+++ b/providers/v1/scaleway/go.mod
@@ -68,6 +68,7 @@ require (
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/tidwall/match v1.2.0 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
+	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/providers/v1/scaleway/go.mod
+++ b/providers/v1/scaleway/go.mod
@@ -66,6 +66,7 @@ require (
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/tidwall/match v1.2.0 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
+	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/providers/v1/scaleway/go.mod
+++ b/providers/v1/scaleway/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.35
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/gjson v1.18.0
+	github.com/tidwall/sjson v1.2.5
 	k8s.io/api v0.36.3
 	sigs.k8s.io/controller-runtime v0.24.1
 )
@@ -66,7 +67,6 @@ require (
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/tidwall/match v1.2.0 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
-	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/providers/v1/scaleway/go.sum
+++ b/providers/v1/scaleway/go.sum
@@ -164,6 +164,7 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
@@ -172,6 +173,8 @@ github.com/tidwall/match v1.2.0/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JT
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
 github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 h1:ilQV1hzziu+LLM3zUTJ0trRztfwgjqKnBWNtSRkbmwM=

--- a/providers/v1/scaleway/go.sum
+++ b/providers/v1/scaleway/go.sum
@@ -152,6 +152,7 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
@@ -160,6 +161,8 @@ github.com/tidwall/match v1.2.0/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JT
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
 github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=


### PR DESCRIPTION

## Problem Statement

The Scaleway provider's `PushSecret` implementation had two gaps that make it unusable for common certificate/credential workflows:

1. **`data[].match.remoteRef.property` was silently ignored.** The provider always pushed the raw value of the selected `secretKey` as the *entire* remote secret value. With several `data` entries targeting the same `remoteKey` with different `property` values (e.g. `tls.crt`, `tls.key`, `ca.crt`, `username`, `password` of one certificate bundle), each entry overwrote the whole remote secret with a single raw value and the entries fought forever — a new Scaleway version was created on every reconcile because the "no change" check compared against a value another entry had just written.
2. **Whole-secret push (`spec.dataTo`) was rejected** with `pushing the whole secret is not yet implemented`, even though the PushSecret controller fully supports `dataTo` and hands the provider a pre-filtered Secret with an empty `secretKey`.

Additionally, `SecretExists` returned `not implemented`, which broke `updatePolicy: IfNotExists`.

## Related Issue

Fixes #6689 

## Proposed Changes

Follow the merge semantics already established by the Infisical provider, adapted to Scaleway's immutable-version model (versions are immutable and CRUDL-only, so every mutation is a new version). All changes are confined to `providers/v1/scaleway/` and `docs/provider/scaleway.md`; no CRD/API changes.

- **Property push = JSON merge** — with `property` set, the value is merged into the remote secret's JSON object: only that property is created/updated, others are preserved. Merge base is the latest version's value when it is a JSON object, else `{}` (raw values are replaced — `updatePolicy: Replace` ownership semantics; this also heals secrets written by the old raw-overwrite behavior). Identical merged JSON → no new version.
- **Dotted keys** — `property: tls.crt` is stored as a literal top-level key `"tls.crt"`, unless the remote JSON already contains a matching nested structure (`{"tls":{"crt":…}}`), which is then updated in place. `GetSecret` property lookup gets the matching fallback (gjson nested path first, then dot-escaped literal key — same idiom as the Azure Key Vault and Kubernetes providers), so pushed keys round-trip.
- **Whole-secret push (`dataTo`)** — with no `secretKey`, the received `secret.Data` (already filtered by the controller's `match.regexp`) is serialized as a JSON object of string values and pushed.
- **Atomic version replacement** — `CreateSecretVersion` is now called with `DisablePrevious: true`, replacing the previous create-then-`DisableSecretVersion` two-call sequence (no window with two enabled versions, one fewer failure point).
- **Property-aware `DeleteSecret`** — deleting a pushed property removes only that key via a new version (previous version disabled); the remote secret itself is deleted once the last property is removed. Missing secret/version/property or non-object value → idempotent no-op.
- **`SecretExists` implemented** — resolves `id:`/`name:`/`path:` refs; true when a latest version exists (and the property exists in it, when set). An empty `id:` value is rejected instead of falling through to an unfiltered list.
- **Docs** — new PushSecret section in `docs/provider/scaleway.md` (merge semantics, dotted keys, versioning, 64KiB payload limit) and correction of the outdated "PushSecret can only use a name reference" note (path refs work).

Testing: TDD throughout; new unit tests against the extended API fake cover property merge (create/merge/dotted/nested/raw-replacement/idempotency), whole-secret push (create/idempotency/with property), property-aware delete (partial/dotted/last-key/no-op cases), `SecretExists` (all ref types and edge cases), and the `GetSecret` fallback with nested-path precedence. `make test` and the lint/license/generation targets pass. Behavior was additionally validated end-to-end against the real Scaleway Secret Manager API (property merge, atomic `DisablePrevious`, idempotence, `dataTo`, property delete, round-trip of dotted keys).

## AI Assistance disclosure

AI assistance used: **Yes**

Tool(s) used: Claude Code (Anthropic)

Purpose of assistance: design specification, implementation, unit tests, documentation, and PR/issue drafting, following a spec → plan → TDD implementation → multi-pass code review workflow.

Parts of the contribution affected: `providers/v1/scaleway/*` (client, tests, fake), `docs/provider/scaleway.md`.

Human validation performed: design decisions (merge semantics, literal-dotted-key handling, `{}` replacement of raw values, `DisablePrevious`) reviewed and approved by the author at each step; full test suite, lint, and license checks run locally; behavior validated by the author against a live Scaleway Secret Manager project (real API), including version accounting and cleanup; final diff reviewed and understood by the author.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
- [x] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [x] I have tested my changes on a live environment to confirm they are working
