### PR TITLE
fix(aws): manage Secrets Manager resource policy only when declared

### DIFF
--- a/docs/provider/aws-secrets-manager.md
+++ b/docs/provider/aws-secrets-manager.md
@@ -152,11 +152,11 @@ To control this behavior set the following provider metadata:
 - `tags` Key-value map of user-defined tags that are attached to the secret.
 - `replicationLocations` takes a list of valid AWS region names where the secret should be replicated.
 
-**Note:** ESO treats the PushSecret as the **source of truth** for tags, resource policy, and replication locations. When any of these resources are specified in `metadata`, they will be added or updated, and resources NOT specified but existing will be removed from AWS. This synchronization happens on every reconciliation, even when the secret value hasn't changed.
+**Note:** ESO treats the PushSecret as the **source of truth** for tags, resource policy, and replication locations. When one of these is specified in `metadata`, its value is the desired state: what is listed is added or updated, and what exists in AWS but is not listed is removed. When one is omitted from `metadata` entirely, ESO does not manage it and leaves the existing AWS state alone. This synchronization happens on every reconciliation, even when the secret value hasn't changed.
 
 - `resourcePolicy` Attach a resource-based policy to the secret for cross-account access or advanced access control.
   - `blockPublicPolicy` (optional) - Set to `true` to validate that the policy doesn't grant public access before applying. Defaults to AWS behavior.
-  - `policySourceRef` (required) - Reference to a ConfigMap or Secret containing the policy JSON.
+  - `policySourceRef` (optional) - Reference to a ConfigMap or Secret containing the policy JSON. Declaring `resourcePolicy` without it means "no policy", and deletes any policy attached to the secret.
     - `kind` - Either `ConfigMap` or `Secret`.
     - `name` - Name of the ConfigMap or Secret.
     - `key` - Key within the ConfigMap/Secret data that contains the policy JSON.
