### PR TITLE
fix(akeyless): use local errors.As target to avoid data race

### DIFF
--- a/providers/v1/akeyless/akeyless_api.go
+++ b/providers/v1/akeyless/akeyless_api.go
@@ -42,7 +42,6 @@ import (
 )
 
 var (
-	apiErr akeyless.GenericOpenAPIError
 	// ErrItemNotExists is returned when a requested item doesn't exist in Akeyless vault.
 	ErrItemNotExists = errors.New("item does not exist")
 	// ErrTokenNotExists is returned when the authentication token is not available.
@@ -90,6 +89,7 @@ func (a *akeylessBase) GetToken(ctx context.Context, accessID, accType, accTypeP
 
 	authOut, res, err := a.RestAPI.Auth(ctx).Body(*authBody).Execute()
 	metrics.ObserveAPICall(constants.ProviderAKEYLESSSM, constants.CallAKEYLESSSMAuth, err)
+	var apiErr akeyless.GenericOpenAPIError
 	if errors.As(err, &apiErr) {
 		return "", fmt.Errorf("authentication failed: %v", string(apiErr.Body()))
 	}
@@ -150,6 +150,7 @@ func (a *akeylessBase) DescribeItem(ctx context.Context, itemName string) (*akey
 	}
 	gsvOut, res, err := a.RestAPI.DescribeItem(ctx).Body(body).Execute()
 	metrics.ObserveAPICall(constants.ProviderAKEYLESSSM, constants.CallAKEYLESSSMDescribeItem, err)
+	var apiErr akeyless.GenericOpenAPIError
 	if errors.As(err, &apiErr) {
 		var item *Item
 		err = json.Unmarshal(apiErr.Body(), &item)
@@ -180,6 +181,7 @@ func (a *akeylessBase) GetCertificate(ctx context.Context, certificateName strin
 	}
 	gcvOut, res, err := a.RestAPI.GetCertificateValue(ctx).Body(body).Execute()
 	metrics.ObserveAPICall(constants.ProviderAKEYLESSSM, constants.CallAKEYLESSSMGetCertificateValue, err)
+	var apiErr akeyless.GenericOpenAPIError
 	if errors.As(err, &apiErr) {
 		return "", fmt.Errorf("can't get certificate value: %v", string(apiErr.Body()))
 	}
@@ -211,6 +213,7 @@ func (a *akeylessBase) GetRotatedSecrets(ctx context.Context, secretName string,
 	}
 	gsvOut, res, err := a.RestAPI.GetRotatedSecretValue(ctx).Body(body).Execute()
 	metrics.ObserveAPICall(constants.ProviderAKEYLESSSM, constants.CallAKEYLESSSMGetRotatedSecretValue, err)
+	var apiErr akeyless.GenericOpenAPIError
 	if errors.As(err, &apiErr) {
 		return "", fmt.Errorf("can't get rotated secret value: %v", string(apiErr.Body()))
 	}
@@ -252,6 +255,7 @@ func (a *akeylessBase) GetDynamicSecrets(ctx context.Context, secretName string)
 	}
 	gsvOut, res, err := a.RestAPI.GetDynamicSecretValue(ctx).Body(body).Execute()
 	metrics.ObserveAPICall(constants.ProviderAKEYLESSSM, constants.CallAKEYLESSSMGetDynamicSecretValue, err)
+	var apiErr akeyless.GenericOpenAPIError
 	if errors.As(err, &apiErr) {
 		return "", fmt.Errorf("can't get dynamic secret value: %v", string(apiErr.Body()))
 	}
@@ -281,6 +285,7 @@ func (a *akeylessBase) GetStaticSecret(ctx context.Context, secretName string, v
 	}
 	gsvOut, res, err := a.RestAPI.GetSecretValue(ctx).Body(body).Execute()
 	metrics.ObserveAPICall(constants.ProviderAKEYLESSSM, constants.CallAKEYLESSSMGetSecretValue, err)
+	var apiErr akeyless.GenericOpenAPIError
 	if errors.As(err, &apiErr) {
 		return "", fmt.Errorf("can't get secret value: %v", string(apiErr.Body()))
 	}
@@ -331,6 +336,7 @@ func (a *akeylessBase) ListSecrets(ctx context.Context, path, tag string) ([]str
 	}
 	lipOut, res, err := a.RestAPI.ListItems(ctx).Body(body).Execute()
 	metrics.ObserveAPICall(constants.ProviderAKEYLESSSM, constants.CallAKEYLESSSMListItems, err)
+	var apiErr akeyless.GenericOpenAPIError
 	if errors.As(err, &apiErr) {
 		return nil, fmt.Errorf("can't get secrets list: %v", string(apiErr.Body()))
 	}


### PR DESCRIPTION
Fixes #6747

## Problem
`errors.As` writes to its target when it matches. The target was a package-level variable shared by all Akeyless API calls, so concurrent reconciles could overwrite each other's error body.

## Solution
Remove the package-level `apiErr` variable and declare it locally in each of the 7 functions that use `errors.As`: `GetToken`, `DescribeItem`, `GetCertificate`, `GetRotatedSecretValue`, `GetDynamicSecrets`, `GetStaticSecret`, and `ListSecrets`.

## Testing
`go test ./...` passes in `providers/v1/akeyless`.

## Checklist
- [x] I have read the contribution guidelines
- [x] All commits are signed with `git commit --signoff`