### PR TITLE
fix(webhook): resolve templated URL before Validate() network check

### DIFF
--- a/providers/v1/webhook/webhook.go
+++ b/providers/v1/webhook/webhook.go
@@ -52,7 +52,6 @@ type WebHook struct {
 	wh        webhook.Webhook
 	store     esv1.GenericStore
 	storeKind string
-	url       string
 }
 
 // Capabilities return the provider-supported capabilities (ReadOnly, WriteOnly, ReadWrite).
@@ -80,7 +79,6 @@ func (p *Provider) NewClient(ctx context.Context, store esv1.GenericStore, kube 
 	if err != nil {
 		return nil, err
 	}
-	whClient.url = provider.URL
 
 	whClient.wh.HTTP, err = whClient.wh.GetHTTPClient(ctx, provider)
 	if err != nil {
@@ -317,7 +315,23 @@ func (w *WebHook) Close(_ context.Context) error {
 // Validate checks if the webhook provider is configured correctly.
 func (w *WebHook) Validate() (esv1.ValidationResult, error) {
 	timeout := 15 * time.Second
-	url := w.url
+
+	provider, err := getProvider(w.store)
+	if err != nil {
+		return esv1.ValidationResultError, fmt.Errorf(errFailedToGetStore, err)
+	}
+
+	// The URL may be templated (e.g. using provider.webhook.secrets), so it
+	// must be resolved before attempting to validate network reachability.
+	escapedData, err := w.wh.GetTemplateData(context.Background(), nil, provider.Secrets, true)
+	if err != nil {
+		return esv1.ValidationResultError, fmt.Errorf("failed to get template data: %w", err)
+	}
+
+	url, err := webhook.ExecuteTemplateString(provider.URL, escapedData)
+	if err != nil {
+		return esv1.ValidationResultError, fmt.Errorf("failed to parse url: %w", err)
+	}
 
 	if err := esutils.NetworkValidate(url, timeout); err != nil {
 		return esv1.ValidationResultError, err

--- a/providers/v1/webhook/webhook.go
+++ b/providers/v1/webhook/webhook.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -323,9 +324,9 @@ func (w *WebHook) Validate() (esv1.ValidationResult, error) {
 	}
 
 	// The URL may reference .remoteRef (e.g. "{{ .remoteRef.key }}"), which is only
-	// known at fetch time, per-ExternalSecret — not at store-validation time. In that
-	// case the store itself may be perfectly valid; we just can't prove reachability
-	// yet, so report Unknown rather than Error.
+	// known at fetch time, per-ExternalSecret, and not at store-validation time. In
+	// that case the store itself may be perfectly valid; we just can't prove
+	// reachability yet, so report Unknown rather than Error.
 	if strings.Contains(provider.URL, ".remoteRef") {
 		return esv1.ValidationResultUnknown, nil
 	}
@@ -339,20 +340,45 @@ func (w *WebHook) Validate() (esv1.ValidationResult, error) {
 	// Kubernetes API is slow or unresponsive.
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	escapedData, err := w.wh.GetTemplateData(ctx, nil, provider.Secrets, false)
+	data, err := w.wh.GetTemplateData(ctx, nil, provider.Secrets, false)
 	if err != nil {
 		return esv1.ValidationResultError, fmt.Errorf("failed to get template data: %w", err)
 	}
 
-	url, err := webhook.ExecuteTemplateString(provider.URL, escapedData)
+	resolvedURL, err := webhook.ExecuteTemplateString(provider.URL, data)
 	if err != nil {
 		return esv1.ValidationResultError, fmt.Errorf("failed to render URL template: %w", err)
 	}
 
-	if err := esutils.NetworkValidate(url, timeout); err != nil {
-		return esv1.ValidationResultError, err
+	if err := esutils.NetworkValidate(resolvedURL, timeout); err != nil {
+		return esv1.ValidationResultError, redactHost(err, provider.URL, resolvedURL)
 	}
 	return esv1.ValidationResultReady, nil
+}
+
+// redactHost hides the host of a templated URL in err.
+//
+// Validate() errors are written to a SecretStore Kubernetes event, see
+// validateStore in pkg/controllers/secretstore/common.go. NetworkValidate dials
+// the host, so the host ends up in the dial error. When the URL is templated on
+// provider.webhook.secrets, a store such as "https://{{ .creds.token }}.example.com"
+// would then publish the token in that event, and events are readable by anyone
+// holding "get events" on the namespace, who may not be allowed to read the
+// referenced secret. The rest of the error is kept so the store owner can still
+// tell a DNS failure from a refused connection or a timeout.
+func redactHost(err error, rawURL, resolvedURL string) error {
+	// A non-templated URL cannot leak a secret, so its error is returned
+	// unchanged, keeping full detail for the store owner.
+	if rawURL == resolvedURL {
+		return err
+	}
+	parsed, parseErr := url.Parse(resolvedURL)
+	// An unparsable resolved URL, or one with no host, leaves nothing safe to
+	// keep, so return a generic message rather than risk leaking the secret.
+	if parseErr != nil || parsed.Hostname() == "" {
+		return errors.New("cannot reach the host resolved from the templated url")
+	}
+	return errors.New(strings.ReplaceAll(err.Error(), parsed.Hostname(), "[REDACTED]"))
 }
 
 // NewProvider creates a new Provider instance.

--- a/providers/v1/webhook/webhook.go
+++ b/providers/v1/webhook/webhook.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/PaesslerAG/jsonpath"
@@ -321,6 +322,14 @@ func (w *WebHook) Validate() (esv1.ValidationResult, error) {
 		return esv1.ValidationResultError, fmt.Errorf(errFailedToGetStore, err)
 	}
 
+	// The URL may reference .remoteRef (e.g. "{{ .remoteRef.key }}"), which is only
+	// known at fetch time, per-ExternalSecret — not at store-validation time. In that
+	// case the store itself may be perfectly valid; we just can't prove reachability
+	// yet, so report Unknown rather than Error.
+	if strings.Contains(provider.URL, ".remoteRef") {
+		return esv1.ValidationResultUnknown, nil
+	}
+
 	// The URL may be templated (e.g. using provider.webhook.secrets), so it
 	// must be resolved before attempting to validate network reachability.
 	// urlEncode has no effect when ref is nil (only remoteRef values are
@@ -337,7 +346,7 @@ func (w *WebHook) Validate() (esv1.ValidationResult, error) {
 
 	url, err := webhook.ExecuteTemplateString(provider.URL, escapedData)
 	if err != nil {
-		return esv1.ValidationResultError, fmt.Errorf("failed to parse url: %w", err)
+		return esv1.ValidationResultError, fmt.Errorf("failed to render URL template: %w", err)
 	}
 
 	if err := esutils.NetworkValidate(url, timeout); err != nil {

--- a/providers/v1/webhook/webhook.go
+++ b/providers/v1/webhook/webhook.go
@@ -323,7 +323,9 @@ func (w *WebHook) Validate() (esv1.ValidationResult, error) {
 
 	// The URL may be templated (e.g. using provider.webhook.secrets), so it
 	// must be resolved before attempting to validate network reachability.
-	escapedData, err := w.wh.GetTemplateData(context.Background(), nil, provider.Secrets, true)
+	// urlEncode has no effect when ref is nil (only remoteRef values are
+	// escaped), but is set explicitly to make the intent unambiguous.
+	escapedData, err := w.wh.GetTemplateData(context.Background(), nil, provider.Secrets, false)
 	if err != nil {
 		return esv1.ValidationResultError, fmt.Errorf("failed to get template data: %w", err)
 	}

--- a/providers/v1/webhook/webhook.go
+++ b/providers/v1/webhook/webhook.go
@@ -325,7 +325,12 @@ func (w *WebHook) Validate() (esv1.ValidationResult, error) {
 	// must be resolved before attempting to validate network reachability.
 	// urlEncode has no effect when ref is nil (only remoteRef values are
 	// escaped), but is set explicitly to make the intent unambiguous.
-	escapedData, err := w.wh.GetTemplateData(context.Background(), nil, provider.Secrets, false)
+	// Bound the Kubernetes secret lookup with the same timeout used for the
+	// network check below, so Validate() cannot hang indefinitely if the
+	// Kubernetes API is slow or unresponsive.
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	escapedData, err := w.wh.GetTemplateData(ctx, nil, provider.Secrets, false)
 	if err != nil {
 		return esv1.ValidationResultError, fmt.Errorf("failed to get template data: %w", err)
 	}

--- a/providers/v1/webhook/webhook_test.go
+++ b/providers/v1/webhook/webhook_test.go
@@ -914,6 +914,14 @@ func TestValidate(t *testing.T) {
 			wantResult: esv1.ValidationResultReady,
 		},
 		{
+			// A URL templated on .remoteRef can't be resolved at store-validation
+			// time — that data only exists per-ExternalSecret, at fetch time. The
+			// store may be perfectly valid; we just can't prove reachability yet.
+			name:       "url templated on remoteRef cannot be resolved at store-validation time",
+			url:        "{{ .remoteRef.key }}",
+			wantResult: esv1.ValidationResultUnknown,
+		},
+		{
 			name: "templated url resolves via provider secrets and validates successfully",
 			url:  "{{ .myconfig.host }}",
 			secrets: []esv1.WebhookSecret{
@@ -969,7 +977,7 @@ func TestValidate(t *testing.T) {
 			name:            "malformed template string surfaces execute template error",
 			url:             "{{ .unclosed.template",
 			wantResult:      esv1.ValidationResultError,
-			wantErrContains: "failed to parse url",
+			wantErrContains: "failed to render URL template",
 		},
 		{
 			name: "missing referenced secret surfaces template data error",

--- a/providers/v1/webhook/webhook_test.go
+++ b/providers/v1/webhook/webhook_test.go
@@ -30,9 +30,12 @@ import (
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
 	"github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
+	esmeta "github.com/external-secrets/external-secrets/apis/meta/v1"
 )
 
 type testCase struct {
@@ -831,6 +834,173 @@ func TestDeleteSecret(t *testing.T) {
 
 			if receivedMethod != tt.expectMethod {
 				t.Errorf("DeleteSecret() used method %v, want %v", receivedMethod, tt.expectMethod)
+			}
+		})
+	}
+}
+
+// makeWebhookStoreWithSecrets builds a ClusterSecretStore whose webhook URL and
+// secrets list can be customized, used to exercise Validate()'s template
+// resolution behavior.
+func makeWebhookStoreWithSecrets(url string, secrets []esv1.WebhookSecret) *esv1.ClusterSecretStore {
+	return &esv1.ClusterSecretStore{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ClusterSecretStore",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "webhook-store",
+			Namespace: "default",
+		},
+		Spec: esv1.SecretStoreSpec{
+			Provider: &esv1.SecretStoreProvider{
+				Webhook: &esv1.WebhookProvider{
+					URL:     url,
+					Secrets: secrets,
+				},
+			},
+		},
+	}
+}
+
+func buildFakeClient(secrets []esv1.WebhookSecret, objects []client.Object) client.Client {
+	if objects != nil {
+		return fake.NewClientBuilder().WithObjects(objects...).Build()
+	}
+	if secrets != nil {
+		return fake.NewClientBuilder().Build()
+	}
+	return nil
+}
+
+func assertValidateError(t *testing.T, err error, wantErrContains string) {
+	t.Helper()
+	if wantErrContains == "" {
+		return
+	}
+	if err == nil {
+		t.Errorf("Validate() expected error containing %q, got nil", wantErrContains)
+		return
+	}
+	if !strings.Contains(err.Error(), wantErrContains) {
+		t.Errorf("Validate() error = %v, want error containing %q", err, wantErrContains)
+	}
+}
+
+func TestValidate(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	secretNamespace := "default"
+
+	tests := []struct {
+		name            string
+		url             string
+		secrets         []esv1.WebhookSecret
+		mockObjects     []client.Object
+		wantResult      esv1.ValidationResult
+		wantErrContains string
+	}{
+		{
+			name:       "hardcoded url validates successfully",
+			url:        ts.URL,
+			wantResult: esv1.ValidationResultReady,
+		},
+		{
+			name: "templated url resolves via provider secrets and validates successfully",
+			url:  "{{ .myconfig.host }}",
+			secrets: []esv1.WebhookSecret{
+				{
+					Name: "myconfig",
+					SecretRef: esmeta.SecretKeySelector{
+						Name:      "webhook-validate-secret",
+						Namespace: &secretNamespace,
+					},
+				},
+			},
+			mockObjects: []client.Object{&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: secretNamespace,
+					Name:      "webhook-validate-secret",
+					Labels: map[string]string{
+						"external-secrets.io/type": "webhook",
+					},
+				},
+				Data: map[string][]byte{
+					"host": []byte(ts.URL),
+				},
+			}},
+			wantResult: esv1.ValidationResultReady,
+		},
+		{
+			name: "templated url resolves but host unreachable returns validation error",
+			url:  "{{ .myconfig.host }}",
+			secrets: []esv1.WebhookSecret{
+				{
+					Name: "myconfig",
+					SecretRef: esmeta.SecretKeySelector{
+						Name:      "webhook-validate-secret-unreachable",
+						Namespace: &secretNamespace,
+					},
+				},
+			},
+			mockObjects: []client.Object{&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: secretNamespace,
+					Name:      "webhook-validate-secret-unreachable",
+					Labels: map[string]string{
+						"external-secrets.io/type": "webhook",
+					},
+				},
+				Data: map[string][]byte{
+					"host": []byte("http://127.0.0.1:1"),
+				},
+			}},
+			wantResult: esv1.ValidationResultError,
+		},
+		{
+			name:            "malformed template string surfaces execute template error",
+			url:             "{{ .unclosed.template",
+			wantResult:      esv1.ValidationResultError,
+			wantErrContains: "failed to parse url",
+		},
+		{
+			name: "missing referenced secret surfaces template data error",
+			url:  "{{ .myconfig.host }}",
+			secrets: []esv1.WebhookSecret{
+				{
+					Name: "myconfig",
+					SecretRef: esmeta.SecretKeySelector{
+						Name:      "does-not-exist",
+						Namespace: &secretNamespace,
+					},
+				},
+			},
+			wantResult:      esv1.ValidationResultError,
+			wantErrContains: "failed to get template data",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := makeWebhookStoreWithSecrets(tt.url, tt.secrets)
+			mockClient := buildFakeClient(tt.secrets, tt.mockObjects)
+
+			prov := &Provider{}
+			c, err := prov.NewClient(context.Background(), store, mockClient, "testnamespace")
+			if err != nil {
+				t.Fatalf("failed to create client: %v", err)
+			}
+
+			result, err := c.Validate()
+
+			if wantErr := tt.wantResult == esv1.ValidationResultError; (err != nil) != wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, wantErr)
+			}
+			assertValidateError(t, err, tt.wantErrContains)
+			if result != tt.wantResult {
+				t.Errorf("Validate() = %v, want %v", result, tt.wantResult)
 			}
 		})
 	}

--- a/providers/v1/webhook/webhook_test.go
+++ b/providers/v1/webhook/webhook_test.go
@@ -892,6 +892,12 @@ func TestValidate(t *testing.T) {
 	}))
 	defer ts.Close()
 
+	unreachableTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	unreachableURL := unreachableTS.URL
+	unreachableTS.Close()
+
 	secretNamespace := "default"
 
 	tests := []struct {
@@ -954,7 +960,7 @@ func TestValidate(t *testing.T) {
 					},
 				},
 				Data: map[string][]byte{
-					"host": []byte("http://127.0.0.1:1"),
+					"host": []byte(unreachableURL),
 				},
 			}},
 			wantResult: esv1.ValidationResultError,