@@ -233,7 +233,12 @@ data:
     }
 ```
 
-**Note:** The resource policy is synchronized on every reconciliation, even when the secret value hasn't changed. If the `resourcePolicy` field is removed from metadata, the existing policy will be deleted from the secret.
+**Note:** The resource policy is synchronized on every reconciliation, even when the secret value hasn't changed. If `resourcePolicy` is not set in the metadata, ESO does not manage the policy and leaves any existing one in place. To delete a policy, keep `resourcePolicy` declared but drop its `policySourceRef`:
+
+```yaml
+      metadata:
+        resourcePolicy: {}
+```
 
 ##### Location Replication
 

--- a/providers/v1/aws/secretsmanager/secretsmanager.go
+++ b/providers/v1/aws/secretsmanager/secretsmanager.go
@@ -936,8 +936,15 @@ func (sm *SecretsManager) manageResourcePolicy(ctx context.Context, metadata *ap
 		return err
 	}
 
-	// Delete policy if policyRef is nil and the policy exists.
+	// NOTE: skip resource policy management completely unless explicitly set in the desired state.
+	// Deleting on absence would make secretsmanager:DeleteResourcePolicy mandatory for every push and
+	// would drop policies attached outside of ESO.
 	if meta.Spec.ResourcePolicy == nil {
+		return nil
+	}
+
+	// An explicitly declared resourcePolicy without a source means "no policy".
+	if meta.Spec.ResourcePolicy.PolicySourceRef == nil {
 		return sm.deleteResourcePolicy(ctx, secretID)
 	}
 

--- a/providers/v1/aws/secretsmanager/secretsmanager_test.go
+++ b/providers/v1/aws/secretsmanager/secretsmanager_test.go
@@ -1724,6 +1724,146 @@ func TestPushSecretEmptyExistingResourcePolicy(t *testing.T) {
 	assert.True(t, putResourcePolicyCalled, "PutResourcePolicy should be called when existing policy is empty")
 }
 
+// A PushSecret that never declares resourcePolicy must not touch the resource policy at all,
+// so that secretsmanager:DeleteResourcePolicy stays optional and policies attached outside of
+// ESO survive. See #6806.
+func TestPushSecretSkipsResourcePolicyWhenNotDeclared(t *testing.T) {
+	metadataVariants := map[string]*apiextensionsv1.JSON{
+		"NoMetadata": nil,
+		"MetadataWithoutResourcePolicy": {
+			Raw: []byte(`{
+				"apiVersion": "kubernetes.external-secrets.io/v1alpha1",
+				"kind": "PushSecretMetadata",
+				"spec": {
+					"tags": {"newTag": "newValue"}
+				}
+			}`),
+		},
+	}
+
+	for name, pushSecretMetadata := range metadataVariants {
+		t.Run(name, func(t *testing.T) {
+			secretKey := fakeSecretKey
+			secretValue := []byte("fake-value")
+			fakeSecret := &corev1.Secret{
+				Data: map[string][]byte{
+					secretKey: secretValue,
+				},
+			}
+			arn := testARN
+			defaultVersion := testDefaultVersion
+			managed := managedBy
+			manager := externalSecrets
+
+			deleteResourcePolicyCalled := false
+			getResourcePolicyCalled := false
+
+			client := fakesm.Client{
+				GetSecretValueFn: fakesm.NewGetSecretValueFn(&awssm.GetSecretValueOutput{
+					ARN:          &arn,
+					SecretBinary: secretValue,
+					VersionId:    &defaultVersion,
+				}, nil),
+				DescribeSecretFn: fakesm.NewDescribeSecretFn(&awssm.DescribeSecretOutput{
+					ARN: &arn,
+					Tags: []types.Tag{
+						{Key: &managed, Value: &manager},
+					},
+					VersionIdsToStages: map[string][]string{
+						defaultVersion: {"AWSCURRENT"},
+					},
+				}, nil),
+				PutSecretValueFn: fakesm.NewPutSecretValueFn(&awssm.PutSecretValueOutput{}, nil),
+				TagResourceFn:    fakesm.NewTagResourceFn(&awssm.TagResourceOutput{}, nil),
+				UntagResourceFn:  fakesm.NewUntagResourceFn(&awssm.UntagResourceOutput{}, nil),
+				// Mimic a least-privilege principal: the calls are denied, so reaching them fails the push.
+				GetResourcePolicyFn: func(_ context.Context, _ *awssm.GetResourcePolicyInput, _ ...func(*awssm.Options)) (*awssm.GetResourcePolicyOutput, error) {
+					getResourcePolicyCalled = true
+					return nil, errors.New("AccessDeniedException: not authorized to perform secretsmanager:GetResourcePolicy")
+				},
+				DeleteResourcePolicyFn: func(_ context.Context, _ *awssm.DeleteResourcePolicyInput, _ ...func(*awssm.Options)) (*awssm.DeleteResourcePolicyOutput, error) {
+					deleteResourcePolicyCalled = true
+					return nil, errors.New("AccessDeniedException: not authorized to perform secretsmanager:DeleteResourcePolicy")
+				},
+			}
+
+			sm := SecretsManager{
+				client: &client,
+			}
+
+			err := sm.PushSecret(context.Background(), fakeSecret, fake.PushSecretData{
+				SecretKey: secretKey,
+				RemoteKey: fakeKey,
+				Metadata:  pushSecretMetadata,
+			})
+			require.NoError(t, err)
+			assert.False(t, deleteResourcePolicyCalled, "DeleteResourcePolicy should not be called when resourcePolicy is not declared")
+			assert.False(t, getResourcePolicyCalled, "GetResourcePolicy should not be called when resourcePolicy is not declared")
+		})
+	}
+}
+
+// An explicitly declared resourcePolicy without a policySourceRef is the opt-in way to remove a policy.
+func TestPushSecretDeletesResourcePolicyWhenDeclaredWithoutSource(t *testing.T) {
+	secretKey := fakeSecretKey
+	secretValue := []byte("fake-value")
+	fakeSecret := &corev1.Secret{
+		Data: map[string][]byte{
+			secretKey: secretValue,
+		},
+	}
+	arn := testARN
+	defaultVersion := testDefaultVersion
+	managed := managedBy
+	manager := externalSecrets
+
+	var capturedDeleteInput *awssm.DeleteResourcePolicyInput
+
+	client := fakesm.Client{
+		GetSecretValueFn: fakesm.NewGetSecretValueFn(&awssm.GetSecretValueOutput{
+			ARN:          &arn,
+			SecretBinary: secretValue,
+			VersionId:    &defaultVersion,
+		}, nil),
+		DescribeSecretFn: fakesm.NewDescribeSecretFn(&awssm.DescribeSecretOutput{
+			ARN: &arn,
+			Tags: []types.Tag{
+				{Key: &managed, Value: &manager},
+			},
+			VersionIdsToStages: map[string][]string{
+				defaultVersion: {"AWSCURRENT"},
+			},
+		}, nil),
+		PutSecretValueFn: fakesm.NewPutSecretValueFn(&awssm.PutSecretValueOutput{}, nil),
+		TagResourceFn:    fakesm.NewTagResourceFn(&awssm.TagResourceOutput{}, nil),
+		UntagResourceFn:  fakesm.NewUntagResourceFn(&awssm.UntagResourceOutput{}, nil),
+		DeleteResourcePolicyFn: fakesm.NewDeleteResourcePolicyFn(&awssm.DeleteResourcePolicyOutput{}, nil, func(input *awssm.DeleteResourcePolicyInput) {
+			capturedDeleteInput = input
+		}),
+	}
+
+	sm := SecretsManager{
+		client: &client,
+	}
+
+	err := sm.PushSecret(context.Background(), fakeSecret, fake.PushSecretData{
+		SecretKey: secretKey,
+		RemoteKey: fakeKey,
+		Metadata: &apiextensionsv1.JSON{
+			Raw: []byte(`{
+				"apiVersion": "kubernetes.external-secrets.io/v1alpha1",
+				"kind": "PushSecretMetadata",
+				"spec": {
+					"resourcePolicy": {}
+				}
+			}`),
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, capturedDeleteInput, "DeleteResourcePolicy should be called when resourcePolicy is declared without a source")
+	assert.Equal(t, fakeKey, *capturedDeleteInput.SecretId)
+}
+
 func TestDeleteSecret(t *testing.T) {
 	fakeClient := fakesm.Client{}
 	managed := managedBy


### PR DESCRIPTION
## Problem Statement

`manageResourcePolicy` deletes the resource policy whenever `resourcePolicy` is absent from the PushSecret metadata:

```go
// Delete policy if policyRef is nil and the policy exists.
if meta.Spec.ResourcePolicy == nil {
    return sm.deleteResourcePolicy(ctx, secretID)
}
```

There is no existence check despite the comment, and no check that the user ever opted into policy management. Since #6025 this runs on every reconciliation of every PushSecret targeting an existing secret, so:

- `secretsmanager:DeleteResourcePolicy` is required by every PushSecret user, while the docs say it is only needed with the `resourcePolicy` metadata option. A least-privilege principal fails the whole push with `AccessDeniedException`.
- A policy attached out of band (Terraform, an account's security tooling) is silently removed by an unrelated PushSecret. With broad IAM nobody notices, because deleting a non-existent policy returns 200.

## Related Issue

Fixes #6806

## Proposed Changes

Skip resource-policy management entirely unless `resourcePolicy` is declared, matching `patchTags` and `manageRegionReplication` in the same file — both already return early when their field is absent.

On its own that would regress a documented behaviour. `docs/provider/aws-secrets-manager.md:236` currently promises:

> If the `resourcePolicy` field is removed from metadata, the existing policy will be deleted from the secret.

So removal-by-omission is real and can't just disappear — it moves to an explicit gesture. A declared `resourcePolicy` with no `policySourceRef` now means "no policy" and deletes it:

```yaml
      metadata:
        resourcePolicy: {}
