### PR TITLE
test(e2e): run only the legs a pull request can affect

### DIFF
--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -99,10 +99,11 @@ env:
   # trusted pull_request path, where the checkout falls back to github.sha (the
   # PR merge ref).
   TARGET_SHA: ${{ github.event.client_payload.slash_command.args.named.sha }}
-  # PR under test, for the affected-only matrix filter. Set on the trusted
-  # pull_request path and in the fork dispatch payload; empty on any other
-  # event, which means run every enabled leg.
-  PR_NUMBER: ${{ github.event.pull_request.number || github.event.client_payload.pull_request.number }}
+  # Base branch the change is measured against, for the affected-only matrix.
+  # The comment path gets it from the dispatched PR object, the review path
+  # from an explicit field in ok-to-test-review.yml. Anything absent or empty
+  # falls back to main, which over-selects rather than under-selects.
+  BASE_REF: ${{ github.event.pull_request.base.ref || github.event.client_payload.pull_request.base.ref || 'main' }}
   # Ephemeral tag: images are only ever loaded into kind, never pushed, so a
   # fixed tag keeps the build and test jobs in sync without passing a version.
   VERSION: "e2e"
@@ -115,7 +116,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read # list the PR's changed files, to narrow the matrix
     outputs:
       matrix: ${{ steps.set.outputs.matrix }}
     steps:
@@ -127,33 +127,25 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ env.TARGET_SHA || github.sha }}
+          # Full history, blobless, so the affected-only diff below can find a
+          # merge base without paying for file contents it never reads.
+          fetch-depth: 0
+          filter: blob:none
           persist-credentials: false
 
-      # Only narrows the matrix, so every failure path here must end with no
-      # changed.txt, which the next step reads as "run everything". A partial
-      # list is the dangerous case: it looks valid and would silently drop
-      # legs, so publish the file only once its length matches the PR.
-      - name: List the PR's changed files
-        if: env.PR_NUMBER != ''
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
+      # Diff the revision that was actually checked out, never the live PR
+      # endpoint: the fork path pins TARGET_SHA so that a push landing after
+      # /ok-to-test cannot change which legs run against the approved commit.
+      # Any failure leaves changed.txt absent, which runs every leg.
+      - name: List the changed files
         run: |
-          if ! gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" \
-               --paginate --jq '.[].filename' > fetched.txt; then
-            echo "::warning::could not list changed files; running every leg"
-            exit 0
+          if git rev-parse --verify --quiet "origin/${BASE_REF}" >/dev/null &&
+             git diff --name-only "origin/${BASE_REF}...HEAD" > fetched.txt; then
+            mv fetched.txt changed.txt
+            echo "changed files: $(grep -c '' < changed.txt)"
+          else
+            echo "::warning::cannot diff against origin/${BASE_REF}; running every leg"
           fi
-          # --paginate stops silently at the API's 3000-file cap, and a
-          # mid-pagination error still leaves the earlier pages on disk.
-          want="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.changed_files')" || want=""
-          got="$(grep -c '' < fetched.txt)"
-          if [ -z "${want}" ] || [ "${want}" != "${got}" ]; then
-            echo "::warning::changed-file list looks incomplete (${got} fetched, PR reports ${want:-unknown}); running every leg"
-            exit 0
-          fi
-          mv fetched.txt changed.txt
-          echo "changed files: ${got}"
 
       - name: Validate and build the e2e matrix
         id: set

--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -99,6 +99,10 @@ env:
   # trusted pull_request path, where the checkout falls back to github.sha (the
   # PR merge ref).
   TARGET_SHA: ${{ github.event.client_payload.slash_command.args.named.sha }}
+  # PR under test, for the affected-only matrix filter. Set on the trusted
+  # pull_request path and in the fork dispatch payload; empty on any other
+  # event, which means run every enabled leg.
+  PR_NUMBER: ${{ github.event.pull_request.number || github.event.client_payload.pull_request.number }}
   # Ephemeral tag: images are only ever loaded into kind, never pushed, so a
   # fixed tag keeps the build and test jobs in sync without passing a version.
   VERSION: "e2e"
@@ -111,6 +115,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read # list the PR's changed files, to narrow the matrix
     outputs:
       matrix: ${{ steps.set.outputs.matrix }}
     steps:
@@ -124,6 +129,32 @@ jobs:
           ref: ${{ env.TARGET_SHA || github.sha }}
           persist-credentials: false
 
