### PR TITLE
docs(webhook): add debugging guide and fix stale secret-label claim

### DIFF
--- a/docs/provider/webhook.md
+++ b/docs/provider/webhook.md
@@ -213,4 +213,124 @@ spec:
 ```
 
 ### Webhook as generators
-You can also leverage webhooks as generators, following the same syntax. The only difference is that the webhook generator needs its source secrets to be labeled, as opposed to webhook secretstores. Please see the [generator-webhook](../api/generator/webhook.md) documentation for more information.
+You can also leverage webhooks as generators, following the same syntax. Please see the
+[generator-webhook](../api/generator/webhook.md) documentation for more information.
+
+Note that source secrets must be labeled for both secretstores and generators, see
+[Referenced secrets must be labeled](#referenced-secrets-must-be-labeled) below.
+
+### Debugging
+
+#### Start with the store status and events
+
+Most webhook problems surface on the `SecretStore` itself rather than in the logs:
+
+```sh
+kubectl describe secretstore <name> -n <namespace>
+```
+
+A `Ready` condition of `False` with reason `InvalidProviderConfig` means the client could
+not be created or that store validation failed. The accompanying event carries the
+underlying error, which is usually more specific than the condition message.
+
+For per-secret failures, check the `ExternalSecret` instead:
+
+```sh
+kubectl describe externalsecret <name> -n <namespace>
+```
+
+#### Increase the operator log level
+
+Run the controller with `--loglevel debug` to get the reconcile decisions for each object.
+This logs what the operator did and why, but it deliberately does not log HTTP request or
+response contents, see below.
+
+#### Why there is no built-in request or response dump
+
+The webhook provider renders `url`, `headers` and `body` through the templating engine, and
+those templates typically contain credentials pulled from the referenced secrets. Dumping
+requests or responses would therefore write those credentials to the operator log, where
+anyone with log access could read them. That is why no trace or wire-dump option is
+provided, and why one is unlikely to be added.
+
+!!! warning
+      Setting `GODEBUG=http2debug=2` on the operator does produce HTTP/2 frame dumps
+      including authorization headers and full bodies, entirely unredacted. It only covers
+      HTTP/2, it is not a supported debugging path, and it must not be enabled against a
+      production instance.
+
+#### Inspecting traffic with a logging proxy
+
+The supported way to see the traffic is to put a proxy between the operator and the target
+service, and read the proxy's logs. Point the webhook `url` at the proxy over plain HTTP so
+the request is readable there, and let the proxy terminate TLS towards the real endpoint.
+Running it as a sidecar keeps the plaintext hop inside the pod.
+
+```yaml
+# Sidecar on the external-secrets deployment. Logs every request line and header,
+# then forwards to the real endpoint over HTTPS.
+- name: debug-proxy
+  image: nginx:alpine
+  ports:
+    - containerPort: 8080
+  volumeMounts:
+    - name: debug-proxy-config
+      mountPath: /etc/nginx/conf.d
+```
+
+```nginx
+# debug-proxy-config
+log_format dump escape=none '$request_method $uri $args -> $upstream_status'
+                            ' req_headers="$http_authorization"';
+
+server {
+  listen 8080;
+  access_log /dev/stdout dump;
+  location / {
+    proxy_pass https://secrets.example.com;
+    proxy_set_header Host secrets.example.com;
+  }
+}
+```
+
+Then set `url: "http://localhost:8080/..."` on the store while debugging. Remember that the
+proxy log now contains the same credentials the operator refuses to log, so treat it as
+sensitive and remove the sidecar when you are done.
+
+#### Referenced secrets must be labeled
+
+Every secret referenced from `provider.webhook.secrets` must carry the label
+`external-secrets.io/type: webhook`. This applies to both secretstores and generators.
+Without it the lookup fails with:
+
+```
+secret does not contain needed label 'external-secrets.io/type: webhook'. Update secret label to use it with webhook
+```
+
+#### Template values are two levels deep
+
+Secrets listed under `secrets` are exposed as `.<name>.<keyInSecret>`, not `.<name>`. For:
+
+```yaml
+secrets:
+  - name: creds
+    secretRef:
+      name: webhook-credentials
+```
+
+the values are `{{ .creds.username }}` and `{{ .creds.password }}`. Referring to
+`{{ .creds }}` renders a Go map rather than a value. Note also that every key of the
+referenced secret is exposed; a `key` field on the `secretRef` does not narrow it.
+
+#### A templated `url` is validated before templating
+
+Store validation performs a reachability check against `spec.provider.webhook.url` as
+written, before the templating engine runs. A url whose host comes from a template
+therefore fails validation with a message such as:
+
+```
+error accessing external store: dial tcp :443: connect: connection refused
+```
+
+even when the templated request itself would succeed. Keep the host literal and template
+only the path or query string.

--- a/docs/provider/webhook.md
+++ b/docs/provider/webhook.md
@@ -152,6 +152,8 @@ kind: Secret
 metadata:
   name: webhook-credentials
   namespace: externalsecrets
+  labels:
+    external-secrets.io/type: webhook # Also required for auth.ntlm secrets
 data:
   username: dGVzdA== # "test"
   password: dGVzdA== # "test"
@@ -227,6 +229,8 @@ Most webhook problems surface on the `SecretStore` itself rather than in the log
 
 ```sh
 kubectl describe secretstore <name> -n <namespace>
