### PR TITLE
fix(vault): only apply deprecated token-cache flags when explicitly set

### DIFF
--- a/providers/v1/vault/provider.go
+++ b/providers/v1/vault/provider.go
@@ -323,6 +323,24 @@ func initCache(size int) {
 	})
 }
 
+// resolveVaultCacheConfig applies the deprecated experimental cache flags on top of
+// the supported flags, but only when the deprecated flag was explicitly set by the
+// user. It returns the effective (enableCache, cacheSize) and warns for each
+// experimental flag actually used. Guarding on fs.Changed rather than the flag value
+// avoids the non-zero default of --experimental-vault-token-cache-size silently
+// overriding --vault-token-cache-size on every start (issue #6733).
+func resolveVaultCacheConfig(fs *pflag.FlagSet, enableCache, experimentalEnableCache bool, tokenCacheSize, experimentalCacheSize int) (bool, int) {
+	if fs.Changed("experimental-enable-vault-token-cache") {
+		logger.Info("DEPRECATION WARNING: --experimental-enable-vault-token-cache is deprecated. Please use --enable-vault-token-cache instead. This flag will be removed in a future release.")
+		enableCache = experimentalEnableCache
+	}
+	if fs.Changed("experimental-vault-token-cache-size") {
+		logger.Info("DEPRECATION WARNING: --experimental-vault-token-cache-size is deprecated. Please use --vault-token-cache-size instead. This flag will be removed in a future release.")
+		tokenCacheSize = experimentalCacheSize
+	}
+	return enableCache, tokenCacheSize
+}
+
 func init() {
 	var (
 		vaultTokenCacheSize     int
@@ -360,16 +378,9 @@ func init() {
 	feature.Register(feature.Feature{
 		Flags: fs,
 		Initialize: func() {
-			// Check for deprecated experimental flags and warn users
-			if experimentalEnableCache {
-				logger.Info("DEPRECATION WARNING: --experimental-enable-vault-token-cache is deprecated. Please use --enable-vault-token-cache instead. This flag will be removed in a future release.")
-				enableCache = true
-			}
-			if experimentalCacheSize > 0 {
-				logger.Info("DEPRECATION WARNING: --experimental-vault-token-cache-size is deprecated. Please use --vault-token-cache-size instead. This flag will be removed in a future release.")
-				vaultTokenCacheSize = experimentalCacheSize
-			}
-			initCache(vaultTokenCacheSize)
+			var size int
+			enableCache, size = resolveVaultCacheConfig(fs, enableCache, experimentalEnableCache, vaultTokenCacheSize, experimentalCacheSize)
+			initCache(size)
 		},
 	})
 }

--- a/providers/v1/vault/provider_flags_test.go
+++ b/providers/v1/vault/provider_flags_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright © The ESO Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vault
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveVaultCacheConfig covers the flag-reconciliation logic that was
+// previously inlined in init() and untested. The key regression (issue #6733) is
+// that the deprecated experimental cache flags must only take effect when the user
+// explicitly sets them, so the supported --vault-token-cache-size is honored and no
+// spurious deprecation warning fires on a vanilla install.
+func TestResolveVaultCacheConfig(t *testing.T) {
+	cases := []struct {
+		name       string
+		args       []string
+		wantEnable bool
+		wantSize   int
+	}{
+		{"nothing set", nil, false, defaultCacheSize},
+		{"supported only", []string{"--enable-vault-token-cache", "--vault-token-cache-size=1000"}, true, 1000},
+		{"deprecated only", []string{"--experimental-enable-vault-token-cache", "--experimental-vault-token-cache-size=5000"}, true, 5000},
+		{"both set: deprecated overrides", []string{"--vault-token-cache-size=1000", "--experimental-vault-token-cache-size=5000"}, false, 5000},
+		{"explicit disable of deprecated bool overrides supported", []string{"--enable-vault-token-cache", "--experimental-enable-vault-token-cache=false"}, false, defaultCacheSize},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			var (
+				enableCache bool
+				expEnable   bool
+				size        int
+				expSize     int
+			)
+			fs.BoolVar(&enableCache, "enable-vault-token-cache", false, "")
+			fs.IntVar(&size, "vault-token-cache-size", defaultCacheSize, "")
+			fs.BoolVar(&expEnable, "experimental-enable-vault-token-cache", false, "")
+			fs.IntVar(&expSize, "experimental-vault-token-cache-size", defaultCacheSize, "")
+			require.NoError(t, fs.Parse(tc.args))
+
+			gotEnable, gotSize := resolveVaultCacheConfig(fs, enableCache, expEnable, size, expSize)
+			assert.Equal(t, tc.wantEnable, gotEnable)
+			assert.Equal(t, tc.wantSize, gotSize)
+		})
+	}
+}


