### PR TITLE
fix(webhook): push the raw value when spec.body is unset

### DIFF
--- a/providers/v1/webhook/pkg/webhook/webhook.go
+++ b/providers/v1/webhook/pkg/webhook/webhook.go
@@ -261,16 +261,19 @@ func (w *Webhook) PushWebhookData(ctx context.Context, provider *Spec, data []by
 		return fmt.Errorf("failed to parse url: %w", err)
 	}
 
-	bodyt := provider.Body
-	if bodyt == "" {
-		bodyt = fmt.Sprintf("{{ .remoteRef.%s }}", remoteKey.GetRemoteKey())
-	}
-	body, err := ExecuteTemplate(bodyt, rawData)
-	if err != nil {
-		return fmt.Errorf("failed to parse body: %w", err)
+	// With no spec.body the payload is only the value being pushed, so write
+	// it directly. Splicing the remote key into a template made it a field
+	// expression, which silently broke dotted keys. See issue #6776.
+	body := data
+	if provider.Body != "" {
+		rendered, err := ExecuteTemplate(provider.Body, rawData)
+		if err != nil {
+			return fmt.Errorf("failed to parse body: %w", err)
+		}
+		body = rendered.Bytes()
 	}
 
-	if _, err := w.executeRequest(ctx, provider, body.Bytes(), url, method, rawData); err != nil {
+	if _, err := w.executeRequest(ctx, provider, body, url, method, rawData); err != nil {
 		return fmt.Errorf("failed to push webhook data: %w", err)
 	}
 

--- a/providers/v1/webhook/webhook_test.go
+++ b/providers/v1/webhook/webhook_test.go
@@ -489,6 +489,51 @@ want:
   body: '{"secretkey":"value"}'
   err: ''
 ---
+case: default body with a dotted remote key
+args:
+  url: /api/pushsecret?id={{ .remoteRef.remoteKey }}
+  key: key.with.dots
+  secretkey: secretkey
+  pushsecret: true
+  secret:
+    name: test-secret
+    data:
+      secretkey: real-secret-value
+want:
+  path: /api/pushsecret?id=key.with.dots
+  body: 'real-secret-value'
+  err: ''
+---
+case: default body with a dashed remote key
+args:
+  url: /api/pushsecret?id={{ .remoteRef.remoteKey }}
+  key: my-key
+  secretkey: secretkey
+  pushsecret: true
+  secret:
+    name: test-secret
+    data:
+      secretkey: real-secret-value
+want:
+  path: /api/pushsecret?id=my-key
+  body: 'real-secret-value'
+  err: ''
+---
+case: default body with a slashed remote key
+args:
+  url: /api/pushsecret?id={{ .remoteRef.remoteKey }}
+  key: path/to/key
+  secretkey: secretkey
+  pushsecret: true
+  secret:
+    name: test-secret
+    data:
+      secretkey: real-secret-value
+want:
+  path: /api/pushsecret?id=path%2Fto%2Fkey
+  body: 'real-secret-value'
+  err: ''
+---
 case: pushing without secret key
 args:
   url: /api/pushsecret?id={{ .remoteRef.remoteKey }}


### PR DESCRIPTION
## Problem Statement

With `spec.body` unset, the default push body was synthesised as `{{ .remoteRef.<remoteKey> }}`, which makes the remote key part of a Go template field expression while the value to push is injected as a single map entry. A dotted key resolves as a field chain, misses, and renders as `<no value>`. Nothing errors, so the provider POSTs that string and PushSecret reports success. Dashed and slashed keys hit the same splicing and fail to parse.

## Related Issue

Fixes #6776

## Proposed Changes

With no `spec.body` the payload is only ever the value being pushed, so write it directly instead of round-tripping it through a template. Byte-identical to the old behaviour for remote keys that happen to be valid template field names, and the template maps stay populated so a user-supplied body or url still reaches the value through the documented `{{ index .remoteRef .remoteRef.remoteKey }}` form.

Three push cases added for dotted, dashed and slashed keys with no body set. All three fail on main.

Leaving `missingkey` alone on purpose: secretKey is omitted from the template map when empty, so `missingkey=error` would start erroring on the url example in `docs/provider/webhook.md`. Worth a separate change.

## AI Assistance disclosure

AI assistance used: Yes

Code assistance, and review of the code.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test` (bar the pre-existing network-gated `runtime/esutils` TestValidate)
- [x] I ensured my PR is ready for review with `make reviewable`
- [x] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [ ] I have tested my changes on a live environment to confirm they are working
