### PR TITLE
fix(clusterexternalsecret): remove namespace finalizer when namespace no longer matches selector

### DIFF
--- a/pkg/controllers/clusterexternalsecret/clusterexternalsecret_controller.go
+++ b/pkg/controllers/clusterexternalsecret/clusterexternalsecret_controller.go
@@ -489,9 +489,26 @@ func (r *Reconciler) deleteOutdatedExternalSecrets(ctx context.Context, namespac
 	failedNamespaces := map[string]error{}
 	// Loop through existing namespaces first to make sure they still have our labels
 	for _, namespace := range getRemovedNamespaces(namespaces, provisionedNamespaces) {
-		err := r.deleteExternalSecret(ctx, esName, cesName, namespace)
+		var ns v1.Namespace
+		err := r.Get(ctx, types.NamespacedName{Name: namespace}, &ns)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			r.Log.Error(err, "unable to get namespace for finalizer cleanup")
+			failedNamespaces[namespace] = err
+			continue
+		}
+
+		err = r.deleteExternalSecret(ctx, esName, cesName, namespace)
 		if err != nil {
 			r.Log.Error(err, "unable to delete external secret")
+			failedNamespaces[namespace] = err
+			continue
+		}
+
+		if err := r.removeNamespaceFinalizer(ctx, r.Log, &ns, cesName); err != nil {
+			r.Log.Error(err, "unable to remove namespace finalizer")
 			failedNamespaces[namespace] = err
 		}
 	}

--- a/pkg/controllers/clusterexternalsecret/clusterexternalsecret_controller.go
+++ b/pkg/controllers/clusterexternalsecret/clusterexternalsecret_controller.go
@@ -170,10 +170,18 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, clusterExte
 
 		return ctrl.Result{}, err
 	}
-
 	failedNamespaces := r.deleteOutdatedExternalSecrets(ctx, namespaces, esName, clusterExternalSecret.Name, clusterExternalSecret.Status.ProvisionedNamespaces)
 
+	// Snapshot which namespaces failed cleanup before gatherProvisionedNamespaces
+	// adds unrelated provisioning failures into the same map, so we can keep
+	// them provisioned and retry cleanup on the next reconcile pass.
+	unfinishedCleanup := make([]string, 0, len(failedNamespaces))
+	for ns := range failedNamespaces {
+		unfinishedCleanup = append(unfinishedCleanup, ns)
+	}
+
 	provisionedNamespaces := r.gatherProvisionedNamespaces(ctx, log, clusterExternalSecret, namespaces, esName, failedNamespaces)
+	provisionedNamespaces = append(provisionedNamespaces, unfinishedCleanup...)
 
 	condition := NewClusterExternalSecretCondition(failedNamespaces)
 	SetClusterExternalSecretCondition(clusterExternalSecret, *condition)
