### PR TITLE
fix(kubernetes): honor PushSecret remoteNamespace on delete and exists

### DIFF
--- a/apis/externalsecrets/v1/provider.go
+++ b/apis/externalsecrets/v1/provider.go
@@ -79,10 +79,15 @@ type SecretsClient interface {
 	// PushSecret will write a single secret into the provider
 	PushSecret(ctx context.Context, secret *corev1.Secret, data PushSecretData) error
 
-	// DeleteSecret will delete the secret from a provider
+	// DeleteSecret will delete the secret from a provider.
+	// Callers must pass the full PushSecretData, not data.Match.RemoteRef:
+	// PushSecretRemoteRef carries no metadata, so providers that route by
+	// metadata (e.g. kubernetes remoteNamespace) cannot locate the pushed secret.
 	DeleteSecret(ctx context.Context, remoteRef PushSecretRemoteRef) error
 
 	// SecretExists checks if a secret is already present in the provider at the given location.
+	// As with DeleteSecret, callers must pass the full PushSecretData so
+	// metadata-aware providers check the same location PushSecret wrote to.
 	SecretExists(ctx context.Context, remoteRef PushSecretRemoteRef) (bool, error)
 
 	// Validate checks if the client is configured correctly

--- a/docs/provider/kubernetes.md
+++ b/docs/provider/kubernetes.md
@@ -520,13 +520,15 @@ spec:
 | targetMergePolicy | string: `Merge`, `Replace`, `Ignore` | The targetMergePolicy defines how ESO merges the metadata produced by the sourceMergePolicy with the target secret. With `Merge`, the source metadata is merged with the existing metadata from the target secret. `Replace` will replace the target metadata with the metadata defined in the source. `Ignore` leaves the target metadata as is. |
 | labels            | `map[string]string`                  | The labels.                                                                                                                                                                                                                                                                                                                                       |
 | annotations       | `map[string]string`                  | The annotations.                                                                                                                                                                                                                                                                                                                                  |
-| remoteNamespace   | string                               | The Namespace in which the remote Secret will created in if defined.                                                                                                                                                                                                                                                                              |
+| remoteNamespace   | string                               | The Namespace in which the remote Secret will created in if defined. Push, delete, and exists operations all target this namespace, so the store's credentials need `get`/`update`/`delete` on Secrets in the override namespace, not only in the store's own `remoteNamespace`.                                                                                                                                      |
 
 ### Implementation Considerations
 
 When using the PushSecret feature and configuring the permissions for the SecretStore, consider the following:
 
 * **RBAC Configuration**: Ensure that the Role-Based Access Control (RBAC) configuration for the SecretStore grants the appropriate permissions for creating, reading, and updating resources in the target cluster.
+
+* **Namespace overrides on delete**: when `data[].metadata.spec.remoteNamespace` is set (ClusterSecretStore only), `DeleteSecret` and `SecretExists` honor the override just like `PushSecret`. A token scoped to the store namespace only will start seeing `forbidden` on deletion in the override namespace; grant the `delete` verb in each override namespace you use.
 
 * **Least Privilege Principle**: Adhere to the principle of least privilege when assigning permissions to the SecretStore. Only provide the minimum required permissions to accomplish the desired synchronization between Secrets.
 

--- a/pkg/controllers/pushsecret/pushsecret_controller.go
+++ b/pkg/controllers/pushsecret/pushsecret_controller.go
@@ -474,8 +474,11 @@ func (r *Reconciler) DeleteAllSecretsFromStore(ctx context.Context, client esv1.
 }
 
 // DeleteSecretFromStore removes a specific secret from a given secret store.
+// Pass the full PushSecretData (not just Match.RemoteRef) so providers that
+// route by metadata (e.g. kubernetes remoteNamespace) can delete the same
+// location they pushed to.
 func (r *Reconciler) DeleteSecretFromStore(ctx context.Context, client esv1.SecretsClient, data esapi.PushSecretData) error {
-	return client.DeleteSecret(ctx, data.Match.RemoteRef)
+	return client.DeleteSecret(ctx, data)
 }
 
 // PushSecretToProviders pushes the secret data to the specified secret stores.
@@ -590,7 +593,9 @@ func (r *Reconciler) pushSecretEntry(
 	}
 
 	if params.updatePolicy == esapi.PushSecretUpdatePolicyIfNotExists {
-		exists, err := secretClient.SecretExists(ctx, params.data.Match.RemoteRef)
+		// Pass full PushSecretData so metadata-aware providers (e.g. kubernetes
+		// remoteNamespace) check the same remote location as PushSecret.
+		exists, err := secretClient.SecretExists(ctx, params.data)
 		if err != nil {
 			return fmt.Errorf("could not verify if secret exists in store: %w", err)
 		}

--- a/pkg/controllers/pushsecret/pushsecret_controller_test.go
+++ b/pkg/controllers/pushsecret/pushsecret_controller_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -782,6 +783,107 @@ var _ = Describe("PushSecret controller", func() {
 				return !exists || len(secrets) == 0
 			}, time.Second*10, time.Second).Should(BeTrue())
 
+			return true
+		}
+	}
+
+	// Pins the controller -> provider wiring for delete: the provider must
+	// receive the full PushSecretData (carrying metadata), not the bare
+	// Match.RemoteRef which has no GetMetadata. Reverting DeleteSecretFromStore
+	// to Match.RemoteRef fails this test.
+	deletePassesFullPushSecretData := func(tc *testCase) {
+		captured := make(chan esv1.PushSecretRemoteRef, 1)
+		fakeProvider.WithDeleteSecretCaptureFn(func(_ context.Context, ref esv1.PushSecretRemoteRef) error {
+			captured <- ref
+			return nil
+		})
+		tc.pushsecret = &v1alpha1.PushSecret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      PushSecretName,
+				Namespace: PushSecretNamespace,
+			},
+			Spec: v1alpha1.PushSecretSpec{
+				DeletionPolicy:  v1alpha1.PushSecretDeletionPolicyDelete,
+				RefreshInterval: &metav1.Duration{Duration: time.Second},
+				SecretStoreRefs: []v1alpha1.PushSecretStoreRef{
+					{
+						Name: PushSecretStore,
+						Kind: "SecretStore",
+					},
+				},
+				Selector: v1alpha1.PushSecretSelector{
+					Secret: &v1alpha1.PushSecretSecret{
+						Name: SecretName,
+					},
+				},
+				Data: []v1alpha1.PushSecretData{
+					{
+						Match: v1alpha1.PushSecretMatch{
+							SecretKey: defaultKey,
+							RemoteRef: v1alpha1.PushSecretRemoteRef{
+								RemoteKey: defaultPath,
+							},
+						},
+						Metadata: &apiextensionsv1.JSON{
+							Raw: []byte(`{"apiVersion":"kubernetes.external-secrets.io/v1alpha1","kind":"PushSecretMetadata","spec":{"remoteNamespace":"capture-ns"}}`),
+						},
+					},
+				},
+			},
+		}
+		tc.assert = func(_ *v1alpha1.PushSecret, secret *v1.Secret) bool {
+			By("deleting source Secret to trigger provider delete")
+			Expect(k8sClient.Delete(context.Background(), secret, &client.DeleteOptions{})).Should(Succeed())
+
+			By("checking the provider received full PushSecretData with metadata")
+			Eventually(func() bool {
+				select {
+				case ref := <-captured:
+					data, ok := ref.(esv1.PushSecretData)
+					if !ok {
+						return false
+					}
+					m := data.GetMetadata()
+					return m != nil && bytes.Contains(m.Raw, []byte("capture-ns"))
+				default:
+					return false
+				}
+			}, time.Second*10, time.Second).Should(BeTrue())
+			return true
+		}
+	}
+
+	// Same wiring pin for the IfNotExists existence check: SecretExists must
+	// receive the full PushSecretData so metadata-aware providers check the
+	// same location PushSecret writes to. Reverting line to Match.RemoteRef
+	// fails this test.
+	existsPassesFullPushSecretData := func(tc *testCase) {
+		captured := make(chan esv1.PushSecretRemoteRef, 1)
+		fakeProvider.WithSecretExistsFn(func(_ context.Context, ref esv1.PushSecretRemoteRef) (bool, error) {
+			select {
+			case captured <- ref:
+			default:
+			}
+			return false, nil
+		})
+		tc.pushsecret.Spec.UpdatePolicy = v1alpha1.PushSecretUpdatePolicyIfNotExists
+		tc.pushsecret.Spec.Data[0].Metadata = &apiextensionsv1.JSON{
+			Raw: []byte(`{"apiVersion":"kubernetes.external-secrets.io/v1alpha1","kind":"PushSecretMetadata","spec":{"remoteNamespace":"capture-ns"}}`),
+		}
+		tc.assert = func(_ *v1alpha1.PushSecret, _ *v1.Secret) bool {
+			Eventually(func() bool {
+				select {
+				case ref := <-captured:
+					data, ok := ref.(esv1.PushSecretData)
+					if !ok {
+						return false
+					}
+					m := data.GetMetadata()
+					return m != nil && bytes.Contains(m.Raw, []byte("capture-ns"))
+				default:
+					return false
+				}
+			}, time.Second*10, time.Second).Should(BeTrue())
 			return true
 		}
 	}
