### PR TITLE
fix(esoctl): bootstrap generator leaves the tree incomplete

### DIFF
--- a/cmd/esoctl/generator/bootstrap.go
+++ b/cmd/esoctl/generator/bootstrap.go
@@ -240,18 +240,23 @@ func updateTypesClusterFile(rootDir string, cfg Config) error {
 	}
 
 	content := string(data)
+	jsonTag := lowerCamel(cfg.GeneratorName) + "Spec"
 
-	// Check if already exists
-	if strings.Contains(content, cfg.GeneratorKind) {
+	// Each fragment is looked for on its own. A single check would refuse to touch a
+	// file that carries one of them and is missing the others, which is exactly the
+	// state an interrupted or partially matching run leaves behind.
+	enumAdded := enumListsKind(content, cfg.GeneratorName)
+	constAdded := strings.Contains(content, cfg.GeneratorKind+" GeneratorKind = ")
+	specAdded := strings.Contains(content, fmt.Sprintf("json:%q", jsonTag+",omitempty"))
+
+	if enumAdded && constAdded && specAdded {
 		fmt.Printf("⚠ Generator kind already exists in types_cluster.go\n")
 		return nil
 	}
 
 	lines := strings.Split(content, "\n")
 	newLines := make([]string, 0, len(lines)+2)
-	enumAdded := false
-	constAdded := false
-	specAdded := false
+	changed := false
 
 	for i, line := range lines {
 		// Update the enum validation annotation
@@ -260,6 +265,7 @@ func updateTypesClusterFile(rootDir string, cfg Config) error {
 			// kind happens to be last stops working as soon as one is added.
 			line = strings.TrimRight(line, "\n") + ";" + cfg.GeneratorName
 			enumAdded = true
+			changed = true
 		}
 
 		newLines = append(newLines, line)
@@ -275,6 +281,7 @@ func updateTypesClusterFile(rootDir string, cfg Config) error {
 					cfg.GeneratorKind, cfg.GeneratorName)
 				newLines = append(newLines, constValueLine)
 				constAdded = true
+				changed = true
 			}
 		}
 
@@ -283,13 +290,23 @@ func updateTypesClusterFile(rootDir string, cfg Config) error {
 			// Look ahead to check if next line is closing brace of the struct
 			if i+1 < len(lines) && strings.TrimSpace(lines[i+1]) == "}" {
 				// Add the new spec field
-				jsonTag := lowerCamel(cfg.GeneratorName) + "Spec"
 				specLine := fmt.Sprintf("\t%sSpec             *%sSpec             `json:\"%s,omitempty\"`",
 					cfg.GeneratorName, cfg.GeneratorName, jsonTag)
 				newLines = append(newLines, specLine)
 				specAdded = true
+				changed = true
 			}
 		}
+	}
+
+	// Whatever could be placed is written, so that a later run can finish the job.
+	// Discarding the lot because one anchor did not match is how a tree ends up
+	// half-patched with nothing said about it.
+	if changed {
+		if err := os.WriteFile(filepath.Clean(typesClusterFile), []byte(strings.Join(newLines, "\n")), 0o600); err != nil { //nolint:gosec // paths are constructed internally
+			return err
+		}
+		fmt.Printf("✓ Updated types_cluster.go\n")
 	}
 
 	if !enumAdded || !constAdded || !specAdded {
@@ -301,14 +318,9 @@ func updateTypesClusterFile(rootDir string, cfg Config) error {
 			fmt.Printf("   2. Add the const: %s GeneratorKind = \"%s\"\n", cfg.GeneratorKind, cfg.GeneratorName)
 		}
 		if !specAdded {
-			fmt.Printf("   3. Add to GeneratorSpec struct: %sSpec *%sSpec `json:\"%sSpec,omitempty\"`\n",
-				cfg.GeneratorName, cfg.GeneratorName, strings.ToLower(cfg.GeneratorName))
+			fmt.Printf("   3. Add to GeneratorSpec struct: %sSpec *%sSpec `json:\"%s,omitempty\"`\n",
+				cfg.GeneratorName, cfg.GeneratorName, jsonTag)
 		}
-	} else {
-		if err := os.WriteFile(filepath.Clean(typesClusterFile), []byte(strings.Join(newLines, "\n")), 0o600); err != nil { //nolint:gosec // paths are constructed internally
-			return err
-		}
-		fmt.Printf("✓ Updated types_cluster.go\n")
 	}
 
 	return nil