@@ -487,28 +495,16 @@ func (r *Reconciler) deferPatch(ctx context.Context, log logr.Logger, clusterExt
 
 func (r *Reconciler) deleteOutdatedExternalSecrets(ctx context.Context, namespaces []v1.Namespace, esName, cesName string, provisionedNamespaces []string) map[string]error {
 	failedNamespaces := map[string]error{}
-	// Loop through existing namespaces first to make sure they still have our labels
 	for _, namespace := range getRemovedNamespaces(namespaces, provisionedNamespaces) {
-		var ns v1.Namespace
-		err := r.Get(ctx, types.NamespacedName{Name: namespace}, &ns)
+		err := r.deleteExternalSecret(ctx, esName, cesName, namespace)
 		if err != nil {
-			if apierrors.IsNotFound(err) {
-				continue
-			}
-			r.Log.Error(err, "unable to get namespace for finalizer cleanup")
+			r.Log.Error(err, "unable to delete external secret", "namespace", namespace)
 			failedNamespaces[namespace] = err
 			continue
 		}
 
-		err = r.deleteExternalSecret(ctx, esName, cesName, namespace)
-		if err != nil {
-			r.Log.Error(err, "unable to delete external secret")
-			failedNamespaces[namespace] = err
-			continue
-		}
-
-		if err := r.removeNamespaceFinalizer(ctx, r.Log, &ns, cesName); err != nil {
-			r.Log.Error(err, "unable to remove namespace finalizer")
+		if err := r.updateNamespaceRemoveFinalizer(ctx, r.Log, namespace, r.buildCESFinalizer(cesName)); err != nil {
+			r.Log.Error(err, "unable to remove namespace finalizer", "namespace", namespace)
 			failedNamespaces[namespace] = err
 		}
 	}

--- a/pkg/controllers/clusterexternalsecret/clusterexternalsecret_controller_test.go
+++ b/pkg/controllers/clusterexternalsecret/clusterexternalsecret_controller_test.go
@@ -551,6 +551,12 @@ var _ = Describe("ClusterExternalSecret controller", func() {
 					ns.Labels = map[string]string{}
 					return k8sClient.Update(ctx, &ns)
 				}).WithTimeout(timeout).WithPolling(interval).Should(Succeed())
+
+				Eventually(func(g Gomega) {
+					var ns v1.Namespace
+					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: namespaces[0].Name}, &ns)).ShouldNot(HaveOccurred())
+					g.Expect(ns.Finalizers).ShouldNot(ContainElement(fmt.Sprintf("externalsecrets.external-secrets.io/ces-%s", created.Name)))
+				}).WithTimeout(timeout).WithPolling(interval).Should(Succeed())
 			},
 			expectedClusterExternalSecret: func(namespaces []v1.Namespace, created esv1.ClusterExternalSecret) esv1.ClusterExternalSecret {
 				return esv1.ClusterExternalSecret{

--- a/pkg/controllers/clusterexternalsecret/clusterexternalsecret_controller_test.go
+++ b/pkg/controllers/clusterexternalsecret/clusterexternalsecret_controller_test.go
@@ -542,6 +542,14 @@ var _ = Describe("ClusterExternalSecret controller", func() {
 					}
 				}).WithTimeout(timeout).WithPolling(interval).Should(Succeed())
 
+				// Confirm the finalizer was actually added before we test its removal,
+				// so a regression in ensureNamespaceFinalizer wouldn't slip past this test.
+				Eventually(func(g Gomega) {
+					var ns v1.Namespace
+					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: namespaces[0].Name}, &ns)).ShouldNot(HaveOccurred())
+					g.Expect(ns.Finalizers).Should(ContainElement(fmt.Sprintf("externalsecrets.external-secrets.io/ces-%s", created.Name)))
+				}).WithTimeout(timeout).WithPolling(interval).Should(Succeed())
+
 				// Retry on conflict since controller may be updating namespace with finalizers
 				Eventually(func() error {
 					var ns v1.Namespace


### PR DESCRIPTION
Fixes #6677

## Problem
When a namespace stops matching a ClusterExternalSecret's `namespaceSelectors` (e.g. via relabeling), the controller correctly deletes the associated ExternalSecret via `deleteOutdatedExternalSecrets()`, but never removes the namespace finalizer (`externalsecrets.external-secrets.io/ces-<name>`) it had previously added. This leaves the namespace with a stale finalizer that nothing ever cleans up, causing `kubectl delete ns` to hang indefinitely in `Terminating` state.

## Fix
`deleteOutdatedExternalSecrets()` now fetches the namespace, deletes the ExternalSecret, and — only if that succeeds — removes the CES's finalizer from the namespace, reusing the existing `removeNamespaceFinalizer()` helper (same helper already used by `cleanupNamespaceResources()` on the CES-deletion path).

The order matters: finalizer removal only happens **after** successful ExternalSecret deletion. If deletion fails, the finalizer is intentionally left in place so the next reconcile loop retries cleanup — avoiding a race where the namespace could finish deleting before the ExternalSecret is actually cleaned up.

## Testing
Extended the existing test "Should delete external secrets when namespaces no longer match" to assert the namespace finalizer is also removed after reconciliation. All 13 specs in the `clusterexternalsecret` controller suite pass locally.
<img width="720" height="94" alt="Screenshot 2026-07-23 025834" src="https://github.com/user-attachments/assets/8eee876f-e5dc-4e0d-b6fe-6d4dee321dea" />