@@ -2365,6 +2467,8 @@ var _ = Describe("PushSecret controller", func() {
 		Entry("should delete secrets with properties and update status correctly", syncAndDeleteWithProperties),
 		Entry("should delete after DeletionPolicy changed from Delete to None", syncChangePolicyAndDeleteSuccessfully),
 		Entry("should cleanup provider secrets when source Secret is deleted", deleteProviderSecretsOnSourceSecretDeleted),
+		Entry("should pass full PushSecretData to provider on delete", deletePassesFullPushSecretData),
+		Entry("should pass full PushSecretData to provider on exists check", existsPassesFullPushSecretData),
 		Entry("should track deletion tasks if Delete fails", failDelete),
 		Entry("should track deleted stores if Delete fails", failDeleteStore),
 		Entry("should delete all secrets if SecretStore changes", deleteWholeStore),

--- a/providers/v1/kubernetes/client.go
+++ b/providers/v1/kubernetes/client.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/tidwall/gjson"
 	v1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -82,8 +83,16 @@ func (c *Client) GetSecret(ctx context.Context, ref esv1.ExternalSecretDataRemot
 
 // DeleteSecret removes a secret value from Kubernetes.
 // It requires a property to be specified in the RemoteRef.
+// When remoteRef carries PushSecretData metadata with remoteNamespace
+// (ClusterSecretStore), deletion targets that namespace, matching PushSecret.
 func (c *Client) DeleteSecret(ctx context.Context, remoteRef esv1.PushSecretRemoteRef) error {
-	extSecret, getErr := c.userSecretClient.Get(ctx, remoteRef.GetRemoteKey(), metav1.GetOptions{})
+	targetNamespace, err := c.namespaceFromPushRef(remoteRef)
+	if err != nil {
+		return err
+	}
+	secretClient := c.secretsClientFor(targetNamespace)
+
+	extSecret, getErr := secretClient.Get(ctx, remoteRef.GetRemoteKey(), metav1.GetOptions{})
 	metrics.ObserveAPICall(constants.ProviderKubernetes, constants.CallKubernetesGetSecret, getErr)
 	if getErr != nil {
 		if apierrors.IsNotFound(getErr) {
@@ -99,15 +108,22 @@ func (c *Client) DeleteSecret(ctx context.Context, remoteRef esv1.PushSecretRemo
 		}
 
 		if len(extSecret.Data) > 1 {
-			return c.removeProperty(ctx, extSecret, remoteRef)
+			return c.removeProperty(ctx, secretClient, extSecret, remoteRef)
 		}
 	}
-	return c.fullDelete(ctx, remoteRef.GetRemoteKey())
+	return c.fullDelete(ctx, secretClient, remoteRef.GetRemoteKey())
 }
 
 // SecretExists checks if a secret exists in Kubernetes.
+// Honors PushSecretData metadata.remoteNamespace the same way PushSecret does.
 func (c *Client) SecretExists(ctx context.Context, ref esv1.PushSecretRemoteRef) (bool, error) {
-	secret, err := c.userSecretClient.Get(ctx, ref.GetRemoteKey(), metav1.GetOptions{})
+	targetNamespace, err := c.namespaceFromPushRef(ref)
+	if err != nil {
+		return false, err
+	}
+	secretClient := c.secretsClientFor(targetNamespace)
+
+	secret, err := secretClient.Get(ctx, ref.GetRemoteKey(), metav1.GetOptions{})
 	metrics.ObserveAPICall(constants.ProviderKubernetes, constants.CallKubernetesGetSecret, err)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -128,16 +144,13 @@ func (c *Client) PushSecret(ctx context.Context, secret *v1.Secret, data esv1.Pu
 		return errors.New("requires property in RemoteRef to push secret value if secret key is defined")
 	}
 
-	targetNamespace := c.store.RemoteNamespace
 	pushMeta, err := metadata.ParseMetadataParameters[PushSecretMetadataSpec](data.GetMetadata())
 	if err != nil {
 		return fmt.Errorf("unable to parse metadata parameters: %w", err)
 	}
-	if pushMeta != nil && pushMeta.Spec.RemoteNamespace != "" {
-		if c.storeKind != esv1.ClusterSecretStoreKind {
-			return fmt.Errorf("remoteNamespace override is only supported with ClusterSecretStore")
-		}
-		targetNamespace = pushMeta.Spec.RemoteNamespace
+	targetNamespace, err := c.pushTargetNamespace(pushMeta)
+	if err != nil {
+		return err
 	}
 
 	secretClient := c.secretsClientFor(targetNamespace)
@@ -151,6 +164,35 @@ func (c *Client) PushSecret(ctx context.Context, secret *v1.Secret, data esv1.Pu
 	return c.createOrUpdate(ctx, secretClient, remoteSecret, func() error {
 		return c.mergePushSecretData(data, pushMeta, remoteSecret, secret)
 	})
+}
+
+// namespaceFromPushRef resolves the remote Kubernetes namespace for push/delete/exists.
+// When the controller passes full PushSecretData (not just Match.RemoteRef),
+// metadata.spec.remoteNamespace is honored for ClusterSecretStore.
+func (c *Client) namespaceFromPushRef(ref esv1.PushSecretRemoteRef) (string, error) {
+	var metaJSON *apiextensionsv1.JSON
+	if psd, ok := ref.(esv1.PushSecretData); ok {
+		metaJSON = psd.GetMetadata()
+	}
+	pushMeta, err := metadata.ParseMetadataParameters[PushSecretMetadataSpec](metaJSON)
+	if err != nil {
+		return "", fmt.Errorf("unable to parse metadata parameters: %w", err)
+	}
+	return c.pushTargetNamespace(pushMeta)
+}
+
+func (c *Client) pushTargetNamespace(pushMeta *metadata.PushSecretMetadata[PushSecretMetadataSpec]) (string, error) {
+	var targetNamespace string
+	if c.store != nil {
+		targetNamespace = c.store.RemoteNamespace
+	}
+	if pushMeta != nil && pushMeta.Spec.RemoteNamespace != "" {
+		if c.storeKind != esv1.ClusterSecretStoreKind {
+			return "", fmt.Errorf("remoteNamespace override is only supported with ClusterSecretStore")
+		}
+		targetNamespace = pushMeta.Spec.RemoteNamespace
+	}
+	return targetNamespace, nil
 }
 
 func (c *Client) mergePushSecretData(remoteRef esv1.PushSecretData, pushMeta *metadata.PushSecretMetadata[PushSecretMetadataSpec], remoteSecret, localSecret *v1.Secret) error {
@@ -426,8 +468,8 @@ func convertMap(in map[string][]byte) map[string]string {
 }
 
 // fullDelete removes remote secret completely.
-func (c *Client) fullDelete(ctx context.Context, secretName string) error {
-	err := c.userSecretClient.Delete(ctx, secretName, metav1.DeleteOptions{})
+func (c *Client) fullDelete(ctx context.Context, secretClient KClient, secretName string) error {
+	err := secretClient.Delete(ctx, secretName, metav1.DeleteOptions{})
 	metrics.ObserveAPICall(constants.ProviderKubernetes, constants.CallKubernetesDeleteSecret, err)
 
 	// gracefully return on not found
@@ -438,9 +480,9 @@ func (c *Client) fullDelete(ctx context.Context, secretName string) error {
 }
 
 // removeProperty removes single data property from remote secret.
-func (c *Client) removeProperty(ctx context.Context, extSecret *v1.Secret, remoteRef esv1.PushSecretRemoteRef) error {
+func (c *Client) removeProperty(ctx context.Context, secretClient KClient, extSecret *v1.Secret, remoteRef esv1.PushSecretRemoteRef) error {
 	delete(extSecret.Data, remoteRef.GetProperty())
-	_, err := c.userSecretClient.Update(ctx, extSecret, metav1.UpdateOptions{})
+	_, err := secretClient.Update(ctx, extSecret, metav1.UpdateOptions{})
 	metrics.ObserveAPICall(constants.ProviderKubernetes, constants.CallKubernetesUpdateSecret, err)
 	return err
 }

--- a/providers/v1/kubernetes/client.go
+++ b/providers/v1/kubernetes/client.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/tidwall/gjson"
 	v1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -81,8 +82,16 @@ func (c *Client) GetSecret(ctx context.Context, ref esv1.ExternalSecretDataRemot
 
 // DeleteSecret removes a secret value from Kubernetes.
 // It requires a property to be specified in the RemoteRef.
+// When remoteRef carries PushSecretData metadata with remoteNamespace
+// (ClusterSecretStore), deletion targets that namespace, matching PushSecret.
 func (c *Client) DeleteSecret(ctx context.Context, remoteRef esv1.PushSecretRemoteRef) error {
-	extSecret, getErr := c.userSecretClient.Get(ctx, remoteRef.GetRemoteKey(), metav1.GetOptions{})
+	targetNamespace, err := c.namespaceFromPushRef(remoteRef)
+	if err != nil {
+		return err
+	}
+	secretClient := c.secretsClientFor(targetNamespace)
+
+	extSecret, getErr := secretClient.Get(ctx, remoteRef.GetRemoteKey(), metav1.GetOptions{})
 	metrics.ObserveAPICall(ProviderKubernetes, CallKubernetesGetSecret, getErr)
 	if getErr != nil {
 		if apierrors.IsNotFound(getErr) {
@@ -98,15 +107,22 @@ func (c *Client) DeleteSecret(ctx context.Context, remoteRef esv1.PushSecretRemo
 		}
 
 		if len(extSecret.Data) > 1 {
-			return c.removeProperty(ctx, extSecret, remoteRef)
+			return c.removeProperty(ctx, secretClient, extSecret, remoteRef)
 		}
 	}
-	return c.fullDelete(ctx, remoteRef.GetRemoteKey())
+	return c.fullDelete(ctx, secretClient, remoteRef.GetRemoteKey())
 }
 
 // SecretExists checks if a secret exists in Kubernetes.
+// Honors PushSecretData metadata.remoteNamespace the same way PushSecret does.
 func (c *Client) SecretExists(ctx context.Context, ref esv1.PushSecretRemoteRef) (bool, error) {
-	secret, err := c.userSecretClient.Get(ctx, ref.GetRemoteKey(), metav1.GetOptions{})
+	targetNamespace, err := c.namespaceFromPushRef(ref)
+	if err != nil {
+		return false, err
+	}
+	secretClient := c.secretsClientFor(targetNamespace)
+
+	secret, err := secretClient.Get(ctx, ref.GetRemoteKey(), metav1.GetOptions{})
 	metrics.ObserveAPICall(ProviderKubernetes, CallKubernetesGetSecret, err)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -127,16 +143,13 @@ func (c *Client) PushSecret(ctx context.Context, secret *v1.Secret, data esv1.Pu
 		return errors.New("requires property in RemoteRef to push secret value if secret key is defined")
 	}
 
-	targetNamespace := c.store.RemoteNamespace
 	pushMeta, err := metadata.ParseMetadataParameters[PushSecretMetadataSpec](data.GetMetadata())
 	if err != nil {
 		return fmt.Errorf("unable to parse metadata parameters: %w", err)
 	}
-	if pushMeta != nil && pushMeta.Spec.RemoteNamespace != "" {
-		if c.storeKind != esv1.ClusterSecretStoreKind {
-			return fmt.Errorf("remoteNamespace override is only supported with ClusterSecretStore")
-		}
-		targetNamespace = pushMeta.Spec.RemoteNamespace
+	targetNamespace, err := c.pushTargetNamespace(pushMeta)
+	if err != nil {
+		return err
 	}
 
 	secretClient := c.secretsClientFor(targetNamespace)
@@ -150,6 +163,39 @@ func (c *Client) PushSecret(ctx context.Context, secret *v1.Secret, data esv1.Pu
 	return c.createOrUpdate(ctx, secretClient, remoteSecret, func() error {
 		return c.mergePushSecretData(data, pushMeta, remoteSecret, secret)
 	})
+}
+
+// namespaceFromPushRef resolves the remote Kubernetes namespace for push/delete/exists.
+// When the controller passes full PushSecretData (not just Match.RemoteRef),
+// metadata.spec.remoteNamespace is honored for ClusterSecretStore.
+func (c *Client) namespaceFromPushRef(ref esv1.PushSecretRemoteRef) (string, error) {
+	// Callers are required to pass the full PushSecretData (see SecretsClient
+	// interface docs). The assertion remains as a defensive default: a bare
+	// PushSecretRemoteRef carries no metadata, so fall back to the store
+	// namespace rather than error.
+	var metaJSON *apiextensionsv1.JSON
+	if psd, ok := ref.(esv1.PushSecretData); ok {
+		metaJSON = psd.GetMetadata()
+	}
+	pushMeta, err := metadata.ParseMetadataParameters[PushSecretMetadataSpec](metaJSON)
+	if err != nil {
+		return "", fmt.Errorf("unable to parse metadata parameters: %w", err)
+	}
+	return c.pushTargetNamespace(pushMeta)
+}
+
+func (c *Client) pushTargetNamespace(pushMeta *metadata.PushSecretMetadata[PushSecretMetadataSpec]) (string, error) {
+	// newClient always assigns store (erroring out when Provider.Kubernetes is
+	// nil), and secretsClientFor dereferences c.store unguarded, so no nil
+	// guard here: store is never nil on a constructed client.
+	targetNamespace := c.store.RemoteNamespace
+	if pushMeta != nil && pushMeta.Spec.RemoteNamespace != "" {
+		if c.storeKind != esv1.ClusterSecretStoreKind {
+			return "", fmt.Errorf("remoteNamespace override is only supported with ClusterSecretStore")
+		}
+		targetNamespace = pushMeta.Spec.RemoteNamespace
+	}
+	return targetNamespace, nil
 }
 
 func (c *Client) mergePushSecretData(remoteRef esv1.PushSecretData, pushMeta *metadata.PushSecretMetadata[PushSecretMetadataSpec], remoteSecret, localSecret *v1.Secret) error {
@@ -425,8 +471,8 @@ func convertMap(in map[string][]byte) map[string]string {
 }
 
 // fullDelete removes remote secret completely.
-func (c *Client) fullDelete(ctx context.Context, secretName string) error {
-	err := c.userSecretClient.Delete(ctx, secretName, metav1.DeleteOptions{})
+func (c *Client) fullDelete(ctx context.Context, secretClient KClient, secretName string) error {
+	err := secretClient.Delete(ctx, secretName, metav1.DeleteOptions{})
 	metrics.ObserveAPICall(ProviderKubernetes, CallKubernetesDeleteSecret, err)
 
 	// gracefully return on not found
@@ -437,9 +483,9 @@ func (c *Client) fullDelete(ctx context.Context, secretName string) error {
 }
 
 // removeProperty removes single data property from remote secret.
-func (c *Client) removeProperty(ctx context.Context, extSecret *v1.Secret, remoteRef esv1.PushSecretRemoteRef) error {
+func (c *Client) removeProperty(ctx context.Context, secretClient KClient, extSecret *v1.Secret, remoteRef esv1.PushSecretRemoteRef) error {
 	delete(extSecret.Data, remoteRef.GetProperty())
-	_, err := c.userSecretClient.Update(ctx, extSecret, metav1.UpdateOptions{})
+	_, err := secretClient.Update(ctx, extSecret, metav1.UpdateOptions{})
 	metrics.ObserveAPICall(ProviderKubernetes, CallKubernetesUpdateSecret, err)
 	return err
 }

--- a/providers/v1/kubernetes/client_test.go
+++ b/providers/v1/kubernetes/client_test.go
@@ -1684,3 +1684,71 @@ func TestPushSecretRemoteNamespaceRejectedForSecretStore(t *testing.T) {
 		t.Errorf("error should mention ClusterSecretStore, got: %v", err)
 	}
 }
+
+func TestDeleteSecretAndExistsHonorRemoteNamespace(t *testing.T) {
+	secretKey := "secret-key"
+	storeNamespace := "store-ns"
+	targetNamespace := "target-ns"
+
+	fakeClientset := fake.NewSimpleClientset()
+	coreV1 := fakeClientset.CoreV1()
+
+	p := &Client{
+		userCoreV1:       coreV1,
+		userSecretClient: coreV1.Secrets(storeNamespace),
+		storeKind:        esv1.ClusterSecretStoreKind,
+		store: &esv1.KubernetesProvider{
+			RemoteNamespace: storeNamespace,
+		},
+	}
+
+	localSecret := &v1.Secret{
+		Data: map[string][]byte{secretKey: []byte("bar")},
+	}
+	data := testingfake.PushSecretData{
+		SecretKey: secretKey,
+		RemoteKey: "mysec",
+		Property:  "secret",
+		Metadata: &apiextensionsv1.JSON{
+			Raw: []byte(`{"apiVersion":"kubernetes.external-secrets.io/v1alpha1", "kind": "PushSecretMetadata", "spec": {"remoteNamespace": "` + targetNamespace + `"}}`),
+		},
+	}
+
+	if err := p.PushSecret(t.Context(), localSecret, data); err != nil {
+		t.Fatalf("PushSecret failed: %v", err)
+	}
+
+	// Same-name decoy in the store namespace: pre-fix DeleteSecret would hit this.
+	_, err := coreV1.Secrets(storeNamespace).Create(t.Context(), &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "mysec", Namespace: storeNamespace},
+		Data:       map[string][]byte{"secret": []byte("decoy")},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("create decoy secret: %v", err)
+	}
+
+	exists, err := p.SecretExists(t.Context(), data)
+	if err != nil {
+		t.Fatalf("SecretExists failed: %v", err)
+	}
+	if !exists {
+		t.Fatal("SecretExists should find the secret in the remoteNamespace override")
+	}
+
+	if err := p.DeleteSecret(t.Context(), data); err != nil {
+		t.Fatalf("DeleteSecret failed: %v", err)
+	}
+
+	_, err = coreV1.Secrets(targetNamespace).Get(t.Context(), "mysec", metav1.GetOptions{})
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("secret should be deleted from target namespace %q, got err: %v", targetNamespace, err)
+	}
+
+	decoy, err := coreV1.Secrets(storeNamespace).Get(t.Context(), "mysec", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("decoy in store namespace should be untouched: %v", err)
+	}
+	if string(decoy.Data["secret"]) != "decoy" {
+		t.Errorf("decoy data mutated: %q", decoy.Data["secret"])
+	}
+}

--- a/providers/v1/kubernetes/client_test.go
+++ b/providers/v1/kubernetes/client_test.go
@@ -39,6 +39,9 @@ import (
 
 const (
 	errSomethingWentWrong = "Something went wrong"
+	testSecretKey         = "secret-key"
+	testStoreNamespace    = "store-ns"
+	testTargetNamespace   = "target-ns"
 )
 
 type fakeClient struct {
@@ -658,6 +661,7 @@ func TestSecretExists(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &Client{
 				userSecretClient: &fakeClient{t: t, secretMap: tt.secrets, err: tt.clientErr},
+				store:            &esv1.KubernetesProvider{},
 			}
 			got, err := p.SecretExists(context.Background(), tt.ref)
 			if (err != nil) != tt.wantErr {
@@ -843,6 +847,7 @@ func TestDeleteSecret(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &Client{
 				userSecretClient: tt.fields.Client,
+				store:            &esv1.KubernetesProvider{},
 			}
 			err := p.DeleteSecret(context.Background(), tt.ref)
 			if (err != nil) != tt.wantErr {
@@ -859,7 +864,7 @@ func TestDeleteSecret(t *testing.T) {
 }
 
 func TestPushSecret(t *testing.T) {
-	secretKey := "secret-key"
+	secretKey := testSecretKey
 	type fields struct {
 		Client KClient
 	}
@@ -1615,9 +1620,9 @@ func TestPushSecret(t *testing.T) {
 }
 
 func TestPushSecretRemoteNamespaceRouting(t *testing.T) {
-	secretKey := "secret-key"
-	storeNamespace := "store-ns"
-	targetNamespace := "target-ns"
+	secretKey := testSecretKey
+	storeNamespace := testStoreNamespace
+	targetNamespace := testTargetNamespace
 
 	fakeClientset := fake.NewSimpleClientset()
 	coreV1 := fakeClientset.CoreV1()
@@ -1682,5 +1687,199 @@ func TestPushSecretRemoteNamespaceRejectedForSecretStore(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "ClusterSecretStore") {
 		t.Errorf("error should mention ClusterSecretStore, got: %v", err)
+	}
+}
+
+func TestDeleteSecretAndExistsHonorRemoteNamespace(t *testing.T) {
+	secretKey := testSecretKey
+	storeNamespace := testStoreNamespace
+	targetNamespace := testTargetNamespace
+
+	fakeClientset := fake.NewSimpleClientset()
+	coreV1 := fakeClientset.CoreV1()
+
+	p := &Client{
+		userCoreV1:       coreV1,
+		userSecretClient: coreV1.Secrets(storeNamespace),
+		storeKind:        esv1.ClusterSecretStoreKind,
+		store: &esv1.KubernetesProvider{
+			RemoteNamespace: storeNamespace,
+		},
+	}
+
+	data := testingfake.PushSecretData{
+		SecretKey: secretKey,
+		RemoteKey: "mysec",
+		Property:  "secret",
+		Metadata: &apiextensionsv1.JSON{
+			Raw: []byte(`{"apiVersion":"kubernetes.external-secrets.io/v1alpha1", "kind": "PushSecretMetadata", "spec": {"remoteNamespace": "` + targetNamespace + `"}}`),
+		},
+	}
+
+	// Seed the target secret directly rather than via PushSecret: a push
+	// regression should fail its own test, not this one.
+	_, err := coreV1.Secrets(targetNamespace).Create(t.Context(), &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "mysec", Namespace: targetNamespace},
+		Data:       map[string][]byte{"secret": []byte("bar")},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("create target secret: %v", err)
+	}
+
+	// Same-name decoy in the store namespace: pre-fix DeleteSecret would hit this.
+	_, err = coreV1.Secrets(storeNamespace).Create(t.Context(), &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "mysec", Namespace: storeNamespace},
+		Data:       map[string][]byte{"secret": []byte("decoy")},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("create decoy secret: %v", err)
+	}
+
+	exists, err := p.SecretExists(t.Context(), data)
+	if err != nil {
+		t.Fatalf("SecretExists failed: %v", err)
+	}
+	if !exists {
+		t.Fatal("SecretExists should find the secret in the remoteNamespace override")
+	}
+
+	if err := p.DeleteSecret(t.Context(), data); err != nil {
+		t.Fatalf("DeleteSecret failed: %v", err)
+	}
+
+	_, err = coreV1.Secrets(targetNamespace).Get(t.Context(), "mysec", metav1.GetOptions{})
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("secret should be deleted from target namespace %q, got err: %v", targetNamespace, err)
+	}
+
+	decoy, err := coreV1.Secrets(storeNamespace).Get(t.Context(), "mysec", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("decoy in store namespace should be untouched: %v", err)
+	}
+	if string(decoy.Data["secret"]) != "decoy" {
+		t.Errorf("decoy data mutated: %q", decoy.Data["secret"])
+	}
+}
+
+// With an override set and the same-named secret present only in the store
+// namespace, SecretExists must report false: reporting true makes an
+// updatePolicy=IfNotExists push skip the override namespace entirely.
+// Fails on base (checks store namespace), passes with the fix.
+func TestSecretExistsRemoteNamespaceIgnoresStoreNamespaceSecret(t *testing.T) {
+	storeNamespace := testStoreNamespace
+	targetNamespace := testTargetNamespace
+
+	fakeClientset := fake.NewSimpleClientset()
+	coreV1 := fakeClientset.CoreV1()
+
+	p := &Client{
+		userCoreV1:       coreV1,
+		userSecretClient: coreV1.Secrets(storeNamespace),
+		storeKind:        esv1.ClusterSecretStoreKind,
+		store: &esv1.KubernetesProvider{
+			RemoteNamespace: storeNamespace,
+		},
+	}
+
+	_, err := coreV1.Secrets(storeNamespace).Create(t.Context(), &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "mysec", Namespace: storeNamespace},
+		Data:       map[string][]byte{"secret": []byte("store-only")},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("create store-namespace secret: %v", err)
+	}
+
+	data := testingfake.PushSecretData{
+		SecretKey: testSecretKey,
+		RemoteKey: "mysec",
+		Metadata: &apiextensionsv1.JSON{
+			Raw: []byte(`{"apiVersion":"kubernetes.external-secrets.io/v1alpha1", "kind": "PushSecretMetadata", "spec": {"remoteNamespace": "` + targetNamespace + `"}}`),
+		},
+	}
+
+	exists, err := p.SecretExists(t.Context(), data)
+	if err != nil {
+		t.Fatalf("SecretExists failed: %v", err)
+	}
+	if exists {
+		t.Fatal("SecretExists must not see the store-namespace secret when remoteNamespace overrides to an empty namespace")
+	}
+}
+
+// Multi-key secret in the override namespace: deleting one property must go
+// through removeProperty and leave sibling keys intact.
+func TestDeleteSecretRemoteNamespaceRemovesOnlyProperty(t *testing.T) {
+	storeNamespace := testStoreNamespace
+	targetNamespace := testTargetNamespace
+
+	fakeClientset := fake.NewSimpleClientset()
+	coreV1 := fakeClientset.CoreV1()
+
+	p := &Client{
+		userCoreV1:       coreV1,
+		userSecretClient: coreV1.Secrets(storeNamespace),
+		storeKind:        esv1.ClusterSecretStoreKind,
+		store: &esv1.KubernetesProvider{
+			RemoteNamespace: storeNamespace,
+		},
+	}
+
+	_, err := coreV1.Secrets(targetNamespace).Create(t.Context(), &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "mysec", Namespace: targetNamespace},
+		Data: map[string][]byte{
+			"secret": []byte("bar"),
+			"other":  []byte("keep"),
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("create multi-key secret: %v", err)
+	}
+
+	data := testingfake.PushSecretData{
+		SecretKey: testSecretKey,
+		RemoteKey: "mysec",
+		Property:  "secret",
+		Metadata: &apiextensionsv1.JSON{
+			Raw: []byte(`{"apiVersion":"kubernetes.external-secrets.io/v1alpha1", "kind": "PushSecretMetadata", "spec": {"remoteNamespace": "` + targetNamespace + `"}}`),
+		},
+	}
+
+	if err := p.DeleteSecret(t.Context(), data); err != nil {
+		t.Fatalf("DeleteSecret failed: %v", err)
+	}
+
+	got, err := coreV1.Secrets(targetNamespace).Get(t.Context(), "mysec", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("secret should still exist after property removal: %v", err)
+	}
+	if _, ok := got.Data["secret"]; ok {
+		t.Error("property 'secret' should have been removed")
+	}
+	if string(got.Data["other"]) != "keep" {
+		t.Errorf("sibling property 'other' mutated: %q", got.Data["other"])
+	}
+}
+
+// DeleteSecret and SecretExists inherit the PushSecret rejection of
+// remoteNamespace overrides for non-ClusterSecretStore.
+func TestDeleteSecretAndExistsRemoteNamespaceRejectedForSecretStore(t *testing.T) {
+	p := &Client{
+		userSecretClient: &fakeClient{t: t, secretMap: map[string]*v1.Secret{}},
+		storeKind:        esv1.SecretStoreKind,
+		store:            &esv1.KubernetesProvider{},
+	}
+
+	data := testingfake.PushSecretData{
+		RemoteKey: "mysec",
+		Metadata: &apiextensionsv1.JSON{
+			Raw: []byte(`{"apiVersion":"kubernetes.external-secrets.io/v1alpha1", "kind": "PushSecretMetadata", "spec": {"remoteNamespace": "other-ns"}}`),
+		},
+	}
+
+	if err := p.DeleteSecret(t.Context(), data); err == nil || !strings.Contains(err.Error(), "ClusterSecretStore") {
+		t.Errorf("DeleteSecret should reject remoteNamespace for SecretStore, got: %v", err)
+	}
+	if _, err := p.SecretExists(t.Context(), data); err == nil || !strings.Contains(err.Error(), "ClusterSecretStore") {
+		t.Errorf("SecretExists should reject remoteNamespace for SecretStore, got: %v", err)
 	}
 }

--- a/runtime/testing/fake/fake.go
+++ b/runtime/testing/fake/fake.go
@@ -47,6 +47,9 @@ type Client struct {
 	SecretExistsFn  func(context.Context, esv1.PushSecretRemoteRef) (bool, error)
 	SetSecretFn     func() error
 	DeleteSecretFn  func() error
+	// DeleteSecretCaptureFn, when set, takes precedence over DeleteSecretFn
+	// and receives the ref so tests can assert what the controller passed.
+	DeleteSecretCaptureFn func(context.Context, esv1.PushSecretRemoteRef) error
 }
 
 // New returns a fake provider/client with default no-op behavior.
@@ -90,10 +93,14 @@ func (v *Client) GetPushSecretData() map[string]SetSecretCallArgs {
 	return result
 }
 
-func (v *Client) DeleteSecret(_ context.Context, _ esv1.PushSecretRemoteRef) error {
+func (v *Client) DeleteSecret(ctx context.Context, ref esv1.PushSecretRemoteRef) error {
 	v.mu.RLock()
+	captureFn := v.DeleteSecretCaptureFn
 	fn := v.DeleteSecretFn
 	v.mu.RUnlock()
+	if captureFn != nil {
+		return captureFn(ctx, ref)
+	}
 	return fn()
 }
 
@@ -178,6 +185,14 @@ func (v *Client) WithDeleteSecretFn(fn func() error) *Client {
 	return v
 }
 
+// WithDeleteSecretCaptureFn installs a DeleteSecret function that captures the ref.
+func (v *Client) WithDeleteSecretCaptureFn(fn func(context.Context, esv1.PushSecretRemoteRef) error) *Client {
+	v.mu.Lock()
+	v.DeleteSecretCaptureFn = fn
+	v.mu.Unlock()
+	return v
+}
+
 // WithSecretExistsFn installs a custom SecretExists function under the client lock.
 func (v *Client) WithSecretExistsFn(fn func(context.Context, esv1.PushSecretRemoteRef) (bool, error)) *Client {
 	v.mu.Lock()
@@ -230,6 +245,7 @@ func (v *Client) Reset() {
 	v.SetSecretFn = func() error {
 		return nil
 	}
+	v.DeleteSecretCaptureFn = nil
 	v.DeleteSecretFn = func() error {
 		return nil
 	}


### PR DESCRIPTION
## Summary

`metadata.spec.remoteNamespace` on Kubernetes `PushSecret` (ClusterSecretStore) already redirects **PushSecret** writes to an override namespace, but **DeleteSecret** and **SecretExists** always used the store's `remoteNamespace`.

Two consequences:

1. With `DeletionPolicy: Delete`, the secret in the override namespace is left behind (delete looks in the wrong place and no-ops / misses).
2. If a same-named secret exists in the store namespace, delete can remove that decoy instead of the pushed secret.

Root cause: the PushSecret controller passed only `Match.RemoteRef` (remoteKey/property) into `DeleteSecret` / `SecretExists`, dropping metadata. Secret Server's docs already call out this metadata gap for folder routing; Kubernetes exposes the same class of bug via `remoteNamespace`.

## Fix

- Controller passes full `PushSecretData` into delete/exists (still satisfies `PushSecretRemoteRef`).
- Kubernetes provider resolves `metadata.spec.remoteNamespace` for delete/exists the same way as push.

## Testing

```
cd providers/v1/kubernetes
go test . -count=1 -run 'TestPushSecretRemoteNamespace|TestDeleteSecretAndExistsHonorRemoteNamespace|TestDeleteSecret$|TestSecretExists$'
# PASS

cd ../..
go test ./pkg/controllers/pushsecret/ -count=1
# PASS
```

New unit test pushes into an override namespace, plants a same-name decoy in the store namespace, then asserts `SecretExists` / `DeleteSecret` hit the override and leave the decoy untouched.

## AI Assistance disclosure

AI assistance used: Yes

Tool(s) used: Cursor (agent-assisted editing)

Purpose of assistance: implementing the fix and its tests

Parts of the contribution affected: the controller change, the kubernetes provider change, and all new tests were drafted with the agent and reviewed by me

Human validation performed: reviewed the full diff and the CI results before submitting.