### PR TITLE
DO NOT MERGE: probe for #6785 affected-only matrix

### DIFF
--- a/e2e/suites/provider/cases/fake/provider.go
+++ b/e2e/suites/provider/cases/fake/provider.go
@@ -105,3 +105,6 @@ func (s *Provider) CreateStore() {
 	err := s.framework.CRClient.Create(GinkgoT().Context(), fakeStore)
 	Expect(err).ToNot(HaveOccurred())
 }
+
+// Probe for the affected-only matrix (external-secrets#6785). Should select
+// core-smoke, flux and argocd. Throwaway; do not merge.

--- a/providers/v1/vault/auth_approle.go
+++ b/providers/v1/vault/auth_approle.go
@@ -77,3 +77,6 @@ func (c *client) requestTokenWithAppRoleRef(ctx context.Context, appRole *esv1.V
 	}
 	return nil
 }
+
+// Probe for the affected-only matrix (external-secrets#6785). Reverted
+// before this branch is dropped; do not merge.

--- a/providers/v1/vault/auth_approle.go
+++ b/providers/v1/vault/auth_approle.go
@@ -77,6 +77,3 @@ func (c *client) requestTokenWithAppRoleRef(ctx context.Context, appRole *esv1.V
 	}
 	return nil
 }
-
-// Probe for the affected-only matrix (external-secrets#6785). Reverted
-// before this branch is dropped; do not merge.


### PR DESCRIPTION
Throwaway draft used to observe the affected-only matrix in real CI. Its base is the #6785 branch, so its diff is one file under `providers/v1/vault/` and the resolver should select exactly two legs, `core-smoke` and `vault`, instead of all sixteen.

The parent PR #6792 cannot demonstrate this itself: the filter reads a PR's cumulative changed files, and #6792 edits `matrix.py` and `matrix.yaml`, which are shared machinery, so it correctly selects everything.

Will be closed and the branch deleted once the behaviour is confirmed. Refs #6785.