### PR TITLE
fix(api): stop defaulting optional ExternalSecret strategy fields

### DIFF
--- a/apis/externalsecrets/v1/externalsecret_types.go
+++ b/apis/externalsecrets/v1/externalsecret_types.go
@@ -172,8 +172,8 @@ type TemplateFrom struct {
 	Literal *string `json:"literal,omitempty"`
 
 	// Used to define a decoding Strategy for the rendered template values.
+	// Defaults to None when omitted.
 	// +optional
-	// +kubebuilder:default="None"
 	ValuesDecodingStrategy ExternalSecretDecodingStrategy `json:"valuesDecodingStrategy,omitempty"`
 }
 
@@ -297,7 +297,6 @@ type ExternalSecretDataRemoteRef struct {
 
 	// +optional
 	// Policy for fetching tags/labels from provider secrets, possible options are Fetch, None. Defaults to None
-	// +kubebuilder:default="None"
 	MetadataPolicy ExternalSecretMetadataPolicy `json:"metadataPolicy,omitempty"`
 
 	// +optional
@@ -309,13 +308,11 @@ type ExternalSecretDataRemoteRef struct {
 	Version string `json:"version,omitempty"`
 
 	// +optional
-	// Used to define a conversion Strategy
-	// +kubebuilder:default="Default"
+	// Used to define a conversion Strategy. Defaults to Default when omitted.
 	ConversionStrategy ExternalSecretConversionStrategy `json:"conversionStrategy,omitempty"`
 
 	// +optional
-	// Used to define a decoding Strategy
-	// +kubebuilder:default="None"
+	// Used to define a decoding Strategy. Defaults to None when omitted.
 	DecodingStrategy ExternalSecretDecodingStrategy `json:"decodingStrategy,omitempty"`
 
 	// +optional
@@ -498,13 +495,11 @@ type ExternalSecretFind struct {
 	Tags map[string]string `json:"tags,omitempty"`
 
 	// +optional
-	// Used to define a conversion Strategy
-	// +kubebuilder:default="Default"
+	// Used to define a conversion Strategy. Defaults to Default when omitted.
 	ConversionStrategy ExternalSecretConversionStrategy `json:"conversionStrategy,omitempty"`
 
 	// +optional
-	// Used to define a decoding Strategy
-	// +kubebuilder:default="None"
+	// Used to define a decoding Strategy. Defaults to None when omitted.
 	DecodingStrategy ExternalSecretDecodingStrategy `json:"decodingStrategy,omitempty"`
 
 	// +optional

--- a/config/crds/bases/external-secrets.io_clusterexternalsecrets.yaml
+++ b/config/crds/bases/external-secrets.io_clusterexternalsecrets.yaml
@@ -92,15 +92,15 @@ spec:
                             which secret (version/property/..) to fetch.
                           properties:
                             conversionStrategy:
-                              default: Default
-                              description: Used to define a conversion Strategy
+                              description: Used to define a conversion Strategy. Defaults
+                                to Default when omitted.
                               enum:
                               - Default
                               - Unicode
                               type: string
                             decodingStrategy:
-                              default: None
-                              description: Used to define a decoding Strategy
+                              description: Used to define a decoding Strategy. Defaults
+                                to None when omitted.
                               enum:
                               - Auto
                               - Base64
@@ -111,7 +111,6 @@ spec:
                               description: Key is the key used in the Provider, mandatory
                               type: string
                             metadataPolicy:
-                              default: None
                               description: Policy for fetching tags/labels from provider
                                 secrets, possible options are Fetch, None. Defaults
                                 to None
@@ -235,15 +234,15 @@ spec:
                             Note: Extract does not support sourceRef.Generator or sourceRef.GeneratorRef.
                           properties:
                             conversionStrategy:
-                              default: Default
-                              description: Used to define a conversion Strategy
+                              description: Used to define a conversion Strategy. Defaults
+                                to Default when omitted.
                               enum:
                               - Default
                               - Unicode
                               type: string
                             decodingStrategy:
-                              default: None
-                              description: Used to define a decoding Strategy
+                              description: Used to define a decoding Strategy. Defaults
+                                to None when omitted.
                               enum:
                               - Auto
                               - Base64
@@ -254,7 +253,6 @@ spec:
                               description: Key is the key used in the Provider, mandatory
                               type: string
                             metadataPolicy:
-                              default: None
                               description: Policy for fetching tags/labels from provider
                                 secrets, possible options are Fetch, None. Defaults
                                 to None
@@ -286,15 +284,15 @@ spec:
                             Note: Find does not support sourceRef.Generator or sourceRef.GeneratorRef.
                           properties:
                             conversionStrategy:
-                              default: Default
-                              description: Used to define a conversion Strategy
+                              description: Used to define a conversion Strategy. Defaults
+                                to Default when omitted.
                               enum:
                               - Default
                               - Unicode
                               type: string
                             decodingStrategy:
-                              default: None
-                              description: Used to define a decoding Strategy
+                              description: Used to define a decoding Strategy. Defaults
+                                to None when omitted.
                               enum:
                               - Auto
                               - Base64
@@ -777,9 +775,9 @@ spec:
                                     nested paths like "spec.database.config" or "data".
                                   type: string
                                 valuesDecodingStrategy:
-                                  default: None
-                                  description: Used to define a decoding Strategy
-                                    for the rendered template values.
+                                  description: |-
+                                    Used to define a decoding Strategy for the rendered template values.
+                                    Defaults to None when omitted.
                                   enum:
                                   - Auto
                                   - Base64

--- a/config/crds/bases/external-secrets.io_clusterpushsecrets.yaml
+++ b/config/crds/bases/external-secrets.io_clusterpushsecrets.yaml
@@ -655,9 +655,9 @@ spec:
                                 nested paths like "spec.database.config" or "data".
                               type: string
                             valuesDecodingStrategy:
-                              default: None
-                              description: Used to define a decoding Strategy for
-                                the rendered template values.
+                              description: |-
+                                Used to define a decoding Strategy for the rendered template values.
+                                Defaults to None when omitted.
                               enum:
                               - Auto
                               - Base64

--- a/config/crds/bases/external-secrets.io_externalsecrets.yaml
+++ b/config/crds/bases/external-secrets.io_externalsecrets.yaml
@@ -78,15 +78,15 @@ spec:
                         which secret (version/property/..) to fetch.
                       properties:
                         conversionStrategy:
-                          default: Default
-                          description: Used to define a conversion Strategy
+                          description: Used to define a conversion Strategy. Defaults
+                            to Default when omitted.
                           enum:
                           - Default
                           - Unicode
                           type: string
                         decodingStrategy:
-                          default: None
-                          description: Used to define a decoding Strategy
+                          description: Used to define a decoding Strategy. Defaults
+                            to None when omitted.
                           enum:
                           - Auto
                           - Base64
@@ -97,7 +97,6 @@ spec:
                           description: Key is the key used in the Provider, mandatory
                           type: string
                         metadataPolicy:
-                          default: None
                           description: Policy for fetching tags/labels from provider
                             secrets, possible options are Fetch, None. Defaults to
                             None
@@ -220,15 +219,15 @@ spec:
                         Note: Extract does not support sourceRef.Generator or sourceRef.GeneratorRef.
                       properties:
                         conversionStrategy:
-                          default: Default
-                          description: Used to define a conversion Strategy
+                          description: Used to define a conversion Strategy. Defaults
+                            to Default when omitted.
                           enum:
                           - Default
                           - Unicode
                           type: string
                         decodingStrategy:
-                          default: None
-                          description: Used to define a decoding Strategy
+                          description: Used to define a decoding Strategy. Defaults
+                            to None when omitted.
                           enum:
                           - Auto
                           - Base64
@@ -239,7 +238,6 @@ spec:
                           description: Key is the key used in the Provider, mandatory
                           type: string
                         metadataPolicy:
-                          default: None
                           description: Policy for fetching tags/labels from provider
                             secrets, possible options are Fetch, None. Defaults to
                             None
@@ -271,15 +269,15 @@ spec:
                         Note: Find does not support sourceRef.Generator or sourceRef.GeneratorRef.
                       properties:
                         conversionStrategy:
-                          default: Default
-                          description: Used to define a conversion Strategy
+                          description: Used to define a conversion Strategy. Defaults
+                            to Default when omitted.
                           enum:
                           - Default
                           - Unicode
                           type: string
                         decodingStrategy:
-                          default: None
-                          description: Used to define a decoding Strategy
+                          description: Used to define a decoding Strategy. Defaults
+                            to None when omitted.
                           enum:
                           - Auto
                           - Base64
@@ -756,9 +754,9 @@ spec:
                                 nested paths like "spec.database.config" or "data".
                               type: string
                             valuesDecodingStrategy:
-                              default: None
-                              description: Used to define a decoding Strategy for
-                                the rendered template values.
+                              description: |-
+                                Used to define a decoding Strategy for the rendered template values.
+                                Defaults to None when omitted.
                               enum:
                               - Auto
                               - Base64

--- a/config/crds/bases/external-secrets.io_pushsecrets.yaml
+++ b/config/crds/bases/external-secrets.io_pushsecrets.yaml
@@ -577,9 +577,9 @@ spec:
                             nested paths like "spec.database.config" or "data".
                           type: string
                         valuesDecodingStrategy:
-                          default: None
-                          description: Used to define a decoding Strategy for the
-                            rendered template values.
+                          description: |-
+                            Used to define a decoding Strategy for the rendered template values.
+                            Defaults to None when omitted.
                           enum:
                           - Auto
                           - Base64

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -88,15 +88,13 @@ spec:
                               which secret (version/property/..) to fetch.
                             properties:
                               conversionStrategy:
-                                default: Default
-                                description: Used to define a conversion Strategy
+                                description: Used to define a conversion Strategy. Defaults to Default when omitted.
                                 enum:
                                   - Default
                                   - Unicode
                                 type: string
                               decodingStrategy:
-                                default: None
-                                description: Used to define a decoding Strategy
+                                description: Used to define a decoding Strategy. Defaults to None when omitted.
                                 enum:
                                   - Auto
                                   - Base64
@@ -107,7 +105,6 @@ spec:
                                 description: Key is the key used in the Provider, mandatory
                                 type: string
                               metadataPolicy:
-                                default: None
                                 description: Policy for fetching tags/labels from provider secrets, possible options are Fetch, None. Defaults to None
                                 enum:
                                   - None
@@ -223,15 +220,13 @@ spec:
                               Note: Extract does not support sourceRef.Generator or sourceRef.GeneratorRef.
                             properties:
                               conversionStrategy:
-                                default: Default
-                                description: Used to define a conversion Strategy
+                                description: Used to define a conversion Strategy. Defaults to Default when omitted.
                                 enum:
                                   - Default
                                   - Unicode
                                 type: string
                               decodingStrategy:
-                                default: None
-                                description: Used to define a decoding Strategy
+                                description: Used to define a decoding Strategy. Defaults to None when omitted.
                                 enum:
                                   - Auto
                                   - Base64
@@ -242,7 +237,6 @@ spec:
                                 description: Key is the key used in the Provider, mandatory
                                 type: string
                               metadataPolicy:
-                                default: None
                                 description: Policy for fetching tags/labels from provider secrets, possible options are Fetch, None. Defaults to None
                                 enum:
                                   - None
@@ -269,15 +263,13 @@ spec:
                               Note: Find does not support sourceRef.Generator or sourceRef.GeneratorRef.
                             properties:
                               conversionStrategy:
-                                default: Default
-                                description: Used to define a conversion Strategy
+                                description: Used to define a conversion Strategy. Defaults to Default when omitted.
                                 enum:
                                   - Default
                                   - Unicode
                                 type: string
                               decodingStrategy:
-                                default: None
-                                description: Used to define a decoding Strategy
+                                description: Used to define a decoding Strategy. Defaults to None when omitted.
                                 enum:
                                   - Auto
                                   - Base64
@@ -727,8 +719,9 @@ spec:
                                       nested paths like "spec.database.config" or "data".
                                     type: string
                                   valuesDecodingStrategy:
-                                    default: None
-                                    description: Used to define a decoding Strategy for the rendered template values.
+                                    description: |-
+                                      Used to define a decoding Strategy for the rendered template values.
+                                      Defaults to None when omitted.
                                     enum:
                                       - Auto
                                       - Base64
@@ -2247,8 +2240,9 @@ spec:
                                   nested paths like "spec.database.config" or "data".
                                 type: string
                               valuesDecodingStrategy:
-                                default: None
-                                description: Used to define a decoding Strategy for the rendered template values.
+                                description: |-
+                                  Used to define a decoding Strategy for the rendered template values.
+                                  Defaults to None when omitted.
                                 enum:
                                   - Auto
                                   - Base64
@@ -13559,15 +13553,13 @@ spec:
                           which secret (version/property/..) to fetch.
                         properties:
                           conversionStrategy:
-                            default: Default
-                            description: Used to define a conversion Strategy
+                            description: Used to define a conversion Strategy. Defaults to Default when omitted.
                             enum:
                               - Default
                               - Unicode
                             type: string
                           decodingStrategy:
-                            default: None
-                            description: Used to define a decoding Strategy
+                            description: Used to define a decoding Strategy. Defaults to None when omitted.
                             enum:
                               - Auto
                               - Base64
@@ -13578,7 +13570,6 @@ spec:
                             description: Key is the key used in the Provider, mandatory
                             type: string
                           metadataPolicy:
-                            default: None
                             description: Policy for fetching tags/labels from provider secrets, possible options are Fetch, None. Defaults to None
                             enum:
                               - None
@@ -13694,15 +13685,13 @@ spec:
                           Note: Extract does not support sourceRef.Generator or sourceRef.GeneratorRef.
                         properties:
                           conversionStrategy:
-                            default: Default
-                            description: Used to define a conversion Strategy
+                            description: Used to define a conversion Strategy. Defaults to Default when omitted.
                             enum:
                               - Default
                               - Unicode
                             type: string
                           decodingStrategy:
-                            default: None
-                            description: Used to define a decoding Strategy
+                            description: Used to define a decoding Strategy. Defaults to None when omitted.
                             enum:
                               - Auto
                               - Base64
@@ -13713,7 +13702,6 @@ spec:
                             description: Key is the key used in the Provider, mandatory
                             type: string
                           metadataPolicy:
-                            default: None
                             description: Policy for fetching tags/labels from provider secrets, possible options are Fetch, None. Defaults to None
                             enum:
                               - None
@@ -13740,15 +13728,13 @@ spec:
                           Note: Find does not support sourceRef.Generator or sourceRef.GeneratorRef.
                         properties:
                           conversionStrategy:
-                            default: Default
-                            description: Used to define a conversion Strategy
+                            description: Used to define a conversion Strategy. Defaults to Default when omitted.
                             enum:
                               - Default
                               - Unicode
                             type: string
                           decodingStrategy:
-                            default: None
-                            description: Used to define a decoding Strategy
+                            description: Used to define a decoding Strategy. Defaults to None when omitted.
                             enum:
                               - Auto
                               - Base64
@@ -14198,8 +14184,9 @@ spec:
                                   nested paths like "spec.database.config" or "data".
                                 type: string
                               valuesDecodingStrategy:
-                                default: None
-                                description: Used to define a decoding Strategy for the rendered template values.
+                                description: |-
+                                  Used to define a decoding Strategy for the rendered template values.
+                                  Defaults to None when omitted.
                                 enum:
                                   - Auto
                                   - Base64
@@ -15431,8 +15418,9 @@ spec:
                               nested paths like "spec.database.config" or "data".
                             type: string
                           valuesDecodingStrategy:
-                            default: None
-                            description: Used to define a decoding Strategy for the rendered template values.
+                            description: |-
+                              Used to define a decoding Strategy for the rendered template values.
+                              Defaults to None when omitted.
                             enum:
                               - Auto
                               - Base64

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -4747,7 +4747,7 @@ ExternalSecretConversionStrategy
 </td>
 <td>
 <em>(Optional)</em>
-<p>Used to define a conversion Strategy</p>
+<p>Used to define a conversion Strategy. Defaults to Default when omitted.</p>
 </td>
 </tr>
 <tr>
@@ -4761,7 +4761,7 @@ ExternalSecretDecodingStrategy
 </td>
 <td>
 <em>(Optional)</em>
-<p>Used to define a decoding Strategy</p>
+<p>Used to define a decoding Strategy. Defaults to None when omitted.</p>
 </td>
 </tr>
 <tr>
@@ -4913,7 +4913,7 @@ ExternalSecretConversionStrategy
 </td>
 <td>
 <em>(Optional)</em>
-<p>Used to define a conversion Strategy</p>
+<p>Used to define a conversion Strategy. Defaults to Default when omitted.</p>
 </td>
 </tr>
 <tr>
@@ -4927,7 +4927,7 @@ ExternalSecretDecodingStrategy
 </td>
 <td>
 <em>(Optional)</em>
-<p>Used to define a decoding Strategy</p>
+<p>Used to define a decoding Strategy. Defaults to None when omitted.</p>
 </td>
 </tr>
 <tr>
@@ -12202,7 +12202,8 @@ ExternalSecretDecodingStrategy
 </td>
 <td>
 <em>(Optional)</em>
-<p>Used to define a decoding Strategy for the rendered template values.</p>
+<p>Used to define a decoding Strategy for the rendered template values.
+Defaults to None when omitted.</p>
 </td>
 </tr>
 </tbody>

--- a/pkg/controllers/externalsecret/externalsecret_crd_defaults_test.go
+++ b/pkg/controllers/externalsecret/externalsecret_crd_defaults_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright © The ESO Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package externalsecret
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
+	ctest "github.com/external-secrets/external-secrets/pkg/controllers/commontest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// Guards issue #6797: the API server must not inject values into these optional
+// strategy fields, because an injected value is a permanent diff for any
+// apply-based reconciler comparing against the source manifest.
+var _ = Describe("ExternalSecret CRD defaulting", func() {
+	var namespace string
+
+	BeforeEach(func() {
+		var err error
+		namespace, err = ctest.CreateNamespace("test-crd-defaults", k8sClient)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("leaves omitted strategy fields absent", func() {
+		es := &esv1.ExternalSecret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "no-defaults",
+				Namespace: namespace,
+			},
+			Spec: esv1.ExternalSecretSpec{
+				SecretStoreRef: esv1.SecretStoreRef{Name: "unused"},
+				Target: esv1.ExternalSecretTarget{
+					Template: &esv1.ExternalSecretTemplate{
+						TemplateFrom: []esv1.TemplateFrom{{
+							Secret: &esv1.TemplateRef{
+								Name:  "tpl",
+								Items: []esv1.TemplateRefItem{{Key: "key"}},
+							},
+						}},
+					},
+				},
+				Data: []esv1.ExternalSecretData{{
+					SecretKey: "key",
+					RemoteRef: esv1.ExternalSecretDataRemoteRef{Key: "remote-key"},
+				}},
+				DataFrom: []esv1.ExternalSecretDataFromRemoteRef{
+					{Extract: &esv1.ExternalSecretDataRemoteRef{Key: "remote-key"}},
+					{Find: &esv1.ExternalSecretFind{Path: new("some/path")}},
+				},
+			},
+		}
+		Expect(k8sClient.Create(context.Background(), es)).To(Succeed())
+
+		stored := &esv1.ExternalSecret{}
+		Expect(k8sClient.Get(context.Background(), types.NamespacedName{
+			Name:      es.Name,
+			Namespace: es.Namespace,
+		}, stored)).To(Succeed())
+
+		By("checking data[].remoteRef")
+		remoteRef := stored.Spec.Data[0].RemoteRef
+		Expect(remoteRef.MetadataPolicy).To(BeEmpty())
+		Expect(remoteRef.ConversionStrategy).To(BeEmpty())
+		Expect(remoteRef.DecodingStrategy).To(BeEmpty())
+
+		By("checking dataFrom[].extract")
+		extract := stored.Spec.DataFrom[0].Extract
+		Expect(extract.MetadataPolicy).To(BeEmpty())
+		Expect(extract.ConversionStrategy).To(BeEmpty())
+		Expect(extract.DecodingStrategy).To(BeEmpty())
+
+		By("checking dataFrom[].find")
+		find := stored.Spec.DataFrom[1].Find
+		Expect(find.ConversionStrategy).To(BeEmpty())
+		Expect(find.DecodingStrategy).To(BeEmpty())
+
+		By("checking target.template.templateFrom[]")
+		Expect(stored.Spec.Target.Template.TemplateFrom[0].ValuesDecodingStrategy).To(BeEmpty())
+	})
+})

--- a/providers/v1/cloudru/secretmanager/client_test.go
+++ b/providers/v1/cloudru/secretmanager/client_test.go
@@ -267,9 +267,11 @@ func TestClientGetAllSecrets(t *testing.T) {
 				mock.MockAccessSecretVersion([]byte(`{"some": "value", "another": "value", "foo": {"bar": "baz"}}`), nil)
 				mock.MockAccessSecretVersion([]byte(`{"second_secret": "prop_value"}`), nil)
 			},
+			// The provider returns paths; the conversion strategy replaces the
+			// slash so the key is valid in a Secret.
 			wantPayload: map[string][]byte{
 				"secret1":        []byte(`{"some": "value", "another": "value", "foo": {"bar": "baz"}}`),
-				"storage/secret": []byte(`{"second_secret": "prop_value"}`),
+				"storage_secret": []byte(`{"second_secret": "prop_value"}`),
 			},
 			wantErr: nil,
 		},
@@ -293,7 +295,7 @@ func TestClientGetAllSecrets(t *testing.T) {
 			},
 			wantPayload: map[string][]byte{
 				"secret":         []byte(`{"some": "value", "another": "value", "foo": {"bar": "baz"}}`),
-				"storage/secret": []byte(`top_secret`),
+				"storage_secret": []byte(`top_secret`),
 			},
 			wantErr: nil,
 		},
@@ -312,7 +314,7 @@ func TestClientGetAllSecrets(t *testing.T) {
 				mock.MockAccessSecretVersion([]byte(`value1`), nil)
 			},
 			wantPayload: map[string][]byte{
-				"oss/snmp-auths/secret1": []byte(`value1`),
+				"oss_snmp-auths_secret1": []byte(`value1`),
 			},
 			wantErr: nil,
 		},

