### PR TITLE
feat(keepersecurity): support pushing whole secrets

### DIFF
--- a/providers/v1/keepersecurity/client.go
+++ b/providers/v1/keepersecurity/client.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"maps"
 	"regexp"
+	"sort"
 	"strings"
 
 	ksm "github.com/keeper-security/secrets-manager-go/core"
@@ -215,16 +216,13 @@ func (c *Client) Close(_ context.Context) error {
 // PushSecret creates or updates a secret in Keeper Security.
 func (c *Client) PushSecret(_ context.Context, secret *corev1.Secret, data esv1.PushSecretData) error {
 	if data.GetSecretKey() == "" {
-		return errors.New("pushing the whole secret is not yet implemented")
+		return c.pushWholeSecret(secret, data.GetRemoteKey())
 	}
 
-	// Close implements cleanup operations for the Keeper Security client
 	value := secret.Data[data.GetSecretKey()]
 	parts, err := c.buildSecretNameAndKey(data)
 	if err != nil {
 		return err
-		// PushSecret creates or updates a secret in Keeper Security.
-		// Currently only supports pushing individual secret values, not entire secrets.
 	}
 
 	record, err := c.findSecretByName(parts[0])
@@ -240,6 +238,36 @@ func (c *Client) PushSecret(_ context.Context, secret *corev1.Secret, data esv1.
 	}
 
 	_, err = c.createSecret(parts[0], parts[1], value)
+	return err
+}
+
+func (c *Client) pushWholeSecret(secret *corev1.Secret, name string) error {
+	record, err := c.findSecretByName(name)
+	if err != nil {
+		return err
+	}
+
+	if record == nil {
+		_, err = c.createSecretWithCustomFields(name, secret.Data)
+		return err
+	}
+
+	if record.Type() != externalSecretType {
+		return fmt.Errorf(errInvalidSecretType, externalSecretType, record.Title(), record.Type())
+	}
+
+	for key, value := range secret.Data {
+		if len(record.GetCustomFieldsByLabel(key)) > 0 {
+			record.SetCustomFieldValueSingle(key, string(value))
+			continue
+		}
+		if err := record.AddCustomField(newCustomSecretField(key, value)); err != nil {
+			return err
+		}
+	}
+
+	err = c.ksmClient.Save(record)
+	metrics.ObserveAPICall(constants.ProviderKeeperSecurity, constants.CallKeeperSecuritySave, err)
 	return err
 }
 
@@ -303,15 +331,35 @@ func (c *Client) createSecret(name, key string, value []byte) (string, error) {
 			ksm.NewUrl(string(value)),
 		)
 	default:
-		field := ksm.KeeperRecordField{Type: secretType, Label: key}
-		externalSecretRecord.Custom = append(externalSecretRecord.Custom,
-			ksm.Secret{KeeperRecordField: field, Value: []string{string(value)}},
-		)
+		externalSecretRecord.Custom = append(externalSecretRecord.Custom, newCustomSecretField(key, value))
 	}
 
 	uid, err := c.ksmClient.CreateSecretWithRecordData("", c.folderID, externalSecretRecord)
 	metrics.ObserveAPICall(constants.ProviderKeeperSecurity, constants.CallKeeperSecurityCreateSecretWithRecordData, err)
 	return uid, err
