### PR TITLE
test(e2e): skip the global addon uninstall on disposable clusters

### DIFF
--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -231,12 +231,9 @@ jobs:
       # both into the e2e pod; entrypoint.sh runs ginkgo with them.
       TEST_SUITES: ${{ matrix.suite }}
       GINKGO_LABELS: ${{ matrix.labels }}
-      # Each leg gets a fresh kind cluster and throws it away with the runner, so
-      # uninstalling the global addons on the way out costs about a minute and
-      # buys nothing. Safe here specifically because TEST_SUITES above is a
-      # single suite: the suites share a cluster, and two of them install an
-      # "eso" release with different values, so the helper ignores this whenever
-      # more than one suite is scheduled.
+      # The kind cluster goes away with the runner, so uninstalling the global
+      # addons costs about a minute and buys nothing. Safe because TEST_SUITES
+      # above is a single suite; the helper refuses this for several.
       E2E_SKIP_GLOBAL_TEARDOWN: "true"
     steps:
       - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0

--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -231,6 +231,13 @@ jobs:
       # both into the e2e pod; entrypoint.sh runs ginkgo with them.
       TEST_SUITES: ${{ matrix.suite }}
       GINKGO_LABELS: ${{ matrix.labels }}
+      # Each leg gets a fresh kind cluster and throws it away with the runner, so
+      # uninstalling the global addons on the way out costs about a minute and
+      # buys nothing. Safe here specifically because TEST_SUITES above is a
+      # single suite: the suites share a cluster, and two of them install an
+      # "eso" release with different values, so the helper ignores this whenever
+      # more than one suite is scheduled.
+      E2E_SKIP_GLOBAL_TEARDOWN: "true"
     steps:
       - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:

--- a/docs/contributing/process.md
+++ b/docs/contributing/process.md
@@ -91,11 +91,9 @@ run managed tests.
 make test.e2e GINKGO_LABELS='gcp&&!managed'
 ```
 
-Setting `E2E_SKIP_GLOBAL_TEARDOWN=true` leaves the global addons (the ESO release
-itself) installed when the suite finishes, which saves about a minute. Only do
-that against a throwaway cluster you are about to delete: it is exported like the
-other variables above, so it applies to whatever your kube context points at.
-CI sets it on the kind legs, and `make test.managed` clears it.
+`E2E_SKIP_GLOBAL_TEARDOWN=true` leaves the ESO release installed when the suite
+finishes, saving about a minute. Only for a throwaway cluster: it applies to
+whatever your kube context points at. `make test.managed` clears it.
 
 #### Managed Kubernetes e2e tests
 

--- a/docs/contributing/process.md
+++ b/docs/contributing/process.md
@@ -91,6 +91,12 @@ run managed tests.
 make test.e2e GINKGO_LABELS='gcp&&!managed'
 ```
 
+Setting `E2E_SKIP_GLOBAL_TEARDOWN=true` leaves the global addons (the ESO release
+itself) installed when the suite finishes, which saves about a minute. Only do
+that against a throwaway cluster you are about to delete: it is exported like the
+other variables above, so it applies to whatever your kube context points at.
+CI sets it on the kind legs, and `make test.managed` clears it.
+
 #### Managed Kubernetes e2e tests
 
 There's another suite of e2e tests that integrate with managed Kubernetes offerings.

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -8,6 +8,10 @@ DOCKER_BUILD_ARGS     ?=
 export E2E_IMAGE_NAME ?= ghcr.io/external-secrets/external-secrets-e2e
 export GINKGO_LABELS ?= !managed
 export TEST_SUITES ?= provider generator flux argocd
+# Leave the global addons installed on the way out. Only sensible for a cluster
+# you are about to delete; ignored when TEST_SUITES names more than one suite,
+# since the suites share a cluster. Off by default, CI sets it per leg.
+export E2E_SKIP_GLOBAL_TEARDOWN ?=
 
 export OCI_IMAGE_NAME = ghcr.io/external-secrets/external-secrets
 