+      # Only narrows the matrix, so every failure path here must end with no
+      # changed.txt, which the next step reads as "run everything". A partial
+      # list is the dangerous case: it looks valid and would silently drop
+      # legs, so publish the file only once its length matches the PR.
+      - name: List the PR's changed files
+        if: env.PR_NUMBER != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          if ! gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" \
+               --paginate --jq '.[].filename' > fetched.txt; then
+            echo "::warning::could not list changed files; running every leg"
+            exit 0
+          fi
+          # --paginate stops silently at the API's 3000-file cap, and a
+          # mid-pagination error still leaves the earlier pages on disk.
+          want="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.changed_files')" || want=""
+          got="$(grep -c '' < fetched.txt)"
+          if [ -z "${want}" ] || [ "${want}" != "${got}" ]; then
+            echo "::warning::changed-file list looks incomplete (${got} fetched, PR reports ${want:-unknown}); running every leg"
+            exit 0
+          fi
+          mv fetched.txt changed.txt
+          echo "changed files: ${got}"
+
       - name: Validate and build the e2e matrix
         id: set
         # This job has no secrets in scope. matrix.py reads only matrix.yaml and
@@ -131,8 +162,13 @@ jobs:
         # without ever touching a secret value.
         run: |
           ./e2e/matrix.py check
+          ./e2e/matrix.py selftest
           ./e2e/matrix.py plan
-          matrix="$(./e2e/matrix.py json)"
+          if [ -s changed.txt ]; then
+            matrix="$(./e2e/matrix.py json --changed changed.txt)"
+          else
+            matrix="$(./e2e/matrix.py json)"
+          fi
           echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
 
   build:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,6 +28,7 @@ jobs:
     permissions:
       id-token: write # for oidc auth with aws/gcp/azure
       contents: read  # for checkout
+      pull-requests: read # prepare-matrix lists changed files to pick legs
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor !='dependabot[bot]'
     uses: ./.github/workflows/e2e-reusable.yml
     secrets:
@@ -135,6 +136,7 @@ jobs:
     permissions:
       id-token: write # for oidc auth with aws/gcp/azure
       contents: read  # for checkout
+      pull-requests: read # prepare-matrix lists changed files to pick legs
     needs: guard-fork
     if: github.event_name == 'repository_dispatch'
     uses: ./.github/workflows/e2e-reusable.yml

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,6 @@ jobs:
     permissions:
       id-token: write # for oidc auth with aws/gcp/azure
       contents: read  # for checkout
-      pull-requests: read # prepare-matrix lists changed files to pick legs
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor !='dependabot[bot]'
     uses: ./.github/workflows/e2e-reusable.yml
     secrets:
@@ -136,7 +135,6 @@ jobs:
     permissions:
       id-token: write # for oidc auth with aws/gcp/azure
       contents: read  # for checkout
-      pull-requests: read # prepare-matrix lists changed files to pick legs
     needs: guard-fork
     if: github.event_name == 'repository_dispatch'
     uses: ./.github/workflows/e2e-reusable.yml

--- a/.github/workflows/ok-to-test-review.yml
+++ b/.github/workflows/ok-to-test-review.yml
@@ -86,8 +86,9 @@ jobs:
         esac
 
     # Emit the client_payload fields e2e.yml consumes on the comment path:
-    # slash_command.args.named.sha (the target SHA) and pull_request.number
-    # (used by report-fork to comment the result). jq quotes both safely.
+    # slash_command.args.named.sha, pull_request.number (report-fork comments
+    # the result) and pull_request.base.ref (the affected-only matrix diffs
+    # against it). jq quotes all three safely.
     - name: Dispatch ok-to-test-command
       if: steps.cmd.outputs.match == 'true'
       env:
@@ -95,11 +96,13 @@ jobs:
         REPO: ${{ github.repository }}
         SHA: ${{ github.event.review.commit_id }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
+        BASE_REF: ${{ github.event.pull_request.base.ref }}
       run: |
-        jq -cn --arg sha "$SHA" --argjson num "$PR_NUMBER" '{
+        jq -cn --arg sha "$SHA" --argjson num "$PR_NUMBER" \
+               --arg base "$BASE_REF" '{
           event_type: "ok-to-test-command",
           client_payload: {
             slash_command: { args: { named: { sha: $sha } } },
-            pull_request: { number: $num }
+            pull_request: { number: $num, base: { ref: $base } }
           }
         }' | gh api --method POST "repos/${REPO}/dispatches" --input -

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -67,10 +67,54 @@ Each `area` is one leg:
   providers: [aws]                # for the coverage check only
   secret_groups: [aws]            # which credential groups this leg receives
   needs_secrets: true             # mirror of "secret_groups is non-empty"
-  paths:                          # phase 2 seed (affected-only), unused today
+  paths:                          # globs that select this leg on a PR
     - "providers/v1/aws/**"
     - "e2e/suites/provider/cases/aws/**"