+}
+
+func (c *Client) createSecretWithCustomFields(name string, data map[string][]byte) (string, error) {
+	externalSecretRecord := ksm.NewRecordCreate(externalSecretType, name)
+	keys := make([]string, 0, len(data))
+	for key := range data {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		externalSecretRecord.Custom = append(externalSecretRecord.Custom, newCustomSecretField(key, data[key]))
+	}
+
+	uid, err := c.ksmClient.CreateSecretWithRecordData("", c.folderID, externalSecretRecord)
+	metrics.ObserveAPICall(constants.ProviderKeeperSecurity, constants.CallKeeperSecurityCreateSecretWithRecordData, err)
+	return uid, err
+}
+
+func newCustomSecretField(key string, value []byte) ksm.Secret {
+	return ksm.Secret{
+		KeeperRecordField: ksm.KeeperRecordField{Type: secretType, Label: key},
+		Value:             []string{string(value)},
+	}
 }
 
 func (c *Client) updateSecret(secret *ksm.Record, key string, value []byte) error {

--- a/providers/v1/keepersecurity/client_test.go
+++ b/providers/v1/keepersecurity/client_test.go
@@ -959,12 +959,17 @@ func TestClientPushSecretWholeSecretCreatesCustomFields(t *testing.T) {
 	}
 
 	got := make(map[string]string, len(created.Custom))
+	labels := make([]string, 0, len(created.Custom))
 	for _, rawField := range created.Custom {
 		field, ok := rawField.(ksm.Secret)
 		if !ok {
 			t.Fatalf("created custom field has type %T, want ksm.Secret", rawField)
 		}
+		labels = append(labels, field.Label)
 		got[field.Label] = field.Value[0]
+	}
+	if !reflect.DeepEqual(labels, []string{"token", "username"}) {
+		t.Fatalf("created custom field labels = %v, want %v", labels, []string{"token", "username"})
 	}
 	want := map[string]string{"token": "secret", "username": "alice"}
 	if !reflect.DeepEqual(got, want) {

--- a/providers/v1/keepersecurity/client_test.go
+++ b/providers/v1/keepersecurity/client_test.go
@@ -926,6 +926,111 @@ func TestClientPushSecret(t *testing.T) {
 	}
 }
 
+func TestClientPushSecretWholeSecretCreatesCustomFields(t *testing.T) {
+	var created *ksm.RecordCreate
+	c := &Client{
+		ksmClient: &fake.MockKeeperClient{
+			GetSecretsByTitleFn: func(recordTitle string) ([]*ksm.Record, error) {
+				return nil, nil
+			},
+			CreateSecretWithRecordDataFn: func(_, _ string, recordData *ksm.RecordCreate) (string, error) {
+				created = recordData
+				return "record5", nil
+			},
+		},
+		folderID: folderID,
+	}
+
+	err := c.PushSecret(context.Background(), &corev1.Secret{Data: map[string][]byte{
+		"username": []byte("alice"),
+		"token":    []byte("secret"),
+	}}, testingfake.PushSecretData{RemoteKey: "bundle"})
+	if err != nil {
+		t.Fatalf("PushSecret() error = %v", err)
+	}
+	if created == nil {
+		t.Fatal("PushSecret() did not create a record")
+	}
+	if created.RecordType != externalSecretType || created.Title != "bundle" {
+		t.Fatalf("created record metadata = (%q, %q), want (%q, %q)", created.RecordType, created.Title, externalSecretType, "bundle")
+	}
+	if len(created.Fields) != 0 {
+		t.Fatalf("created standard fields = %d, want 0", len(created.Fields))
+	}
+
+	got := make(map[string]string, len(created.Custom))
+	for _, rawField := range created.Custom {
+		field, ok := rawField.(ksm.Secret)
+		if !ok {
+			t.Fatalf("created custom field has type %T, want ksm.Secret", rawField)
+		}
+		got[field.Label] = field.Value[0]
+	}
+	want := map[string]string{"token": "secret", "username": "alice"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("created custom fields = %v, want %v", got, want)
+	}
+}
+
+func TestClientPushSecretWholeSecretUpdatesCustomFields(t *testing.T) {
+	record := &ksm.Record{
+		Uid: "record5",
+		RecordDict: map[string]any{
+			"type":  externalSecretType,
+			"title": "bundle",
+			"custom": []interface{}{
+				map[string]interface{}{
+					"type":  secretType,
+					"label": "existing",
+					"value": []interface{}{"old"},
+				},
+			},
+		},
+	}
+	var saved *ksm.Record
+	c := &Client{
+		ksmClient: &fake.MockKeeperClient{
+			GetSecretsByTitleFn: func(recordTitle string) ([]*ksm.Record, error) {
+				return []*ksm.Record{record}, nil
+			},
+			SaveFn: func(updated *ksm.Record) error {
+				saved = updated
+				return nil
+			},
+		},
+		folderID: folderID,
+	}
+
+	err := c.PushSecret(context.Background(), &corev1.Secret{Data: map[string][]byte{
+		"existing": []byte("updated"),
+		"new":      []byte("added"),
+	}}, testingfake.PushSecretData{RemoteKey: "bundle"})
+	if err != nil {
+		t.Fatalf("PushSecret() error = %v", err)
+	}
+	if saved == nil {
+		t.Fatal("PushSecret() did not save the existing record")
+	}
+	if got := customFieldValue(saved, "existing"); got != "updated" {
+		t.Errorf("existing custom field = %q, want %q", got, "updated")
+	}
+	if got := customFieldValue(saved, "new"); got != "added" {
+		t.Errorf("new custom field = %q, want %q", got, "added")
+	}
+}
+
+func customFieldValue(record *ksm.Record, label string) string {
+	fields := record.GetCustomFieldsByLabel(label)
+	if len(fields) == 0 {
+		return ""
+	}
+	values, ok := fields[0]["value"].([]interface{})
+	if !ok || len(values) == 0 {
+		return ""
+	}
+	return fmt.Sprint(values[0])
+}
+
 func generateRecords() []*ksm.Record {
 	records := make([]*ksm.Record, 0, 3)
 	for i := range 3 {


### PR DESCRIPTION
## Summary

- implement KeeperSecurity bundle-mode PushSecret when SecretKey is empty
- create each source key as a secret custom field and update or add fields on existing externalSecrets records
- preserve existing per-key record/key behavior
- add coverage for create and update paths

Fixes #5974

## Validation

- go test ./... (from providers/v1/keepersecurity)
- git diff --check