@@ -46,6 +50,12 @@ test.run: ## Load prebuilt image tarballs into kind and run the e2e suite
 	kind load image-archive --name="external-secrets" $(E2E_ARTIFACT_DIR)/e2e.tar
 	./run.sh
 
+# This target runs against whatever the current kube context points at, which is
+# not ours to leave dirty. Makefile exports are file scoped, so without this an
+# exported E2E_SKIP_GLOBAL_TEARDOWN would reach the recipe and leave ESO
+# installed on a real cluster. override also beats a command-line assignment,
+# which a plain target-specific value would not.
+test.managed: override E2E_SKIP_GLOBAL_TEARDOWN =
 test.managed: e2e-image ## Run e2e tests against current kube context
 	$(MAKE) -C ../ docker.build \
 		VERSION=$(VERSION) \

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -8,9 +8,8 @@ DOCKER_BUILD_ARGS     ?=
 export E2E_IMAGE_NAME ?= ghcr.io/external-secrets/external-secrets-e2e
 export GINKGO_LABELS ?= !managed
 export TEST_SUITES ?= provider generator flux argocd
-# Leave the global addons installed on the way out. Only sensible for a cluster
-# you are about to delete; ignored when TEST_SUITES names more than one suite,
-# since the suites share a cluster. Off by default, CI sets it per leg.
+# Leave the global addons installed on the way out. Only for a cluster you are
+# about to delete. Off by default; CI sets it per leg.
 export E2E_SKIP_GLOBAL_TEARDOWN ?=
 
 export OCI_IMAGE_NAME = ghcr.io/external-secrets/external-secrets
@@ -50,11 +49,8 @@ test.run: ## Load prebuilt image tarballs into kind and run the e2e suite
 	kind load image-archive --name="external-secrets" $(E2E_ARTIFACT_DIR)/e2e.tar
 	./run.sh
 
-# This target runs against whatever the current kube context points at, which is
-# not ours to leave dirty. Makefile exports are file scoped, so without this an
-# exported E2E_SKIP_GLOBAL_TEARDOWN would reach the recipe and leave ESO
-# installed on a real cluster. override also beats a command-line assignment,
-# which a plain target-specific value would not.
+# Runs against the current kube context, which is not ours to leave dirty.
+# override beats both an inherited and a command-line value.
 test.managed: override E2E_SKIP_GLOBAL_TEARDOWN =
 test.managed: e2e-image ## Run e2e tests against current kube context
 	$(MAKE) -C ../ docker.build \

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -21,7 +21,7 @@ scoped per provider, and how to add or enable a provider.
 | `e2e/suites/provider/cases/import.go` | Blank-imports every provider case into the single `provider.test` binary. Providers are told apart at run time by Ginkgo label. |
 | `e2e/matrix.yaml` | Source of truth for the fan-out: one `area` (leg) per provider, with its suite, label filter, secret groups, and trigger paths. |
 | `e2e/matrix.py` | Validates the matrix (`check`), emits the CI matrix JSON (`json`), and prints the per-leg credential plan (`plan`). |
-| `e2e/run.sh` | Host-side launcher. Runs `kubectl run` to start the e2e pod, forwarding `TEST_SUITES`, `GINKGO_LABELS`, and the (scoped) credentials as pod env. |
+| `e2e/run.sh` | Host-side launcher. Runs `kubectl run` to start the e2e pod, forwarding `TEST_SUITES`, `GINKGO_LABELS`, `E2E_SKIP_GLOBAL_TEARDOWN`, and the (scoped) credentials as pod env. |
 | `e2e/entrypoint.sh` | In-pod entry (image `CMD`). Loops over `TEST_SUITES` and runs `ginkgo -label-filter="$GINKGO_LABELS"` against each `<suite>.test`. |
 | `.github/workflows/e2e.yml` | Non-managed e2e. Fans out into per-provider legs. Owns the `e2e-required` gate. |
 | `.github/workflows/e2e-reusable.yml` | The reusable build + matrix-test pipeline that `e2e.yml` calls. |