--- a/providers/v1/crd/crd_test.go
+++ b/providers/v1/crd/crd_test.go
@@ -488,7 +488,9 @@ func TestClientGetAllSecrets(t *testing.T) {
 			client: func() *Client { return ssClient(makeStore(wlRule("^app-.*$")), "ns1", objA, objB) },
 		},
 		{
-			name: "CSS namespaced kind uses namespace/name keys", wantKeys: []string{"ns1/app-a", "ns2/sys-b"},
+			// The provider builds namespace/name keys; the conversion strategy
+			// then replaces the slash so the key is valid in a Secret.
+			name: "CSS namespaced kind uses namespace/name keys", wantKeys: []string{"ns1_app-a", "ns2_sys-b"},
 			client: func() *Client {
 				return cssClient(makeStore(),
 					widget("app-a", "ns1", map[string]any{"password": "a"}),
@@ -686,9 +688,9 @@ func TestWhitelistGetAllSecrets(t *testing.T) {
 		rules    []esv1.CRDProviderWhitelistRule
 		wantKeys []string
 	}{
-		{name: "allow only ns1", rules: []esv1.CRDProviderWhitelistRule{wlRuleNS("^ns1$", "")}, wantKeys: []string{"ns1/app-a"}},
-		{name: "ns1 + name rule", rules: []esv1.CRDProviderWhitelistRule{wlRuleNS("^ns1$", ""), wlRuleNS("", "^app-b$")}, wantKeys: []string{"ns1/app-a", "ns2/app-b"}},
-		{name: "filter to ns2", rules: []esv1.CRDProviderWhitelistRule{wlRuleNS("^ns2$", "")}, wantKeys: []string{"ns2/app-b"}},
+		{name: "allow only ns1", rules: []esv1.CRDProviderWhitelistRule{wlRuleNS("^ns1$", "")}, wantKeys: []string{"ns1_app-a"}},
+		{name: "ns1 + name rule", rules: []esv1.CRDProviderWhitelistRule{wlRuleNS("^ns1$", ""), wlRuleNS("", "^app-b$")}, wantKeys: []string{"ns1_app-a", "ns2_app-b"}},
+		{name: "filter to ns2", rules: []esv1.CRDProviderWhitelistRule{wlRuleNS("^ns2$", "")}, wantKeys: []string{"ns2_app-b"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/runtime/esutils/utils.go
+++ b/runtime/esutils/utils.go
@@ -270,7 +270,9 @@ func convert(strategy esv1.ExternalSecretConversionStrategy, str string) string 
 			rv != '.' &&
 			rv != '_' {
 			switch strategy {
-			case esv1.ExternalSecretConversionDefault:
+			// An empty strategy means the field was omitted, which the API
+			// documents as Default. Decode() folds "" in the same way.
+			case esv1.ExternalSecretConversionDefault, "":
 				newName[rk] = "_"
 			case esv1.ExternalSecretConversionUnicode:
 				newName[rk] = fmt.Sprintf("_U%04x_", rv)

--- a/runtime/esutils/utils_test.go
+++ b/runtime/esutils/utils_test.go
@@ -229,6 +229,31 @@ func TestConvertKeys(t *testing.T) {
 				"_U1f600_foo_U1f601_bar_U1f602_baz_U1f608_bing": []byte(`noop`),
 			},
 		},
+		{
+			// An omitted conversionStrategy must behave as Default, otherwise
+			// the key keeps characters a Secret cannot hold. See issue #6797.
+			name: "empty strategy converts as Default",
+			args: args{
+				strategy: "",
+				in: map[string][]byte{
+					"foo$bar%baz*bing": []byte(`noop`),
+				},
+			},
+			want: map[string][]byte{
+				"foo_bar_baz_bing": []byte(`noop`),
+			},
+		},
+		{
+			name: "empty strategy collides like Default",
+			args: args{
+				strategy: "",
+				in: map[string][]byte{
+					"foo$bar%baz*bing": []byte(`noop`),
+					"foo_bar_baz$bing": []byte(`noop`),
+				},
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/tests/__snapshot__/clusterexternalsecret-v1.yaml
+++ b/tests/__snapshot__/clusterexternalsecret-v1.yaml
@@ -9,10 +9,10 @@ spec:
   externalSecretSpec:
     data:
     - remoteRef:
-        conversionStrategy: "Default"
-        decodingStrategy: "None"
+        conversionStrategy: "Default" # "Default", "Unicode"
+        decodingStrategy: "Auto" # "Auto", "Base64", "Base64URL", "None"
         key: string
-        metadataPolicy: "None"
+        metadataPolicy: "None" # "None", "Fetch"
         nullBytePolicy: "Ignore" # "Ignore", "Fail"
         property: string
         version: string
@@ -27,16 +27,16 @@ spec:
           name: string
     dataFrom:
     - extract:
-        conversionStrategy: "Default"
-        decodingStrategy: "None"
+        conversionStrategy: "Default" # "Default", "Unicode"
+        decodingStrategy: "Auto" # "Auto", "Base64", "Base64URL", "None"
         key: string
-        metadataPolicy: "None"
+        metadataPolicy: "None" # "None", "Fetch"
         nullBytePolicy: "Ignore" # "Ignore", "Fail"
         property: string
         version: string
       find:
-        conversionStrategy: "Default"
-        decodingStrategy: "None"
+        conversionStrategy: "Default" # "Default", "Unicode"
+        decodingStrategy: "Auto" # "Auto", "Base64", "Base64URL", "None"
         name:
           regexp: string
         nullBytePolicy: "Ignore" # "Ignore", "Fail"
@@ -101,7 +101,7 @@ spec:
               templateAs: "Values"
             name: string
           target: "Data"
-          valuesDecodingStrategy: "None"
+          valuesDecodingStrategy: "Auto" # "Auto", "Base64", "Base64URL", "None"
         type: string
   namespaceSelector:
     matchExpressions:

--- a/tests/__snapshot__/externalsecret-v1.yaml
+++ b/tests/__snapshot__/externalsecret-v1.yaml
@@ -4,10 +4,10 @@ metadata: {}
 spec:
   data:
   - remoteRef:
-      conversionStrategy: "Default"
-      decodingStrategy: "None"
+      conversionStrategy: "Default" # "Default", "Unicode"
+      decodingStrategy: "Auto" # "Auto", "Base64", "Base64URL", "None"
       key: string
-      metadataPolicy: "None"
+      metadataPolicy: "None" # "None", "Fetch"
       nullBytePolicy: "Ignore" # "Ignore", "Fail"
       property: string
       version: string
@@ -22,16 +22,16 @@ spec:
         name: string
   dataFrom:
   - extract:
-      conversionStrategy: "Default"
-      decodingStrategy: "None"
+      conversionStrategy: "Default" # "Default", "Unicode"
+      decodingStrategy: "Auto" # "Auto", "Base64", "Base64URL", "None"
       key: string
-      metadataPolicy: "None"
+      metadataPolicy: "None" # "None", "Fetch"
       nullBytePolicy: "Ignore" # "Ignore", "Fail"
       property: string
       version: string
     find:
-      conversionStrategy: "Default"
-      decodingStrategy: "None"
+      conversionStrategy: "Default" # "Default", "Unicode"
+      decodingStrategy: "Auto" # "Auto", "Base64", "Base64URL", "None"
       name:
         regexp: string
       nullBytePolicy: "Ignore" # "Ignore", "Fail"
@@ -96,7 +96,7 @@ spec:
             templateAs: "Values"
           name: string
         target: "Data"
-        valuesDecodingStrategy: "None"
+        valuesDecodingStrategy: "Auto" # "Auto", "Base64", "Base64URL", "None"
       type: string
 status:
   binding:

--- a/tests/__snapshot__/pushsecret-v1alpha1.yaml
+++ b/tests/__snapshot__/pushsecret-v1alpha1.yaml
@@ -76,7 +76,7 @@ spec:
           templateAs: "Values"
         name: string
       target: "Data"
-      valuesDecodingStrategy: "None"
+      valuesDecodingStrategy: "Auto" # "Auto", "Base64", "Base64URL", "None"
     type: string
   updatePolicy: "Replace"
 status:


### PR DESCRIPTION
## Problem Statement

#6453 dropped the `kubebuilder:default` from `nullBytePolicy` because a field that can be omitted does not need one, fixing #6398 where the injected value made ArgoCD fight the API server forever. The same markers were still on the neighbouring strategy fields, so anyone who omits those still gets the permanent diff. The reporter of #6398 was already pinning `conversionStrategy: Default`, `decodingStrategy: None` and `metadataPolicy: None` in git, which is exactly the workaround these defaults force on GitOps users.

## Related Issue

Fixes #6797

## Proposed Changes

Removes six markers, all on ExternalSecret v1: `valuesDecodingStrategy` on `TemplateFrom`; `metadataPolicy`, `conversionStrategy` and `decodingStrategy` on `ExternalSecretDataRemoteRef`, which covers both `data[].remoteRef` and `dataFrom[].extract`; and `conversionStrategy` and `decodingStrategy` on `ExternalSecretFind`. All six already had `+optional`, so no marker is added. One correction to the table in #6797: it labels two of the six as `ExternalSecretDataFromRemoteRef` (extract), but they are on `ExternalSecretFind`; extract shares `ExternalSecretDataRemoteRef` with `data[].remoteRef`. Six sites is right, two labels were not.

PushSecret has the same class of problem and is deliberately **not** in this PR. Its `deletionPolicy` is a top-level scalar rather than a field inside an atomic list, which changes both the GitOps symptom and the migration story, and it is the one field that would need a behavioural change in a finalizer path. Worth its own PR and its own review attention. The PushSecret and ClusterPushSecret CRDs do still appear in this diff, in exactly one place each: `spec.template.templateFrom[].valuesDecodingStrategy`, because they embed the shared `esv1.ExternalSecretTemplate`.

Once a marker is gone the field can legitimately hold the empty string, so every consumer has to read empty as the documented default. Five of the six already did: `metadataPolicy` is only ever compared against `ExternalSecretMetadataPolicyFetch` (10 sites), and the decoding fields all route through `decoding.Decode`, which has had `case "": return in, nil` since before this work. `conversionStrategy` did not, so this fixes it: `convert()` in `runtime/esutils/utils.go` sent empty to `default:` and returned the character unchanged, so a key such as `foo@bar` stayed `foo@bar` instead of becoming `foo_bar`. That is not just a cosmetic difference, `ValidateKeys` in the controller then rejects the key with `key has invalid character /`, so omitting `conversionStrategy` against a provider that returns path-like keys would fail reconciliation outright. `Decode()` in the same pipeline already folds empty onto its default, and `ExternalSecretConversionStrategy` is `Enum=Default;Unicode` with no `None` member, so empty can only ever mean unset.

Because of that fix, four existing tests changed expectations. They passed an empty strategy directly, which bypasses the API server that would have injected `Default`, and then asserted keys a Secret cannot legally hold (`ns1/app-a`, `storage/secret`, `oss/snmp-auths/secret1`). They now assert what a real cluster has always produced (`ns1_app-a`, `storage_secret`, `oss_snmp-auths_secret1`). Flagging it explicitly because on a first read it looks like a behaviour regression in two providers, and it is the opposite.

Two things I would rather you heard from me than found yourself:

**`v1beta1` keeps its markers.** For a default install that is inert: those versions are `unservedversion` and `deprecatedversion`, and read-path defaulting uses the storage-version schema (v1). But `hack/helm.generate.sh` templates `served:` off `crds.unsafeServeV1Beta1`, so v1beta1 can be served on request, and write-path defaulting uses the *request* version's schema. A user with that flag on who applies to `external-secrets.io/v1beta1` still gets the values injected and stored. I can remove the v1beta1 markers too if you would rather the fix be complete for that path; the fields are name-identical and conversion is `None`, so nothing is dropped.

**`make test.crds` is the repo's backwards-compat tripwire and it fired.** The snapshots under `tests/__snapshot__/` are regenerated on purpose here. Worth knowing that `cty` renders an enum with no default by falling back to the *first* enum member, so `decodingStrategy` samples now read `"Auto" # "Auto", "Base64", "Base64URL", "None"` rather than `"None"`. These files are test fixtures, not published docs, so nobody copy-pastes them, and the comment lists every valid value. If you would prefer the samples keep showing the real default, reordering the enum marker to `None;Auto;Base64;Base64URL` fixes it and is semantically inert since OpenAPI `enum` is a set. Say the word and I will add it.

## Migration

Removing a default does not strip the value from objects the API server already defaulted, so I measured it on kind v1.34.0 rather than guess. Upgrading the CRD alone changes nothing; the next apply is what matters. All four field shapes, under both apply modes:

| Field | Client-side apply | Server-side apply |
| --- | --- | --- |
| `spec.data[].remoteRef` | pruned | pruned |
| `spec.dataFrom[].extract` | pruned | pruned |
| `spec.dataFrom[].find` | pruned | pruned |
| `spec.target.template.templateFrom[]` | pruned | pruned |

All six fields sit inside arrays with no `x-kubernetes-list-type`, so those lists are atomic: the next apply of the unchanged manifest replaces each entry wholesale and takes the injected siblings with it. Newly created objects are clean. So users get relief on their next sync with no manual step, and can then drop a pinned field or an `ignoreDifferences` entry. Probably worth a release note saying so.

One behaviour change to call out for the release notes rather than bury: an external policy that reads these fields, for example a Kyverno or CEL rule shaped like `d.remoteRef.decodingStrategy in ['None','Base64']`, previously always saw a populated value and will now see `""`.

## AI Assistance disclosure

AI assistance used: Yes

Code assistance, and review of the code.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
- [x] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [x] I have tested my changes on a live environment to confirm they are working
