### PR TITLE
feat(dvls): add vault name support to secret keys

### DIFF
--- a/apis/externalsecrets/v1/secretstore_dvls_types.go
+++ b/apis/externalsecrets/v1/secretstore_dvls_types.go
@@ -27,7 +27,9 @@ type DVLSProvider struct {
 	ServerURL string `json:"serverUrl"`
 
 	// Vault is the name or UUID of the vault to fetch secrets from.
-	// When omitted, the vault must be specified in the secret key using the legacy format "<vault-id>/<entry-id>".
+	// When omitted, each secret key must name its own vault: the first slash or backslash
+	// separates the vault from the entry reference. Both accept a name or a UUID, and the entry
+	// reference may include a folder path. This allows one store to serve secrets from many vaults.
 	// +optional
 	Vault string `json:"vault,omitempty"`
 

--- a/config/crds/bases/external-secrets.io_clustersecretstores.yaml
+++ b/config/crds/bases/external-secrets.io_clustersecretstores.yaml
@@ -2481,7 +2481,9 @@ spec:
                       vault:
                         description: |-
                           Vault is the name or UUID of the vault to fetch secrets from.
-                          When omitted, the vault must be specified in the secret key using the legacy format "<vault-id>/<entry-id>".
+                          When omitted, each secret key must name its own vault: the first slash or backslash
+                          separates the vault from the entry reference. Both accept a name or a UUID, and the entry
+                          reference may include a folder path. This allows one store to serve secrets from many vaults.
                         type: string
                     required:
                     - auth

--- a/config/crds/bases/external-secrets.io_secretstores.yaml
+++ b/config/crds/bases/external-secrets.io_secretstores.yaml
@@ -2481,7 +2481,9 @@ spec:
                       vault:
                         description: |-
                           Vault is the name or UUID of the vault to fetch secrets from.
-                          When omitted, the vault must be specified in the secret key using the legacy format "<vault-id>/<entry-id>".
+                          When omitted, each secret key must name its own vault: the first slash or backslash
+                          separates the vault from the entry reference. Both accept a name or a UUID, and the entry
+                          reference may include a folder path. This allows one store to serve secrets from many vaults.
                         type: string
                     required:
                     - auth

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -4641,7 +4641,9 @@ spec:
                         vault:
                           description: |-
                             Vault is the name or UUID of the vault to fetch secrets from.
-                            When omitted, the vault must be specified in the secret key using the legacy format "<vault-id>/<entry-id>".
+                            When omitted, each secret key must name its own vault: the first slash or backslash
+                            separates the vault from the entry reference. Both accept a name or a UUID, and the entry
+                            reference may include a folder path. This allows one store to serve secrets from many vaults.
                           type: string
                       required:
                         - auth
@@ -17841,7 +17843,9 @@ spec:
                         vault:
                           description: |-
                             Vault is the name or UUID of the vault to fetch secrets from.
-                            When omitted, the vault must be specified in the secret key using the legacy format "<vault-id>/<entry-id>".
+                            When omitted, each secret key must name its own vault: the first slash or backslash
+                            separates the vault from the entry reference. Both accept a name or a UUID, and the entry
+                            reference may include a folder path. This allows one store to serve secrets from many vaults.
                           type: string
                       required:
                         - auth

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -3900,7 +3900,9 @@ string
 <td>
 <em>(Optional)</em>
 <p>Vault is the name or UUID of the vault to fetch secrets from.
-When omitted, the vault must be specified in the secret key using the legacy format &ldquo;<vault-id>/<entry-id>&rdquo;.</p>
+When omitted, each secret key must name its own vault: the first slash or backslash
+separates the vault from the entry reference. Both accept a name or a UUID, and the entry
+reference may include a folder path. This allows one store to serve secrets from many vaults.</p>
 </td>
 </tr>
 <tr>

--- a/docs/provider/devolutions-server.md
+++ b/docs/provider/devolutions-server.md
@@ -35,7 +35,7 @@ kubectl create secret generic dvls-credentials \
 | Field | Description |
 |-------|-------------|
 | `serverUrl` | The URL of your DVLS instance (e.g., `https://dvls.example.com`) |
-| `vault` | (Optional) The name or UUID of the vault to fetch secrets from. When omitted, the vault must be specified in the secret key using the legacy `<vault-id>/<entry-id>` format. |
+| `vault` | (Optional) The name or UUID of the vault to fetch secrets from. When omitted, each secret key names its own vault as `<vault>/<entry>`, letting one store serve many vaults. |
 | `insecure` | (Optional) Set to `true` to allow plain HTTP connections. **Not recommended for production.** |
 | `auth.secretRef.appId` | Reference to the secret containing the Application ID |
 | `auth.secretRef.appSecret` | Reference to the secret containing the Application Secret |
@@ -44,7 +44,11 @@ kubectl create secret generic dvls-credentials \
 
 ## Referencing Secrets
 
-Entries can be referenced by **UUID** or **name**:
+How a key is interpreted depends on whether the store sets `vault`.
+
+### Store with a vault
+
+The vault is configured in the SecretStore's `vault` field (name or UUID), so the key only needs to identify the entry:
 
 | Format | Example |
 |--------|---------|
@@ -53,7 +57,33 @@ Entries can be referenced by **UUID** or **name**:
 | Entry name with folder path | `infrastructure/databases/db-credentials` |
 | Folder path with backslashes | `infrastructure\databases\db-credentials` |
 
-The vault is configured in the SecretStore's `vault` field (name or UUID), so the key only needs to identify the entry.
+### Store without a vault
+
+The first segment of the key names the vault, and the rest identifies the entry exactly as above. This lets a single `ClusterSecretStore` serve every app in the cluster, each pointing at its own vault:
+
+| Format | Example |
+|--------|---------|
+| Vault name and entry name | `payments/db-credentials` |
+| Vault name with folder path | `payments/infrastructure/databases/db-credentials` |
+| Vault UUID and entry UUID | `054890f4-.../be3b23b3-...` |
+
+The vault and the entry each accept a name or a UUID.
+
+**UUID-shaped names are reserved.** A segment that parses as a UUID is always treated as an ID, never looked up as a name. So a vault, folder or entry whose name happens to look like a UUID cannot be addressed by that name — use its real UUID instead. For the same reason a folder path cannot start with a UUID-shaped segment: `payments/<uuid-like-folder>/db-credentials` is rejected.
+
+```yaml
+{% include 'dvls-cluster-secret-store.yaml' %}
+```
+
+A key with no separator is rejected, since there is no vault to fall back to. Empty path segments (`payments//db-credentials`) and a trailing segment after an entry UUID are also rejected.
+
+**Access:** DVLS grants are per vault, so the application identity behind a shared store needs read access to every vault its keys reference. This is the trade-off against a per-app store.
+
+**Cost:** resolving a vault **name** enumerates every vault visible to the identity. The result is cached for the lifetime of one reconciliation, so a key set spanning many vaults costs a single enumeration — but a new client is created per ExternalSecret refresh, so a large fleet on one shared store repeats it per refresh. Use vault UUIDs or a longer `refreshInterval` if that matters.
+
+**Renames:** a vault name is a convenience reference, not a stable identifier. Renaming a vault changes what its old name resolves to. Use UUIDs where that matters.
+
+**Missing vault vs. missing entry:** DVLS addresses an entry as `/vault/{vault}/entry/{entry}`, so a `404` alone cannot say which of the two is gone. The provider confirms the vault before reporting an entry as absent, so a deleted or inaccessible vault surfaces as an error rather than an empty secret. This matters under `deletionPolicy: Delete`, where a secret reported absent is removed from the cluster.
 
 ### Folder paths
 
@@ -64,6 +94,8 @@ folder/subfolder/entry-name
 folder\subfolder\entry-name
 ```
 
+These examples assume the store sets `vault`. Without it the first segment is read as the vault, so the same entry is `payments/folder/subfolder/entry-name`.
+
 **Note:** When using backslashes in YAML, you must escape them with a double backslash (`\\`):
 
 ```yaml
@@ -72,9 +104,11 @@ key: "folder\\subfolder\\entry-name"
 
 Forward slashes do not need escaping and are recommended for simplicity.
 
-**Important:** Entry names containing forward slashes (`/`) or backslashes (`\`) are not supported with name-based lookups, as those characters are interpreted as path separators. Use the entry UUID instead.
+**Important:** Entry and vault names containing forward slashes (`/`) or backslashes (`\`) are not supported with name-based lookups, as those characters are interpreted as separators. Use the UUID instead.
 
 The folder path is **optional**. Without a path, the provider searches across all folders in the vault. If multiple entries share the same name in different folders, you can either specify the folder path or use the entry UUID to disambiguate.
+
+A folder path matches the given folder **and its subfolders**, so it narrows a search rather than pinning an exact folder.
 
 **Name-based lookups** resolve the name to a UUID at runtime via an API call. If multiple credential entries match, an error is returned. For write-heavy scenarios (frequent `PushSecret` operations), prefer UUID references to avoid the extra lookup per operation.
 

--- a/docs/snippets/dvls-cluster-secret-store.yaml
+++ b/docs/snippets/dvls-cluster-secret-store.yaml
@@ -1,0 +1,58 @@
+---
+# One store for the whole cluster: no vault, so each key names its own.
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: dvls-cluster-store
+spec:
+  provider:
+    dvls:
+      serverUrl: 'https://dvls.example.com'
+      auth:
+        secretRef:
+          appId:
+            name: dvls-credentials
+            namespace: external-secrets
+            key: app-id
+          appSecret:
+            name: dvls-credentials
+            namespace: external-secrets
+            key: app-secret
+---
+# The payments app reads from its own vault.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: payments-credentials
+  namespace: payments
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: dvls-cluster-store
+  target:
+    name: payments-secret
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        key: 'payments/db-credentials'
+---
+# The billing app reads from a different vault, through the same store.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: billing-credentials
+  namespace: billing
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: dvls-cluster-store
+  target:
+    name: billing-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: password
+      remoteRef:
+        key: 'billing/infrastructure/databases/db-credentials'
+        property: password

--- a/docs/snippets/dvls-push-secret.yaml
+++ b/docs/snippets/dvls-push-secret.yaml
@@ -15,5 +15,5 @@ spec:
         secretKey: password
         remoteRef:
           # When vault is set in the SecretStore, remoteKey is the entry name
-          # (or path/name). Without vault, use the legacy 'vault-uuid/entry-uuid' format.
+          # (or path/name). Without vault, prefix it with the vault: 'my-vault/db-credentials'.
           remoteKey: 'db-credentials'

--- a/go.mod
+++ b/go.mod
@@ -206,7 +206,7 @@ require (
 	github.com/BeyondTrust/go-client-library-passwordsafe v1.3.0 // indirect
 	github.com/DelineaXPM/dsv-sdk-go/v2 v2.2.0 // indirect
 	github.com/DelineaXPM/tss-sdk-go/v3 v3.0.2 // indirect
-	github.com/Devolutions/go-dvls v0.19.1 // indirect
+	github.com/Devolutions/go-dvls v0.20.1 // indirect
 	github.com/Onboardbase/go-cryptojs-aes-decrypt v0.0.0-20230430095000-27c0d3a9016d // indirect
 	github.com/ProtonMail/go-crypto v1.4.1 // indirect
 	github.com/ProtonMail/gopenpgp/v3 v3.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/DelineaXPM/dsv-sdk-go/v2 v2.2.0 h1:62E66sDf+Hs1TChuu3R7d+0U5s7yV84QIO
 github.com/DelineaXPM/dsv-sdk-go/v2 v2.2.0/go.mod h1:58Pflli0BtqeF0VgluDSSVE5QlIfLOJvat0JSvo/d70=
 github.com/DelineaXPM/tss-sdk-go/v3 v3.0.2 h1:8wRzxlo6fujNoDbnp6PnawY3moxqQelxpJGzTHG7Qoo=
 github.com/DelineaXPM/tss-sdk-go/v3 v3.0.2/go.mod h1:VmyoHQ25FhSVHTI3/ptQNOviNEMfCy2ALAf/3E4Eqxg=
-github.com/Devolutions/go-dvls v0.19.1 h1:7EEHGr7qRJ4kYeFmBVf6PP7oSDDtw0EUdMi7UB3awns=
-github.com/Devolutions/go-dvls v0.19.1/go.mod h1:I0YI4GujLbbUojNnKLGVguiWUvnE2J9ltgwxTmtTRyo=
+github.com/Devolutions/go-dvls v0.20.1 h1:px6wRQEJLWdms1I/iHvPKdLXP5o1mjgSbX9aXazm9/8=
+github.com/Devolutions/go-dvls v0.20.1/go.mod h1:I0YI4GujLbbUojNnKLGVguiWUvnE2J9ltgwxTmtTRyo=
 github.com/HdrHistogram/hdrhistogram-go v1.1.0/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob0t8PQPMybUNFM=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=

--- a/providers/v1/dvls/auth.go
+++ b/providers/v1/dvls/auth.go
@@ -36,40 +36,59 @@ func (r *realVaultClient) GetByName(ctx context.Context, name string) (dvls.Vaul
 	return r.vaults.GetByNameWithContext(ctx, name)
 }
 
-// NewDVLSClient creates a new authenticated DVLS client and resolves the vault.
-func NewDVLSClient(ctx context.Context, kube kclient.Client, storeKind, namespace string, provider *esv1.DVLSProvider) (credentialClient, string, error) {
+func (r *realVaultClient) Get(ctx context.Context, id string) (dvls.Vault, error) {
+	return r.vaults.GetWithContext(ctx, id)
+}
+
+func (r *realVaultClient) List(ctx context.Context) ([]dvls.Vault, error) {
+	return r.vaults.ListWithContext(ctx)
+}
+
+// storeClients holds the service clients and resolved vault for a DVLS store.
+type storeClients struct {
+	cred        credentialClient
+	vaults      vaultGetter
+	vaultID     string
+	pinnedVault bool
+}
+
+// newStoreClients creates a new authenticated DVLS client and resolves the vault.
+func newStoreClients(ctx context.Context, kube kclient.Client, storeKind, namespace string, provider *esv1.DVLSProvider) (*storeClients, error) {
 	if provider == nil {
-		return nil, "", fmt.Errorf("missing provider configuration")
+		return nil, fmt.Errorf("missing provider configuration")
 	}
 
 	appID, err := resolvers.SecretKeyRef(ctx, kube, storeKind, namespace, &provider.Auth.SecretRef.AppID)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to get appId: %w", err)
+		return nil, fmt.Errorf("failed to get appId: %w", err)
 	}
 
 	appSecret, err := resolvers.SecretKeyRef(ctx, kube, storeKind, namespace, &provider.Auth.SecretRef.AppSecret)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to get appSecret: %w", err)
+		return nil, fmt.Errorf("failed to get appSecret: %w", err)
 	}
 
 	client, err := dvls.NewClient(appID, appSecret, provider.ServerURL)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to create DVLS client: %w", err)
+		return nil, fmt.Errorf("failed to create DVLS client: %w", err)
 	}
 
-	credClient := &realCredentialClient{cred: client.Entries.Credential}
+	clients := &storeClients{
+		cred:   &realCredentialClient{cred: client.Entries.Credential},
+		vaults: &realVaultClient{vaults: client.Vaults},
+	}
 
-	// When vault is empty, the provider operates in legacy mode where
-	// the vault ID is expected in the secret key (<vault-id>/<entry-id>).
+	// When vault is empty, each secret key names its own vault (<vault>/<entry>).
 	if provider.Vault == "" {
-		return credClient, "", nil
+		return clients, nil
 	}
 
-	vaultCl := &realVaultClient{vaults: client.Vaults}
-	vaultID, err := resolveVaultRef(ctx, provider.Vault, vaultCl)
+	vaultID, err := resolveVaultRef(ctx, provider.Vault, clients.vaults)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to resolve vault: %w", err)
+		return nil, fmt.Errorf("failed to resolve vault: %w", err)
 	}
+	clients.vaultID = vaultID
+	clients.pinnedVault = true
 
-	return credClient, vaultID, nil
+	return clients, nil
 }

--- a/providers/v1/dvls/auth_test.go
+++ b/providers/v1/dvls/auth_test.go
@@ -31,7 +31,7 @@ import (
 	esmeta "github.com/external-secrets/external-secrets/apis/meta/v1"
 )
 
-func TestNewDVLSClient_CrossNamespaceSecurityConstraint(t *testing.T) {
+func TestNewStoreClients_CrossNamespaceSecurityConstraint(t *testing.T) {
 	otherNamespace := "other-namespace"
 
 	tests := []struct {
@@ -107,12 +107,11 @@ func TestNewDVLSClient_CrossNamespaceSecurityConstraint(t *testing.T) {
 				},
 			}
 
-			credClient, vaultID, err := NewDVLSClient(context.Background(), kube, tt.storeKind, tt.namespace, provider)
+			clients, err := newStoreClients(context.Background(), kube, tt.storeKind, tt.namespace, provider)
 
 			if tt.expectError {
 				require.Error(t, err)
-				require.Nil(t, credClient)
-				require.Empty(t, vaultID)
+				require.Nil(t, clients)
 				if tt.errorMsg != "" {
 					assert.Contains(t, err.Error(), tt.errorMsg)
 				}

--- a/providers/v1/dvls/client.go
+++ b/providers/v1/dvls/client.go
@@ -37,18 +37,39 @@ const (
 
 var errNotImplemented = errors.New("not implemented")
 
+// vaultError reports a failure to resolve or reach a vault, as opposed to a missing entry.
+// isNotFoundError rejects it outright, so a 404 from a vault endpoint cannot become
+// NoSecretErr and let deletionPolicy: Delete prune a live Secret.
+type vaultError struct {
+	vaultRef string
+	err      error
+}
+
+func (e *vaultError) Error() string {
+	if e.vaultRef == "" {
+		return fmt.Sprintf("failed to list DVLS vaults: %v", e.err)
+	}
+	return fmt.Sprintf("vault %q was not found or is unreachable: %v", e.vaultRef, e.err)
+}
+
+func (e *vaultError) Unwrap() error { return e.err }
+
 var _ esv1.SecretsClient = &Client{}
 
 // Client implements the SecretsClient interface for DVLS.
-// The nameCache maps entry name/path keys to resolved UUIDs, avoiding
-// repeated GetEntries calls during a single reconciliation. The cache is
-// not persisted: each reconciliation creates a new Client via NewClient,
-// so stale entries (e.g. deleted or renamed) are naturally discarded.
+// The nameCache maps vault-scoped entry name/path keys to resolved UUIDs, avoiding
+// repeated GetEntries calls during a single reconciliation. vaultIndex does the same
+// for vault names. Neither is persisted: each reconciliation creates a new Client via
+// NewClient, so stale entries (e.g. deleted or renamed) are naturally discarded.
 type Client struct {
-	cred      credentialClient
-	vaultID   string
-	mu        sync.RWMutex
-	nameCache map[string]string
+	cred        credentialClient
+	vaults      vaultGetter
+	vaultID     string
+	pinnedVault bool
+	mu          sync.RWMutex
+	nameCache   map[string]string
+	indexMu     sync.Mutex
+	vaultIndex  map[string]string
 }
 
 type credentialClient interface {
@@ -60,6 +81,8 @@ type credentialClient interface {
 
 type vaultGetter interface {
 	GetByName(ctx context.Context, name string) (dvls.Vault, error)
+	Get(ctx context.Context, id string) (dvls.Vault, error)
+	List(ctx context.Context) ([]dvls.Vault, error)
 }
 
 type realCredentialClient struct {
@@ -82,9 +105,16 @@ func (r *realCredentialClient) DeleteByID(ctx context.Context, vaultID, entryID 
 	return r.cred.DeleteByIdWithContext(ctx, vaultID, entryID)
 }
 
-// NewClient creates a new DVLS secrets client.
-func NewClient(cred credentialClient, vaultID string) *Client {
-	return &Client{cred: cred, vaultID: vaultID, nameCache: make(map[string]string)}
+// NewClient creates a new DVLS secrets client. When pinnedVault is true the store
+// configured a vault and vaultID holds it; otherwise the vault comes from the key.
+func NewClient(cred credentialClient, vaults vaultGetter, vaultID string, pinnedVault bool) *Client {
+	return &Client{
+		cred:        cred,
+		vaults:      vaults,
+		vaultID:     vaultID,
+		pinnedVault: pinnedVault,
+		nameCache:   make(map[string]string),
+	}
 }
 
 // GetSecret retrieves a secret from DVLS.
@@ -102,6 +132,9 @@ func (c *Client) GetSecret(ctx context.Context, ref esv1.ExternalSecretDataRemot
 		return nil, fmt.Errorf(errVaultNotFound, vaultID, err)
 	}
 	if isNotFoundError(err) {
+		if vaultErr := c.confirmVault(ctx, vaultID); vaultErr != nil {
+			return nil, vaultErr
+		}
 		return nil, esv1.NoSecretErr
 	}
 	if err != nil {
@@ -141,6 +174,9 @@ func (c *Client) GetSecretMap(ctx context.Context, ref esv1.ExternalSecretDataRe
 		return nil, fmt.Errorf(errVaultNotFound, vaultID, err)
 	}
 	if isNotFoundError(err) {
+		if vaultErr := c.confirmVault(ctx, vaultID); vaultErr != nil {
+			return nil, vaultErr
+		}
 		return nil, esv1.NoSecretErr
 	}
 	if err != nil {
@@ -161,9 +197,6 @@ func (c *Client) PushSecret(ctx context.Context, secret *corev1.Secret, data esv
 		return errors.New("secret is required for DVLS push")
 	}
 	vaultID, entryID, err := c.resolveRef(ctx, data.GetRemoteKey())
-	if isVaultNotFoundError(err) {
-		return fmt.Errorf(errVaultNotFound, c.vaultID, err)
-	}
 	if isNotFoundError(err) {
 		return fmt.Errorf("entry %q not found: entry must exist before pushing secrets", data.GetRemoteKey())
 	}
@@ -181,6 +214,9 @@ func (c *Client) PushSecret(ctx context.Context, secret *corev1.Secret, data esv
 		return fmt.Errorf(errVaultNotFound, vaultID, err)
 	}
 	if isNotFoundError(err) {
+		if vaultErr := c.confirmVault(ctx, vaultID); vaultErr != nil {
+			return vaultErr
+		}
 		return fmt.Errorf("entry %s not found in vault %s: entry must exist before pushing secrets", entryID, vaultID)
 	}
 	if err != nil {
@@ -210,6 +246,10 @@ func (c *Client) DeleteSecret(ctx context.Context, ref esv1.PushSecretRemoteRef)
 	}
 	if err := c.cred.DeleteByID(ctx, vaultID, entryID); err != nil {
 		if isNotFoundError(err) {
+			// Only idempotent once the vault is known to be reachable.
+			if vaultErr := c.confirmVault(ctx, vaultID); vaultErr != nil {
+				return vaultErr
+			}
 			return nil
 		}
 		return fmt.Errorf("failed to delete entry %q from vault %q: %w", entryID, vaultID, err)
@@ -229,6 +269,9 @@ func (c *Client) SecretExists(ctx context.Context, ref esv1.PushSecretRemoteRef)
 
 	_, err = c.cred.GetByID(ctx, vaultID, entryID)
 	if isNotFoundError(err) {
+		if vaultErr := c.confirmVault(ctx, vaultID); vaultErr != nil {
+			return false, vaultErr
+		}
 		return false, nil
 	}
 	if err != nil {
@@ -242,6 +285,10 @@ func (c *Client) Validate() (esv1.ValidationResult, error) {
 	if c.cred == nil {
 		return esv1.ValidationResultError, errors.New("DVLS client is not initialized")
 	}
+	// Without a pinned vault, keys name their own vault and need a vault client to resolve it.
+	if !c.pinnedVault && c.vaults == nil {
+		return esv1.ValidationResultError, errors.New("DVLS vault client is not initialized")
+	}
 	return esv1.ValidationResultReady, nil
 }
 
@@ -251,22 +298,103 @@ func (c *Client) Close(_ context.Context) error {
 }
 
 // resolveRef resolves a key to a vault ID and entry ID.
-// When c.vaultID is set, the key is treated as an entry reference.
-// When c.vaultID is empty, the key is parsed as the legacy "<vault-uuid>/<entry-uuid>" format.
+// When the store pins a vault, the whole key is an entry reference inside it.
+// Otherwise the first separator splits a vault reference from the entry reference:
+//
+//	"my-vault/db-creds"             → vault "my-vault", entry "db-creds"
+//	"my-vault/folder/db-creds"      → vault "my-vault", path "folder", entry "db-creds"
+//	"<vault-uuid>/<entry-uuid>"     → both used directly
 func (c *Client) resolveRef(ctx context.Context, key string) (vaultID, entryID string, err error) {
-	if c.vaultID == "" {
-		return parseLegacyRef(key)
+	if c.pinnedVault {
+		entryID, err = c.resolveEntryRef(ctx, c.vaultID, key)
+		return c.vaultID, entryID, err
 	}
-	entryID, err = c.resolveEntryRef(ctx, key)
-	return c.vaultID, entryID, err
+
+	vaultRef, entryRef, err := splitVaultRef(key)
+	if err != nil {
+		return "", "", err
+	}
+	vaultID, err = c.resolveVault(ctx, vaultRef)
+	if err != nil {
+		return "", "", err
+	}
+	entryID, err = c.resolveEntryRef(ctx, vaultID, entryRef)
+	return vaultID, entryID, err
 }
 
-// resolveEntryRef resolves an entry reference to a UUID.
+// confirmVault reports whether a 404 from the entry endpoint really means the entry is gone.
+// The SDK addresses entries as /vault/{vaultID}/entry/{entryID}, so a 404 is ambiguous: an
+// unreachable vault looks identical to a deleted entry. Returning nil means the vault is
+// reachable and the caller may treat the entry as absent.
+func (c *Client) confirmVault(ctx context.Context, vaultID string) error {
+	if c.vaults == nil {
+		return nil
+	}
+	if _, err := c.vaults.Get(ctx, vaultID); err != nil {
+		return &vaultError{vaultRef: vaultID, err: err}
+	}
+	return nil
+}
+
+// resolveVault resolves a vault reference (name or UUID) to a vault UUID, caching names.
+func (c *Client) resolveVault(ctx context.Context, vaultRef string) (string, error) {
+	if isUUID(vaultRef) {
+		return vaultRef, nil
+	}
+	if c.vaults == nil {
+		return "", fmt.Errorf("cannot resolve vault %q by name: no vault client configured", vaultRef)
+	}
+
+	index, err := c.loadVaultIndex(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	id, ok := index[vaultRef]
+	if !ok {
+		return "", &vaultError{vaultRef: vaultRef, err: dvls.ErrVaultNotFound}
+	}
+	return id, nil
+}
+
+// loadVaultIndex lists every visible vault once and indexes it by name. GetByName would
+// enumerate all vaults per lookup, so a single index keeps a multi-vault key set to one call.
+// The lock is held across List so concurrent callers share one enumeration.
+func (c *Client) loadVaultIndex(ctx context.Context) (map[string]string, error) {
+	c.indexMu.Lock()
+	defer c.indexMu.Unlock()
+
+	if c.vaultIndex != nil {
+		return c.vaultIndex, nil
+	}
+
+	vaults, err := c.vaults.List(ctx)
+	if err != nil {
+		return nil, &vaultError{err: err}
+	}
+
+	index := make(map[string]string, len(vaults))
+	for _, v := range vaults {
+		// DVLS enforces unique vault names; fail loudly rather than pick one arbitrarily.
+		if _, dup := index[v.Name]; dup {
+			return nil, fmt.Errorf("found multiple vaults named %q; use the vault UUID to select one", v.Name)
+		}
+		if !isUUID(v.Id) {
+			return nil, fmt.Errorf("vault %q has an invalid UUID: %q", v.Name, v.Id)
+		}
+		index[v.Name] = v.Id
+	}
+
+	c.vaultIndex = index
+	return index, nil
+}
+
+// resolveEntryRef resolves an entry reference to a UUID within the given vault.
 // The key can be:
 //   - A UUID: used directly.
 //   - A name: looked up via GetEntries.
 //   - A path/name: "folder/subfolder/entry-name" — path is used to filter.
-func (c *Client) resolveEntryRef(ctx context.Context, key string) (entryID string, err error) {
+func (c *Client) resolveEntryRef(ctx context.Context, vaultID, key string) (entryID string, err error) {
 	key = strings.TrimSpace(key)
 	if key == "" {
 		return "", errors.New("entry reference cannot be empty")
@@ -277,9 +405,10 @@ func (c *Client) resolveEntryRef(ctx context.Context, key string) (entryID strin
 		return key, nil
 	}
 
-	// Return cached result if available.
+	// Return cached result if available. Scoped by vault: one client can serve several.
+	cacheKey := vaultID + "/" + key
 	c.mu.RLock()
-	id, ok := c.nameCache[key]
+	id, ok := c.nameCache[cacheKey]
 	c.mu.RUnlock()
 	if ok {
 		return id, nil
@@ -296,11 +425,12 @@ func (c *Client) resolveEntryRef(ctx context.Context, key string) (entryID strin
 		opts.Path = &entryPath
 	}
 
-	entries, err := c.cred.GetEntries(ctx, c.vaultID, opts)
-	if isVaultNotFoundError(err) {
-		return "", fmt.Errorf(errVaultNotFound, c.vaultID, err)
-	}
+	entries, err := c.cred.GetEntries(ctx, vaultID, opts)
 	if err != nil {
+		// A missing entry yields an empty list, so a not-found here is about the vault.
+		if isNotFoundError(err) || isVaultNotFoundError(err) {
+			return "", &vaultError{vaultRef: vaultID, err: err}
+		}
 		return "", fmt.Errorf("failed to resolve entry %q: %w", key, err)
 	}
 
@@ -309,7 +439,7 @@ func (c *Client) resolveEntryRef(ctx context.Context, key string) (entryID strin
 		return "", fmt.Errorf("entry %q not found in vault: %w", key, dvls.ErrEntryNotFound)
 	case 1:
 		c.mu.Lock()
-		c.nameCache[key] = entries[0].Id
+		c.nameCache[cacheKey] = entries[0].Id
 		c.mu.Unlock()
 		return entries[0].Id, nil
 	default:
@@ -321,31 +451,38 @@ func (c *Client) resolveEntryRef(ctx context.Context, key string) (entryID strin
 	}
 }
 
-// parseLegacyRef parses the legacy secret reference format "<vault-uuid>/<entry-uuid>".
-// This preserves backward compatibility for users who don't set the vault field.
-func parseLegacyRef(key string) (vaultID, entryID string, err error) {
-	parts := strings.SplitN(key, "/", 2)
-	if len(parts) != 2 {
-		return "", "", fmt.Errorf("invalid key format: expected '<vault-id>/<entry-id>', got %q", key)
+// splitVaultRef splits "<vault-ref>/<entry-ref>" on the first separator. Both forward
+// slashes and backslashes are accepted, matching parseEntryRef.
+// Empty segments are rejected, and a UUID entry segment must be the whole entry reference,
+// so keys that failed validation before vault names were supported keep failing.
+func splitVaultRef(key string) (vaultRef, entryRef string, err error) {
+	key = strings.TrimSpace(key)
+	idx := strings.IndexAny(key, `/\`)
+	if idx < 0 {
+		return "", "", fmt.Errorf("invalid key format: expected '<vault>/<entry>', got %q", key)
 	}
 
-	vaultID = strings.TrimSpace(parts[0])
-	entryID = strings.TrimSpace(parts[1])
+	vaultRef = strings.TrimSpace(key[:idx])
+	entryRef = strings.TrimSpace(key[idx+1:])
 
-	if vaultID == "" {
-		return "", "", errors.New("vault ID cannot be empty")
+	if vaultRef == "" {
+		return "", "", errors.New("vault reference cannot be empty")
 	}
-	if entryID == "" {
-		return "", "", errors.New("entry ID cannot be empty")
-	}
-	if !isUUID(vaultID) {
-		return "", "", fmt.Errorf("invalid vault UUID: %q", vaultID)
-	}
-	if !isUUID(entryID) {
-		return "", "", fmt.Errorf("invalid entry UUID: %q", entryID)
+	if entryRef == "" {
+		return "", "", errors.New("entry reference cannot be empty")
 	}
 
-	return vaultID, entryID, nil
+	segments := strings.Split(strings.ReplaceAll(entryRef, "/", `\`), `\`)
+	for _, segment := range segments {
+		if strings.TrimSpace(segment) == "" {
+			return "", "", fmt.Errorf("invalid key format: empty path segment in %q", key)
+		}
+	}
+	if len(segments) > 1 && isUUID(strings.TrimSpace(segments[0])) {
+		return "", "", fmt.Errorf("invalid key format: entry UUID %q must be the whole entry reference", segments[0])
+	}
+
+	return vaultRef, entryRef, nil
 }
 
 // resolveVaultRef resolves a vault reference (name or UUID) to a vault UUID.
@@ -356,6 +493,9 @@ func resolveVaultRef(ctx context.Context, vaultRef string, vc vaultGetter) (stri
 	vault, err := vc.GetByName(ctx, vaultRef)
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve vault %q: %w", vaultRef, err)
+	}
+	if !isUUID(vault.Id) {
+		return "", fmt.Errorf("vault %q resolved to an invalid UUID: %q", vaultRef, vault.Id)
 	}
 	return vault.Id, nil
 }
@@ -419,6 +559,11 @@ func extractPushValue(secret *corev1.Secret, data esv1.PushSecretData) ([]byte, 
 
 func isNotFoundError(err error) bool {
 	if err == nil {
+		return false
+	}
+
+	// A vault-stage failure is never a missing secret, even when the cause is a 404.
+	if _, ok := errors.AsType[*vaultError](err); ok {
 		return false
 	}
 

--- a/providers/v1/dvls/client_test.go
+++ b/providers/v1/dvls/client_test.go
@@ -21,10 +21,14 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/Devolutions/go-dvls"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
@@ -33,6 +37,8 @@ import (
 
 const (
 	testVaultUUID    = "00000000-0000-0000-0000-000000000001"
+	testVaultUUID2   = "00000000-0000-0000-0000-0000000000a1"
+	testVaultName2   = "other-vault"
 	testEntryUUID    = "00000000-0000-0000-0000-000000000002"
 	testEntryUUID3   = "00000000-0000-0000-0000-000000000003"
 	testEntryUUID4   = "00000000-0000-0000-0000-000000000004"
@@ -53,28 +59,44 @@ type mockCredentialClient struct {
 	deleteErr     error
 	lastUpdated   dvls.Entry
 	lastDeleted   string
+
+	mu           sync.Mutex
+	entriesCalls map[string]int
+}
+
+func (m *mockCredentialClient) countEntriesCall(vaultID string) {
+	m.mu.Lock()
+	m.entriesCalls[vaultID]++
+	m.mu.Unlock()
 }
 
 func newMockCredentialClient(entries map[string]dvls.Entry) *mockCredentialClient {
 	if entries == nil {
 		entries = make(map[string]dvls.Entry)
 	}
-	return &mockCredentialClient{entries: entries}
+	return &mockCredentialClient{entries: entries, entriesCalls: make(map[string]int)}
 }
 
-func (m *mockCredentialClient) GetByID(_ context.Context, _, entryID string) (dvls.Entry, error) {
+// entryMatchesVault scopes lookups to a vault so wrong-vault bugs are visible. Entries with
+// no VaultId belong to every vault, keeping single-vault fixtures terse.
+func entryMatchesVault(e dvls.Entry, vaultID string) bool {
+	return e.VaultId == "" || e.VaultId == vaultID
+}
+
+func (m *mockCredentialClient) GetByID(_ context.Context, vaultID, entryID string) (dvls.Entry, error) {
 	if m.getErr != nil {
 		return dvls.Entry{}, m.getErr
 	}
 
-	if entry, ok := m.entries[entryID]; ok {
+	if entry, ok := m.entries[entryID]; ok && entryMatchesVault(entry, vaultID) {
 		return entry, nil
 	}
 
 	return dvls.Entry{}, &dvls.RequestError{Err: fmt.Errorf("unexpected status code %d", http.StatusNotFound), Url: entryID, StatusCode: http.StatusNotFound}
 }
 
-func (m *mockCredentialClient) GetEntries(_ context.Context, _ string, opts dvls.GetEntriesOptions) ([]dvls.Entry, error) {
+func (m *mockCredentialClient) GetEntries(_ context.Context, vaultID string, opts dvls.GetEntriesOptions) ([]dvls.Entry, error) {
+	m.countEntriesCall(vaultID)
 	if m.getEntriesErr != nil {
 		return nil, m.getEntriesErr
 	}
@@ -83,7 +105,7 @@ func (m *mockCredentialClient) GetEntries(_ context.Context, _ string, opts dvls
 	}
 	var matches []dvls.Entry
 	for _, e := range m.entries {
-		if e.Name == *opts.Name {
+		if e.Name == *opts.Name && entryMatchesVault(e, vaultID) {
 			if opts.Path != nil && e.Path != *opts.Path {
 				continue
 			}
@@ -102,9 +124,14 @@ func (m *mockCredentialClient) Update(_ context.Context, entry dvls.Entry) (dvls
 	return entry, nil
 }
 
-func (m *mockCredentialClient) DeleteByID(_ context.Context, _, entryID string) error {
+func (m *mockCredentialClient) DeleteByID(_ context.Context, vaultID, entryID string) error {
 	if m.deleteErr != nil {
 		return m.deleteErr
+	}
+
+	// Mirror the API: deleting an entry the vault does not hold is a 404.
+	if entry, ok := m.entries[entryID]; !ok || !entryMatchesVault(entry, vaultID) {
+		return &dvls.RequestError{Err: fmt.Errorf("unexpected status code %d", http.StatusNotFound), Url: entryID, StatusCode: http.StatusNotFound}
 	}
 
 	delete(m.entries, entryID)
@@ -115,8 +142,16 @@ func (m *mockCredentialClient) DeleteByID(_ context.Context, _, entryID string) 
 // --- Mock vault client ---
 
 type mockVaultClient struct {
-	vaults map[string]dvls.Vault
-	getErr error
+	vaults     map[string]dvls.Vault
+	getErr     error
+	getByIDErr error
+	listErr    error
+	duplicate  string
+	listGate   chan struct{}
+
+	mu        sync.Mutex
+	listCalls int
+	getCalls  int
 }
 
 func newMockVaultClient(vaults map[string]dvls.Vault) *mockVaultClient {
@@ -134,6 +169,40 @@ func (m *mockVaultClient) GetByName(_ context.Context, name string) (dvls.Vault,
 		return v, nil
 	}
 	return dvls.Vault{}, dvls.ErrVaultNotFound
+}
+
+// Get reports the vault as reachable unless getByIDErr is set, so tests that expect a
+// plain missing entry keep working and only vault-outage tests opt in.
+func (m *mockVaultClient) Get(_ context.Context, id string) (dvls.Vault, error) {
+	m.mu.Lock()
+	m.getCalls++
+	m.mu.Unlock()
+	if m.getByIDErr != nil {
+		return dvls.Vault{}, m.getByIDErr
+	}
+	return dvls.Vault{Id: id}, nil
+}
+
+func (m *mockVaultClient) List(_ context.Context) ([]dvls.Vault, error) {
+	m.mu.Lock()
+	m.listCalls++
+	m.mu.Unlock()
+	// listGate lets a test hold List open to prove concurrent callers share one enumeration.
+	if m.listGate != nil {
+		<-m.listGate
+	}
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+	list := make([]dvls.Vault, 0, len(m.vaults)+1)
+	for name, v := range m.vaults {
+		v.Name = name
+		list = append(list, v)
+	}
+	if m.duplicate != "" {
+		list = append(list, dvls.Vault{Id: testVaultUUID2, Name: m.duplicate})
+	}
+	return list, nil
 }
 
 // --- Test stubs ---
@@ -157,12 +226,28 @@ type pushSecretRemoteRefStub struct {
 func (p pushSecretRemoteRefStub) GetRemoteKey() string { return p.remoteKey }
 func (p pushSecretRemoteRefStub) GetProperty() string  { return p.property }
 
-// --- Helper to create a test client ---
+// --- Helpers to create a test client ---
 
+// newTestClient builds a client with the vault pinned by the store.
 func newTestClient(entries map[string]dvls.Entry) (*Client, *mockCredentialClient) {
 	mockCred := newMockCredentialClient(entries)
-	c := NewClient(mockCred, testVaultUUID)
+	c := NewClient(mockCred, newMockVaultClient(nil), testVaultUUID, true)
 	return c, mockCred
+}
+
+// newDynamicTestClient builds a client with no pinned vault, so keys carry the vault.
+func newDynamicTestClient(entries map[string]dvls.Entry, vaults map[string]dvls.Vault) (*Client, *mockCredentialClient, *mockVaultClient) {
+	mockCred := newMockCredentialClient(entries)
+	mockVault := newMockVaultClient(vaults)
+	c := NewClient(mockCred, mockVault, "", false)
+	return c, mockCred, mockVault
+}
+
+func defaultTestVaults() map[string]dvls.Vault {
+	return map[string]dvls.Vault{
+		testVaultName:  {Id: testVaultUUID, Name: testVaultName},
+		testVaultName2: {Id: testVaultUUID2, Name: testVaultName2},
+	}
 }
 
 // --- Tests: parseEntryRef ---
@@ -272,14 +357,14 @@ func TestResolveEntryRef(t *testing.T) {
 
 	t.Run("UUID passthrough", func(t *testing.T) {
 		c, _ := newTestClient(nil)
-		entryID, err := c.resolveEntryRef(context.Background(), testEntryUUID)
+		entryID, err := c.resolveEntryRef(context.Background(), testVaultUUID, testEntryUUID)
 		assert.NoError(t, err)
 		assert.Equal(t, testEntryUUID, entryID)
 	})
 
 	t.Run("name resolved", func(t *testing.T) {
 		c, _ := newTestClient(map[string]dvls.Entry{testEntryUUID: entry})
-		entryID, err := c.resolveEntryRef(context.Background(), testEntryName)
+		entryID, err := c.resolveEntryRef(context.Background(), testVaultUUID, testEntryName)
 		assert.NoError(t, err)
 		assert.Equal(t, testEntryUUID, entryID)
 	})
@@ -293,7 +378,7 @@ func TestResolveEntryRef(t *testing.T) {
 			SubType: dvls.EntryCredentialSubTypeDefault,
 		}
 		c, _ := newTestClient(map[string]dvls.Entry{testEntryUUID: entryInPath})
-		entryID, err := c.resolveEntryRef(context.Background(), "go-dvls/folders/my-entry")
+		entryID, err := c.resolveEntryRef(context.Background(), testVaultUUID, "go-dvls/folders/my-entry")
 		assert.NoError(t, err)
 		assert.Equal(t, testEntryUUID, entryID)
 	})
@@ -302,14 +387,14 @@ func TestResolveEntryRef(t *testing.T) {
 		entryA := dvls.Entry{Id: testEntryUUID, Name: "db", Path: `prod`, Type: dvls.EntryCredentialType, SubType: dvls.EntryCredentialSubTypeDefault}
 		entryB := dvls.Entry{Id: testEntryUUID5, Name: "db", Path: `staging`, Type: dvls.EntryCredentialType, SubType: dvls.EntryCredentialSubTypeDefault}
 		c, _ := newTestClient(map[string]dvls.Entry{testEntryUUID: entryA, testEntryUUID5: entryB})
-		entryID, err := c.resolveEntryRef(context.Background(), "prod/db")
+		entryID, err := c.resolveEntryRef(context.Background(), testVaultUUID, "prod/db")
 		assert.NoError(t, err)
 		assert.Equal(t, testEntryUUID, entryID)
 	})
 
 	t.Run("name not found", func(t *testing.T) {
 		c, _ := newTestClient(nil)
-		_, err := c.resolveEntryRef(context.Background(), "nonexistent")
+		_, err := c.resolveEntryRef(context.Background(), testVaultUUID, "nonexistent")
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, dvls.ErrEntryNotFound)
 	})
@@ -321,7 +406,7 @@ func TestResolveEntryRef(t *testing.T) {
 			testEntryUUID3: entry2,
 			testEntryUUID4: entry3,
 		})
-		_, err := c.resolveEntryRef(context.Background(), "dup")
+		_, err := c.resolveEntryRef(context.Background(), testVaultUUID, "dup")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "found 2 credential entries")
 		assert.Contains(t, err.Error(), testEntryUUID3)
@@ -330,33 +415,48 @@ func TestResolveEntryRef(t *testing.T) {
 
 	t.Run("empty key", func(t *testing.T) {
 		c, _ := newTestClient(nil)
-		_, err := c.resolveEntryRef(context.Background(), "")
+		_, err := c.resolveEntryRef(context.Background(), testVaultUUID, "")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "cannot be empty")
 	})
 
 	t.Run("trailing separator produces empty name", func(t *testing.T) {
 		c, _ := newTestClient(nil)
-		_, err := c.resolveEntryRef(context.Background(), "folder/")
+		_, err := c.resolveEntryRef(context.Background(), testVaultUUID, "folder/")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "entry name cannot be empty")
 	})
 
+	// A non-404 failure is not a vault verdict, so it keeps the plain message and its chain.
 	t.Run("GetEntries API error", func(t *testing.T) {
 		c, mockCred := newTestClient(nil)
-		mockCred.getEntriesErr = errors.New("network error")
-		_, err := c.resolveEntryRef(context.Background(), testNonExistName)
+		wrapped := errors.New("network error")
+		mockCred.getEntriesErr = wrapped
+		_, err := c.resolveEntryRef(context.Background(), testVaultUUID, testNonExistName)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to resolve entry")
-		assert.Contains(t, err.Error(), "network error")
+		assert.ErrorIs(t, err, wrapped)
+		assert.False(t, isNotFoundError(err))
 	})
 
 	t.Run("vault not found during name resolution", func(t *testing.T) {
 		c, mockCred := newTestClient(nil)
 		mockCred.getEntriesErr = dvls.ErrVaultNotFound
-		_, err := c.resolveEntryRef(context.Background(), testNonExistName)
+		_, err := c.resolveEntryRef(context.Background(), testVaultUUID, testNonExistName)
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, dvls.ErrVaultNotFound)
+		assert.False(t, isNotFoundError(err))
+	})
+
+	// A 404 from GetEntries is a vault/transport failure, never a missing entry: a missing
+	// name returns an empty list. It must not reach isNotFoundError or GetSecret would
+	// report NoSecretErr and deletionPolicy: Delete would prune a live Secret.
+	t.Run("GetEntries 404 is not treated as not-found", func(t *testing.T) {
+		c, mockCred := newTestClient(nil)
+		mockCred.getEntriesErr = &dvls.RequestError{Err: errors.New("unexpected status code 404"), StatusCode: http.StatusNotFound}
+		_, err := c.resolveEntryRef(context.Background(), testVaultUUID, testNonExistName)
+		assert.Error(t, err)
+		assert.False(t, isNotFoundError(err))
 	})
 
 	t.Run("cache hit avoids second GetEntries call", func(t *testing.T) {
@@ -369,79 +469,73 @@ func TestResolveEntryRef(t *testing.T) {
 		c, mockCred := newTestClient(map[string]dvls.Entry{testEntryUUID: entry})
 
 		// First call populates the cache.
-		id1, err := c.resolveEntryRef(context.Background(), testEntryName)
+		id1, err := c.resolveEntryRef(context.Background(), testVaultUUID, testEntryName)
 		assert.NoError(t, err)
 		assert.Equal(t, testEntryUUID, id1)
 
 		// Remove entries from mock so only the cache can satisfy the lookup.
 		mockCred.entries = map[string]dvls.Entry{}
 
-		id2, err := c.resolveEntryRef(context.Background(), testEntryName)
+		id2, err := c.resolveEntryRef(context.Background(), testVaultUUID, testEntryName)
 		assert.NoError(t, err)
 		assert.Equal(t, testEntryUUID, id2)
 	})
 }
 
-// --- Tests: parseLegacyRef ---
+// --- Tests: splitVaultRef ---
 
-func TestParseLegacyRef(t *testing.T) {
-	t.Run("valid format", func(t *testing.T) {
-		vaultID, entryID, err := parseLegacyRef(testVaultUUID + "/" + testEntryUUID)
-		assert.NoError(t, err)
-		assert.Equal(t, testVaultUUID, vaultID)
-		assert.Equal(t, testEntryUUID, entryID)
-	})
+func TestSplitVaultRef(t *testing.T) {
+	tests := []struct {
+		name      string
+		key       string
+		wantVault string
+		wantEntry string
+		wantErr   string
+	}{
+		{name: "legacy UUID pair", key: testVaultUUID + "/" + testEntryUUID, wantVault: testVaultUUID, wantEntry: testEntryUUID},
+		{name: "vault name and entry name", key: "my-vault/db-creds", wantVault: "my-vault", wantEntry: "db-creds"},
+		{name: "vault name with folder path", key: "my-vault/infra/dbs/db-creds", wantVault: "my-vault", wantEntry: "infra/dbs/db-creds"},
+		{name: "backslash separator", key: `my-vault\db-creds`, wantVault: "my-vault", wantEntry: "db-creds"},
+		{name: "vault UUID with entry name", key: testVaultUUID + "/db-creds", wantVault: testVaultUUID, wantEntry: "db-creds"},
+		{name: "surrounding whitespace", key: "  my-vault/db-creds  ", wantVault: "my-vault", wantEntry: "db-creds"},
+		{name: "uppercase UUIDs", key: strings.ToUpper(testVaultUUID) + "/" + strings.ToUpper(testEntryUUID), wantVault: strings.ToUpper(testVaultUUID), wantEntry: strings.ToUpper(testEntryUUID)},
 
-	t.Run("no separator", func(t *testing.T) {
-		_, _, err := parseLegacyRef(testEntryUUID)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid key format")
-	})
+		{name: "no separator", key: testEntryUUID, wantErr: "invalid key format"},
+		{name: "empty vault", key: "/" + testEntryUUID, wantErr: "vault reference cannot be empty"},
+		{name: "empty entry", key: testVaultUUID + "/", wantErr: "entry reference cannot be empty"},
+		// These two fail locally today and must keep failing: PushSecret and DeleteSecret
+		// share this parser, so accepting them would let an old broken key mutate a real entry.
+		{name: "doubled separator", key: testVaultUUID + "//" + testEntryUUID, wantErr: "empty path segment"},
+		{name: "mixed doubled separator", key: `my-vault/\db-creds`, wantErr: "empty path segment"},
+		{name: "entry UUID with trailing segment", key: testVaultUUID + "/" + testEntryUUID + "/extra", wantErr: "must be the whole entry reference"},
+		{name: "trailing separator on path", key: "my-vault/folder/", wantErr: "empty path segment"},
+	}
 
-	t.Run("empty vault", func(t *testing.T) {
-		_, _, err := parseLegacyRef("/" + testEntryUUID)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "vault ID cannot be empty")
-	})
-
-	t.Run("empty entry", func(t *testing.T) {
-		_, _, err := parseLegacyRef(testVaultUUID + "/")
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "entry ID cannot be empty")
-	})
-
-	t.Run("invalid vault UUID", func(t *testing.T) {
-		_, _, err := parseLegacyRef("not-a-uuid/" + testEntryUUID)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid vault UUID")
-	})
-
-	t.Run("invalid entry UUID", func(t *testing.T) {
-		_, _, err := parseLegacyRef(testVaultUUID + "/not-a-uuid")
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid entry UUID")
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vaultRef, entryRef, err := splitVaultRef(tt.key)
+			if tt.wantErr != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantVault, vaultRef)
+			assert.Equal(t, tt.wantEntry, entryRef)
+		})
+	}
 }
 
-// --- Tests: resolveRef legacy mode ---
+// --- Tests: resolveRef mode switching ---
 
-func TestResolveRef_LegacyMode(t *testing.T) {
+func TestResolveRef_PinnedVault(t *testing.T) {
 	entry := dvls.Entry{
 		Id: testEntryUUID, Name: "test",
 		Type: dvls.EntryCredentialType, SubType: dvls.EntryCredentialSubTypeDefault,
 		Data: &dvls.EntryCredentialDefaultData{Password: "pass"},
 	}
 
-	t.Run("legacy format when vaultID is empty", func(t *testing.T) {
-		mockCred := newMockCredentialClient(map[string]dvls.Entry{testEntryUUID: entry})
-		c := NewClient(mockCred, "")
-		vaultID, entryID, err := c.resolveRef(context.Background(), testVaultUUID+"/"+testEntryUUID)
-		assert.NoError(t, err)
-		assert.Equal(t, testVaultUUID, vaultID)
-		assert.Equal(t, testEntryUUID, entryID)
-	})
-
-	t.Run("new format with name when vaultID is set", func(t *testing.T) {
+	t.Run("name resolved in pinned vault", func(t *testing.T) {
 		c, _ := newTestClient(map[string]dvls.Entry{testEntryUUID: entry})
 		vaultID, entryID, err := c.resolveRef(context.Background(), "test")
 		assert.NoError(t, err)
@@ -449,12 +543,182 @@ func TestResolveRef_LegacyMode(t *testing.T) {
 		assert.Equal(t, testEntryUUID, entryID)
 	})
 
-	t.Run("new format when vaultID is set", func(t *testing.T) {
+	t.Run("UUID resolved in pinned vault", func(t *testing.T) {
 		c, _ := newTestClient(map[string]dvls.Entry{testEntryUUID: entry})
 		vaultID, entryID, err := c.resolveRef(context.Background(), testEntryUUID)
 		assert.NoError(t, err)
 		assert.Equal(t, testVaultUUID, vaultID)
 		assert.Equal(t, testEntryUUID, entryID)
+	})
+
+	// A pinned vault keeps '/' meaning folder path, so a key that looks like
+	// "<vault>/<entry>" must not be reinterpreted as a vault reference.
+	t.Run("slash stays a folder path", func(t *testing.T) {
+		inFolder := dvls.Entry{
+			Id: testEntryUUID3, Name: "db", Path: "prod",
+			Type: dvls.EntryCredentialType, SubType: dvls.EntryCredentialSubTypeDefault,
+		}
+		c, _ := newTestClient(map[string]dvls.Entry{testEntryUUID3: inFolder})
+		vaultID, entryID, err := c.resolveRef(context.Background(), "prod/db")
+		assert.NoError(t, err)
+		assert.Equal(t, testVaultUUID, vaultID)
+		assert.Equal(t, testEntryUUID3, entryID)
+	})
+}
+
+func TestResolveRef_VaultInKey(t *testing.T) {
+	entry := dvls.Entry{
+		Id: testEntryUUID, Name: "test", VaultId: testVaultUUID,
+		Type: dvls.EntryCredentialType, SubType: dvls.EntryCredentialSubTypeDefault,
+	}
+
+	t.Run("legacy UUID pair needs no vault lookup", func(t *testing.T) {
+		c, _, mockVault := newDynamicTestClient(map[string]dvls.Entry{testEntryUUID: entry}, defaultTestVaults())
+		vaultID, entryID, err := c.resolveRef(context.Background(), testVaultUUID+"/"+testEntryUUID)
+		assert.NoError(t, err)
+		assert.Equal(t, testVaultUUID, vaultID)
+		assert.Equal(t, testEntryUUID, entryID)
+		assert.Equal(t, 0, mockVault.listCalls)
+	})
+
+	t.Run("vault name and entry name", func(t *testing.T) {
+		c, _, _ := newDynamicTestClient(map[string]dvls.Entry{testEntryUUID: entry}, defaultTestVaults())
+		vaultID, entryID, err := c.resolveRef(context.Background(), testVaultName+"/test")
+		assert.NoError(t, err)
+		assert.Equal(t, testVaultUUID, vaultID)
+		assert.Equal(t, testEntryUUID, entryID)
+	})
+
+	t.Run("vault name with folder path", func(t *testing.T) {
+		inFolder := dvls.Entry{
+			Id: testEntryUUID3, Name: "db", Path: `infra\dbs`, VaultId: testVaultUUID,
+			Type: dvls.EntryCredentialType, SubType: dvls.EntryCredentialSubTypeDefault,
+		}
+		c, _, _ := newDynamicTestClient(map[string]dvls.Entry{testEntryUUID3: inFolder}, defaultTestVaults())
+		vaultID, entryID, err := c.resolveRef(context.Background(), testVaultName+"/infra/dbs/db")
+		assert.NoError(t, err)
+		assert.Equal(t, testVaultUUID, vaultID)
+		assert.Equal(t, testEntryUUID3, entryID)
+	})
+
+	t.Run("single segment key is rejected", func(t *testing.T) {
+		c, _, _ := newDynamicTestClient(nil, defaultTestVaults())
+		_, _, err := c.resolveRef(context.Background(), "db-creds")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid key format")
+	})
+
+	t.Run("unknown vault name", func(t *testing.T) {
+		c, _, _ := newDynamicTestClient(nil, defaultTestVaults())
+		_, _, err := c.resolveRef(context.Background(), "nope/db-creds")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), `vault "nope"`)
+		assert.False(t, isNotFoundError(err))
+	})
+
+	// The vault index is built once per client: GetByName enumerates every vault per call,
+	// so resolving N names must not cost N enumerations.
+	t.Run("vault index built once", func(t *testing.T) {
+		other := dvls.Entry{
+			Id: testEntryUUID4, Name: "test", VaultId: testVaultUUID2,
+			Type: dvls.EntryCredentialType, SubType: dvls.EntryCredentialSubTypeDefault,
+		}
+		c, _, mockVault := newDynamicTestClient(map[string]dvls.Entry{testEntryUUID: entry, testEntryUUID4: other}, defaultTestVaults())
+
+		_, _, err := c.resolveRef(context.Background(), testVaultName+"/test")
+		assert.NoError(t, err)
+		_, _, err = c.resolveRef(context.Background(), testVaultName2+"/test")
+		assert.NoError(t, err)
+		assert.Equal(t, 1, mockVault.listCalls)
+	})
+
+	// nameCache is keyed by vault: one client now serves several, so an unscoped cache
+	// would return the first vault's entry for every later vault. Repeating each lookup
+	// also pins the cache itself — a removed cache would issue a second GetEntries.
+	t.Run("same entry name resolves per vault", func(t *testing.T) {
+		other := dvls.Entry{
+			Id: testEntryUUID4, Name: "test", VaultId: testVaultUUID2,
+			Type: dvls.EntryCredentialType, SubType: dvls.EntryCredentialSubTypeDefault,
+		}
+		c, mockCred, _ := newDynamicTestClient(map[string]dvls.Entry{testEntryUUID: entry, testEntryUUID4: other}, defaultTestVaults())
+
+		for range 2 {
+			vaultID, entryID, err := c.resolveRef(context.Background(), testVaultName+"/test")
+			assert.NoError(t, err)
+			assert.Equal(t, testVaultUUID, vaultID)
+			assert.Equal(t, testEntryUUID, entryID)
+
+			vaultID, entryID, err = c.resolveRef(context.Background(), testVaultName2+"/test")
+			assert.NoError(t, err)
+			assert.Equal(t, testVaultUUID2, vaultID)
+			assert.Equal(t, testEntryUUID4, entryID)
+		}
+
+		// One lookup per vault, not per reference.
+		assert.Equal(t, map[string]int{testVaultUUID: 1, testVaultUUID2: 1}, mockCred.entriesCalls)
+	})
+
+	t.Run("duplicate vault names error", func(t *testing.T) {
+		c, _, mockVault := newDynamicTestClient(nil, defaultTestVaults())
+		mockVault.duplicate = testVaultName
+		_, _, err := c.resolveRef(context.Background(), testVaultName+"/test")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "multiple vaults named")
+	})
+
+	t.Run("vault list error is not a not-found", func(t *testing.T) {
+		c, _, mockVault := newDynamicTestClient(nil, defaultTestVaults())
+		mockVault.listErr = &dvls.RequestError{Err: errors.New("unexpected status code 404"), StatusCode: http.StatusNotFound}
+		_, _, err := c.resolveRef(context.Background(), testVaultName+"/test")
+		assert.Error(t, err)
+		assert.False(t, isNotFoundError(err))
+	})
+
+	// Holds List open so every other goroutine is in flight while the first enumerates.
+	// Without the lock spanning List, the waiters would each start their own enumeration.
+	t.Run("concurrent callers share one enumeration", func(t *testing.T) {
+		other := dvls.Entry{
+			Id: testEntryUUID4, Name: "test", VaultId: testVaultUUID2,
+			Type: dvls.EntryCredentialType, SubType: dvls.EntryCredentialSubTypeDefault,
+		}
+		c, _, mockVault := newDynamicTestClient(map[string]dvls.Entry{testEntryUUID: entry, testEntryUUID4: other}, defaultTestVaults())
+		mockVault.listGate = make(chan struct{})
+
+		var wg sync.WaitGroup
+		for i := range 20 {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				name := testVaultName
+				if i%2 == 0 {
+					name = testVaultName2
+				}
+				_, _, err := c.resolveRef(context.Background(), name+"/test")
+				assert.NoError(t, err)
+			}(i)
+		}
+
+		// Give every goroutine time to pile up, then confirm only one reached List.
+		for range 50 {
+			time.Sleep(time.Millisecond)
+			mockVault.mu.Lock()
+			calls := mockVault.listCalls
+			mockVault.mu.Unlock()
+			require.LessOrEqual(t, calls, 1, "more than one goroutine entered List")
+		}
+
+		close(mockVault.listGate)
+		wg.Wait()
+		assert.Equal(t, 1, mockVault.listCalls)
+	})
+
+	t.Run("invalid vault UUID from List is rejected", func(t *testing.T) {
+		c, _, _ := newDynamicTestClient(nil, map[string]dvls.Vault{
+			testVaultName: {Id: "not-a-uuid", Name: testVaultName},
+		})
+		_, _, err := c.resolveRef(context.Background(), testVaultName+"/test")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid UUID")
 	})
 }
 
@@ -468,15 +732,22 @@ func TestClient_Validate(t *testing.T) {
 		assert.Equal(t, esv1.ValidationResultError, result)
 	})
 
-	t.Run("empty vault ID is valid (legacy mode)", func(t *testing.T) {
-		c := &Client{cred: newMockCredentialClient(nil), vaultID: ""}
+	t.Run("pinned vault without vault client is valid", func(t *testing.T) {
+		c := &Client{cred: newMockCredentialClient(nil), vaultID: testVaultUUID, pinnedVault: true}
 		result, err := c.Validate()
 		assert.NoError(t, err)
 		assert.Equal(t, esv1.ValidationResultReady, result)
 	})
 
+	t.Run("vault in key requires a vault client", func(t *testing.T) {
+		c := &Client{cred: newMockCredentialClient(nil)}
+		result, err := c.Validate()
+		assert.Error(t, err)
+		assert.Equal(t, esv1.ValidationResultError, result)
+	})
+
 	t.Run("initialized client", func(t *testing.T) {
-		c := NewClient(newMockCredentialClient(nil), testVaultUUID)
+		c := NewClient(newMockCredentialClient(nil), newMockVaultClient(nil), testVaultUUID, true)
 		result, err := c.Validate()
 		assert.NoError(t, err)
 		assert.Equal(t, esv1.ValidationResultReady, result)
@@ -484,10 +755,11 @@ func TestClient_Validate(t *testing.T) {
 }
 
 func TestNewClient(t *testing.T) {
-	c := NewClient(nil, "")
+	c := NewClient(nil, nil, "", false)
 	assert.NotNil(t, c)
 	assert.Nil(t, c.cred)
 	assert.Empty(t, c.vaultID)
+	assert.False(t, c.pinnedVault)
 }
 
 // --- Tests: entryToSecretMap ---
@@ -666,6 +938,158 @@ func TestClient_GetSecret_VaultNotFoundDuringNameResolution(t *testing.T) {
 	_, err := c.GetSecret(context.Background(), esv1.ExternalSecretDataRemoteRef{Key: testNonExistName})
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, dvls.ErrVaultNotFound)
+	assert.NotErrorIs(t, err, esv1.NoSecretErr)
+}
+
+// An unreachable vault must surface as an error, never as NoSecretErr: the reconciler
+// treats NoSecretErr as "the secret is gone" and deletionPolicy: Delete acts on it.
+func TestClient_GetSecret_VaultErrorIsNotNoSecretErr(t *testing.T) {
+	notFound := &dvls.RequestError{Err: errors.New("unexpected status code 404"), StatusCode: http.StatusNotFound}
+
+	t.Run("vault list 404", func(t *testing.T) {
+		c, _, mockVault := newDynamicTestClient(nil, defaultTestVaults())
+		mockVault.listErr = notFound
+		_, err := c.GetSecret(context.Background(), esv1.ExternalSecretDataRemoteRef{Key: testVaultName + "/db"})
+		assert.Error(t, err)
+		assert.NotErrorIs(t, err, esv1.NoSecretErr)
+	})
+
+	t.Run("unknown vault name", func(t *testing.T) {
+		c, _, _ := newDynamicTestClient(nil, defaultTestVaults())
+		_, err := c.GetSecret(context.Background(), esv1.ExternalSecretDataRemoteRef{Key: "nope/db"})
+		assert.Error(t, err)
+		assert.NotErrorIs(t, err, esv1.NoSecretErr)
+	})
+
+	t.Run("GetEntries 404", func(t *testing.T) {
+		c, mockCred := newTestClient(nil)
+		mockCred.getEntriesErr = notFound
+		_, err := c.GetSecret(context.Background(), esv1.ExternalSecretDataRemoteRef{Key: testNonExistName})
+		assert.Error(t, err)
+		assert.NotErrorIs(t, err, esv1.NoSecretErr)
+	})
+
+	t.Run("GetSecretMap vault list 404", func(t *testing.T) {
+		c, _, mockVault := newDynamicTestClient(nil, defaultTestVaults())
+		mockVault.listErr = notFound
+		_, err := c.GetSecretMap(context.Background(), esv1.ExternalSecretDataRemoteRef{Key: testVaultName + "/db"})
+		assert.Error(t, err)
+		assert.NotErrorIs(t, err, esv1.NoSecretErr)
+	})
+}
+
+// The SDK addresses entries as /vault/{vaultID}/entry/{entryID}, so a direct 404 cannot
+// distinguish a deleted entry from an unreachable vault. Legacy "<vault-uuid>/<entry-uuid>"
+// keys hit this path with no name resolution at all, so the vault must be confirmed before
+// the entry is reported absent.
+func TestClient_DirectNotFound_DisambiguatesVault(t *testing.T) {
+	notFound := &dvls.RequestError{Err: errors.New("unexpected status code 404"), StatusCode: http.StatusNotFound}
+	legacyKey := testVaultUUID + "/" + testEntryUUID
+
+	newClient := func(vaultReachable bool) (*Client, *mockVaultClient) {
+		c, _, mockVault := newDynamicTestClient(nil, defaultTestVaults())
+		if !vaultReachable {
+			mockVault.getByIDErr = notFound
+		}
+		return c, mockVault
+	}
+
+	t.Run("GetSecret reports absent when vault is reachable", func(t *testing.T) {
+		c, mockVault := newClient(true)
+		_, err := c.GetSecret(context.Background(), esv1.ExternalSecretDataRemoteRef{Key: legacyKey})
+		assert.ErrorIs(t, err, esv1.NoSecretErr)
+		assert.Equal(t, 1, mockVault.getCalls)
+	})
+
+	t.Run("GetSecret errors when vault is unreachable", func(t *testing.T) {
+		c, _ := newClient(false)
+		_, err := c.GetSecret(context.Background(), esv1.ExternalSecretDataRemoteRef{Key: legacyKey})
+		assert.Error(t, err)
+		assert.NotErrorIs(t, err, esv1.NoSecretErr)
+	})
+
+	t.Run("GetSecretMap errors when vault is unreachable", func(t *testing.T) {
+		c, _ := newClient(false)
+		_, err := c.GetSecretMap(context.Background(), esv1.ExternalSecretDataRemoteRef{Key: legacyKey})
+		assert.Error(t, err)
+		assert.NotErrorIs(t, err, esv1.NoSecretErr)
+	})
+
+	t.Run("DeleteSecret is idempotent only when vault is reachable", func(t *testing.T) {
+		c, _ := newClient(true)
+		assert.NoError(t, c.DeleteSecret(context.Background(), pushSecretRemoteRefStub{remoteKey: legacyKey}))
+
+		c, _ = newClient(false)
+		assert.Error(t, c.DeleteSecret(context.Background(), pushSecretRemoteRefStub{remoteKey: legacyKey}))
+	})
+
+	t.Run("SecretExists reports false only when vault is reachable", func(t *testing.T) {
+		c, _ := newClient(true)
+		exists, err := c.SecretExists(context.Background(), pushSecretRemoteRefStub{remoteKey: legacyKey})
+		assert.NoError(t, err)
+		assert.False(t, exists)
+
+		c, _ = newClient(false)
+		exists, err = c.SecretExists(context.Background(), pushSecretRemoteRefStub{remoteKey: legacyKey})
+		assert.Error(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("PushSecret errors on vault outage rather than blaming the entry", func(t *testing.T) {
+		secret := &corev1.Secret{Data: map[string][]byte{"key": []byte("val")}}
+		data := pushSecretDataStub{remoteKey: legacyKey, secretKey: "key"}
+
+		c, _ := newClient(false)
+		err := c.PushSecret(context.Background(), secret, data)
+		assert.Error(t, err)
+		assert.NotContains(t, err.Error(), "must exist before pushing")
+
+		c, _ = newClient(true)
+		err = c.PushSecret(context.Background(), secret, data)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "must exist before pushing")
+	})
+}
+
+// Ordinary transport failures must keep their error chain: a reconciler canceling its
+// context needs errors.Is(err, context.Canceled) to keep working.
+func TestClient_TransportErrorsPreserveChain(t *testing.T) {
+	c, mockCred := newTestClient(nil)
+	mockCred.getEntriesErr = fmt.Errorf("dialing: %w", context.Canceled)
+
+	_, err := c.GetSecret(context.Background(), esv1.ExternalSecretDataRemoteRef{Key: testNonExistName})
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.NotErrorIs(t, err, esv1.NoSecretErr)
+}
+
+// DeleteSecret and SecretExists must not report success / "absent" when the vault is
+// unreachable, or a push flow would silently skip real work.
+func TestClient_MutatingPaths_VaultErrorSurfaces(t *testing.T) {
+	notFound := &dvls.RequestError{Err: errors.New("unexpected status code 404"), StatusCode: http.StatusNotFound}
+
+	t.Run("DeleteSecret", func(t *testing.T) {
+		c, _, mockVault := newDynamicTestClient(nil, defaultTestVaults())
+		mockVault.listErr = notFound
+		err := c.DeleteSecret(context.Background(), pushSecretRemoteRefStub{remoteKey: testVaultName + "/db"})
+		assert.Error(t, err)
+	})
+
+	t.Run("SecretExists", func(t *testing.T) {
+		c, _, mockVault := newDynamicTestClient(nil, defaultTestVaults())
+		mockVault.listErr = notFound
+		exists, err := c.SecretExists(context.Background(), pushSecretRemoteRefStub{remoteKey: testVaultName + "/db"})
+		assert.Error(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("PushSecret names the vault reference", func(t *testing.T) {
+		c, _, _ := newDynamicTestClient(nil, defaultTestVaults())
+		secret := &corev1.Secret{Data: map[string][]byte{"key": []byte("val")}}
+		err := c.PushSecret(context.Background(), secret, pushSecretDataStub{remoteKey: "nope/db", secretKey: "key"})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), `vault "nope"`)
+	})
 }
 
 // --- Tests: GetSecretMap ---

--- a/providers/v1/dvls/go.mod
+++ b/providers/v1/dvls/go.mod
@@ -3,7 +3,7 @@ module github.com/external-secrets/external-secrets/providers/v1/dvls
 go 1.26.5
 
 require (
-	github.com/Devolutions/go-dvls v0.19.1
+	github.com/Devolutions/go-dvls v0.20.1
 	github.com/external-secrets/external-secrets/apis v0.0.0
 	github.com/external-secrets/external-secrets/runtime v0.0.0
 	github.com/google/uuid v1.6.0

--- a/providers/v1/dvls/go.sum
+++ b/providers/v1/dvls/go.sum
@@ -1,7 +1,7 @@
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
 dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
-github.com/Devolutions/go-dvls v0.19.1 h1:7EEHGr7qRJ4kYeFmBVf6PP7oSDDtw0EUdMi7UB3awns=
-github.com/Devolutions/go-dvls v0.19.1/go.mod h1:I0YI4GujLbbUojNnKLGVguiWUvnE2J9ltgwxTmtTRyo=
+github.com/Devolutions/go-dvls v0.20.1 h1:px6wRQEJLWdms1I/iHvPKdLXP5o1mjgSbX9aXazm9/8=
+github.com/Devolutions/go-dvls v0.20.1/go.mod h1:I0YI4GujLbbUojNnKLGVguiWUvnE2J9ltgwxTmtTRyo=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=

--- a/providers/v1/dvls/provider.go
+++ b/providers/v1/dvls/provider.go
@@ -44,12 +44,12 @@ func (p *Provider) NewClient(ctx context.Context, store esv1.GenericStore, kube 
 
 	storeKind := store.GetObjectKind().GroupVersionKind().Kind
 
-	credClient, vaultID, err := NewDVLSClient(ctx, kube, storeKind, namespace, dvlsProvider)
+	clients, err := newStoreClients(ctx, kube, storeKind, namespace, dvlsProvider)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create DVLS client: %w", err)
 	}
 
-	return NewClient(credClient, vaultID), nil
+	return NewClient(clients.cred, clients.vaults, clients.vaultID, clients.pinnedVault), nil
 }
 
 // ValidateStore validates the SecretStore configuration.

--- a/providers/v1/dvls/provider_test.go
+++ b/providers/v1/dvls/provider_test.go
@@ -247,7 +247,7 @@ func TestProvider_ValidateStore(t *testing.T) {
 		assert.Contains(t, err.Error(), "serverUrl is required")
 	})
 
-	t.Run("case 3a: should accept empty vault (uses default)", func(t *testing.T) {
+	t.Run("case 3a: should accept empty vault (vault comes from the key)", func(t *testing.T) {
 		store := &esv1.SecretStore{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "dvls-store",


### PR DESCRIPTION
## Problem Statement
DVLS grants permissions per vault, so an app with its own vault needs its own store. A vault-less store looks like it could serve many vaults, but every key then has to be `<vault-uuid>/<entry-uuid>`, both halves strictly UUIDs. No names, no folder paths, and the GUIDs change whenever an entry is recreated. That makes manifests unreviewable, so in practice you end up with one store per app per environment.

Separately, a vault-level failure can be reported as a missing secret. `esv1.NoSecretErr` tells the reconciler the secret is gone, and under `deletionPolicy: Delete` the controller deletes the Kubernetes Secret. Two paths reach it. `resolveEntryRef` wraps `GetEntries` errors with `%w` and `dvls.IsNotFound` matches any wrapped 404, but a missing entry returns an empty list, so a 404 there really means the vault is gone. And `/vault/{vault}/entry/{entry}` returns the same 404 whether the entry or the vault is missing, which legacy GUID keys hit with no vault check at all. Both predate this change and are reachable today on the name-lookup path from #6099, but a shared store makes an unreachable vault routine.

## Proposed Changes

When a store doesn't set `vault`, the first `/` (or `\`) in the key is the vault and the rest is the entry. Either side can be a name or a UUID.

```yaml
# one ClusterSecretStore, no vault field
key: "payments/db-credentials"    # vault name + entry name
key: "payments/infrastructure/databases/db-creds"    # vault name + folder path + entry name
key: "054890f4-.../be3b23b3-..."   # legacy GUID pair, still works
```

Stores that do set `vault` are unchanged. The key is still just an entry reference, and `/` still means folder path. Legacy GUID keys needed no special case either: a UUID in the vault slot passes straight through, so they still cost one `GetByID`.

`splitVaultRef` replaces `parseLegacyRef`. Same split on the first separator, minus the two `isUUID` guards. It still rejects empty segments and a UUID entry followed by more segments, since those already fail today and `PushSecret`, `DeleteSecret` and `SecretExists` share this parser. Letting them through could turn a previously broken key into a real write.

Vault names resolve through a name-to-UUID index, built once per client from `Vaults.List`, because `GetByName` walks every vault on every call. `nameCache` is keyed per vault too, now that one client can serve several. This is also why go-dvls moves to v0.20.1, which fixes the `page` vs `pageNumber` bug that broke name lookup past 100 vaults.

For the data-loss fix, `vaultError` marks vault-level failures and `isNotFoundError` rejects that type, so a vault 404 can't become `NoSecretErr` any more. `confirmVault` settles the ambiguous entry 404 with one `Vaults.Get` before calling an entry missing, on the miss path only. `resolveVaultRef` and the index also reject a non-UUID `Vault.Id`, which is where the UUID check from the #6099 review ended up.

Two behaviour notes: keys that used to fail instantly now do a lookup, like `vault\entry`, and a segment that parses as a UUID is always an ID, so a name that looks like a UUID can't be reached by name. The only API change is the `Vault` doc comment.

## AI Assistance disclosure
AI assistance used: Yes

**Tool(s) used:**
Claude Code (Opus 5) for the plan and implementation. Codex GPT 5.6-sol for two adversarial review passes, one on the plan, one on the finished diff.

**Purpose of assistance:**
Writing the implementation, tests and documentation; researching the existing provider and the `go-dvls` SDK; and adversarially reviewing the result.

**Parts of the contribution affected:**
Provider code, tests, docs and snippet. The generated CRDs, `docs/api/spec.md` and snapshots are `make reviewable` output.

**Human validation performed:**
- Made the design decisions, corrections and scope calls
- Validated the old GUID format and vault based secret store kept working after the change.
- Validated the changes in a live environment and made sure they worked
- Manually read the plan and final diff, committed and signed off

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
- [x] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [x] I have tested my changes on a live environment to confirm they are working