```

That shape is free to take on this meaning because it was previously an error: `resolveResourcePolicy` rejects a nil ref with `policySourceRef is nil`, failing the push. So no configuration that works today changes behaviour — only configurations that were already broken, plus the omission case that this PR is about.

I also considered calling `GetResourcePolicy` first and deleting only when a policy is attached — the literal reading of the old comment. Rejected: `GetResourcePolicy` would stay mandatory for every push, so the docs would still be wrong; it costs an API call per reconciliation; and ESO would still delete a policy it was never asked to manage.

Distinguishing "no `resourcePolicy` key" from "`resourcePolicy: null`" through the raw metadata, the way `patchTags` inspects raw tags, is not needed here. `patchTags` has to do that because `constructMetadataWithDefaults` injects the `managed-by` tag; no default is injected for the resource policy, so the typed nil already reflects the user's input.

Docs updated for the new omission and removal semantics.


## AI Assistance disclosure

AI assistance used: Yes

If yes provide details:

Tool(s) used: Claude Code

Purpose of assistance: locating the defect, drafting the fix, tests and docs wording.

Parts of the contribution affected: all of the diff, the issue and this description.

Human validation performed: reviewed the diff; confirmed both new tests fail on stock `main` and pass with the fix; ran `make test`, `go test -race ./secretsmanager/...` and `make LINT_TARGET=providers/v1/aws lint` locally, all green. Not validated against a live AWS account.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
- [x] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [ ] I have tested my changes on a live environment to confirm they are working

One box left unticked deliberately: I have not exercised this against a live AWS account, so the behaviour is covered by unit tests only. `make test` and `make check-diff` are green on a tree rebased onto current main, with no regenerated artefacts left over.

Assisted-By: Claude <noreply@anthropic.com>