@@ -157,6 +157,21 @@ make -C e2e matrix.plan
 
 # run a single provider locally (overrides the Makefile defaults)
 make -C e2e test.run TEST_SUITES=provider GINKGO_LABELS="vault && !managed"
+
+# skip uninstalling the global addons on the way out, for a cluster you are
+# about to delete anyway. Saves about a minute per run on the provider,
+# generator and argocd suites; every kind leg in e2e-reusable.yml sets it, and
+# e2e-managed.yml deliberately does not.
+#
+# Refused, with a line on stderr, when TEST_SUITES names more than one suite:
+# entrypoint.sh runs those against one cluster and two of them install an "eso"
+# release with different values. That guard only sees its own process, so two
+# separate single-suite runs against one cluster would still collide.
+#
+# Do not use it against a cluster you did not create. make test.managed clears
+# it for that reason.
+make -C e2e test.run TEST_SUITES=provider GINKGO_LABELS="vault && !managed" \
+  E2E_SKIP_GLOBAL_TEARDOWN=true
 ```
 
 ## Adding or enabling a provider

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -158,18 +158,10 @@ make -C e2e matrix.plan
 # run a single provider locally (overrides the Makefile defaults)
 make -C e2e test.run TEST_SUITES=provider GINKGO_LABELS="vault && !managed"
 
-# skip uninstalling the global addons on the way out, for a cluster you are
-# about to delete anyway. Saves about a minute per run on the provider,
-# generator and argocd suites; every kind leg in e2e-reusable.yml sets it, and
-# e2e-managed.yml deliberately does not.
-#
-# Refused, with a line on stderr, when TEST_SUITES names more than one suite:
-# entrypoint.sh runs those against one cluster and two of them install an "eso"
-# release with different values. That guard only sees its own process, so two
-# separate single-suite runs against one cluster would still collide.
-#
-# Do not use it against a cluster you did not create. make test.managed clears
-# it for that reason.
+# leave the global addons installed, for a cluster you are about to delete.
+# Saves about a minute; the kind legs set it, e2e-managed.yml does not.
+# Refused (stderr) when TEST_SUITES names several suites, and that guard sees
+# only its own process, so two single-suite runs on one cluster still collide.
 make -C e2e test.run TEST_SUITES=provider GINKGO_LABELS="vault && !managed" \
   E2E_SKIP_GLOBAL_TEARDOWN=true
 ```

--- a/e2e/framework/addon/addon.go
+++ b/e2e/framework/addon/addon.go
@@ -81,28 +81,11 @@ func UninstallGlobalAddons() {
 	}
 }
 
-// skipGlobalTeardownVar opts a run out of uninstalling the global addons.
-// e2e/run.sh forwards it into the e2e pod; CI sets it per leg.
 const skipGlobalTeardownVar = "E2E_SKIP_GLOBAL_TEARDOWN"
 