--- a/providers/v1/webhook/webhook_test.go
+++ b/providers/v1/webhook/webhook_test.go
@@ -872,17 +872,19 @@ func buildFakeClient(secrets []esv1.WebhookSecret, objects []client.Object) clie
 	return nil
 }
 
-func assertValidateError(t *testing.T, err error, wantErrContains string) {
+func assertValidateError(t *testing.T, err error, wantErrContains, wantErrNotContains string) {
 	t.Helper()
-	if wantErrContains == "" {
-		return
+	if wantErrContains != "" {
+		if err == nil {
+			t.Errorf("Validate() expected error containing %q, got nil", wantErrContains)
+			return
+		}
+		if !strings.Contains(err.Error(), wantErrContains) {
+			t.Errorf("Validate() error = %v, want error containing %q", err, wantErrContains)
+		}
 	}
-	if err == nil {
-		t.Errorf("Validate() expected error containing %q, got nil", wantErrContains)
-		return
-	}
-	if !strings.Contains(err.Error(), wantErrContains) {
-		t.Errorf("Validate() error = %v, want error containing %q", err, wantErrContains)
+	if wantErrNotContains != "" && err != nil && strings.Contains(err.Error(), wantErrNotContains) {
+		t.Errorf("Validate() error = %v, must not contain %q", err, wantErrNotContains)
 	}
 }
 
@@ -901,12 +903,13 @@ func TestValidate(t *testing.T) {
 	secretNamespace := "default"
 
 	tests := []struct {
-		name            string
-		url             string
-		secrets         []esv1.WebhookSecret
-		mockObjects     []client.Object
-		wantResult      esv1.ValidationResult
-		wantErrContains string
+		name               string
+		url                string
+		secrets            []esv1.WebhookSecret
+		mockObjects        []client.Object
+		wantResult         esv1.ValidationResult
+		wantErrContains    string
+		wantErrNotContains string
 	}{
 		{
 			name:       "hardcoded url validates successfully",
@@ -915,7 +918,7 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			// A URL templated on .remoteRef can't be resolved at store-validation
-			// time — that data only exists per-ExternalSecret, at fetch time. The
+			// time, that data only exists per-ExternalSecret, at fetch time. The
 			// store may be perfectly valid; we just can't prove reachability yet.
 			name:       "url templated on remoteRef cannot be resolved at store-validation time",
 			url:        "{{ .remoteRef.key }}",
@@ -974,6 +977,74 @@ func TestValidate(t *testing.T) {
 			wantResult: esv1.ValidationResultError,
 		},
 		{
+			// The resolved host reaches a Kubernetes event through the store
+			// condition, so a secret used inside the host must not show up there.
+			name: "secret used in the host is redacted from the validation error",
+			url:  "https://{{ .myconfig.token }}.example.invalid",
+			secrets: []esv1.WebhookSecret{
+				{
+					Name: "myconfig",
+					SecretRef: esmeta.SecretKeySelector{
+						Name:      "webhook-validate-secret-in-host",
+						Namespace: &secretNamespace,
+					},
+				},
+			},
+			mockObjects: []client.Object{&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: secretNamespace,
+					Name:      "webhook-validate-secret-in-host",
+					Labels: map[string]string{
+						"external-secrets.io/type": "webhook",
+					},
+				},
+				Data: map[string][]byte{
+					"token": []byte("s3cr3t-token"),
+				},
+			}},
+			wantResult:         esv1.ValidationResultError,
+			wantErrContains:    "[REDACTED]",
+			wantErrNotContains: "s3cr3t-token",
+		},
+		{
+			// A non-templated URL cannot leak a secret, so the connection error
+			// is reported in full and nothing is redacted.
+			name:               "non-templated unreachable url keeps the full error",
+			url:                unreachableURL,
+			wantResult:         esv1.ValidationResultError,
+			wantErrContains:    "connection refused",
+			wantErrNotContains: "[REDACTED]",
+		},
+		{
+			// The resolved URL cannot be parsed (the secret injects a space into
+			// the host), so the error falls back to a generic message.
+			name: "templated url that resolves to an unparsable url is reported generically",
+			url:  "http://{{ .myconfig.host }}",
+			secrets: []esv1.WebhookSecret{
+				{
+					Name: "myconfig",
+					SecretRef: esmeta.SecretKeySelector{
+						Name:      "webhook-validate-secret-unparsable",
+						Namespace: &secretNamespace,
+					},
+				},
+			},
+			mockObjects: []client.Object{&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: secretNamespace,
+					Name:      "webhook-validate-secret-unparsable",
+					Labels: map[string]string{
+						"external-secrets.io/type": "webhook",
+					},
+				},
+				Data: map[string][]byte{
+					"host": []byte("a b"),
+				},
+			}},
+			wantResult:      esv1.ValidationResultError,
+			wantErrContains: "cannot reach the host resolved from the templated url",
+		},
+		{
 			name:            "malformed template string surfaces execute template error",
 			url:             "{{ .unclosed.template",
 			wantResult:      esv1.ValidationResultError,
@@ -1012,7 +1083,7 @@ func TestValidate(t *testing.T) {
 			if wantErr := tt.wantResult == esv1.ValidationResultError; (err != nil) != wantErr {
 				t.Errorf("Validate() error = %v, wantErr %v", err, wantErr)
 			}
-			assertValidateError(t, err, tt.wantErrContains)
+			assertValidateError(t, err, tt.wantErrContains, tt.wantErrNotContains)
 			if result != tt.wantResult {
 				t.Errorf("Validate() = %v, want %v", result, tt.wantResult)
 			}


### PR DESCRIPTION
## Problem Statement

`WebHook.Validate()` used the raw, unexpanded `provider.URL` when checking network reachability. SecretStores with a templated URL (e.g. `{{ .myconfig.host }}` backed by `provider.webhook.secrets`) always failed validation with a bogus connection error and got stuck in `InvalidProviderConfig`, even though the resolved URL would have been reachable.

## Related Issue

Fixes #6659

## Proposed Changes

- `Validate()` now resolves the templated URL via `GetTemplateData` + `ExecuteTemplateString` before calling `NetworkValidate` — mirroring the exact pattern already used by `GetWebhookData`, `PushWebhookData`, and `DeleteSecret`.
- Removed the now-dead `url` field from the `WebHook` struct and its assignment in `NewClient`.
- Added `TestValidate` with 5 table-driven subtests: hardcoded URL, templated URL resolves+succeeds, templated URL resolves but unreachable, malformed template, missing referenced secret. `Validate()` coverage 92.3%.

## Checklist
- [x] I have read the contribution guidelines
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review