### PR TITLE
fix(infisical): scope dataFrom.find.path in list requests

### DIFF
--- a/docs/provider/infisical.md
+++ b/docs/provider/infisical.md
@@ -651,7 +651,7 @@ Use `dataFrom.find` to filter secrets by name regex and/or folder path:
 The following restrictions apply:
 
 - `find.name.regexp` matches against the secret name. At least one of `find.name` or `find.path` must be provided.
-- `find.path` filters by folder path prefix. The value must be an absolute path starting with `/` (e.g. `/my-app`). It is matched against the `secretPath` field of each secret.
+- `find.path` is the folder the search starts from. The value must be an absolute path starting with `/` (e.g. `/my-app`). It is sent to Infisical as the path of the list request and is searched recursively, so sub-folders are reachable without `recursive` on the store. For that `find` entry it takes precedence over `secretsScope.secretsPath`, and it may point outside it, as an absolute `remoteRef.key` already can.
 - `find.tags` is **not supported** and returns an error if set.
 
 ---

--- a/docs/provider/infisical.md
+++ b/docs/provider/infisical.md
@@ -650,8 +650,8 @@ Use `dataFrom.find` to filter secrets by name regex and/or folder path:
 
 The following restrictions apply:
 
-- `find.name.regexp` matches against the secret name. With neither `find.name` nor `find.path` set, the provider lists `secretsScope.secretsPath` using the store's `recursive` setting.
-- `find.path` is the folder the search starts from. The value must be an absolute path starting with `/` (e.g. `/my-app`). It is sent to Infisical as the path of the list request and is searched recursively, so sub-folders are reachable without `recursive` on the store. For that `find` entry it takes precedence over `secretsScope.secretsPath`, and it may point outside it, as an absolute `remoteRef.key` already can.
+- `find.name.regexp` matches against the secret name. It filters what came back and does not change what was asked for.
+- `find.path` is the folder the search starts from. The value must be an absolute path starting with `/` (e.g. `/my-app`). It is sent to Infisical as the path of the list request. Whether sub-folders are read is the store's `recursive` setting, which a find path says nothing about. For that `find` entry it takes precedence over `secretsScope.secretsPath`, and it may point outside it, as an absolute `remoteRef.key` already can. A path naming a folder that does not exist fails the sync rather than returning nothing.
 - `find.tags` is **not supported** and returns an error if set.
 
 ---

--- a/docs/provider/infisical.md
+++ b/docs/provider/infisical.md
@@ -650,7 +650,7 @@ Use `dataFrom.find` to filter secrets by name regex and/or folder path:
 
 The following restrictions apply:
 
-- `find.name.regexp` matches against the secret name. At least one of `find.name` or `find.path` must be provided.
+- `find.name.regexp` matches against the secret name. With neither `find.name` nor `find.path` set, the provider lists `secretsScope.secretsPath` using the store's `recursive` setting.
 - `find.path` is the folder the search starts from. The value must be an absolute path starting with `/` (e.g. `/my-app`). It is sent to Infisical as the path of the list request and is searched recursively, so sub-folders are reachable without `recursive` on the store. For that `find` entry it takes precedence over `secretsScope.secretsPath`, and it may point outside it, as an absolute `remoteRef.key` already can.
 - `find.tags` is **not supported** and returns an error if set.
 

--- a/docs/snippets/infisical-filtered-secrets.yaml
+++ b/docs/snippets/infisical-filtered-secrets.yaml
@@ -16,7 +16,7 @@ spec:
         name:
           regexp: "^DB_.*"
         # Optionally also search from a folder (must be an absolute path
-        # starting with `/`). It is searched recursively, and the name above
-        # still applies. Omit to use the store's secretsScope.secretsPath and
-        # recursive settings.
+        # starting with `/`). Whether sub-folders are read follows the store's
+        # recursive setting, and the name above still applies. Omit to search
+        # from the store's secretsScope.secretsPath instead.
         # path: /my-app

--- a/docs/snippets/infisical-filtered-secrets.yaml
+++ b/docs/snippets/infisical-filtered-secrets.yaml
@@ -15,6 +15,7 @@ spec:
         # Filter by secret name using a regular expression.
         name:
           regexp: "^DB_.*"
-        # Optionally also restrict to a folder path (must be an absolute path
-        # starting with `/`). Omit to search the entire secretsScope.secretsPath.
+        # Optionally search from a folder instead (must be an absolute path
+        # starting with `/`). It is searched recursively. Omit to use the
+        # store's secretsScope.secretsPath and recursive settings.
         # path: /my-app

