### PR TITLE
fix: bump codeqls together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    groups:
+      codeql:
+        patterns:
+          - "github/codeql-action/*"
 
   - package-ecosystem: "docker"
     directory: "/"


### PR DESCRIPTION
## Problem Statement

codeql bumps of dependabot are independent.

It leads to issue of version mismatch like this:L

Error: Loaded a configuration file for version '4.37.3', but running version '4.36.3'.

To fix that, let's ensure init and analyse are bundled together, through a dependabot group.

Example errors:

https://github.com/external-secrets/external-secrets/pull/6666 

https://github.com/external-secrets/external-secrets/pull/6668

## Related Issue

None other than CI runs

## Proposed Changes

Bump dependabot changes for codeql together

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
desig(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## AI Assistance disclosure

Did you use an script, LLM, or AI assisted development tool for this contribution?

AI assistance used: No

If yes provide details: 

Tool(s) used: no

Purpose of assistance:

Parts of the contribution affected:

Human validation performed:

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
- [ ] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [ ] I have tested my changes on a live environment to confirm they are working