+# or, for a cluster-scoped store
+kubectl describe clustersecretstore <name>
 ```
 
 A `Ready` condition of `False` with reason `InvalidProviderConfig` means the client could
@@ -266,9 +270,11 @@ service, and read the proxy's logs. Point the webhook `url` at the proxy over pl
 the request is readable there, and let the proxy terminate TLS towards the real endpoint.
 Running it as a sidecar keeps the plaintext hop inside the pod.
 
+Add the sidecar and its config volume to the external-secrets deployment. Only the fields
+relevant to the proxy are shown; keep the rest of the pod spec as it is.
+
 ```yaml
-# Sidecar on the external-secrets deployment. Logs every request line and header,
-# then forwards to the real endpoint over HTTPS.
+# spec.template.spec.containers
 - name: debug-proxy
   image: nginx:alpine
   ports:
@@ -276,32 +282,60 @@ Running it as a sidecar keeps the plaintext hop inside the pod.
   volumeMounts:
     - name: debug-proxy-config
       mountPath: /etc/nginx/conf.d
+# spec.template.spec.volumes
+- name: debug-proxy-config
+  configMap:
+    name: debug-proxy-config
 ```
 
-```nginx
-# debug-proxy-config
-log_format dump escape=none '$request_method $uri $args -> $upstream_status'
-                            ' req_headers="$http_authorization"';
+The key must end in `.conf`, because the stock nginx config only includes
+`/etc/nginx/conf.d/*.conf`. With any other key the sidecar starts and serves the default
+nginx page instead of proxying.
 
-server {
-  listen 8080;
-  access_log /dev/stdout dump;
-  location / {
-    proxy_pass https://secrets.example.com;
-    proxy_set_header Host secrets.example.com;
-  }
-}
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: debug-proxy-config
+data:
+  debug-proxy.conf: |
+    log_format dump escape=none '$request_method $uri $args -> $upstream_status'
+                                ' authorization="$http_authorization"';
+
+    server {
+      listen 8080;
+      access_log /dev/stdout dump;
+      location / {
+        proxy_pass https://secrets.example.com;
+        proxy_set_header Host secrets.example.com;
+        # nginx sends no SNI by default, which breaks endpoints that select a
+        # certificate by server name.
+        proxy_ssl_server_name on;
+      }
+    }
 ```
+
+That logs the request method, path and query, the upstream status, and the `Authorization`
+header. Add more `$http_<header>` variables to the `log_format` for other headers. Request
+and response bodies are not captured; use `mirror` or a dedicated capture proxy if you need
+them.
 
 Then set `url: "http://localhost:8080/..."` on the store while debugging. Remember that the
 proxy log now contains the same credentials the operator refuses to log, so treat it as
 sensitive and remove the sidecar when you are done.
 
+!!! warning
+      nginx does not verify the upstream certificate unless `proxy_ssl_verify on` and
+      `proxy_ssl_trusted_certificate` are set, so this proxy is deliberately more permissive
+      than the operator. Do not use it to diagnose TLS trust problems: a `caProvider` or
+      certificate error will appear to go away as soon as the proxy is in the path.
+
 #### Referenced secrets must be labeled
 
-Every secret referenced from `provider.webhook.secrets` must carry the label
-`external-secrets.io/type: webhook`. This applies to both secretstores and generators.
-Without it the lookup fails with:
+Every Secret the webhook reads must carry the label `external-secrets.io/type: webhook`.
+That covers `spec.provider.webhook.secrets` on a `SecretStore` or `ClusterSecretStore`,
+`spec.secrets` on a `Webhook` generator, and the `usernameSecret` and `passwordSecret` of
+`auth.ntlm`, which resolve through the same code path. Without it the lookup fails with:
 
 ```
 secret does not contain needed label 'external-secrets.io/type: webhook'. Update secret label to use it with webhook


### PR DESCRIPTION
## Problem Statement

There is no documentation on how to debug the webhook provider. The workaround recommended twice on #5576, putting a logging proxy between the operator and the target service, exists only in that thread, and the reason no built-in request dump is offered is not written down anywhere.

The page also carries a stale claim: that only the generator needs its source secrets labeled, "as opposed to webhook secretstores". True when the generator landed in #3121, but #3753 made store secrets require the label too and the page was never updated. Following it produces a failure whose message names the label you were told you did not need.

## Related Issue

Refs #5576. Does not close it: the built-in trace option asked for there is a separate decision, still labelled for the community meeting. This is only the documentation half, which that issue itself raised as possibly sufficient.

## Proposed Changes

Adds a Debugging section: where failures surface, the log level flag, why no wire dump exists (templated urls, headers and bodies routinely carry credentials), and the logging proxy sidecar alternative with an nginx example.

Documents the three misconfigurations whose errors point away from their cause: the required `external-secrets.io/type: webhook` label, template values being `.<name>.<keyInSecret>` rather than `.<name>`, and store validation probing `url` before templating runs.

Fixes the stale label sentence. Documentation only, no behaviour change.