--- a/docs/snippets/infisical-filtered-secrets.yaml
+++ b/docs/snippets/infisical-filtered-secrets.yaml
@@ -15,7 +15,8 @@ spec:
         # Filter by secret name using a regular expression.
         name:
           regexp: "^DB_.*"
-        # Optionally search from a folder instead (must be an absolute path
-        # starting with `/`). It is searched recursively. Omit to use the
-        # store's secretsScope.secretsPath and recursive settings.
+        # Optionally also search from a folder (must be an absolute path
+        # starting with `/`). It is searched recursively, and the name above
+        # still applies. Omit to use the store's secretsScope.secretsPath and
+        # recursive settings.
         # path: /my-app

--- a/e2e/suites/provider/cases/infisical/infisical.go
+++ b/e2e/suites/provider/cases/infisical/infisical.go
@@ -84,13 +84,16 @@ var _ = Describe("[infisical]", Label("infisical"), Ordered, func() {
 	)
 })
 
-// findPathScopesTheSearch covers #6685: the store is not recursive, so the
-// nested secret is only reachable if find.path is the path the provider asks
-// Infisical for. The sibling repeats DB_HOST, which is the #6230 layout, and
-// carries a key of its own, since the SDK collapses duplicates by key and
-// could leave the in-scope value standing even if the sibling leaked in.
+// findPathScopesTheSearch covers #6685: without find.path reaching the request
+// the provider asks from the store's scope, which is the project root here, and
+// every seed below answers. Three of them are left out of the expectation for
+// three different reasons. The sibling repeats DB_HOST, which is the #6230
+// layout, and carries a key of its own, since the SDK collapses duplicates by
+// key and could leave the in-scope value standing even if the sibling leaked in.
+// The nested one is out because this store is not recursive, and a find path
+// says where to look rather than how far.
 func findPathScopesTheSearch(f *framework.Framework) (string, func(*framework.TestCase)) {
-	return "[infisical] should search from find.path and not into a folder that merely starts with it", func(tc *framework.TestCase) {
+	return "[infisical] should search from find.path, no deeper and not into a folder that merely starts with it", func(tc *framework.TestCase) {
 		root := "/find-path-" + f.Namespace.Name
 		tc.Secrets = map[string]framework.SecretEntry{
 			root + "/DB_HOST":            {Value: "root-value"},
@@ -102,7 +105,6 @@ func findPathScopesTheSearch(f *framework.Framework) (string, func(*framework.Te
 			Type: v1.SecretTypeOpaque,
 			Data: map[string][]byte{
 				"DB_HOST": []byte("root-value"),
-				"API_KEY": []byte("nested-value"),
 			},
 		}
 		tc.ExternalSecret.Spec.DataFrom = []esv1.ExternalSecretDataFromRemoteRef{

--- a/e2e/suites/provider/cases/infisical/infisical.go
+++ b/e2e/suites/provider/cases/infisical/infisical.go
@@ -37,8 +37,8 @@ const (
 // path through the provider's PushSecret implementation.
 // FindByTag is excluded because the provider does not implement tag lookup
 // (it returns "find by tags not supported"), and FindByNameWithPath is
-// excluded because the provider matches ref.Path as a prefix of the absolute
-// Infisical secret path, which a bare namespace name never satisfies.
+// excluded because it searches from a bare namespace name, while Infisical
+// wants an absolute folder path.
 var _ = Describe("[infisical]", Label("infisical"), Ordered, func() {
 	f := framework.New("infisical")
 	infisical := addon.NewInfisical()

--- a/e2e/suites/provider/cases/infisical/infisical.go
+++ b/e2e/suites/provider/cases/infisical/infisical.go
@@ -26,6 +26,7 @@ import (
 	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
 	esv1alpha1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
 	"github.com/external-secrets/external-secrets/runtime/testing/fake"
+	v1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -71,6 +72,7 @@ var _ = Describe("[infisical]", Label("infisical"), Ordered, func() {
 		// DeletionPolicyDelete depends on GetSecret returning NoSecretErr for a
 		// missing key, which the provider now does (see issue #6413).
 		framework.Compose(withUniversalAuth, f, common.DeletionPolicyDelete, useUniversalAuth(prov)),
+		framework.Compose(withUniversalAuth, f, findPathScopesTheSearch, useUniversalAuth(prov)),
 		// one case through a ClusterSecretStore to cover the cluster-scoped path
 		framework.Compose(withUniversalAuthCluster, f, common.JSONDataFromSync, useUniversalAuthClusterStore(prov)),
 	)
@@ -81,6 +83,33 @@ var _ = Describe("[infisical]", Label("infisical"), Ordered, func() {
 		framework.Compose(withUniversalAuth, f, pushSecretDeletesOnPolicy(prov), useUniversalAuthForPush(prov)),
 	)
 })
+
+// findPathScopesTheSearch covers #6685: the store is not recursive, so the
+// nested secret is only reachable if find.path is the path the provider asks
+// Infisical for. The sibling repeats DB_HOST, which is the #6230 layout, and
+// carries a key of its own, since the SDK collapses duplicates by key and
+// could leave the in-scope value standing even if the sibling leaked in.
+func findPathScopesTheSearch(f *framework.Framework) (string, func(*framework.TestCase)) {
+	return "[infisical] should search from find.path and not into a folder that merely starts with it", func(tc *framework.TestCase) {
+		root := "/find-path-" + f.Namespace.Name
+		tc.Secrets = map[string]framework.SecretEntry{
+			root + "/DB_HOST":            {Value: "root-value"},
+			root + "/nested/API_KEY":     {Value: "nested-value"},
+			root + "-other/DB_HOST":      {Value: "sibling-value"},
+			root + "-other/OUT_OF_SCOPE": {Value: "sibling-only"},
+		}
+		tc.ExpectedSecret = &v1.Secret{
+			Type: v1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				"DB_HOST": []byte("root-value"),
+				"API_KEY": []byte("nested-value"),
+			},
+		}
+		tc.ExternalSecret.Spec.DataFrom = []esv1.ExternalSecretDataFromRemoteRef{
+			{Find: &esv1.ExternalSecretFind{Path: &root}},
+		}
+	}
+}
 
 func useUniversalAuth(prov *infisicalProvider) func(*framework.TestCase) {
 	return func(tc *framework.TestCase) {

--- a/e2e/suites/provider/cases/infisical/infisical.go
+++ b/e2e/suites/provider/cases/infisical/infisical.go
@@ -19,6 +19,7 @@ package infisical
 import (
 	//nolint
 	. "github.com/onsi/ginkgo/v2"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/external-secrets/external-secrets-e2e/framework"
 	"github.com/external-secrets/external-secrets-e2e/framework/addon"
@@ -26,7 +27,6 @@ import (
 	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
 	esv1alpha1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
 	"github.com/external-secrets/external-secrets/runtime/testing/fake"
-	v1 "k8s.io/api/core/v1"
 )
 
 const (

--- a/e2e/suites/provider/cases/infisical/provider.go
+++ b/e2e/suites/provider/cases/infisical/provider.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	infisicalSdk "github.com/infisical/go-sdk"
+	"github.com/infisical/go-sdk/packages/models"
 
 	//nolint
 	. "github.com/onsi/ginkgo/v2"
@@ -42,8 +43,9 @@ const (
 	credentialsSecretName = "infisical-credentials"
 	clientIDKey           = "clientId"
 	clientSecretKey       = "clientSecret"
-	// scopePath is the secret path the store is scoped to. All e2e keys live
-	// directly under it; the provider resolves bare keys against this path.
+	// scopePath is the secret path the store is scoped to. The provider
+	// resolves bare keys against it; a case that needs a folder seeds an
+	// absolute key instead.
 	scopePath = "/"
 )
 
@@ -76,6 +78,7 @@ func newInfisicalProvider(f *framework.Framework, a *addon.Infisical) *infisical
 // suite writes through the SDK rather than via PushSecret.
 func (s *infisicalProvider) CreateSecret(key string, val framework.SecretEntry) {
 	secretPath, name := secretAddress(scopePath, key)
+	s.ensureFolder(secretPath)
 	_, err := s.addon.SDKClient.Secrets().Create(infisicalSdk.CreateSecretOptions{
 		ProjectID:             s.addon.ProjectID,
 		Environment:           s.addon.EnvironmentSlug,
@@ -108,6 +111,46 @@ func (s *infisicalProvider) DeleteSecret(key string) {
 		SecretKey:   name,
 	})
 	Expect(err).ToNot(HaveOccurred())
+}
+
+// Infisical answers a write into a folder that does not exist with a 404
+// rather than creating it, so a key seeded below scopePath needs its parents
+// first. Cases share parents, hence the lookup before each create.
+func (s *infisicalProvider) ensureFolder(secretPath string) {
+	trimmed := strings.Trim(secretPath, "/")
+	if trimmed == "" {
+		return
+	}
+
+	parent := "/"
+	for _, name := range strings.Split(trimmed, "/") {
+		existing, err := s.addon.SDKClient.Folders().List(infisicalSdk.ListFoldersOptions{
+			ProjectID:   s.addon.ProjectID,
+			Environment: s.addon.EnvironmentSlug,
+			Path:        parent,
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		if !hasFolder(existing, name) {
+			_, err = s.addon.SDKClient.Folders().Create(infisicalSdk.CreateFolderOptions{
+				ProjectID:   s.addon.ProjectID,
+				Environment: s.addon.EnvironmentSlug,
+				Path:        parent,
+				Name:        name,
+			})
+			Expect(err).ToNot(HaveOccurred())
+		}
+		parent = path.Join(parent, name)
+	}
+}
+
+func hasFolder(folders []models.Folder, name string) bool {
+	for _, f := range folders {
+		if f.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 // secretAddress mirrors the provider's key resolution so the seeded path

--- a/providers/v1/infisical/client.go
+++ b/providers/v1/infisical/client.go
@@ -154,11 +154,21 @@ func (p *Provider) GetAllSecrets(_ context.Context, ref esv1.ExternalSecretFind)
 		return nil, errTagsNotImplemented
 	}
 
+	// A find path is the root to search from, so it replaces the store's scope
+	// and is searched recursively. An empty one is not a path, and passing it on
+	// would ask the SDK for the whole project.
+	secretPath := p.apiScope.SecretPath
+	recursive := p.apiScope.Recursive
+	if ref.Path != nil && *ref.Path != "" {
+		secretPath = *ref.Path
+		recursive = true
+	}
+
 	secrets, err := p.sdkClient.Secrets().List(infisical.ListSecretsOptions{
 		Environment:            p.apiScope.EnvironmentSlug,
 		ProjectSlug:            p.apiScope.ProjectSlug,
-		SecretPath:             p.apiScope.SecretPath,
-		Recursive:              p.apiScope.Recursive,
+		SecretPath:             secretPath,
+		Recursive:              recursive,
 		ExpandSecretReferences: p.apiScope.ExpandSecretReferences,
 		IncludeImports:         true,
 	})
@@ -167,29 +177,24 @@ func (p *Provider) GetAllSecrets(_ context.Context, ref esv1.ExternalSecretFind)
 		return nil, err
 	}
 
-	secretMap := make(map[string][]byte)
-	for _, secret := range secrets {
-		secretMap[secret.SecretKey] = []byte(secret.SecretValue)
-	}
-	if ref.Name == nil && ref.Path == nil {
+	if ref.Name == nil {
+		secretMap := make(map[string][]byte, len(secrets))
+		for _, secret := range secrets {
+			secretMap[secret.SecretKey] = []byte(secret.SecretValue)
+		}
 		return secretMap, nil
 	}
 
-	var matcher *find.Matcher
-	if ref.Name != nil {
-		m, err := find.New(*ref.Name)
-		if err != nil {
-			return nil, err
-		}
-		matcher = m
+	matcher, err := find.New(*ref.Name)
+	if err != nil {
+		return nil, err
 	}
 
 	selected := map[string][]byte{}
 	for _, secret := range secrets {
-		if (matcher != nil && !matcher.MatchName(secret.SecretKey)) || (ref.Path != nil && !strings.HasPrefix(secret.SecretPath, *ref.Path)) {
-			continue
+		if matcher.MatchName(secret.SecretKey) {
+			selected[secret.SecretKey] = []byte(secret.SecretValue)
 		}
-		selected[secret.SecretKey] = []byte(secret.SecretValue)
 	}
 	return selected, nil
 }

--- a/providers/v1/infisical/client.go
+++ b/providers/v1/infisical/client.go
@@ -154,21 +154,19 @@ func (p *Provider) GetAllSecrets(_ context.Context, ref esv1.ExternalSecretFind)
 		return nil, errTagsNotImplemented
 	}
 
-	// A find path is the root to search from, so it replaces the store's scope
-	// and is searched recursively. An empty one is not a path, and passing it on
-	// would ask the SDK for the whole project.
+	// A find path says where to look, not how far: whether subfolders are read
+	// stays with the store's recursive setting. An empty one is not a path, and
+	// passing it on would ask the SDK for the whole project.
 	secretPath := p.apiScope.SecretPath
-	recursive := p.apiScope.Recursive
 	if ref.Path != nil && *ref.Path != "" {
 		secretPath = *ref.Path
-		recursive = true
 	}
 
 	secrets, err := p.sdkClient.Secrets().List(infisical.ListSecretsOptions{
 		Environment:            p.apiScope.EnvironmentSlug,
 		ProjectSlug:            p.apiScope.ProjectSlug,
 		SecretPath:             secretPath,
-		Recursive:              recursive,
+		Recursive:              p.apiScope.Recursive,
 		ExpandSecretReferences: p.apiScope.ExpandSecretReferences,
 		IncludeImports:         true,
 	})

--- a/providers/v1/infisical/client_test.go
+++ b/providers/v1/infisical/client_test.go
@@ -17,9 +17,18 @@ limitations under the License.
 package infisical
 
 import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
 	"testing"
 
+	infisical "github.com/infisical/go-sdk"
 	"github.com/stretchr/testify/assert"
+
+	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
 )
 
 func TestGetSecretAddress(t *testing.T) {
@@ -67,5 +76,187 @@ func TestGetSecretAddress(t *testing.T) {
 		path, key := getSecretAddress("/scope", "a/b/c/name")
 		assert.Equal(t, "/scope/a/b/c", path)
 		assert.Equal(t, "name", key)
+	})
+}
+
+// listStub answers the Infisical list endpoint with body and keeps the query it
+// was called with, so tests can assert on the request instead of the response.
+type listStub struct {
+	mu    sync.Mutex
+	query url.Values
+	calls int
+}
+
+func (s *listStub) provider(t *testing.T, scope *ClientScope, body string, status int) *Provider {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.mu.Lock()
+		s.query = r.URL.Query()
+		s.calls++
+		s.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(srv.Close)
+
+	return &Provider{
+		sdkClient: infisical.NewInfisicalClient(context.Background(), infisical.Config{SiteUrl: srv.URL}),
+		apiScope:  scope,
+	}
+}
+
+func (s *listStub) get(key string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.query.Get(key)
+}
+
+func TestGetAllSecretsListRequest(t *testing.T) {
+	const emptyList = `{"secrets":[],"imports":[]}`
+
+	storeScope := func(path string, recursive bool) *ClientScope {
+		return &ClientScope{
+			EnvironmentSlug:        "dev",
+			ProjectSlug:            "proj",
+			SecretPath:             path,
+			Recursive:              recursive,
+			ExpandSecretReferences: true,
+		}
+	}
+
+	tests := []struct {
+		name          string
+		scope         *ClientScope
+		find          esv1.ExternalSecretFind
+		wantPath      string
+		wantRecursive string
+	}{
+		{
+			name:          "find path becomes the request root and is searched recursively",
+			scope:         storeScope("/store-default", false),
+			find:          esv1.ExternalSecretFind{Path: new("/app")},
+			wantPath:      "/app",
+			wantRecursive: "true",
+		},
+		{
+			name:          "without a find path the store scope is left alone",
+			scope:         storeScope("/store-default", false),
+			find:          esv1.ExternalSecretFind{},
+			wantPath:      "/store-default",
+			wantRecursive: "false",
+		},
+		{
+			name:          "a recursive store stays recursive",
+			scope:         storeScope("/store-default", true),
+			find:          esv1.ExternalSecretFind{},
+			wantPath:      "/store-default",
+			wantRecursive: "true",
+		},
+		{
+			name:          "the project root is a valid find path",
+			scope:         storeScope("/store-default", false),
+			find:          esv1.ExternalSecretFind{Path: new("/")},
+			wantPath:      "/",
+			wantRecursive: "true",
+		},
+		{
+			// The SDK turns an empty SecretPath into "/", so an empty find path
+			// would widen the request to the whole project if it were passed on.
+			name:          "an empty find path keeps the store scope",
+			scope:         storeScope("/store-default", false),
+			find:          esv1.ExternalSecretFind{Path: new("")},
+			wantPath:      "/store-default",
+			wantRecursive: "false",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stub := &listStub{}
+			p := stub.provider(t, tt.scope, emptyList, http.StatusOK)
+
+			_, err := p.GetAllSecrets(context.Background(), tt.find)
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.wantPath, stub.get("secretPath"))
+			assert.Equal(t, tt.wantRecursive, stub.get("recursive"))
+			assert.Equal(t, "dev", stub.get("environment"))
+			assert.Equal(t, "proj", stub.get("workspaceSlug"))
+			assert.Equal(t, "true", stub.get("include_imports"))
+			assert.Equal(t, "true", stub.get("expandSecretReferences"))
+		})
+	}
+}
+
+func TestGetAllSecretsResults(t *testing.T) {
+	scope := &ClientScope{EnvironmentSlug: "dev", ProjectSlug: "proj", SecretPath: "/store-default"}
+
+	t.Run("the path scopes the request and the name filters what comes back", func(t *testing.T) {
+		body := `{"secrets":[
+			{"secretKey":"DB_HOST","secretValue":"db","secretPath":"/app"},
+			{"secretKey":"API_KEY","secretValue":"key","secretPath":"/app/nested"}
+		],"imports":[]}`
+
+		stub := &listStub{}
+		p := stub.provider(t, scope, body, http.StatusOK)
+
+		got, err := p.GetAllSecrets(context.Background(), esv1.ExternalSecretFind{
+			Path: new("/app"),
+			Name: &esv1.FindName{RegExp: "^DB_"},
+		})
+		assert.NoError(t, err)
+
+		assert.Equal(t, "/app", stub.get("secretPath"))
+		assert.Equal(t, map[string][]byte{"DB_HOST": []byte("db")}, got)
+	})
+
+	t.Run("imported secrets are returned even though they carry another path", func(t *testing.T) {
+		body := `{"secrets":[
+			{"secretKey":"LOCAL","secretValue":"local","secretPath":"/app"}
+		],"imports":[
+			{"secretPath":"/shared","environment":"dev","folderId":"f1","secrets":[
+				{"secretKey":"IMPORTED","secretValue":"imported","secretPath":"/shared"}
+			]}
+		]}`
+
+		stub := &listStub{}
+		p := stub.provider(t, scope, body, http.StatusOK)
+
+		got, err := p.GetAllSecrets(context.Background(), esv1.ExternalSecretFind{Path: new("/app")})
+		assert.NoError(t, err)
+		assert.Equal(t, map[string][]byte{
+			"LOCAL":    []byte("local"),
+			"IMPORTED": []byte("imported"),
+		}, got)
+	})
+
+	t.Run("an api error is not swallowed", func(t *testing.T) {
+		stub := &listStub{}
+		p := stub.provider(t, scope, `{"message":"forbidden"}`, http.StatusForbidden)
+
+		_, err := p.GetAllSecrets(context.Background(), esv1.ExternalSecretFind{Path: new("/app")})
+		assert.Error(t, err)
+	})
+
+	t.Run("an invalid name regexp fails before anything is selected", func(t *testing.T) {
+		stub := &listStub{}
+		p := stub.provider(t, scope, `{"secrets":[],"imports":[]}`, http.StatusOK)
+
+		_, err := p.GetAllSecrets(context.Background(), esv1.ExternalSecretFind{
+			Name: &esv1.FindName{RegExp: "("},
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("finding by tags is still unsupported", func(t *testing.T) {
+		stub := &listStub{}
+		p := stub.provider(t, scope, `{"secrets":[],"imports":[]}`, http.StatusOK)
+
+		_, err := p.GetAllSecrets(context.Background(), esv1.ExternalSecretFind{Tags: map[string]string{"env": "dev"}})
+		assert.ErrorIs(t, err, errTagsNotImplemented)
+		assert.Zero(t, stub.calls)
 	})
 }

--- a/providers/v1/infisical/client_test.go
+++ b/providers/v1/infisical/client_test.go
@@ -213,12 +213,12 @@ func TestGetAllSecretsResults(t *testing.T) {
 		assert.Equal(t, map[string][]byte{"DB_HOST": []byte("db")}, got)
 	})
 
-	t.Run("imported secrets are returned even though they carry another path", func(t *testing.T) {
+	t.Run("imported secrets are returned even without a path of their own", func(t *testing.T) {
 		body := `{"secrets":[
 			{"secretKey":"LOCAL","secretValue":"local","secretPath":"/app"}
 		],"imports":[
 			{"secretPath":"/shared","environment":"dev","folderId":"f1","secrets":[
-				{"secretKey":"IMPORTED","secretValue":"imported","secretPath":"/shared"}
+				{"secretKey":"IMPORTED","secretValue":"imported"}
 			]}
 		]}`
 

--- a/providers/v1/infisical/client_test.go
+++ b/providers/v1/infisical/client_test.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"sync"
 	"testing"
 
 	infisical "github.com/infisical/go-sdk"
@@ -82,7 +81,6 @@ func TestGetSecretAddress(t *testing.T) {
 // listStub answers the Infisical list endpoint with body and keeps the query it
 // was called with, so tests can assert on the request instead of the response.
 type listStub struct {
-	mu    sync.Mutex
 	query url.Values
 	calls int
 }
@@ -91,10 +89,8 @@ func (s *listStub) provider(t *testing.T, scope *ClientScope, body string, statu
 	t.Helper()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		s.mu.Lock()
 		s.query = r.URL.Query()
 		s.calls++
-		s.mu.Unlock()
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(status)
@@ -109,8 +105,6 @@ func (s *listStub) provider(t *testing.T, scope *ClientScope, body string, statu
 }
 
 func (s *listStub) get(key string) string {
-	s.mu.Lock()
-	defer s.mu.Unlock()
 	return s.query.Get(key)
 }
 

--- a/providers/v1/infisical/client_test.go
+++ b/providers/v1/infisical/client_test.go
@@ -135,11 +135,11 @@ func TestGetAllSecretsListRequest(t *testing.T) {
 		wantRecursive string
 	}{
 		{
-			name:          "find path becomes the request root and is searched recursively",
+			name:          "find path becomes the request root",
 			scope:         storeScope("/store-default", false),
 			find:          esv1.ExternalSecretFind{Path: new("/app")},
 			wantPath:      "/app",
-			wantRecursive: "true",
+			wantRecursive: "false",
 		},
 		{
 			name:          "without a find path the store scope is left alone",
@@ -156,11 +156,18 @@ func TestGetAllSecretsListRequest(t *testing.T) {
 			wantRecursive: "true",
 		},
 		{
+			name:          "a recursive store stays recursive under a find path",
+			scope:         storeScope("/store-default", true),
+			find:          esv1.ExternalSecretFind{Path: new("/app")},
+			wantPath:      "/app",
+			wantRecursive: "true",
+		},
+		{
 			name:          "the project root is a valid find path",
 			scope:         storeScope("/store-default", false),
 			find:          esv1.ExternalSecretFind{Path: new("/")},
 			wantPath:      "/",
-			wantRecursive: "true",
+			wantRecursive: "false",
 		},
 		{
 			// The SDK turns an empty SecretPath into "/", so an empty find path


### PR DESCRIPTION
## Problem Statement

`GetAllSecrets` builds the Infisical list request from the SecretStore's `secretsPath` and `recursive` settings and never passes `find.path` to the API. The path is applied afterwards, as `strings.HasPrefix(secret.SecretPath, *ref.Path)` over whatever came back.

Two things follow from that. Secrets under a `find.path` that the store scope does not already cover were never in the response to filter, so they cannot be reached at all. And the prefix comparison has no notion of a folder boundary, so `find.path: /app` also accepts `/application`.

The field's own contract is "A root path to start the find operations", and the other providers honour it when they build the request: Vault puts it in the search path, AWS and GCP put it in the filter.

## Related Issue

Fixes #6685

Related to #6230 and #6349.

## Proposed Changes

A non-empty `find.path` becomes the `secretPath` of the list request, so it is the root of the find rather than a filter over a wider result. It says where to look and not how far: the depth of the search stays with the store's `recursive`, which the user sets and which a find path has no business overriding. Without a `find.path` the store's `secretsPath` is used as before. The client-side prefix filter is gone; name matching is untouched.

An empty `find.path` is treated as no path. The SDK rewrites an empty `SecretPath` to `/` (`packages/api/secrets/list_secrets.go:34`), so passing it through would quietly turn a store-scoped find into a request for the whole project.

The smaller fix would have been to leave the filter where it is and make it folder-aware. I did not, because it only helps the second half of the problem: a secret the store scope never listed cannot be recovered by a better filter, and it would leave the provider holding a second copy of Infisical's path rules to keep in step with the server's.

Things that change for someone already using this, beyond the bug itself:

- `find.path: /app` no longer matches `/application`. The folder boundary is now the server's rather than a string comparison, so a sibling whose name merely starts with the same characters is no longer returned.
- A `find.path` outside the store's `secretsPath` used to return nothing and now returns what is there. Consistent with an absolute `remoteRef.key`, which already ignores `secretsPath`; the docs say `secretsPath` is a default scope and not a security boundary.
- Imported secrets are now returned. `IncludeImports` is on, and an import carries the path it came from, so the prefix filter dropped it whenever that differed from `find.path`. The same applies to any secret whose response omits `secretPath`, since the field is `omitempty` and `HasPrefix("", "/app")` is false.

The SDK only deduplicates by key on recursive lists (`secrets.go:66`), and recursion still follows the store, so this PR does not change *whether* `EnsureUniqueSecretsByKey` runs for a given store. It does change what that call sees, since the list is now the selected folder rather than the store scope. I have left `SkipUniqueValidation` unset: scoping the request server-side already keeps sibling folders out of the same list call, which covers the `/app/FOOBAR` vs `/crons/FOOBAR` shape in #6230, and changing the flag would alter deduplication for every recursive listing while #6349 is still being discussed. Two secrets with the same name inside one selected subtree still cannot both survive a `map[string][]byte`, and that is a separate question rather than something this PR settles.

### Tests

`providers/v1/infisical/client_test.go` had no coverage for `GetAllSecrets`. The new tests run the real pinned SDK against an `httptest` server and assert on the query it sends, because a test that supplies a fixed response and checks the resulting map passes just as well against the old "fetch wide, filter locally" code.

Five of the eleven fail on the unmodified provider: the path override, `find.path: /`, a find path under a recursive store, path plus name regexp, and the imported-secret case. The other six pass before and after and are there to pin what must not move: no `find.path` leaves the store scope alone, a recursive store stays recursive, an empty path does not widen to `/`, API errors still surface, an invalid regexp still errors, and tags are still refused before any call is made.

Both guards were removed in turn to check that something fails when they are. Dropping the empty-path guard turns the empty-path case red; replacing `p.apiScope.Recursive` with a constant `false` turns both recursive cases red.

There is now an Infisical E2E case as well. It seeds `/find-path-<ns>/DB_HOST` and `/find-path-<ns>/nested/API_KEY`, plus a `/find-path-<ns>-other` folder holding both a second `DB_HOST` and an `OUT_OF_SCOPE` key, against a store scoped to `/` with `recursive: false`. A `find.path` of `/find-path-<ns>` has to return `DB_HOST` and nothing else: the sibling is out because a folder that starts with the same characters is not the same folder, and the nested one is out because the store is not recursive.

The duplicate `DB_HOST` is there for the #6230 layout, but it cannot carry the boundary assertion on its own: the SDK collapses duplicates by key before the provider sees them, so a leak could leave the in-scope value standing. `OUT_OF_SCOPE` has no counterpart, so it fails whichever row survives.

Seeding below `scopePath` needed one change to the suite's helper: Infisical refuses to write into a folder that does not exist, so `CreateSecret` now creates the folder chain first.

The E2E case has not run. My local kind attempt died in `BeforeSuite` verifying the in-cluster API server certificate, before any spec started (`Ran 0 of 420 Specs`), and it took every provider down with it, so I have no result either way. What I could do was seed the case's exact fixture against a standalone `v0.158.0`, the version `e2e/k8s/infisical.values.yaml` pins, and issue the requests the provider will:

```
secretPath=/find-path-ns  recursive=false     <- what this PR sends
   /find-path-ns          DB_HOST=root-value

secretPath=/find-path-ns  recursive=true      <- the same path, recursive store
   /find-path-ns          DB_HOST=root-value
   /find-path-ns/nested   API_KEY=nested-value

secretPath=/              recursive=false     <- what the base revision sends
   (none)
```

The first is the assertion, exactly. The second shows the depth following `recursive` rather than the path. The third is why the case is worth having: on the base revision the store scope is what gets listed, the project root holds no secrets of its own, and the sync produces nothing.

One behaviour does change with this, and it turns out to depend on which Infisical you run. On `v0.158.0` a `find.path` naming a folder that does not exist comes back as a 404:

```
GET /api/v3/secrets/raw?...&secretPath=%2Fdoes-not-exist
404 "Folder with path '/does-not-exist' in environment 'dev' was not found."
```

so a deleted or mistyped path now fails the sync where the old client-side filter would have produced an empty result. A relative path such as `find-path-ns` returns the same 404 rather than being silently ignored, and so does `/find-path-n`, which is the server's own version of the boundary the prefix filter got wrong. I first measured this against `latest`, where the missing-folder cases return an empty list instead, so the version matters and I would not state either as *the* behaviour.

Surfacing the error looks like the better default to me, since a mistyped folder reading as "no secrets here" is worse than a failed sync, but it is a change and I would rather have it called out than discovered. It is in the docs now.

The E2E exclusion comment for `FindByNameWithPath` described the prefix matching this PR removes, so it now gives the reason that survives: the shared case searches from a bare namespace name and Infisical wants an absolute path.

## AI Assistance disclosure

AI assistance used: Yes

Tool(s) used: Claude Code

Purpose of assistance: reading the provider and the pinned SDK, drafting the change and its tests, and reviewing edge cases around imports, empty paths and the interaction with #6230 and #6349.

Parts of the contribution affected: the change in `client.go`, the tests, the documentation wording, and this description.

Human validation performed:

- The failure was reproduced on the base revision before anything was changed: with a store on `/store-default` and `find.path: /app`, the outgoing query carried `secretPath=/store-default&recursive=false`.
- After the change the same test observes `secretPath=/app&recursive=false`, and the whole new file was run once more against an unmodified `client.go` to confirm which assertions are actually load-bearing.
- The empty-path guard and the use of the store's `recursive` were each broken in turn to check that a test fails when they are.
- `make test`, `make lint` and `make check-diff` pass on the branch. `make lint` excludes `*/e2e/*`, so the e2e module was vetted and format-checked separately.
- Infisical API behaviour was checked by hand against a standalone `v0.158.0` I ran locally, which is where the listings and the 404 above come from. The full ESO plus Infisical Kubernetes E2E has not run: it needs a cluster with the addon, and the workflows on this PR are still awaiting approval, so the live-testing box below is unchecked rather than assumed.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
- [x] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [ ] I have tested my changes on a live environment to confirm they are working
