### PR TITLE
feat(generators): add expiresAfter to GitLab deploy token generator

### DIFF
--- a/apis/generators/v1alpha1/types_gitlab.go
+++ b/apis/generators/v1alpha1/types_gitlab.go
@@ -45,6 +45,7 @@ const (
 
 // GitlabDeployTokenSpec defines the desired state to generate a GitLab deploy token.
 // +kubebuilder:validation:XValidation:rule="has(self.projectID) != has(self.groupID)",message="exactly one of projectID or groupID must be set"
+// +kubebuilder:validation:XValidation:rule="!(has(self.expiresAt) && has(self.expiresAfter))",message="expiresAt and expiresAfter are mutually exclusive"
 type GitlabDeployTokenSpec struct {
 	// URL configures the GitLab instance URL. Defaults to https://gitlab.com.
 	// +optional
@@ -77,6 +78,16 @@ type GitlabDeployTokenSpec struct {
 	// cleaned up (on regeneration or when the consuming ExternalSecret is deleted).
 	// +optional
 	ExpiresAt *metav1.Time `json:"expiresAt,omitempty"`
+
+	// ExpiresAfter sets a relative expiry, computed as now + expiresAfter on
+	// each generation, so every token carries a fresh expiry with nothing to
+	// bump by hand. metav1.Duration syntax, largest unit hours (e.g. "720h").
+	// Mutually exclusive with expiresAt; minimum 24h. Keep it larger than the
+	// consuming ExternalSecret refreshInterval so a token cannot expire before
+	// the next rotation replaces it.
+	// +optional
+	// +kubebuilder:validation:XValidation:rule="duration(self) >= duration('24h')",message="expiresAfter must be at least 24h"
+	ExpiresAfter *metav1.Duration `json:"expiresAfter,omitempty"`
 
 	// Username is an optional username for the deploy token. GitLab defaults it to
 	// gitlab+deploy-token-{n} when omitted.

--- a/apis/generators/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/generators/v1alpha1/zz_generated.deepcopy.go
@@ -1270,6 +1270,11 @@ func (in *GitlabDeployTokenSpec) DeepCopyInto(out *GitlabDeployTokenSpec) {
 		in, out := &in.ExpiresAt, &out.ExpiresAt
 		*out = (*in).DeepCopy()
 	}
+	if in.ExpiresAfter != nil {
+		in, out := &in.ExpiresAfter, &out.ExpiresAfter
+		*out = new(apismetav1.Duration)
+		**out = **in
+	}
 	in.Auth.DeepCopyInto(&out.Auth)
 }
 

--- a/config/crds/bases/generators.external-secrets.io_clustergenerators.yaml
+++ b/config/crds/bases/generators.external-secrets.io_clustergenerators.yaml
@@ -941,6 +941,18 @@ spec:
                         required:
                         - token
                         type: object
+                      expiresAfter:
+                        description: |-
+                          ExpiresAfter sets a relative expiry, computed as now + expiresAfter on
+                          each generation, so every token carries a fresh expiry with nothing to
+                          bump by hand. metav1.Duration syntax, largest unit hours (e.g. "720h").
+                          Mutually exclusive with expiresAt; minimum 24h. Keep it larger than the
+                          consuming ExternalSecret refreshInterval so a token cannot expire before
+                          the next rotation replaces it.
+                        type: string
+                        x-kubernetes-validations:
+                        - message: expiresAfter must be at least 24h
+                          rule: duration(self) >= duration('24h')
                       expiresAt:
                         description: |-
                           ExpiresAt is an optional expiry for the deploy token. If omitted the token does
@@ -1000,6 +1012,8 @@ spec:
                     x-kubernetes-validations:
                     - message: exactly one of projectID or groupID must be set
                       rule: has(self.projectID) != has(self.groupID)
+                    - message: expiresAt and expiresAfter are mutually exclusive
+                      rule: '!(has(self.expiresAt) && has(self.expiresAfter))'
                   grafanaSpec:
                     description: GrafanaSpec controls the behavior of the grafana
                       generator.

--- a/config/crds/bases/generators.external-secrets.io_gitlabdeploytokens.yaml
+++ b/config/crds/bases/generators.external-secrets.io_gitlabdeploytokens.yaml
@@ -88,6 +88,18 @@ spec:
                 required:
                 - token
                 type: object
+              expiresAfter:
+                description: |-
+                  ExpiresAfter sets a relative expiry, computed as now + expiresAfter on
+                  each generation, so every token carries a fresh expiry with nothing to
+                  bump by hand. metav1.Duration syntax, largest unit hours (e.g. "720h").
+                  Mutually exclusive with expiresAt; minimum 24h. Keep it larger than the
+                  consuming ExternalSecret refreshInterval so a token cannot expire before
+                  the next rotation replaces it.
+                type: string
+                x-kubernetes-validations:
+                - message: expiresAfter must be at least 24h
+                  rule: duration(self) >= duration('24h')
               expiresAt:
                 description: |-
                   ExpiresAt is an optional expiry for the deploy token. If omitted the token does
@@ -146,6 +158,8 @@ spec:
             x-kubernetes-validations:
             - message: exactly one of projectID or groupID must be set
               rule: has(self.projectID) != has(self.groupID)
+            - message: expiresAt and expiresAfter are mutually exclusive
+              rule: '!(has(self.expiresAt) && has(self.expiresAfter))'
         type: object
     served: true
     storage: true

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -28073,6 +28073,18 @@ spec:
                           required:
                             - token
                           type: object
+                        expiresAfter:
+                          description: |-
+                            ExpiresAfter sets a relative expiry, computed as now + expiresAfter on
+                            each generation, so every token carries a fresh expiry with nothing to
+                            bump by hand. metav1.Duration syntax, largest unit hours (e.g. "720h").
+                            Mutually exclusive with expiresAt; minimum 24h. Keep it larger than the
+                            consuming ExternalSecret refreshInterval so a token cannot expire before
+                            the next rotation replaces it.
+                          type: string
+                          x-kubernetes-validations:
+                            - message: expiresAfter must be at least 24h
+                              rule: duration(self) >= duration('24h')
                         expiresAt:
                           description: |-
                             ExpiresAt is an optional expiry for the deploy token. If omitted the token does
@@ -28129,6 +28141,8 @@ spec:
                       x-kubernetes-validations:
                         - message: exactly one of projectID or groupID must be set
                           rule: has(self.projectID) != has(self.groupID)
+                        - message: expiresAt and expiresAfter are mutually exclusive
+                          rule: '!(has(self.expiresAt) && has(self.expiresAfter))'
                     grafanaSpec:
                       description: GrafanaSpec controls the behavior of the grafana generator.
                       properties:
@@ -30553,6 +30567,18 @@ spec:
                   required:
                     - token
                   type: object
+                expiresAfter:
+                  description: |-
+                    ExpiresAfter sets a relative expiry, computed as now + expiresAfter on
+                    each generation, so every token carries a fresh expiry with nothing to
+                    bump by hand. metav1.Duration syntax, largest unit hours (e.g. "720h").
+                    Mutually exclusive with expiresAt; minimum 24h. Keep it larger than the
+                    consuming ExternalSecret refreshInterval so a token cannot expire before
+                    the next rotation replaces it.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: expiresAfter must be at least 24h
+                      rule: duration(self) >= duration('24h')
                 expiresAt:
                   description: |-
                     ExpiresAt is an optional expiry for the deploy token. If omitted the token does
@@ -30609,6 +30635,8 @@ spec:
               x-kubernetes-validations:
                 - message: exactly one of projectID or groupID must be set
                   rule: has(self.projectID) != has(self.groupID)
+                - message: expiresAt and expiresAfter are mutually exclusive
+                  rule: '!(has(self.expiresAt) && has(self.expiresAfter))'
           type: object
       served: true
       storage: true

--- a/docs/api/generator/gitlab.md
+++ b/docs/api/generator/gitlab.md
@@ -25,7 +25,17 @@ Set exactly one of `spec.projectID` or `spec.groupID`. Both accept either a nume
 
 ### Token lifecycle
 
-GitLab deploy tokens are persistent: unlike short-lived tokens they are not garbage-collected by GitLab on their own. This generator therefore records the created token ID in its generator state and **revokes the previous token** whenever the value is regenerated (on refresh) and when the consuming `ExternalSecret` is deleted. Set `spec.expiresAt` if you also want GitLab to expire the token server-side as a backstop.
+GitLab deploy tokens are persistent: unlike short-lived tokens they are not garbage-collected by GitLab on their own. This generator therefore records the created token ID in its generator state and **revokes the previous token** whenever the value is regenerated (on refresh) and when the consuming `ExternalSecret` is deleted.
+
+You can also have GitLab expire the token server-side as a backstop, using exactly one of:
+
+- `spec.expiresAt`: an absolute expiry (RFC3339 timestamp). It is fixed, so every token minted from the spec inherits the same date and it eventually has to be bumped by hand.
+- `spec.expiresAfter`: a relative expiry, a `metav1.Duration` such as `720h` using the same unit syntax as `refreshInterval` (the largest unit is hours). On every generation the token's `expires_at` is computed as `now + expiresAfter`, so each minted token carries a fresh expiry with nothing to bump. The computed timestamp is sent to GitLab only; it is never written back to the `GitlabDeployToken` object, so a GitOps-managed spec does not drift.
+
+`spec.expiresAt` and `spec.expiresAfter` are mutually exclusive (enforced by a CEL rule). Two things to keep in mind for `expiresAfter`:
+
+- **Minimum `24h`.** The GitLab deploy-token API keeps hourly resolution on the expiry (only the GitLab web UI displays whole days), so `expiresAfter` enforces a conservative `24h` minimum via a CEL rule rather than accepting arbitrarily short lifetimes.
+- **Keep it larger than `refreshInterval`.** If `expiresAfter` is shorter than the consuming `ExternalSecret`'s `refreshInterval`, a token can expire before the next refresh mints its replacement, leaving a gap. Set `expiresAfter` comfortably larger than `refreshInterval`.
 
 ### Example Manifest
 

--- a/docs/api/generator/gitlab.md
+++ b/docs/api/generator/gitlab.md
@@ -34,7 +34,7 @@ You can also have GitLab expire the token server-side as a backstop, using exact
 
 `spec.expiresAt` and `spec.expiresAfter` are mutually exclusive (enforced by a CEL rule). Two things to keep in mind for `expiresAfter`:
 
-- **Minimum `24h`.** The GitLab deploy-token API keeps hourly resolution on the expiry (only the GitLab web UI displays whole days), so `expiresAfter` enforces a conservative `24h` minimum via a CEL rule rather than accepting arbitrarily short lifetimes.
+- **Minimum `24h`.** GitLab stores and enforces `expires_at` to the second, so the `24h` minimum (a CEL rule) is a deliberately conservative floor, not a GitLab limitation. Only the web UI and the `expired` flag in the API response are day-granular: a token whose `expires_at` has passed is refused for authentication straight away, but keeps reporting `expired: false` until the following UTC midnight. Do not read that flag to decide whether a token is still usable.
 - **Keep it larger than `refreshInterval`.** If `expiresAfter` is shorter than the consuming `ExternalSecret`'s `refreshInterval`, a token can expire before the next refresh mints its replacement, leaving a gap. Set `expiresAfter` comfortably larger than `refreshInterval`.
 
 ### Example Manifest

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -28799,6 +28799,25 @@ cleaned up (on regeneration or when the consuming ExternalSecret is deleted).</p
 </tr>
 <tr>
 <td>
+<code>expiresAfter</code></br>
+<em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ExpiresAfter sets a relative expiry, computed as now + expiresAfter on
+each generation, so every token carries a fresh expiry with nothing to
+bump by hand. metav1.Duration syntax, largest unit hours (e.g. &ldquo;720h&rdquo;).
+Mutually exclusive with expiresAt; minimum 24h. Keep it larger than the
+consuming ExternalSecret refreshInterval so a token cannot expire before
+the next rotation replaces it.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>username</code></br>
 <em>
 string
@@ -29027,6 +29046,25 @@ Kubernetes meta/v1.Time
 <p>ExpiresAt is an optional expiry for the deploy token. If omitted the token does
 not expire on the GitLab side and is revoked only when the generator state is
 cleaned up (on regeneration or when the consuming ExternalSecret is deleted).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>expiresAfter</code></br>
+<em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ExpiresAfter sets a relative expiry, computed as now + expiresAfter on
+each generation, so every token carries a fresh expiry with nothing to
+bump by hand. metav1.Duration syntax, largest unit hours (e.g. &ldquo;720h&rdquo;).
+Mutually exclusive with expiresAt; minimum 24h. Keep it larger than the
+consuming ExternalSecret refreshInterval so a token cannot expire before
+the next rotation replaces it.</p>
 </td>
 </tr>
 <tr>

--- a/docs/snippets/generator-gitlab.yaml
+++ b/docs/snippets/generator-gitlab.yaml
@@ -16,7 +16,10 @@ spec:
   scopes:
     - read_repository
     - read_registry
-  expiresAt: "2027-01-01T00:00:00Z" # Optional
+  expiresAt: "2027-01-01T00:00:00Z" # Optional, absolute expiry (RFC3339).
+  # expiresAfter: "720h"            # Optional alternative: relative expiry, min 24h,
+  #                                 # computed as now + expiresAfter on each refresh.
+  #                                 # Mutually exclusive with expiresAt.
   username: "eso" # Optional, GitLab defaults to gitlab+deploy-token-{n}
   auth:
     token:

--- a/generators/v1/gitlab/gitlab.go
+++ b/generators/v1/gitlab/gitlab.go
@@ -55,6 +55,9 @@ const (
 // Generator implements GitLab deploy token generation.
 type Generator struct {
 	httpClient *http.Client
+	// now returns the current time and is overridable in tests so the relative
+	// expiresAfter expiry is deterministic. Defaults to time.Now.
+	now func() time.Time
 }
 
 // deployTokenState is persisted as the generator state so that Cleanup can revoke
@@ -111,6 +114,14 @@ func (g *Generator) generate(ctx context.Context, jsonSpec *apiextensions.JSON, 
 	}
 	if spec.Spec.ExpiresAt != nil {
 		payload["expires_at"] = spec.Spec.ExpiresAt.UTC().Format(time.RFC3339)
+	}
+	// expiresAfter is a relative expiry resolved to an absolute expires_at at each
+	// generation. It stays in the outbound request only; nothing is written back to
+	// the GitlabDeployToken object, so a GitOps-managed spec does not drift. CEL
+	// admission guarantees expiresAt and expiresAfter are never both set.
+	if spec.Spec.ExpiresAfter != nil {
+		expiry := g.clock().Add(spec.Spec.ExpiresAfter.Duration)
+		payload["expires_at"] = expiry.UTC().Format(time.RFC3339)
 	}
 	body, err := json.Marshal(payload)
 	if err != nil {
@@ -226,6 +237,15 @@ func (g *Generator) client() *http.Client {
 		return g.httpClient
 	}
 	return &http.Client{Timeout: requestTimeout}
+}
+
+// clock returns the current time, using the injected now func when set so tests
+// can pin a deterministic value for the expiresAfter calculation.
+func (g *Generator) clock() time.Time {
+	if g.now != nil {
+		return g.now()
+	}
+	return time.Now()
 }
 
 func (g *Generator) fetchAuthToken(ctx context.Context, kube client.Client, namespace string, spec *genv1alpha1.GitlabDeployTokenSpec) (string, error) {

--- a/generators/v1/gitlab/gitlab.go
+++ b/generators/v1/gitlab/gitlab.go
@@ -50,6 +50,12 @@ const (
 	// same value so a shorter transport timeout cannot preempt it and abandon an
 	// in-flight create (which would orphan a deploy token GitLab already minted).
 	requestTimeout = 30 * time.Second
+
+	// minExpiresAfter is the floor for spec.expiresAfter. It mirrors the CEL rule
+	// on GitlabDeployTokenSpec.ExpiresAfter (apis/generators/v1alpha1); keep the
+	// two in sync. validateExpiry re-checks it in code so the invariant still
+	// holds on clusters where CEL admission is not enforced.
+	minExpiresAfter = 24 * time.Hour
 )
 
 // Generator implements GitLab deploy token generation.
@@ -100,6 +106,9 @@ func (g *Generator) generate(ctx context.Context, jsonSpec *apiextensions.JSON, 
 	if err != nil {
 		return nil, nil, fmt.Errorf(errParseSpec, err)
 	}
+	if err := validateExpiry(&spec.Spec); err != nil {
+		return nil, nil, err
+	}
 	token, err := g.fetchAuthToken(ctx, kube, namespace, &spec.Spec)
 	if err != nil {
 		return nil, nil, err
@@ -117,8 +126,9 @@ func (g *Generator) generate(ctx context.Context, jsonSpec *apiextensions.JSON, 
 	}
 	// expiresAfter is a relative expiry resolved to an absolute expires_at at each
 	// generation. It stays in the outbound request only; nothing is written back to
-	// the GitlabDeployToken object, so a GitOps-managed spec does not drift. CEL
-	// admission guarantees expiresAt and expiresAfter are never both set.
+	// the GitlabDeployToken object, so a GitOps-managed spec does not drift.
+	// validateExpiry above (and CEL admission) guarantee expiresAt and expiresAfter
+	// are never both set, so this cannot clobber the expiresAt branch.
 	if spec.Spec.ExpiresAfter != nil {
 		expiry := g.clock().Add(spec.Spec.ExpiresAfter.Duration)
 		payload["expires_at"] = expiry.UTC().Format(time.RFC3339)
@@ -290,6 +300,21 @@ func gitlabError(raw []byte) string {
 		}
 	}
 	return string(raw)
+}
+
+// validateExpiry enforces, in code, the same invariants the CEL rules declare on
+// GitlabDeployTokenSpec (apis/generators/v1alpha1/types_gitlab.go): expiresAt and
+// expiresAfter are mutually exclusive, and expiresAfter has a minExpiresAfter
+// floor. This is defense in depth for clusters where CEL admission is not
+// enforced; the error strings match the CEL messages.
+func validateExpiry(spec *genv1alpha1.GitlabDeployTokenSpec) error {
+	if spec.ExpiresAt != nil && spec.ExpiresAfter != nil {
+		return errors.New("expiresAt and expiresAfter are mutually exclusive")
+	}
+	if spec.ExpiresAfter != nil && spec.ExpiresAfter.Duration < minExpiresAfter {
+		return errors.New("expiresAfter must be at least 24h")
+	}
+	return nil
 }
 
 func parseSpec(data []byte) (*genv1alpha1.GitlabDeployToken, error) {

--- a/generators/v1/gitlab/gitlab_test.go
+++ b/generators/v1/gitlab/gitlab_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -230,6 +231,44 @@ spec:
 			assert.Equal(t, tc.want, sink.body["expires_at"])
 			srv.Close()
 		}
+	})
+
+	t.Run("expiresAfter is resolved to now+duration and never persisted", func(t *testing.T) {
+		// expiresAfter is resolved to an absolute expires_at using the injected
+		// clock, so the wire value is deterministic. The computed expiry must stay
+		// in the request only: it must not leak into the persisted generator state,
+		// otherwise a GitOps-managed GitlabDeployToken spec would drift on refresh.
+		fixed := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+		sink := &captured{}
+		srv := newServer(t, http.StatusCreated, createResp, sink)
+		defer srv.Close()
+
+		raw := fmt.Sprintf(`apiVersion: generators.external-secrets.io/v1alpha1
+kind: GitlabDeployToken
+spec:
+  url: %q
+  projectID: "1"
+  name: "eso-token"
+  scopes:
+  - read_repository
+  expiresAfter: "720h"
+  auth:
+    token:
+      secretRef:
+        name: %q
+        key: %q
+`, srv.URL, testSecret, testKey)
+
+		g := &Generator{httpClient: srv.Client(), now: func() time.Time { return fixed }}
+		_, state, err := g.generate(context.Background(), &apiextensions.JSON{Raw: []byte(raw)}, newKube(), testNamespace)
+		require.NoError(t, err)
+
+		want := fixed.Add(720 * time.Hour).UTC().Format(time.RFC3339)
+		assert.Equal(t, want, sink.body["expires_at"])
+
+		require.NotNil(t, state)
+		assert.NotContains(t, string(state.Raw), "expires",
+			"computed expiry must not be persisted into generator state")
 	})
 
 	t.Run("optional fields omitted are not sent", func(t *testing.T) {

--- a/generators/v1/gitlab/gitlab_test.go
+++ b/generators/v1/gitlab/gitlab_test.go
@@ -271,6 +271,47 @@ spec:
 			"computed expiry must not be persisted into generator state")
 	})
 
+	t.Run("error when both expiresAt and expiresAfter set", func(t *testing.T) {
+		raw := fmt.Sprintf(`apiVersion: generators.external-secrets.io/v1alpha1
+kind: GitlabDeployToken
+spec:
+  projectID: "1"
+  name: "eso-token"
+  scopes:
+  - read_repository
+  expiresAt: "2030-01-01T00:00:00Z"
+  expiresAfter: "720h"
+  auth:
+    token:
+      secretRef:
+        name: %q
+        key: %q
+`, testSecret, testKey)
+		g := &Generator{}
+		_, _, err := g.generate(context.Background(), &apiextensions.JSON{Raw: []byte(raw)}, newKube(), testNamespace)
+		require.ErrorContains(t, err, "mutually exclusive")
+	})
+
+	t.Run("error when expiresAfter is below the 24h minimum", func(t *testing.T) {
+		raw := fmt.Sprintf(`apiVersion: generators.external-secrets.io/v1alpha1
+kind: GitlabDeployToken
+spec:
+  projectID: "1"
+  name: "eso-token"
+  scopes:
+  - read_repository
+  expiresAfter: "1h"
+  auth:
+    token:
+      secretRef:
+        name: %q
+        key: %q
+`, testSecret, testKey)
+		g := &Generator{}
+		_, _, err := g.generate(context.Background(), &apiextensions.JSON{Raw: []byte(raw)}, newKube(), testNamespace)
+		require.ErrorContains(t, err, "at least 24h")
+	})
+
 	t.Run("optional fields omitted are not sent", func(t *testing.T) {
 		sink := &captured{}
 		srv := newServer(t, http.StatusCreated, createResp, sink)

--- a/tests/__snapshot__/clustergenerator-v1alpha1.yaml
+++ b/tests/__snapshot__/clustergenerator-v1alpha1.yaml
@@ -134,6 +134,7 @@ spec:
             key: string
             name: string
             namespace: string
+      expiresAfter: string
       expiresAt: 2024-10-11T12:48:44Z
       groupID: string
       name: string

--- a/tests/__snapshot__/gitlabdeploytoken-v1alpha1.yaml
+++ b/tests/__snapshot__/gitlabdeploytoken-v1alpha1.yaml
@@ -8,6 +8,7 @@ spec:
         key: string
         name: string
         namespace: string
+  expiresAfter: string
   expiresAt: 2024-10-11T12:48:44Z
   groupID: string
   name: string


### PR DESCRIPTION
## Problem Statement

The GitLab deploy token generator only exposes `expiresAt`, an absolute timestamp. That is awkward for automation: the value has to be pushed forward by hand (or by external tooling), otherwise every generated token inherits the same fixed calendar date and they all eventually expire at once. For a credential that ESO rotates on every refresh, what you actually want is "expire this token N after it was minted", relative to creation, not a fixed date.

## Related Issue

Fixes #6680

## Proposed Changes

Add an optional `expiresAfter` field to `GitlabDeployTokenSpec`, a `metav1.Duration` using the same unit syntax as `refreshInterval` (e.g. `720h`; the largest unit is hours). When set, the generator computes `expires_at = now + expiresAfter` at each `Generate` and sends that to the GitLab API, so every minted token carries a fresh relative expiry. `expiresAt` stays as the absolute alternative.

The design keeps the relative expiry out of the Kubernetes object: the computed timestamp goes into the outbound GitLab request only and is never written back to the `GitlabDeployToken` spec or the generator state. A GitOps-managed spec (Argo CD, Flux) therefore does not drift, no controller-side writeback, no perpetual `OutOfSync`.

Validation and behaviour, all backward compatible (existing specs set neither field, or `expiresAt`, and are unaffected):

- `expiresAt` and `expiresAfter` are mutually exclusive, enforced by a struct-level CEL rule (`!(has(self.expiresAt) && has(self.expiresAfter))`). No existing manifest sets both, so this cannot break anything today.
- A field-level CEL rule enforces a conservative minimum of `24h` (`duration(self) >= duration('24h')`) rather than accepting arbitrarily short lifetimes. (The GitLab deploy-token API keeps hourly resolution on the expiry; only the web UI displays whole days.)
- The docs also cover the `refreshInterval` interaction: keep `expiresAfter` comfortably larger than the consuming `ExternalSecret`'s `refreshInterval` so a token cannot expire before the next rotation mints its replacement.

Both invariants are also re-checked in the generator code (mutual exclusion and the 24h floor) as defense in depth for clusters where CEL admission is not enforced, mirroring how `projectID`/`groupID` mutual-exclusion is already enforced in both CEL and code. The kept-in-sync 24h constant is documented on both sides.

Files: API type + CEL and regenerated deepcopy/CRDs; the generator's `Generate` path (with an injectable clock so the relative expiry is unit-tested deterministically) plus the in-code validation guard; unit tests for the wire value, the no-timestamp-in-state invariant, and rejection of both-set and sub-24h specs; and generator docs + example snippet.

Naming note: `expiresAfter` is typed `metav1.Duration` to mirror `refreshInterval` and to pair naturally with the existing `expiresAt`. Sibling credential generators instead express lifetime as integer seconds (`sessionDuration`, `expirationSeconds`). Happy to switch to the seconds-int convention if maintainers prefer, it is a one-field change.

## AI Assistance disclosure

AI assistance used: Yes

Used an AI coding assistant to draft the implementation, tests, and docs from the issue spec. All design decisions, code review, and verification (build, tests, lint, CEL rule checks) were performed and validated by me.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
- [x] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [x] I have tested my changes on a live environment to confirm they are working