@@ -461,16 +473,19 @@ func updateRegisterKindFile(rootDir string, cfg Config) error {
 
 	content := string(data)
 
-	// Check if already exists
-	if strings.Contains(content, fmt.Sprintf("%sKind", cfg.GeneratorName)) {
+	// The constant and the scheme registration are checked apart from each other,
+	// so that a file carrying one of them can still receive the other.
+	kindAdded := strings.Contains(content, fmt.Sprintf("%sKind = reflect.", cfg.GeneratorName))
+	schemeAdded := strings.Contains(content, fmt.Sprintf("SchemeBuilder.Register(&%s{}", cfg.GeneratorName))
+
+	if kindAdded && schemeAdded {
 		fmt.Printf("⚠ Generator kind already exists in register.go\n")
 		return nil
 	}
 
 	lines := strings.Split(content, "\n")
 	newLines := make([]string, 0, len(lines)+4)
-	kindAdded := false
-	schemeAdded := false
+	changed := false
 
 	for i, line := range lines {
 		newLines = append(newLines, line)
@@ -486,6 +501,7 @@ func updateRegisterKindFile(rootDir string, cfg Config) error {
 				kindLine := fmt.Sprintf("\t%sKind = reflect.TypeFor[%s]().Name()", cfg.GeneratorName, cfg.GeneratorName)
 				newLines = append(newLines, kindLine)
 				kindAdded = true
+				changed = true
 			}
 		}
 
@@ -496,8 +512,16 @@ func updateRegisterKindFile(rootDir string, cfg Config) error {
 				registerLine := fmt.Sprintf("\tSchemeBuilder.Register(&%s{}, &%sList{})", cfg.GeneratorName, cfg.GeneratorName)
 				newLines = append(newLines, registerLine)
 				schemeAdded = true
+				changed = true
 			}
 		}
+	}
+
+	if changed {
+		if err := os.WriteFile(filepath.Clean(registerFile), []byte(strings.Join(newLines, "\n")), 0o600); err != nil { //nolint:gosec // paths are constructed internally
+			return err
+		}
+		fmt.Printf("✓ Updated register.go\n")
 	}
 
 	if !kindAdded || !schemeAdded {
@@ -508,11 +532,6 @@ func updateRegisterKindFile(rootDir string, cfg Config) error {
 		if !schemeAdded {
 			fmt.Printf("   2. Add SchemeBuilder registration: SchemeBuilder.Register(&%s{}, &%sList{})\n", cfg.GeneratorName, cfg.GeneratorName)
 		}
-	} else {
-		if err := os.WriteFile(filepath.Clean(registerFile), []byte(strings.Join(newLines, "\n")), 0o600); err != nil { //nolint:gosec // paths are constructed internally
-			return err
-		}
-		fmt.Printf("✓ Updated register.go\n")
 	}
 
 	return nil

--- a/cmd/esoctl/generator/bootstrap.go
+++ b/cmd/esoctl/generator/bootstrap.go
@@ -241,11 +241,16 @@ func updateTypesClusterFile(rootDir string, cfg Config) error {
 
 	content := string(data)
 	jsonTag := lowerCamel(cfg.GeneratorName) + "Spec"
+	lines := strings.Split(content, "\n")
+
+	// Only the enum attached to GeneratorKind is ours to read or write; another
+	// annotation in this file must neither satisfy the check nor receive the value.
+	enumLine := generatorKindEnumLine(lines)
 
 	// Each fragment is looked for on its own. A single check would refuse to touch a
 	// file that carries one of them and is missing the others, which is exactly the
 	// state an interrupted or partially matching run leaves behind.
-	enumAdded := enumListsKind(content, cfg.GeneratorName)
+	enumAdded := enumLine >= 0 && enumListsKind(lines[enumLine], cfg.GeneratorName)
 	constAdded := strings.Contains(content, cfg.GeneratorKind+" GeneratorKind = ")
 	specAdded := strings.Contains(content, fmt.Sprintf("json:%q", jsonTag+",omitempty"))
 
@@ -254,13 +259,12 @@ func updateTypesClusterFile(rootDir string, cfg Config) error {
 		return nil
 	}
 
-	lines := strings.Split(content, "\n")
 	newLines := make([]string, 0, len(lines)+2)
 	changed := false
 
 	for i, line := range lines {
 		// Update the enum validation annotation
-		if !enumAdded && strings.Contains(line, "+kubebuilder:validation:Enum=") {
+		if !enumAdded && i == enumLine {
 			// Append the new generator to the enum list. Anchoring on whichever
 			// kind happens to be last stops working as soon as one is added.
 			line = strings.TrimRight(line, "\n") + ";" + cfg.GeneratorName

--- a/cmd/esoctl/generator/bootstrap.go
+++ b/cmd/esoctl/generator/bootstrap.go
@@ -256,11 +256,9 @@ func updateTypesClusterFile(rootDir string, cfg Config) error {
 	for i, line := range lines {
 		// Update the enum validation annotation
 		if !enumAdded && strings.Contains(line, "+kubebuilder:validation:Enum=") {
-			// Add the new generator to the enum list
-			line = strings.TrimRight(line, "\n")
-			if strings.HasSuffix(line, "Grafana") {
-				line = line + ";" + cfg.GeneratorName
-			}
+			// Append the new generator to the enum list. Anchoring on whichever
+			// kind happens to be last stops working as soon as one is added.
+			line = strings.TrimRight(line, "\n") + ";" + cfg.GeneratorName
 			enumAdded = true
 		}
 
@@ -285,7 +283,7 @@ func updateTypesClusterFile(rootDir string, cfg Config) error {
 			// Look ahead to check if next line is closing brace of the struct
 			if i+1 < len(lines) && strings.TrimSpace(lines[i+1]) == "}" {
 				// Add the new spec field
-				jsonTag := strings.ToLower(cfg.GeneratorName) + "Spec"
+				jsonTag := lowerCamel(cfg.GeneratorName) + "Spec"
 				specLine := fmt.Sprintf("\t%sSpec             *%sSpec             `json:\"%s,omitempty\"`",
 					cfg.GeneratorName, cfg.GeneratorName, jsonTag)
 				newLines = append(newLines, specLine)
@@ -478,14 +476,14 @@ func updateRegisterKindFile(rootDir string, cfg Config) error {
 		newLines = append(newLines, line)
 
 		// Add Kind constant before closing paren of var block
-		if !kindAdded && strings.Contains(line, "Kind = reflect.TypeOf(") && strings.Contains(line, "{}).Name()") {
+		if !kindAdded && strings.Contains(line, "Kind = reflect.") && strings.HasSuffix(strings.TrimSpace(line), ".Name()") {
 			// Look ahead to see if next line is closing paren
 			if i+1 < len(lines) && strings.TrimSpace(lines[i+1]) == ")" {
 				// Add blank line and then the new kind
 				newLines = append(newLines, "")
 				kindComment := fmt.Sprintf("\t// %sKind is the kind name for %s resource.", cfg.GeneratorName, cfg.GeneratorName)
 				newLines = append(newLines, kindComment)
-				kindLine := fmt.Sprintf("\t%sKind = reflect.TypeOf(%s{}).Name()", cfg.GeneratorName, cfg.GeneratorName)
+				kindLine := fmt.Sprintf("\t%sKind = reflect.TypeFor[%s]().Name()", cfg.GeneratorName, cfg.GeneratorName)
 				newLines = append(newLines, kindLine)
 				kindAdded = true
 			}
@@ -505,7 +503,7 @@ func updateRegisterKindFile(rootDir string, cfg Config) error {
 	if !kindAdded || !schemeAdded {
 		fmt.Printf("⚠ Warning: Could not fully update register.go. Please manually add:\n")
 		if !kindAdded {
-			fmt.Printf("   1. Add Kind constant: %sKind = reflect.TypeOf(%s{}).Name()\n", cfg.GeneratorName, cfg.GeneratorName)
+			fmt.Printf("   1. Add Kind constant: %sKind = reflect.TypeFor[%s]().Name()\n", cfg.GeneratorName, cfg.GeneratorName)
 		}
 		if !schemeAdded {
 			fmt.Printf("   2. Add SchemeBuilder registration: SchemeBuilder.Register(&%s{}, &%sList{})\n", cfg.GeneratorName, cfg.GeneratorName)

--- a/cmd/esoctl/generator/bootstrap_test.go
+++ b/cmd/esoctl/generator/bootstrap_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright © The ESO Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const typesClusterFixture = `package v1alpha1
+
+// GeneratorKind represents a kind of generator.
+// +kubebuilder:validation:Enum=Password;MFA
+type GeneratorKind string
+
+const (
+	// GeneratorKindPassword represents a password generator.
+	GeneratorKindPassword GeneratorKind = "Password"
+	// GeneratorKindMFA represents a Multi-Factor Authentication generator.
+	GeneratorKindMFA GeneratorKind = "MFA"
+)
+
+// GeneratorSpec defines the configuration for various supported generator types.
+type GeneratorSpec struct {
+	PasswordSpec *PasswordSpec ` + "`json:\"passwordSpec,omitempty\"`" + `
+	MFASpec      *MFASpec      ` + "`json:\"mfaSpec,omitempty\"`" + `
+}
+`
+
+const registerFixture = `package v1alpha1
+
+var (
+	// PasswordKind is the kind name for Password resource.
+	PasswordKind = reflect.TypeFor[Password]().Name()
+	// MFAKind is the kind name for MFA resource.
+	MFAKind = reflect.TypeFor[MFA]().Name()
+)
+
+func init() {
+	SchemeBuilder.Register(&Password{}, &PasswordList{})
+	SchemeBuilder.Register(&MFA{}, &MFAList{})
+}
+`
+
+func TestLowerCamel(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{name: "Password", want: "password"},
+		{name: "ServiceAccountToken", want: "serviceAccountToken"},
+		{name: "ECRAuthorizationToken", want: "ecrAuthorizationToken"},
+		{name: "STSSessionToken", want: "stsSessionToken"},
+		{name: "SSHKey", want: "sshKey"},
+		{name: "UUID", want: "uuid"},
+		{name: "MFA", want: "mfa"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, lowerCamel(tt.name))
+		})
+	}
+}
+
+// writeFixture lays out the minimum tree the update functions expect and
+// returns the repository root.
+func writeFixture(t *testing.T, relPath, content string) string {
+	t.Helper()
+
+	root := t.TempDir()
+	full := filepath.Join(root, relPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o750))
+	require.NoError(t, os.WriteFile(full, []byte(content), 0o600))
+
+	return root
+}
+
+func TestUpdateTypesClusterFile(t *testing.T) {
+	relPath := filepath.Join("apis", "generators", "v1alpha1", "types_cluster.go")
+	root := writeFixture(t, relPath, typesClusterFixture)
+
+	cfg := Config{
+		GeneratorName: "ECRAuthorizationToken",
+		PackageName:   "ecr",
+		GeneratorKind: "GeneratorKindECRAuthorizationToken",
+	}
+	require.NoError(t, updateTypesClusterFile(root, cfg))
+
+	data, err := os.ReadFile(filepath.Join(root, relPath))
+	require.NoError(t, err)
+	got := string(data)
+
+	// The validation enum must list the new kind, otherwise a ClusterGenerator
+	// referencing it is rejected at admission time. This is not a compile error,
+	// so nothing else catches it.
+	assert.Contains(t, got, "+kubebuilder:validation:Enum=Password;MFA;ECRAuthorizationToken")
+	assert.Contains(t, got, `GeneratorKindECRAuthorizationToken GeneratorKind = "ECRAuthorizationToken"`)
+
+	// The json tag is user-facing API surface and must be lowerCamelCase.
+	assert.Contains(t, got, `json:"ecrAuthorizationTokenSpec,omitempty"`)
+	assert.NotContains(t, got, `json:"ecrauthorizationtokenSpec,omitempty"`)
+}
+
+func TestUpdateRegisterKindFile(t *testing.T) {
+	relPath := filepath.Join("apis", "generators", "v1alpha1", "register.go")
+	root := writeFixture(t, relPath, registerFixture)
+
+	cfg := Config{
+		GeneratorName: "ECRAuthorizationToken",
+		PackageName:   "ecr",
+		GeneratorKind: "GeneratorKindECRAuthorizationToken",
+	}
+	require.NoError(t, updateRegisterKindFile(root, cfg))
+
+	data, err := os.ReadFile(filepath.Join(root, relPath))
+	require.NoError(t, err)
+	got := string(data)
+
+	assert.Contains(t, got, "ECRAuthorizationTokenKind = reflect.TypeFor[ECRAuthorizationToken]().Name()")
+	assert.Contains(t, got, "SchemeBuilder.Register(&ECRAuthorizationToken{}, &ECRAuthorizationTokenList{})")
+}

--- a/cmd/esoctl/generator/bootstrap_test.go
+++ b/cmd/esoctl/generator/bootstrap_test.go
@@ -19,11 +19,15 @@ package generator
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+const typesClusterPath = "apis/generators/v1alpha1/types_cluster.go"
+const registerPath = "apis/generators/v1alpha1/register.go"
 
 const typesClusterFixture = `package v1alpha1
 
@@ -60,6 +64,36 @@ func init() {
 }
 `
 
+func ecrConfig() Config {
+	return Config{
+		GeneratorName: "ECRAuthorizationToken",
+		PackageName:   "ecr",
+		GeneratorKind: "GeneratorKindECRAuthorizationToken",
+	}
+}
+
+// writeFixture lays out the minimum tree the update functions expect and returns
+// the repository root together with the absolute path of the file.
+func writeFixture(t *testing.T, relPath, content string) (root, file string) {
+	t.Helper()
+
+	root = t.TempDir()
+	file = filepath.Join(root, filepath.FromSlash(relPath))
+	require.NoError(t, os.MkdirAll(filepath.Dir(file), 0o750))
+	require.NoError(t, os.WriteFile(file, []byte(content), 0o600))
+
+	return root, file
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	return string(data)
+}
+
 func TestLowerCamel(t *testing.T) {
 	tests := []struct {
 		name string
@@ -81,37 +115,25 @@ func TestLowerCamel(t *testing.T) {
 	}
 }
 
-// writeFixture lays out the minimum tree the update functions expect and
-// returns the repository root.
-func writeFixture(t *testing.T, relPath, content string) string {
-	t.Helper()
+func TestEnumListsKindMatchesWholeValues(t *testing.T) {
+	const enum = "// +kubebuilder:validation:Enum=Password;MFA"
 
-	root := t.TempDir()
-	full := filepath.Join(root, relPath)
-	require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o750))
-	require.NoError(t, os.WriteFile(full, []byte(content), 0o600))
-
-	return root
+	assert.True(t, enumListsKind(enum, "Password"))
+	assert.True(t, enumListsKind(enum, "MFA"))
+	// A prefix of a listed value is not a listed value.
+	assert.False(t, enumListsKind(enum, "Pass"))
+	assert.False(t, enumListsKind(enum, "SSHKey"))
 }
 
 func TestUpdateTypesClusterFile(t *testing.T) {
-	relPath := filepath.Join("apis", "generators", "v1alpha1", "types_cluster.go")
-	root := writeFixture(t, relPath, typesClusterFixture)
+	root, file := writeFixture(t, typesClusterPath, typesClusterFixture)
+	require.NoError(t, updateTypesClusterFile(root, ecrConfig()))
 
-	cfg := Config{
-		GeneratorName: "ECRAuthorizationToken",
-		PackageName:   "ecr",
-		GeneratorKind: "GeneratorKindECRAuthorizationToken",
-	}
-	require.NoError(t, updateTypesClusterFile(root, cfg))
-
-	data, err := os.ReadFile(filepath.Join(root, relPath))
-	require.NoError(t, err)
-	got := string(data)
+	got := readFile(t, file)
 
 	// The validation enum must list the new kind, otherwise a ClusterGenerator
-	// referencing it is rejected at admission time. This is not a compile error,
-	// so nothing else catches it.
+	// naming it is rejected at admission time. That is not a compile error, so
+	// nothing else catches it.
 	assert.Contains(t, got, "+kubebuilder:validation:Enum=Password;MFA;ECRAuthorizationToken")
 	assert.Contains(t, got, `GeneratorKindECRAuthorizationToken GeneratorKind = "ECRAuthorizationToken"`)
 
@@ -121,20 +143,70 @@ func TestUpdateTypesClusterFile(t *testing.T) {
 }
 
 func TestUpdateRegisterKindFile(t *testing.T) {
-	relPath := filepath.Join("apis", "generators", "v1alpha1", "register.go")
-	root := writeFixture(t, relPath, registerFixture)
+	root, file := writeFixture(t, registerPath, registerFixture)
+	require.NoError(t, updateRegisterKindFile(root, ecrConfig()))
 
-	cfg := Config{
-		GeneratorName: "ECRAuthorizationToken",
-		PackageName:   "ecr",
-		GeneratorKind: "GeneratorKindECRAuthorizationToken",
-	}
-	require.NoError(t, updateRegisterKindFile(root, cfg))
-
-	data, err := os.ReadFile(filepath.Join(root, relPath))
-	require.NoError(t, err)
-	got := string(data)
+	got := readFile(t, file)
 
 	assert.Contains(t, got, "ECRAuthorizationTokenKind = reflect.TypeFor[ECRAuthorizationToken]().Name()")
 	assert.Contains(t, got, "SchemeBuilder.Register(&ECRAuthorizationToken{}, &ECRAuthorizationTokenList{})")
+}
+
+// A run that placed some fragments and not others leaves the tree half-patched.
+// The next run has to finish the job, so presence is judged per fragment instead
+// of being inferred from any single one of them.
+func TestUpdateTypesClusterFileCompletesAPartialTree(t *testing.T) {
+	root, file := writeFixture(t, typesClusterPath, typesClusterFixture)
+	require.NoError(t, updateTypesClusterFile(root, ecrConfig()))
+
+	// Drop the enum value back out, leaving the constant and the spec field in
+	// place: this is the state the stale enum anchor used to produce.
+	partial := strings.Replace(readFile(t, file), ";ECRAuthorizationToken", "", 1)
+	require.NotContains(t, partial, ";ECRAuthorizationToken")
+	require.NoError(t, os.WriteFile(file, []byte(partial), 0o600))
+
+	require.NoError(t, updateTypesClusterFile(root, ecrConfig()))
+
+	got := readFile(t, file)
+	assert.Contains(t, got, "+kubebuilder:validation:Enum=Password;MFA;ECRAuthorizationToken")
+	// What was already there must not be duplicated.
+	assert.Equal(t, 1, strings.Count(got, `GeneratorKindECRAuthorizationToken GeneratorKind = "ECRAuthorizationToken"`))
+	assert.Equal(t, 1, strings.Count(got, `json:"ecrAuthorizationTokenSpec,omitempty"`))
+}
+
+func TestUpdateRegisterKindFileCompletesAPartialTree(t *testing.T) {
+	root, file := writeFixture(t, registerPath, registerFixture)
+	require.NoError(t, updateRegisterKindFile(root, ecrConfig()))
+
+	// Drop the scheme registration, keeping the kind constant.
+	partial := strings.Replace(readFile(t, file),
+		"\tSchemeBuilder.Register(&ECRAuthorizationToken{}, &ECRAuthorizationTokenList{})\n", "", 1)
+	require.NotContains(t, partial, "SchemeBuilder.Register(&ECRAuthorizationToken{}")
+	require.NoError(t, os.WriteFile(file, []byte(partial), 0o600))
+
+	require.NoError(t, updateRegisterKindFile(root, ecrConfig()))
+
+	got := readFile(t, file)
+	assert.Contains(t, got, "SchemeBuilder.Register(&ECRAuthorizationToken{}, &ECRAuthorizationTokenList{})")
+	assert.Equal(t, 1, strings.Count(got, "ECRAuthorizationTokenKind = reflect."))
+}
+
+func TestUpdateTypesClusterFileLeavesACompleteTreeAlone(t *testing.T) {
+	root, file := writeFixture(t, typesClusterPath, typesClusterFixture)
+	require.NoError(t, updateTypesClusterFile(root, ecrConfig()))
+
+	complete := readFile(t, file)
+	require.NoError(t, updateTypesClusterFile(root, ecrConfig()))
+
+	assert.Equal(t, complete, readFile(t, file))
+}
+
+func TestUpdateRegisterKindFileLeavesACompleteTreeAlone(t *testing.T) {
+	root, file := writeFixture(t, registerPath, registerFixture)
+	require.NoError(t, updateRegisterKindFile(root, ecrConfig()))
+
+	complete := readFile(t, file)
+	require.NoError(t, updateRegisterKindFile(root, ecrConfig()))
+
+	assert.Equal(t, complete, readFile(t, file))
 }

--- a/cmd/esoctl/generator/bootstrap_test.go
+++ b/cmd/esoctl/generator/bootstrap_test.go
@@ -64,6 +64,33 @@ func init() {
 }
 `
 
+// A second enum in the same file, naming the kind we are about to add. Nothing
+// prevents one from appearing, and it must neither satisfy the presence check nor
+// receive the new value.
+const typesClusterForeignEnumFixture = `package v1alpha1
+
+// DecodingStrategy is unrelated to generators and happens to name the same value.
+// +kubebuilder:validation:Enum=ECRAuthorizationToken;None
+type DecodingStrategy string
+
+// GeneratorKind represents a kind of generator.
+// +kubebuilder:validation:Enum=Password;MFA
+type GeneratorKind string
+
+const (
+	// GeneratorKindPassword represents a password generator.
+	GeneratorKindPassword GeneratorKind = "Password"
+	// GeneratorKindMFA represents a Multi-Factor Authentication generator.
+	GeneratorKindMFA GeneratorKind = "MFA"
+)
+
+// GeneratorSpec defines the configuration for various supported generator types.
+type GeneratorSpec struct {
+	PasswordSpec *PasswordSpec ` + "`json:\"passwordSpec,omitempty\"`" + `
+	MFASpec      *MFASpec      ` + "`json:\"mfaSpec,omitempty\"`" + `
+}
+`
+
 func ecrConfig() Config {
 	return Config{
 		GeneratorName: "ECRAuthorizationToken",
@@ -189,6 +216,29 @@ func TestUpdateRegisterKindFileCompletesAPartialTree(t *testing.T) {
 	got := readFile(t, file)
 	assert.Contains(t, got, "SchemeBuilder.Register(&ECRAuthorizationToken{}, &ECRAuthorizationTokenList{})")
 	assert.Equal(t, 1, strings.Count(got, "ECRAuthorizationTokenKind = reflect."))
+}
+
+func TestUpdateTypesClusterFileIgnoresAForeignEnum(t *testing.T) {
+	root, file := writeFixture(t, typesClusterPath, typesClusterForeignEnumFixture)
+	require.NoError(t, updateTypesClusterFile(root, ecrConfig()))
+
+	got := readFile(t, file)
+
+	// The GeneratorKind enum is the one that must grow...
+	assert.Contains(t, got, "+kubebuilder:validation:Enum=Password;MFA;ECRAuthorizationToken")
+	// ...and the unrelated one must be left exactly as it was.
+	assert.Contains(t, got, "+kubebuilder:validation:Enum=ECRAuthorizationToken;None\n")
+}
+
+func TestGeneratorKindEnumLine(t *testing.T) {
+	lines := strings.Split(typesClusterForeignEnumFixture, "\n")
+
+	i := generatorKindEnumLine(lines)
+	require.GreaterOrEqual(t, i, 0)
+	assert.Equal(t, "// +kubebuilder:validation:Enum=Password;MFA", strings.TrimSpace(lines[i]))
+
+	// A file without the declaration yields no annotation rather than a wrong one.
+	assert.Equal(t, -1, generatorKindEnumLine([]string{"// +kubebuilder:validation:Enum=A", "type Other string"}))
 }
 
 func TestUpdateTypesClusterFileLeavesACompleteTreeAlone(t *testing.T) {

--- a/cmd/esoctl/generator/utils.go
+++ b/cmd/esoctl/generator/utils.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"unicode"
 )
 
 // FindRootDir finds the root directory of the external-secrets repository.
@@ -41,4 +42,28 @@ func FindRootDir(startDir string) string {
 		dir = parent
 	}
 	return ""
+}
+
+// lowerCamel converts a PascalCase kind into the lowerCamelCase form used by the
+// json tags of GeneratorSpec. A leading acronym is lowered as a whole, so
+// ECRAuthorizationToken becomes ecrAuthorizationToken and UUID becomes uuid.
+func lowerCamel(name string) string {
+	runes := []rune(name)
+
+	// length of the leading run of upper-case letters
+	upper := 0
+	for upper < len(runes) && unicode.IsUpper(runes[upper]) {
+		upper++
+	}
+
+	switch {
+	case upper == 0:
+		return name
+	case upper == 1 || upper == len(runes):
+		// a single leading capital, or an all-caps name: lower the whole run
+		return strings.ToLower(string(runes[:upper])) + string(runes[upper:])
+	default:
+		// an acronym followed by another word: its last capital starts that word
+		return strings.ToLower(string(runes[:upper-1])) + string(runes[upper-1:])
+	}
 }

--- a/cmd/esoctl/generator/utils.go
+++ b/cmd/esoctl/generator/utils.go
@@ -19,6 +19,7 @@ package generator
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"unicode"
 )
@@ -42,6 +43,24 @@ func FindRootDir(startDir string) string {
 		dir = parent
 	}
 	return ""
+}
+
+// enumListsKind reports whether a kubebuilder validation enum in content already
+// carries kind as one of its values. Matching whole values rather than a substring
+// keeps a kind from being mistaken for the prefix of a longer one.
+func enumListsKind(content, kind string) bool {
+	for line := range strings.SplitSeq(content, "\n") {
+		_, values, found := strings.Cut(line, "+kubebuilder:validation:Enum=")
+		if !found {
+			continue
+		}
+
+		if slices.Contains(strings.Split(strings.TrimSpace(values), ";"), kind) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // lowerCamel converts a PascalCase kind into the lowerCamelCase form used by the

--- a/cmd/esoctl/generator/utils.go
+++ b/cmd/esoctl/generator/utils.go
@@ -24,6 +24,9 @@ import (
 	"unicode"
 )
 
+// enumMarker introduces the list of permitted values in a kubebuilder validation enum.
+const enumMarker = "+kubebuilder:validation:Enum="
+
 // FindRootDir finds the root directory of the external-secrets repository.
 func FindRootDir(startDir string) string {
 	dir := startDir
@@ -45,22 +48,42 @@ func FindRootDir(startDir string) string {
 	return ""
 }
 
-// enumListsKind reports whether a kubebuilder validation enum in content already
-// carries kind as one of its values. Matching whole values rather than a substring
-// keeps a kind from being mistaken for the prefix of a longer one.
-func enumListsKind(content, kind string) bool {
-	for line := range strings.SplitSeq(content, "\n") {
-		_, values, found := strings.Cut(line, "+kubebuilder:validation:Enum=")
-		if !found {
+// generatorKindEnumLine returns the index of the kubebuilder validation enum that
+// governs `type GeneratorKind string`, or -1 when there is none.
+//
+// The annotation is found from the declaration rather than taken as the first one
+// in the file. Nothing stops another enum from being added to types_cluster.go, and
+// appending a kind to the wrong annotation while silently skipping the right one is
+// the failure this tool already has a history of.
+func generatorKindEnumLine(lines []string) int {
+	for i, line := range lines {
+		if !strings.HasPrefix(strings.TrimSpace(line), "type GeneratorKind ") {
 			continue
 		}
 
-		if slices.Contains(strings.Split(strings.TrimSpace(values), ";"), kind) {
-			return true
+		// Walk back over the doc comment attached to the declaration.
+		for j := i - 1; j >= 0 && strings.HasPrefix(strings.TrimSpace(lines[j]), "//"); j-- {
+			if strings.Contains(lines[j], enumMarker) {
+				return j
+			}
 		}
+
+		return -1
 	}
 
-	return false
+	return -1
+}
+
+// enumListsKind reports whether a kubebuilder validation enum annotation already
+// carries kind as one of its values. Matching whole values rather than a substring
+// keeps a kind from being mistaken for the prefix of a longer one.
+func enumListsKind(annotation, kind string) bool {
+	_, values, found := strings.Cut(annotation, enumMarker)
+	if !found {
+		return false
+	}
+
+	return slices.Contains(strings.Split(strings.TrimSpace(values), ";"), kind)
 }
 
 // lowerCamel converts a PascalCase kind into the lowerCamelCase form used by the


### PR DESCRIPTION
## Problem Statement

`esoctl bootstrap generator` reports success while leaving the tree in a state that does not
compile, and two of its three defects give no warning at all.

## Related Issue

Fixes #6810

## Proposed Changes

- Append to the `GeneratorKind` validation enum unconditionally instead of anchoring on
  whichever kind happens to be last. The old anchor was `Grafana`; the line now ends with
  `MFA`, and the success flag was set outside the check, so the failure was silent.
- Match `register.go` on the `reflect.TypeFor` idiom the file actually uses, and emit that
  idiom rather than the older `reflect.TypeOf` form. Because the old anchor never matched,
  the function returned without writing the file at all, discarding the scheme registration
  it had already computed.
- Derive the `GeneratorSpec` json tag as lowerCamelCase, keeping a leading acronym intact
  (`ECRAuthorizationToken` → `ecrAuthorizationTokenSpec`, `UUID` → `uuidSpec`). It was the
  kind lowercased in full, which is visible API surface.
- Judge presence per fragment rather than from a single one, write whatever could be placed,
  and report only what could not. Raised by CodeRabbit, and it turned out to matter more than
  it first looked: both update paths decided from one fragment whether their work was done,
  so a tree carrying the constant but not the enum value — precisely the state the stale
  anchor produced — was reported as "already exists" and could not be repaired by re-running.

- Locate the enum from the `type GeneratorKind string` declaration instead of taking the
  first `+kubebuilder:validation:Enum` annotation in the file. Also raised by CodeRabbit, and
  the same failure one level up: there is a single annotation in that file today, so the old
  behaviour was correct by accident. A second one naming the kind would satisfy the presence
  check and the GeneratorKind enum would never be updated.

This adds the first tests for `cmd/esoctl/generator`. Each of them fails against the previous
behaviour, so they pin the defects rather than merely describing them; the partial-tree cases
start from a bootstrapped fixture and remove one fragment, which is the state a user of the
released tool is actually in.

Verification done locally: `make test` passes, `make lint` reports no issues, and
`make check-diff` exits with a clean tree.

## AI Assistance disclosure

AI assistance used: Yes

If yes provide details:

Tool(s) used: Claude Code

Purpose of assistance: reproducing the failure, locating the three stale anchors in
`bootstrap.go`, and drafting the patch and its tests.

Parts of the contribution affected: all of it — `cmd/esoctl/generator/bootstrap.go`,
`utils.go` and `bootstrap_test.go`.

Human validation performed: the failure was reproduced by running the scaffold against a
clean checkout before any change was made, and the published reproduction steps were re-run
end to end to confirm they produce the error they claim, down to the file and line. The new
tests were confirmed to fail against the old behaviour by reverting `bootstrap.go` and
running them again.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
- [ ] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [x] I have tested my changes on a live environment to confirm they are working

One portability note from running the gate on macOS, in case it is useful: `make reviewable`
needs GNU sed as `gsed` (`hack/helm.generate.sh`), and `helm.schema.update` fails under
Helm 4 because plugin installation now demands provenance verification. Neither is touched by
this PR; happy to file them separately if you want them.