-  enabled: true                   # whether the phase 1 matrix runs it now
+  enabled: true                   # whether CI runs it at all
+```
+
+## Affected-only selection
+
+On a pull request, a leg runs only when the diff can affect it. `prepare-matrix`
+lists the PR's changed files and passes them to `matrix.py json --changed`,
+which keeps an enabled area when either its `paths` globs match or it is marked
+`always: true`. Any other event runs the full matrix.
+
+Three rules keep this from quietly reducing coverage, all enforced in
+`matrix.py` rather than in workflow YAML:
+
+- **Shared machinery runs everything.** A change matching the top-level
+  `full_matrix_paths` selects every enabled leg. This is load-bearing, not
+  belt-and-braces: `apis/`, `pkg/` and `runtime/` appear in only four areas'
+  `paths`, so per-area matching alone would skip every provider leg on a core
+  change.
+- **Fail open.** No `--changed`, an unreadable file, or an empty list all run
+  the full matrix. A broken diff step must not look like an empty diff. The
+  workflow holds up its end too: it publishes the changed-file list only when
+  the line count matches the PR's own `changed_files`, because `gh api
+  --paginate` stops silently at the API's 3000-file cap and leaves earlier
+  pages on disk if it fails midway. A truncated list is worse than no list,
+  since it narrows the matrix while looking complete.
+- **Something always runs.** `core-smoke` is `always: true`, so the matrix is
+  never empty and the required floor keeps its promise.
+
+Matching is `fnmatch.fnmatchcase`, so `providers/v1/aws/**` covers
+`providers/v1/aws/secretsmanager/client.go` but not `providers/v1/awsx/`. Case
+is significant, so a laptop and a Linux runner agree.
+
+Careful when editing either list: `fnmatch`'s `*` crosses `/`, unlike a shell
+glob. `e2e/*` therefore matches `e2e/suites/provider/cases/aws/x.go` as well as
+`e2e/Dockerfile`, which would quietly make every change run the full matrix.
+That is why the shared `e2e` entries are listed file by file.
+
+`matrix.py selftest` checks the resolver against a table of changed-file sets
+and their expected legs, and runs in `prepare-matrix` beside `check`. Extend it
+when you change the selection rules.
+
+To see what a given diff would select:
+
+```bash
+git diff --name-only origin/main... | ./e2e/matrix.py json --changed -
 ```
 
 Notes:
@@ -178,5 +222,6 @@ make -C e2e test.run TEST_SUITES=provider GINKGO_LABELS="vault && !managed" \
 
 `matrix.py check` (run in `prepare-matrix`) enforces steps 1-3: it fails the
 build if a provider is compiled into the suite but not covered by an area, if
-`needs_secrets` disagrees with `secret_groups`, or if an area names a secret
-group that the workflow does not wire.
+`needs_secrets` disagrees with `secret_groups`, if an area names a secret group
+that the workflow does not wire, or if an enabled area declares no `paths`,
+which would leave it sitting out nearly every PR.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -89,14 +89,15 @@ Three rules keep this from quietly reducing coverage, all enforced in
   `paths`, so per-area matching alone would skip every provider leg on a core
   change.
 - **Fail open.** No `--changed`, an unreadable file, or an empty list all run
-  the full matrix. A broken diff step must not look like an empty diff. The
-  workflow holds up its end too: it publishes the changed-file list only when
-  the line count matches the PR's own `changed_files`, because `gh api
-  --paginate` stops silently at the API's 3000-file cap and leaves earlier
-  pages on disk if it fails midway. A truncated list is worse than no list,
-  since it narrows the matrix while looking complete.
+  the full matrix. A broken diff step must not look like an empty diff.
 - **Something always runs.** `core-smoke` is `always: true`, so the matrix is
   never empty and the required floor keeps its promise.
+- **The diff comes from the revision under test.** `prepare-matrix` runs
+  `git diff --name-only origin/$BASE_REF...HEAD` on what it checked out, not a
+  query against the live pull request. That matters on the fork path, which
+  pins `TARGET_SHA` so a push landing after `/ok-to-test` cannot change which
+  legs run against the approved commit. It also means the list cannot arrive
+  truncated, the way a paginated API result can.
 
 Matching is `fnmatch.fnmatchcase`, so `providers/v1/aws/**` covers
 `providers/v1/aws/secretsmanager/client.go` but not `providers/v1/awsx/`. Case
@@ -220,8 +221,19 @@ make -C e2e test.run TEST_SUITES=provider GINKGO_LABELS="vault && !managed" \
    and wire that group's env vars in `e2e-reusable.yml`.
 4. Set `enabled: true` when you want CI to run it.
 
-`matrix.py check` (run in `prepare-matrix`) enforces steps 1-3: it fails the
-build if a provider is compiled into the suite but not covered by an area, if
-`needs_secrets` disagrees with `secret_groups`, if an area names a secret group
-that the workflow does not wire, or if an enabled area declares no `paths`,
-which would leave it sitting out nearly every PR.
+`matrix.py check` (run in `prepare-matrix`) enforces steps 1-3, and fails the
+build on any of:
+
+- a provider compiled into the suite but not covered by an area;
+- `needs_secrets` disagreeing with `secret_groups`;
+- an area naming a secret group the workflow does not wire;
+- an enabled area declaring no `paths`, which would leave it sitting out
+  nearly every PR;
+- a glob that matches no tracked file, so a typo cannot quietly stop selecting
+  its leg;
+- a suite's own file that no enabled leg selects, which is how the provider
+  suite's bootstrap slipped through once.
+
+The last two exist because a wrong glob is invisible in a way that
+`enabled: false` never was: the leg keeps passing on every PR that happens to
+touch shared machinery, so nothing looks broken.

--- a/e2e/matrix.py
+++ b/e2e/matrix.py
@@ -6,8 +6,10 @@ Subcommands:
           the suite (suites/provider/cases/import.go) is not covered by any
           area, needs_secrets disagrees with secret_groups, or an area names a
           secret group that the reusable workflow does not wire up.
-  json    Print the GitHub Actions matrix (enabled areas only) as compact JSON
-          for the workflow's strategy.matrix.
+  json    Print the GitHub Actions matrix as compact JSON for the workflow's
+          strategy.matrix. With --changed <file|->, keep only the legs that
+          change can affect. See "Affected-only selection" in e2e/README.md.
+  selftest Check the affected-only resolver against a table of known cases.
   plan    Print, per enabled leg, exactly which credential env vars it will
           receive. Derived from each area's secret_groups and the group -> var
           mapping parsed out of e2e-reusable.yml. This reads NO secret values
@@ -19,11 +21,17 @@ matter. YAML is read with PyYAML when present, else via yq (mikefarah), so no
 new runtime dependency is required in CI.
 """
 
+import io
 import json
 import re
 import subprocess
 import sys
+from contextlib import redirect_stderr
+from fnmatch import fnmatchcase
 from pathlib import Path
+
+USAGE = "usage: matrix.py [check|json [--changed <file|->]|plan|selftest]"
+Match = tuple[str, str] | None
 
 HERE = Path(__file__).resolve().parent
 MATRIX = HERE / "matrix.yaml"
@@ -102,6 +110,15 @@ def cmd_check(matrix: dict) -> int:
                     f"in {WORKFLOW.name} (no env var gates on it)"
                 )
 
+    # 4. Selection depends on paths, so an enabled area without them would run
+    # only when full_matrix_paths hits and silently sit out every other PR.
+    for a in areas:
+        if a.get("enabled") and not a.get("paths"):
+            errors.append(
+                f"area {a['name']!r}: enabled but declares no paths, so "
+                "affected-only selection would almost never run it"
+            )
+
     if errors:
         print("ERROR: matrix.yaml is inconsistent:", file=sys.stderr)
         for e in errors:
@@ -116,7 +133,71 @@ def cmd_check(matrix: dict) -> int:
     return 0
 
 
-def cmd_json(matrix: dict) -> int:
+def parse_changed(text: str, source: str) -> list[str] | None:
+    """Non-blank lines of text, or None for "nothing usable, run everything".
+    An empty list is indistinguishable from a diff step that produced
+    nothing, so it must not narrow the matrix."""
+    paths = [line.strip() for line in text.splitlines() if line.strip()]
+    if not paths:
+        print(f"WARNING: no changed paths in {source}; running the full matrix",
+              file=sys.stderr)
+        return None
+    return paths
+
+
+def read_changed(source: str) -> list[str] | None:
+    """Changed paths, one per line, from a file or stdin ("-"). None means
+    "run everything": an unreadable file is a broken diff step, not an empty
+    diff, so it may not narrow the matrix either."""
+    try:
+        text = sys.stdin.read() if source == "-" else Path(source).read_text()
+    except OSError as err:
+        print(f"WARNING: cannot read changed paths from {source!r} ({err}); "
+              "running the full matrix", file=sys.stderr)
+        return None
+    return parse_changed(text, repr(source))
+
+
+def first_match(patterns: list[str], paths: list[str]) -> Match:
+    """First (pattern, path) pair that matches, else None. fnmatchcase, not
+    fnmatch: the latter normalises case per platform, so a laptop and a Linux
+    runner would disagree."""
+    for pattern in patterns:
+        for path in paths:
+            if fnmatchcase(path, pattern):
+                return pattern, path
+    return None
+
+
+def select_areas(matrix: dict, changed: list[str] | None) -> list[dict]:
+    """Enabled areas a change can affect; changed=None runs all of them. An
+    area is kept when it is always-on or one of its paths globs matches, and
+    full_matrix_paths keeps every area. See matrix.yaml for why that is not
+    merely defensive."""
+    enabled = [a for a in matrix["areas"] if a.get("enabled")]
+    if changed is None:
+        return enabled
+
+    if hit := first_match(matrix.get("full_matrix_paths") or [], changed):
+        print(f"full matrix: {hit[1]} matches full_matrix_paths {hit[0]!r}",
+              file=sys.stderr)
+        return enabled
+
+    selected, dropped = [], []
+    for a in enabled:
+        if a.get("always") or first_match(a.get("paths") or [], changed):
+            selected.append(a)
+        else:
+            dropped.append(a["name"])
+    if dropped:
+        print(f"affected-only: {len(selected)} of {len(enabled)} leg(s) "
+              f"selected from {len(changed)} changed file(s); skipping "
+              + ", ".join(dropped), file=sys.stderr)
+    return selected
+
+
+def cmd_json(matrix: dict, changed_from: str | None = None) -> int:
+    changed = read_changed(changed_from) if changed_from else None
     include = [
         {
             "name": a["name"],
@@ -124,8 +205,7 @@ def cmd_json(matrix: dict) -> int:
             "labels": a["labels"],
             "secret_groups": a.get("secret_groups") or [],
         }
-        for a in matrix["areas"]
-        if a.get("enabled")
+        for a in select_areas(matrix, changed)
     ]
     print(json.dumps({"include": include}, separators=(",", ":")))
     return 0
@@ -146,13 +226,116 @@ def cmd_plan(matrix: dict) -> int:
     return 0
 
 
+# (changed paths, expected leg names or ALL) for the resolver. Guards the two
+# rules whose silent failure costs coverage: fail open, and a shared-machinery
+# change running every leg. See cmd_selftest.
+ALL = None  # in the table below: expect every enabled leg
+SELFTEST_CASES: list[tuple[list[str], set[str] | None]] = [
+    # A provider change runs that provider plus the always-on floor.
+    (["providers/v1/vault/client.go"], {"core-smoke", "vault"}),
+    (["e2e/suites/provider/cases/aws/secretsmanager.go"],
+     {"core-smoke", "aws"}),
+    # grafana.go selects the generator leg too: both legs run the same suite
+    # binary from the same Go package, so a change here can break its compile.
+    (["e2e/suites/generator/grafana.go"],
+     {"core-smoke", "generator", "grafana"}),
+    # Two providers at once select both.
+    (["providers/v1/vault/x.go", "providers/v1/gcp/y.go"],
+     {"core-smoke", "vault", "gcp"}),
+    # Shared machinery runs everything, even though most areas do not list it.
+    (["runtime/reconciler.go"], ALL),
+    (["apis/externalsecrets/v1/types.go"], ALL),
+    (["e2e/framework/util.go"], ALL),
+    (["e2e/matrix.yaml"], ALL),
+    ([".github/workflows/e2e-reusable.yml"], ALL),
+    # Every leg runs the same image and cluster, so these are shared too. They
+    # were missed once; a change here skipping the vault leg is the exact
+    # coverage loss affected-only selection must never cause.
+    (["e2e/Dockerfile"], ALL),
+    (["e2e/entrypoint.sh"], ALL),
+    (["e2e/k8s/vault.values.yaml"], ALL),
+    (["e2e/kind.yaml"], ALL),
+    # Unrelated changes still run the floor, never an empty matrix. e2e docs
+    # are deliberately not shared machinery.
+    (["docs/introduction/faq.md"], {"core-smoke"}),
+    (["e2e/README.md"], {"core-smoke"}),
+    # A near miss must not match: awsx is not aws.
+    (["providers/v1/awsx/client.go"], {"core-smoke"}),
+    # Fail open: nothing to go on means run everything.
+    ([], ALL),
+]
+
+
+def cmd_selftest(matrix: dict) -> int:
+    """Exercise select_areas against SELFTEST_CASES. Runs in prepare-matrix
+    beside check, so a regression in the resolver fails the build rather than
+    quietly shrinking the fan-out."""
+    every = {a["name"] for a in matrix["areas"] if a.get("enabled")}
+    failures = 0
+
+    def fail(what: str, detail: str) -> None:
+        nonlocal failures
+        failures += 1
+        print(f"FAIL {what}\n  {detail}", file=sys.stderr)
+
+    for changed, expected in SELFTEST_CASES:
+        want = every if expected is None else expected
+        # select_areas narrates its decision on stderr; capture it so a real
+        # failure is not buried, and so the narration can be asserted on.
+        log = io.StringIO()
+        with redirect_stderr(log):
+            got = {a["name"] for a in select_areas(matrix, changed or None)}
+        if got != want:
+            fail(f"changed={changed}",
+                 f"want {sorted(want)}\n  got  {sorted(got)}")
+        # A wrongly skipped leg is diagnosed from this log, so it has to name
+        # the legs it dropped, or the reason a change ran everything.
+        if changed and got != every and "skipping" not in log.getvalue():
+            fail(f"changed={changed}", "narrowed the matrix, logged no why")
+        if changed and got == every and "full matrix" not in log.getvalue():
+            fail(f"changed={changed}", "ran every leg without logging why")
+
+    # These two own the remaining fail-open rules and select_areas never
+    # reaches them, so exercise them directly rather than trusting them.
+    with redirect_stderr(io.StringIO()):
+        cases = [
+            ("unreadable file", read_changed(str(HERE / "no-such-file")), None),
+            ("blank text", parse_changed("  \n\t\n", "<test>"), None),
+            ("two paths", parse_changed("a/b.go\n c/d.go \n", "<test>"),
+             ["a/b.go", "c/d.go"]),
+        ]
+    for what, got_paths, want_paths in cases:
+        if got_paths != want_paths:
+            fail(f"read_changed/parse_changed on {what}",
+                 f"want {want_paths}, got {got_paths}")
+
+    total = len(SELFTEST_CASES) + len(cases)
+    if failures:
+        print(f"ERROR: {failures} of {total} selftest assertion(s) failed",
+              file=sys.stderr)
+        return 1
+    print(f"matrix.py selftest ok: {total} cases")
+    return 0
+
+
 def main() -> int:
-    cmd = sys.argv[1] if len(sys.argv) > 1 else "check"
-    if cmd not in ("check", "json", "plan"):
-        print(f"usage: {sys.argv[0]} [check|json|plan]", file=sys.stderr)
+    argv = sys.argv[1:]
+    cmd = argv[0] if argv else "check"
+    others = {"check": cmd_check, "plan": cmd_plan, "selftest": cmd_selftest}
+    changed_from = None
+    if cmd == "json":
+        if len(argv) > 1:
+            if argv[1] != "--changed" or len(argv) != 3:
+                print(USAGE, file=sys.stderr)
+                return 2
+            changed_from = argv[2]
+    elif len(argv) > 1 or cmd not in others:
+        print(USAGE, file=sys.stderr)
         return 2
     matrix = load_yaml(MATRIX)
-    return {"check": cmd_check, "json": cmd_json, "plan": cmd_plan}[cmd](matrix)
+    if cmd == "json":
+        return cmd_json(matrix, changed_from)
+    return others[cmd](matrix)
 
 
 if __name__ == "__main__":

--- a/e2e/matrix.py
+++ b/e2e/matrix.py
@@ -77,6 +77,16 @@ def group_to_vars() -> dict[str, list[str]]:
     return mapping
 
 
+def tracked_files() -> list[str]:
+    """Repo-relative tracked paths. The glob rules in check need to know that a
+    pattern corresponds to something real."""
+    out = subprocess.run(
+        ["git", "-C", str(HERE.parent), "ls-files"],
+        check=True, capture_output=True, text=True,
+    ).stdout
+    return out.splitlines()
+
+
 def cmd_check(matrix: dict) -> int:
     areas = matrix["areas"]
     errors: list[str] = []
@@ -118,6 +128,33 @@ def cmd_check(matrix: dict) -> int:
                 f"area {a['name']!r}: enabled but declares no paths, so "
                 "affected-only selection would almost never run it"
             )
+
+    shared = matrix.get("full_matrix_paths") or []
+    live = [a for a in areas if a.get("enabled")]
+    files = tracked_files()
+
+    # 5. Every glob must match something. A typo like providers/v1/Azure/**
+    # stops selecting its leg while check and selftest stay green, and unlike
+    # enabled: false it leaves no trace on later pull requests.
+    labelled = [("full_matrix_paths", g) for g in shared]
+    labelled += [(f"area {a['name']!r}", g) for a in live
+                 for g in (a.get("paths") or [])]
+    for where, glob in labelled:
+        if not any(fnmatchcase(f, glob) for f in files):
+            errors.append(f"{where}: glob {glob!r} matches no tracked file")
+
+    # 6. Every suite's own files must reach some leg. They sit one level above
+    # the per-case globs, so the provider suite's bootstrap was selected by
+    # nothing until it was listed explicitly.
+    selectable = shared + [g for a in live for g in (a.get("paths") or [])]
+    for f in files:
+        parts = f.split("/")
+        if len(parts) == 4 and parts[:2] == ["e2e", "suites"]:
+            if not any(fnmatchcase(f, g) for g in selectable):
+                errors.append(
+                    f"suite file {f} is selected by no enabled leg, so a "
+                    "change to it would skip the legs that run it"
+                )
 
     if errors:
         print("ERROR: matrix.yaml is inconsistent:", file=sys.stderr)
@@ -251,6 +288,9 @@ SELFTEST_CASES: list[tuple[list[str], set[str] | None]] = [
     # Every leg runs the same image and cluster, so these are shared too. They
     # were missed once; a change here skipping the vault leg is the exact
     # coverage loss affected-only selection must never cause.
+    # Every provider leg compiles this bootstrap, and it sits above their
+    # cases/<name>/** globs, so nothing else would select it.
+    (["e2e/suites/provider/suite_test.go"], ALL),
     (["e2e/Dockerfile"], ALL),
     (["e2e/entrypoint.sh"], ALL),
     (["e2e/k8s/vault.values.yaml"], ALL),

--- a/e2e/matrix.py
+++ b/e2e/matrix.py
@@ -255,6 +255,14 @@ SELFTEST_CASES: list[tuple[list[str], set[str] | None]] = [
     (["e2e/entrypoint.sh"], ALL),
     (["e2e/k8s/vault.values.yaml"], ALL),
     (["e2e/kind.yaml"], ALL),
+    # Found by auditing each leg's imports against its globs: these four
+    # dependencies are real but not obvious from the leg's name.
+    (["e2e/suites/generator/testcase.go"],
+     {"core-smoke", "generator", "grafana"}),
+    (["e2e/suites/provider/cases/fake/fake.go"],
+     {"core-smoke", "flux", "argocd"}),
+    (["providers/v1/kubernetes/client.go"], {"core-smoke"}),
+    (["providers/v1/fake/fake.go"], {"core-smoke"}),
     # Unrelated changes still run the floor, never an empty matrix. e2e docs
     # are deliberately not shared machinery.
     (["docs/introduction/faq.md"], {"core-smoke"}),

--- a/e2e/matrix.yaml
+++ b/e2e/matrix.yaml
@@ -95,6 +95,11 @@ areas:
       - "e2e/suites/provider/cases/kubernetes/**"
       - "e2e/suites/provider/cases/template/**"
       - "e2e/suites/provider/cases/common/**"
+      # The providers these specs drive through the controller. Listed even
+      # though always: true already forces this leg, so coverage does not
+      # silently depend on that flag staying set.
+      - "providers/v1/fake/**"
+      - "providers/v1/kubernetes/**"
     always: true
     enabled: true
 
@@ -270,7 +275,10 @@ areas:
     needs_secrets: true
     paths:
       - "generators/v1/grafana/**"
-      - "e2e/suites/generator/grafana.go"
+      # The whole suite dir, not just grafana.go: the bootstrap and the shared
+      # assertion helper live beside it, and naming files one by one would miss
+      # the next shared one somebody adds.
+      - "e2e/suites/generator/**"
     enabled: true
 
   - name: flux
@@ -284,6 +292,7 @@ areas:
       - "pkg/**"
       - "runtime/**"
       - "e2e/suites/flux/**"
+      - "e2e/suites/provider/cases/fake/**" # flux.go drives the fake provider
     enabled: true
 
   - name: argocd
@@ -297,4 +306,5 @@ areas:
       - "pkg/**"
       - "runtime/**"
       - "e2e/suites/argocd/**"
+      - "e2e/suites/provider/cases/fake/**" # argocd.go drives the fake provider
     enabled: true

--- a/e2e/matrix.yaml
+++ b/e2e/matrix.yaml
@@ -74,10 +74,15 @@ full_matrix_paths:
   - "e2e/k8s/**"
   - "e2e/suites/provider/cases/common/**"
   - "e2e/suites/provider/cases/import.go"
+  # The provider suite's bootstrap sits one level above every provider leg's
+  # cases/<name>/** globs, so nothing else selects it. check rule 6 keeps any
+  # future sibling from going uncovered the same way.
+  - "e2e/suites/provider/suite_test.go"
 
 areas:
-  # In-cluster only, no external credentials. The required floor: this leg runs
-  # on every PR (including forks) and is the stable branch-protection gate.
+  # In-cluster only, no external credentials. The required floor: never
+  # filtered out, so it runs whatever a pull request changed. Not "including
+  # forks": a fork PR runs no leg at all until /ok-to-test dispatches.
   - name: core-smoke
     suite: provider
     labels: "(fake || kubernetes || template) && !managed"

--- a/e2e/matrix.yaml
+++ b/e2e/matrix.yaml
@@ -1,7 +1,9 @@
 # Source of truth for the non-managed e2e fan-out (e2e.yml). Each area is one CI
 # leg: a suite binary run under a Ginkgo label filter. The build job compiles
-# the images once; every enabled area runs as its own matrix leg on its own kind
-# cluster, so a flaky addon in one provider cannot fail the others.
+# the images once; each selected area runs as its own matrix leg on its own kind
+# cluster, so a flaky addon in one provider cannot fail the others. On a pull
+# request the selection is the legs the diff can affect (see paths below); every
+# other event runs all enabled areas.
 #
 # Fields:
 #   name          leg id, shown as "test (<name>)" in the checks list.
@@ -21,15 +23,57 @@
 #                 names map to secret sets in e2e-reusable.yml.
 #   needs_secrets convenience mirror of "secret_groups is non-empty". Documents
 #                 intent; not read by CI.
-#   paths         globs whose change should trigger this leg. Seed for the
-#                 phase 2 affected-only resolver; ignored by the static phase 1
-#                 matrix, which runs every enabled area.
-#   enabled       whether phase 1 CI runs this leg now. Disabled areas still
-#                 count for coverage and document the target matrix; flip to true
-#                 to expand the fan-out.
+#   paths         globs whose change triggers this leg. Read by the resolver
+#                 (matrix.py json --changed) on pull requests; every enabled
+#                 area runs on other events. Required on enabled areas, or the
+#                 leg would sit out nearly every PR.
+#   always        opt this leg out of affected-only filtering, so it runs on
+#                 every PR whatever changed. Set on the required floor only:
+#                 something must always run, or the matrix could come out empty.
+#   enabled       whether CI runs this leg at all. Disabled areas still count
+#                 for coverage and document the target matrix; flip to true to
+#                 expand the fan-out.
 #
 # All legs are enabled. Set enabled: false on an area to skip it (e.g. while a
 # provider's e2e is being fixed) without deleting its definition.
+
+# Shared machinery no single leg owns: a change here runs every enabled leg.
+# Not belt-and-braces: apis/, pkg/ and runtime/ appear in only four areas'
+# paths, so per-area matching alone would skip every provider leg on a core
+# change, losing coverage exactly when it matters most.
+#
+# The e2e entries are listed file by file on purpose. Globs are fnmatch, where
+# * crosses /, so "e2e/*" would also match e2e/suites/... and make every change
+# run everything. e2e/README.md is left out so a docs edit stays cheap.
+full_matrix_paths:
+  - "apis/**"
+  - "pkg/**"
+  - "runtime/**"
+  - "cmd/**"
+  - "deploy/**"
+  - "hack/**"
+  - "go.mod"
+  - "go.sum"
+  - "Makefile"
+  - "Dockerfile*"
+  - ".github/workflows/**"
+  # Every leg runs the same image and the same kind cluster, so all of this is
+  # shared: the Dockerfile ADDs entrypoint.sh, k8s/ and all four suite
+  # binaries, and the Makefile creates the cluster from kind.yaml.
+  - "e2e/Dockerfile"
+  - "e2e/entrypoint.sh"
+  - "e2e/go.mod"
+  - "e2e/go.sum"
+  - "e2e/kind.yaml"
+  - "e2e/Makefile"
+  - "e2e/matrix.py"
+  - "e2e/matrix.yaml"
+  - "e2e/run.sh"
+  - "e2e/tools.go"
+  - "e2e/framework/**"
+  - "e2e/k8s/**"
+  - "e2e/suites/provider/cases/common/**"
+  - "e2e/suites/provider/cases/import.go"
 
 areas:
   # In-cluster only, no external credentials. The required floor: this leg runs
@@ -51,6 +95,7 @@ areas:
       - "e2e/suites/provider/cases/kubernetes/**"
       - "e2e/suites/provider/cases/template/**"
       - "e2e/suites/provider/cases/common/**"
+    always: true
     enabled: true
 
   # The CRD provider reads arbitrary custom resources from the local cluster


### PR DESCRIPTION
## Problem Statement

Every enabled leg runs on every PR. Each `area` in `e2e/matrix.yaml` already carries a `paths` list seeded for this, which phase 1 deliberately ignored. The cost shows up two ways: each leg stands up its own runner and kind cluster, so a one-file change pays for the whole fan-out; and because `e2e-required` aggregates the matrix, a leg that depends on an external vendor can fail a PR that touches nothing near it. #6783 changed only `providers/v1/webhook/**`, ran 17 legs, and went red on the grafana leg, whose own declared `paths` the diff never touched.

## Related Issue

Fixes #6785

## Proposed Changes

`prepare-matrix` lists the PR's changed files and passes them to `matrix.py json --changed`, which keeps an enabled area when its `paths` globs match or it is marked `always: true`. Any other event still runs everything, and `matrix.py json` with no flag is unchanged.

Quietly narrowing coverage is the real risk here, so the rules that prevent it are in `matrix.py` rather than in workflow YAML: a change under the new top-level `full_matrix_paths` selects every leg, `core-smoke` is `always: true` so the matrix is never empty, and no `--changed`, an unreadable file or an empty list all fall back to the full matrix. `full_matrix_paths` is load-bearing rather than defensive: `apis/`, `pkg/` and `runtime/` appear in only four of sixteen areas' `paths`, so per-area matching alone would skip every provider leg on a core change.

Two things worth a reviewer's attention. The changed-file list is published only when its length matches the PR's own `changed_files`, because `gh api --paginate` stops silently at the API's 3000-file cap and leaves earlier pages on disk if it fails midway; a truncated list is worse than no list, since it narrows the matrix while looking complete. And the shared `e2e` entries are enumerated file by file because `fnmatch`'s `*` crosses `/`, so `e2e/*` would also match `e2e/suites/...` and make every change run everything.

Each leg's globs were then audited against what it actually depends on: the in-repo packages its specs import (`go list -deps`) and the provider code it drives through the controller, which the specs never import because they go through CRDs. That turned up four real dependencies no leg named: the grafana leg reaches the generator suite's bootstrap and shared assertion helper, `flux` and `argocd` both drive the fake provider case, and `core-smoke` drives the fake and kubernetes providers. Compile breakage was excluded from that audit on purpose, since the build job sits outside the matrix and compiles every suite binary on every run.

`matrix.py selftest` covers the resolver with 24 cases, including one per audit finding, and runs in `prepare-matrix` beside `check`, which also now rejects an enabled area that declares no `paths`. Verified locally: the resolver cases, all CLI exit codes, `actionlint`, and the `yq` fallback with PyYAML unavailable. The fork path's API fetch needs a `repository_dispatch` and so is not exercised by a local run.

## AI Assistance disclosure

AI assistance used: Yes

Code assistance, and review of the code.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
- [x] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [ ] I have tested my changes on a live environment to confirm they are working