### PR DESCRIPTION
experimental-vault-token-cache-size defaults to defaultCacheSize, so the deprecation guard (value > 0) was always true: it printed the warning on every start and overwrote --vault-token-cache-size with the experimental default, so the supported flag never took effect. Guard on fs.Changed() instead of the value for both experimental flags, and extract the logic into resolveVaultCacheConfig with table tests.

Fixes #6733

## Problem Statement
In `providers/v1/vault/provider.go`, the deprecated `--experimental-vault-token-cache-size` flag is registered with a non-zero default (`defaultCacheSize` = 262144). The reconciliation guard `if experimentalCacheSize > 0` is therefore always true, even when the user never passes the flag. This has two effects:
1. The `DEPRECATION WARNING` log line prints on every startup (vanilla Helm install).
2. `vaultTokenCacheSize = experimentalCacheSize` runs unconditionally, so the deprecated flag's default silently overwrites the supported `--vault-token-cache-size`. In practice `--vault-token-cache-size` has never taken effect. Introduced in #5397; affects v2.3.0–v2.8.0. The bool pair is unaffected since its default is `false`.

## Related Issue
Fixes #6733

## Proposed Changes
Guard the deprecated-flag handling on whether the user explicitly set the flag (`fs.Changed(name)`) rather than on the flag value, for both experimental flags (the bool branch is switched too, for symmetry and to honor an explicit `--experimental-enable-vault-token-cache=false`). This works because `cmd/controller/root.go` wires the provider flag set via `AddFlagSet`, which copies the `*pflag.Flag` pointers, so root parsing flips `Changed` on the same structs the provider holds.

The reconciliation logic is extracted from the `init()` closure into a named, side-effect-free `resolveVaultCacheConfig` function, and a table test (`TestResolveVaultCacheConfig`) is added covering {nothing set, supported only, deprecated only, both set, explicit disable}. There was previously no test over this flag wiring, which is how the regression slipped through. Thanks to @alekc for the diagnosis in the issue thread.

## Format
Title follows the format: `fix(vault): only apply deprecated token-cache flags when explicitly set`

## AI Assistance disclosure
Did you use an script, LLM, or AI assisted development tool for this contribution?
AI assistance used: Yes
If yes provide details:
Tool(s) used: Claude (AI assistant)
Purpose of assistance: helping locate the bug in provider.go against @alekc's analysis, drafting the `resolveVaultCacheConfig` refactor and the table test, and drafting this PR description.
Parts of the contribution affected: `resolveVaultCacheConfig` in `providers/v1/vault/provider.go` and `providers/v1/vault/provider_flags_test.go`.
Human validation performed: reviewed the full diff, confirmed the `fs.Changed`/`AddFlagSet` pointer-copy behavior, and ran the tests locally (`go test ./... -run TestResolveVaultCacheConfig` — all cases pass). I understand the change and can explain it without an AI tool.

## Checklist
- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
- [x] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [ ] I have tested my changes on a live environment to confirm they are working