-// SkipGlobalTeardown reports whether a suite should leave the global addons
-// installed instead of uninstalling them on the way out.
-//
-// CI runs every leg against a kind cluster that is discarded immediately
-// afterwards, so uninstalling the ESO release costs about a minute per leg and
-// buys nothing. It is also the only step that can fail a leg whose specs all
-// passed: the release owns the CRDs, so `helm uninstall --wait` waits for CRD
-// deletion, which blocks on finalizers that the controller being removed by the
-// same uninstall is no longer around to release.
-//
-// Off unless asked for, so a run against a cluster it does not own (notably
-// `make test.managed`) keeps cleaning up exactly as before.
-//
-// The TEST_SUITES check is not optional. entrypoint.sh runs each suite binary in
-// turn against one cluster, and the provider and generator suites both install
-// an "eso" release with different values, so a suite that left its release
-// behind would break the next suite's install. A multi-suite run therefore tears
-// down as normal and logs why the request was refused.
+// SkipGlobalTeardown reports whether to leave the global addons installed, for a
+// cluster that is about to be discarded. Off unless asked for, and refused when
+// several suites share the cluster, since two of them install the same release.
 func SkipGlobalTeardown() bool {
 	raw, ok := os.LookupEnv(skipGlobalTeardownVar)
 	if !ok || raw == "" {
@@ -110,9 +93,8 @@ func SkipGlobalTeardown() bool {
 	}
 	skip, err := strconv.ParseBool(raw)
 	if err != nil {
-		// Fall back to tearing down, which is the safe answer, and say so
-		// loudly. Failing here instead would unwind the whole AfterSuite, so a
-		// typo would leave the cluster with neither a teardown nor its logs.
+		// Failing here would unwind the whole AfterSuite, losing the teardown
+		// and the logs, so fall back to tearing down and say so.
 		teardownLogf("%s is not a boolean (%q), so the teardown will run: %v",
 			skipGlobalTeardownVar, raw, err)
 		return false
@@ -120,9 +102,8 @@ func SkipGlobalTeardown() bool {
 	if !skip {
 		return false
 	}
-	// Only covers suites sharing one process's cluster, which is what
-	// entrypoint.sh does. Two separate single-suite runs pointed at the same
-	// cluster are indistinguishable from here and would still collide.
+	// Only sees this process. Two separate single-suite runs against one cluster
+	// would still collide.
 	if suites := strings.Fields(os.Getenv("TEST_SUITES")); len(suites) > 1 {
 		teardownLogf("%s ignored: suites %q share one cluster, so the global "+
 			"addons have to come out between them", skipGlobalTeardownVar,
@@ -134,12 +115,8 @@ func SkipGlobalTeardown() bool {
 	return true
 }
 
-// teardownLogf reports a teardown decision on stderr.
-//
-// Not log.Logf: that writes to GinkgoWriter, and ginkgo drops a passing node's
-// writer output unless the suite runs with -v, which CI does not. These lines
-// have to survive a green run, since they are the only evidence of whether the
-// skip took effect.
+// teardownLogf logs to stderr, not log.Logf: ginkgo drops GinkgoWriter output
+// for a passing node without -v, and these lines must survive a green run.
 func teardownLogf(format string, args ...any) {
 	fmt.Fprintf(os.Stderr, format+"\n", args...)
 }

--- a/e2e/framework/addon/addon.go
+++ b/e2e/framework/addon/addon.go
@@ -17,8 +17,11 @@ limitations under the License.
 package addon
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -76,6 +79,69 @@ func UninstallGlobalAddons() {
 		err := addon.Uninstall()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}
+}
+
+// skipGlobalTeardownVar opts a run out of uninstalling the global addons.
+// e2e/run.sh forwards it into the e2e pod; CI sets it per leg.
+const skipGlobalTeardownVar = "E2E_SKIP_GLOBAL_TEARDOWN"
+
+// SkipGlobalTeardown reports whether a suite should leave the global addons
+// installed instead of uninstalling them on the way out.
+//
+// CI runs every leg against a kind cluster that is discarded immediately
+// afterwards, so uninstalling the ESO release costs about a minute per leg and
+// buys nothing. It is also the only step that can fail a leg whose specs all
+// passed: the release owns the CRDs, so `helm uninstall --wait` waits for CRD
+// deletion, which blocks on finalizers that the controller being removed by the
+// same uninstall is no longer around to release.
+//
+// Off unless asked for, so a run against a cluster it does not own (notably
+// `make test.managed`) keeps cleaning up exactly as before.
+//
+// The TEST_SUITES check is not optional. entrypoint.sh runs each suite binary in
+// turn against one cluster, and the provider and generator suites both install
+// an "eso" release with different values, so a suite that left its release
+// behind would break the next suite's install. A multi-suite run therefore tears
+// down as normal and logs why the request was refused.
+func SkipGlobalTeardown() bool {
+	raw, ok := os.LookupEnv(skipGlobalTeardownVar)
+	if !ok || raw == "" {
+		return false
+	}
+	skip, err := strconv.ParseBool(raw)
+	if err != nil {
+		// Fall back to tearing down, which is the safe answer, and say so
+		// loudly. Failing here instead would unwind the whole AfterSuite, so a
+		// typo would leave the cluster with neither a teardown nor its logs.
+		teardownLogf("%s is not a boolean (%q), so the teardown will run: %v",
+			skipGlobalTeardownVar, raw, err)
+		return false
+	}
+	if !skip {
+		return false
+	}
+	// Only covers suites sharing one process's cluster, which is what
+	// entrypoint.sh does. Two separate single-suite runs pointed at the same
+	// cluster are indistinguishable from here and would still collide.
+	if suites := strings.Fields(os.Getenv("TEST_SUITES")); len(suites) > 1 {
+		teardownLogf("%s ignored: suites %q share one cluster, so the global "+
+			"addons have to come out between them", skipGlobalTeardownVar,
+			strings.Join(suites, " "))
+		return false
+	}
+	teardownLogf("%s set: leaving the global addons installed for the cluster to "+
+		"be discarded with", skipGlobalTeardownVar)
+	return true
+}
+
+// teardownLogf reports a teardown decision on stderr.
+//
+// Not log.Logf: that writes to GinkgoWriter, and ginkgo drops a passing node's
+// writer output unless the suite runs with -v, which CI does not. These lines
+// have to survive a green run, since they are the only evidence of whether the
+// skip took effect.
+func teardownLogf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
 }
 
 // AssetDir returns the path to the k8s asset directory

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -85,5 +85,6 @@ kubectl run --rm \
   --env="GRAFANA_TOKEN=${GRAFANA_TOKEN:-}" \
   --env="VERSION=${VERSION}" \
   --env="TEST_SUITES=${TEST_SUITES}" \
+  --env="E2E_SKIP_GLOBAL_TEARDOWN=${E2E_SKIP_GLOBAL_TEARDOWN:-}" \
   --overrides='{ "apiVersion": "v1", "spec":{"serviceAccountName": "external-secrets-e2e"}}' \
   e2e --image=${E2E_IMAGE_NAME}:${VERSION}

--- a/e2e/suites/argocd/suite_test.go
+++ b/e2e/suites/argocd/suite_test.go
@@ -41,8 +41,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 var _ = SynchronizedAfterSuite(func() {
 	// noop
 }, func() {
-	// The pre-deletion below exists only so the uninstall that follows it can
-	// complete, so it is skipped together with it.
+	// The pre-deletion serves only the uninstall, so it is skipped with it.
 	if !addon.SkipGlobalTeardown() {
 		_, _, cl := util.NewConfig()
 		By("Deleting any pending generator states")

--- a/e2e/suites/argocd/suite_test.go
+++ b/e2e/suites/argocd/suite_test.go
@@ -41,18 +41,22 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 var _ = SynchronizedAfterSuite(func() {
 	// noop
 }, func() {
-	_, _, cl := util.NewConfig()
-	By("Deleting any pending generator states")
-	generatorStates := &genv1alpha1.GeneratorStateList{}
-	err := cl.List(GinkgoT().Context(), generatorStates)
-	Expect(err).ToNot(HaveOccurred())
-	for _, generatorState := range generatorStates.Items {
-		err = cl.Delete(GinkgoT().Context(), &generatorState)
+	// The pre-deletion below exists only so the uninstall that follows it can
+	// complete, so it is skipped together with it.
+	if !addon.SkipGlobalTeardown() {
+		_, _, cl := util.NewConfig()
+		By("Deleting any pending generator states")
+		generatorStates := &genv1alpha1.GeneratorStateList{}
+		err := cl.List(GinkgoT().Context(), generatorStates)
 		Expect(err).ToNot(HaveOccurred())
-	}
+		for _, generatorState := range generatorStates.Items {
+			err = cl.Delete(GinkgoT().Context(), &generatorState)
+			Expect(err).ToNot(HaveOccurred())
+		}
 
-	By("Cleaning up global addons")
-	addon.UninstallGlobalAddons()
+		By("Cleaning up global addons")
+		addon.UninstallGlobalAddons()
+	}
 	if CurrentSpecReport().Failed() {
 		addon.PrintLogs()
 	}

--- a/e2e/suites/flux/suite_test.go
+++ b/e2e/suites/flux/suite_test.go
@@ -41,13 +41,9 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 var _ = SynchronizedAfterSuite(func() {
 	// noop
 }, func() {
-	// uninstallFlux is gated together with the global addons, not left running.
-	// FluxHelmRelease.Uninstall deletes the HelmRelease and waits for its
-	// finalizers.fluxcd.io finalizer to clear; without that, uninstallFlux's
-	// `kubectl delete -f install.yaml` removes the flux-system namespace while
-	// helm-controller is still needed to release that finalizer, and kubectl
-	// waits on it with a 168h default. That hangs the suite until ginkgo's
-	// timeout, on a leg whose specs all passed.
+	// uninstallFlux is gated too: on its own it deletes the flux-system namespace
+	// while helm-controller is still needed to clear the HelmRelease finalizer
+	// that UninstallGlobalAddons clears first, and kubectl waits 168h on that.
 	if !addon.SkipGlobalTeardown() {
 		cfg := &addon.Config{}
 		cfg.KubeConfig, cfg.KubeClientSet, cfg.CRClient = util.NewConfig()

--- a/e2e/suites/flux/suite_test.go
+++ b/e2e/suites/flux/suite_test.go
@@ -41,23 +41,32 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 var _ = SynchronizedAfterSuite(func() {
 	// noop
 }, func() {
-	cfg := &addon.Config{}
-	cfg.KubeConfig, cfg.KubeClientSet, cfg.CRClient = util.NewConfig()
-	By("Deleting any pending generator states")
-	generatorStates := &genv1alpha1.GeneratorStateList{}
-	err := cfg.CRClient.List(GinkgoT().Context(), generatorStates)
-	Expect(err).ToNot(HaveOccurred())
-	for _, generatorState := range generatorStates.Items {
-		err = cfg.CRClient.Delete(GinkgoT().Context(), &generatorState)
+	// uninstallFlux is gated together with the global addons, not left running.
+	// FluxHelmRelease.Uninstall deletes the HelmRelease and waits for its
+	// finalizers.fluxcd.io finalizer to clear; without that, uninstallFlux's
+	// `kubectl delete -f install.yaml` removes the flux-system namespace while
+	// helm-controller is still needed to release that finalizer, and kubectl
+	// waits on it with a 168h default. That hangs the suite until ginkgo's
+	// timeout, on a leg whose specs all passed.
+	if !addon.SkipGlobalTeardown() {
+		cfg := &addon.Config{}
+		cfg.KubeConfig, cfg.KubeClientSet, cfg.CRClient = util.NewConfig()
+		By("Deleting any pending generator states")
+		generatorStates := &genv1alpha1.GeneratorStateList{}
+		err := cfg.CRClient.List(GinkgoT().Context(), generatorStates)
 		Expect(err).ToNot(HaveOccurred())
-	}
+		for _, generatorState := range generatorStates.Items {
+			err = cfg.CRClient.Delete(GinkgoT().Context(), &generatorState)
+			Expect(err).ToNot(HaveOccurred())
+		}
 
-	By("Cleaning up global addons")
-	addon.UninstallGlobalAddons()
+		By("Cleaning up global addons")
+		addon.UninstallGlobalAddons()
+		uninstallFlux()
+	}
 	if CurrentSpecReport().Failed() {
 		addon.PrintLogs()
 	}
-	uninstallFlux()
 })
 
 func TestE2E(t *testing.T) {

--- a/e2e/suites/generator/suite_test.go
+++ b/e2e/suites/generator/suite_test.go
@@ -44,8 +44,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 var _ = SynchronizedAfterSuite(func() {
 	// noop
 }, func() {
-	// The pre-deletion below exists only so the uninstall that follows it can
-	// complete, so it is skipped together with it.
+	// The pre-deletion serves only the uninstall, so it is skipped with it.
 	if !addon.SkipGlobalTeardown() {
 		cfg := &addon.Config{}
 		cfg.KubeConfig, cfg.KubeClientSet, cfg.CRClient = util.NewConfig()

--- a/e2e/suites/generator/suite_test.go
+++ b/e2e/suites/generator/suite_test.go
@@ -44,18 +44,22 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 var _ = SynchronizedAfterSuite(func() {
 	// noop
 }, func() {
-	cfg := &addon.Config{}
-	cfg.KubeConfig, cfg.KubeClientSet, cfg.CRClient = util.NewConfig()
-	By("Deleting any pending generator states")
-	generatorStates := &genv1alpha1.GeneratorStateList{}
-	err := cfg.CRClient.List(GinkgoT().Context(), generatorStates)
-	Expect(err).ToNot(HaveOccurred())
-	for _, generatorState := range generatorStates.Items {
-		err = cfg.CRClient.Delete(GinkgoT().Context(), &generatorState)
+	// The pre-deletion below exists only so the uninstall that follows it can
+	// complete, so it is skipped together with it.
+	if !addon.SkipGlobalTeardown() {
+		cfg := &addon.Config{}
+		cfg.KubeConfig, cfg.KubeClientSet, cfg.CRClient = util.NewConfig()
+		By("Deleting any pending generator states")
+		generatorStates := &genv1alpha1.GeneratorStateList{}
+		err := cfg.CRClient.List(GinkgoT().Context(), generatorStates)
 		Expect(err).ToNot(HaveOccurred())
+		for _, generatorState := range generatorStates.Items {
+			err = cfg.CRClient.Delete(GinkgoT().Context(), &generatorState)
+			Expect(err).ToNot(HaveOccurred())
+		}
+		By("Cleaning up global addons")
+		addon.UninstallGlobalAddons()
 	}
-	By("Cleaning up global addons")
-	addon.UninstallGlobalAddons()
 	if CurrentSpecReport().Failed() {
 		addon.PrintLogs()
 	}

--- a/e2e/suites/provider/suite_test.go
+++ b/e2e/suites/provider/suite_test.go
@@ -44,29 +44,33 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 var _ = SynchronizedAfterSuite(func() {
 	// noop
 }, func() {
-	cfg := &addon.Config{}
-	cfg.KubeConfig, cfg.KubeClientSet, cfg.CRClient = util.NewConfig()
+	// The pre-deletions below exist only so the uninstall that follows them can
+	// complete, so they are skipped together with it.
+	if !addon.SkipGlobalTeardown() {
+		cfg := &addon.Config{}
+		cfg.KubeConfig, cfg.KubeClientSet, cfg.CRClient = util.NewConfig()
 
-	By("Deleting any pending generator states")
-	generatorStates := &genv1alpha1.GeneratorStateList{}
-	err := cfg.CRClient.List(GinkgoT().Context(), generatorStates)
-	Expect(err).ToNot(HaveOccurred())
-	for _, generatorState := range generatorStates.Items {
-		err = cfg.CRClient.Delete(GinkgoT().Context(), &generatorState)
+		By("Deleting any pending generator states")
+		generatorStates := &genv1alpha1.GeneratorStateList{}
+		err := cfg.CRClient.List(GinkgoT().Context(), generatorStates)
 		Expect(err).ToNot(HaveOccurred())
-	}
+		for _, generatorState := range generatorStates.Items {
+			err = cfg.CRClient.Delete(GinkgoT().Context(), &generatorState)
+			Expect(err).ToNot(HaveOccurred())
+		}
 
-	By("Deleting all ClusterExternalSecrets")
-	externalSecretsList := &v1.ClusterExternalSecretList{}
-	err = cfg.CRClient.List(GinkgoT().Context(), externalSecretsList)
-	Expect(err).ToNot(HaveOccurred())
-	for _, externalSecret := range externalSecretsList.Items {
-		err = cfg.CRClient.Delete(GinkgoT().Context(), &externalSecret)
+		By("Deleting all ClusterExternalSecrets")
+		externalSecretsList := &v1.ClusterExternalSecretList{}
+		err = cfg.CRClient.List(GinkgoT().Context(), externalSecretsList)
 		Expect(err).ToNot(HaveOccurred())
-	}
+		for _, externalSecret := range externalSecretsList.Items {
+			err = cfg.CRClient.Delete(GinkgoT().Context(), &externalSecret)
+			Expect(err).ToNot(HaveOccurred())
+		}
 
-	By("Cleaning up global addons")
-	addon.UninstallGlobalAddons()
+		By("Cleaning up global addons")
+		addon.UninstallGlobalAddons()
+	}
 	if CurrentSpecReport().Failed() {
 		addon.PrintLogs()
 	}

--- a/e2e/suites/provider/suite_test.go
+++ b/e2e/suites/provider/suite_test.go
@@ -44,8 +44,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 var _ = SynchronizedAfterSuite(func() {
 	// noop
 }, func() {
-	// The pre-deletions below exist only so the uninstall that follows them can
-	// complete, so they are skipped together with it.
+	// The pre-deletions serve only the uninstall, so they are skipped with it.
 	if !addon.SkipGlobalTeardown() {
 		cfg := &addon.Config{}
 		cfg.KubeConfig, cfg.KubeClientSet, cfg.CRClient = util.NewConfig()


### PR DESCRIPTION
## Problem Statement

Every e2e leg ends by uninstalling the global ESO addon from a kind cluster that is destroyed seconds later. Measured as the gap between the last spec and the summary line on run 30891520574: 64.5s on the webhook leg and 64.5s on core-smoke, identical to a tenth of a second, so it is fixed-cost rather than load dependent. It is also the only step that can fail a leg whose specs all passed, which is what happened to the scaleway leg on #6774: 18 passed, 0 failed, then `uninstallation completed with 1 error(s): context deadline exceeded` after 364s. The release owns the CRDs, so `helm uninstall --wait` waits for CRD deletion, which blocks on finalizer-bearing custom resources, while the same uninstall removes the controller that would release those finalizers.

## Related Issue

Fixes #6777

## Proposed Changes

`E2E_SKIP_GLOBAL_TEARDOWN` gates `UninstallGlobalAddons()` and the pre-deletions that exist only to let it complete. Default off, so any run against a cluster it does not own behaves exactly as before; `e2e-reusable.yml` sets it on the kind legs and `e2e-managed.yml` deliberately does not. Per-spec `AfterEach` cleanup is untouched: ClusterExternalSecret specs select target namespaces by selector, so namespaces left behind by earlier specs could change what a later spec sees, and per-test addons reuse release names.

The suites share one cluster per pod (`entrypoint.sh` loops over `TEST_SUITES`) and both the provider and generator suites install an `eso` release with different values, so the flag is refused, with a line on stderr, whenever more than one suite is scheduled. `test.managed` uses `override` to clear it, because Makefile exports are file scoped and that target runs against whatever the current kube context is.

flux's own `uninstallFlux()` is gated along with the global addons rather than left running, which is a change from how I first wrote it. `FluxHelmRelease.Uninstall()` deletes the `HelmRelease` and waits for its `finalizers.fluxcd.io` finalizer to clear. Skip that and leave `uninstallFlux()` running, and its `kubectl delete -f install.yaml` removes the `flux-system` namespace while helm-controller is still needed to release that finalizer, with kubectl waiting on it under a 168h default. That turns a green flux suite red at the ginkgo timeout instead, so gating both is the only version that helps.

Not included, and listed separately in the issue: `--timeout` on `helm uninstall`, dumping remaining custom resources with their finalizers on failure, and fixing the underlying finalizer race for callers that genuinely need the uninstall.

One consequence worth knowing: `PrintLogs()` on failure now runs while the ESO pods still exist, where previously the uninstall had already removed them.

## AI Assistance disclosure

AI assistance used: Yes

Code assistance, and review of the code.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
- [x] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [ ] I have tested my changes on a live environment to confirm they are working
