### PR TITLE
fix(oracle)!: return NoSecretErr on a missing secret so deletionPolicy applies

### DIFF
--- a/docs/provider/oracle-vault.md
+++ b/docs/provider/oracle-vault.md
@@ -99,8 +99,9 @@ When a secret is removed from the OCI Vault the provider reports it as missing, 
     OCI answers with `NotAuthorizedOrNotFound` both when a secret does not exist and
     when the caller is not allowed to read it, and the two cannot be told apart from
     outside. Revoking read access on a secret therefore looks exactly like deleting it,
-    and with `deletionPolicy: Delete` the Kubernetes Secret is removed. Use the default
-    `deletionPolicy: Retain` if you would rather keep the Secret when access is lost.
+    and with `deletionPolicy: Delete` or `deletionPolicy: Merge` the Kubernetes Secrets
+    WILL BE DELETED. Use the default `deletionPolicy: Retain` if you would rather keep
+    the Secret when access is lost.
 
 ## PushSecrets and retrieving multiple secrets.
 When using [PushSecrets](https://external-secrets.io/latest/guides/pushsecrets/), the compartment OCID and encryption key OCID must be specified in the

--- a/docs/provider/oracle-vault.md
+++ b/docs/provider/oracle-vault.md
@@ -90,6 +90,18 @@ The operator will fetch the OCI Vault Secret and inject it as a `Kind=Secret`.
 kubectl get secret oracle-secret-to-create -o jsonpath='{.data.dev-secret-test}' | base64 -d
 ```
 
+### Deletion policy
+
+When a secret is removed from the OCI Vault the provider reports it as missing, so
+`spec.target.deletionPolicy` (`Delete` or `Merge`) applies to the Kubernetes Secret.
+
+!!! warning
+    OCI answers with `NotAuthorizedOrNotFound` both when a secret does not exist and
+    when the caller is not allowed to read it, and the two cannot be told apart from
+    outside. Revoking read access on a secret therefore looks exactly like deleting it,
+    and with `deletionPolicy: Delete` the Kubernetes Secret is removed. Use the default
+    `deletionPolicy: Retain` if you would rather keep the Secret when access is lost.
+
 ## PushSecrets and retrieving multiple secrets.
 When using [PushSecrets](https://external-secrets.io/latest/guides/pushsecrets/), the compartment OCID and encryption key OCID must be specified in the
 Oracle SecretStore. You can find your compartment and encryption key OCIDs in the OCI console.

--- a/providers/v1/oracle/oracle.go
+++ b/providers/v1/oracle/oracle.go
@@ -438,6 +438,14 @@ func (vms *VaultManagementService) filteredSummaryResult(ctx context.Context, se
 			Key: *summary.SecretName,
 		})
 		if err != nil {
+			// Listing the summaries and reading each secret are not atomic, so a
+			// secret can go away in between. Skip it and keep the rest of the
+			// result: letting NoSecretErr out of here would surface from
+			// GetAllSecrets as "the whole find is gone" and let deletionPolicy
+			// remove every key of the Kubernetes Secret because one member did.
+			if errors.Is(err, esv1.NoSecretErr) {
+				continue
+			}
 			return nil, err
 		}
 		secretMap[*summary.SecretName] = secret

--- a/providers/v1/oracle/oracle.go
+++ b/providers/v1/oracle/oracle.go
@@ -235,6 +235,13 @@ func (vms *VaultManagementService) GetAllSecrets(ctx context.Context, ref esv1.E
 }
 
 // GetSecret retrieves a specific secret from the Oracle Cloud Infrastructure Vault.
+//
+//	if GetSecret returns an error with type NoSecretError
+//	then the secret entry will be deleted depending on the deletionPolicy.
+//
+// OCI reports a missing secret and a secret the caller is not allowed to read
+// with the same response, so a revoked IAM policy is surfaced here as a deleted
+// secret. See the Oracle provider docs for what that means for deletionPolicy.
 func (vms *VaultManagementService) GetSecret(ctx context.Context, ref esv1.ExternalSecretDataRemoteRef) ([]byte, error) {
 	if esutils.IsNil(vms.Client) {
 		return nil, errors.New(errUninitalizedOracleProvider)
@@ -246,6 +253,9 @@ func (vms *VaultManagementService) GetSecret(ctx context.Context, ref esv1.Exter
 		Stage:      secrets.GetSecretBundleByNameStageEnum(ref.Version),
 	})
 	if err != nil {
+		if isSecretNotFoundErr(err) {
+			return nil, esv1.NoSecretErr
+		}
 		return nil, sanitizeOCISDKErr(err)
 	}
 
@@ -281,7 +291,7 @@ func decodeBundle(sec secrets.GetSecretBundleByNameResponse) ([]byte, error) {
 func (vms *VaultManagementService) GetSecretMap(ctx context.Context, ref esv1.ExternalSecretDataRemoteRef) (map[string][]byte, error) {
 	data, err := vms.GetSecret(ctx, ref)
 	if err != nil {
-		return nil, sanitizeOCISDKErr(err)
+		return nil, err
 	}
 	kv := make(map[string]string)
 	err = json.Unmarshal(data, &kv)
@@ -392,14 +402,26 @@ func (vms *VaultManagementService) getSecretBundleWithCode(ctx context.Context, 
 func getSecretBundleCode(err error) int {
 	if err != nil {
 		// If we got a 404 service error, try to create the secret.
-
-		if serviceErr, ok := err.(common.ServiceError); ok && serviceErr.GetHTTPStatusCode() == 404 {
+		if isSecretNotFoundErr(err) {
 			return SecretNotFound
 		}
 		return SecretAPIError
 	}
 	// Otherwise, update the existing secret.
 	return SecretExists
+}
+
+// isSecretNotFoundErr reports whether err is an OCI service error for a secret
+// that does not exist. It asserts common.ServiceError rather than
+// common.ServiceErrorRichInfo because the former is what declares
+// GetHTTPStatusCode, and a plain service error carries no rich info.
+//
+// OCI answers with 404 NotAuthorizedOrNotFound both when the secret is missing
+// and when the caller may not read it, so the two cases are indistinguishable
+// from here.
+func isSecretNotFoundErr(err error) bool {
+	serviceErr, ok := common.IsServiceError(err)
+	return ok && serviceErr.GetHTTPStatusCode() == 404
 }
 
 func (vms *VaultManagementService) filteredSummaryResult(ctx context.Context, secretSummaries []vault.SecretSummary, ref esv1.ExternalSecretFind) (map[string][]byte, error) {

--- a/providers/v1/oracle/oracle_test.go
+++ b/providers/v1/oracle/oracle_test.go
@@ -219,6 +219,43 @@ func TestGetSecretMap(t *testing.T) {
 	}
 }
 
+// A secret that is missing in the vault must surface as esv1.NoSecretErr,
+// because that is what the ExternalSecret controller gates
+// spec.target.deletionPolicy on.
+func TestOracleVaultGetSecretNotFound(t *testing.T) {
+	sm := VaultManagementService{}
+
+	notFound := makeValidVaultTestCaseCustom(func(smtc *vaultTestCase) {
+		smtc.apiErr = &fakeoracle.ServiceError{Code: 404}
+	})
+	sm.Client = notFound.mockClient
+
+	_, err := sm.GetSecret(context.Background(), *notFound.ref)
+	assert.ErrorIs(t, err, esv1.NoSecretErr)
+
+	// GetSecretMap delegates to GetSecret and must propagate it unchanged.
+	_, err = sm.GetSecretMap(context.Background(), *notFound.ref)
+	assert.ErrorIs(t, err, esv1.NoSecretErr)
+
+	// Any other service error is a real failure and must not be mistaken for a
+	// missing secret, otherwise deletionPolicy would fire on an outage.
+	serverErr := makeValidVaultTestCaseCustom(func(smtc *vaultTestCase) {
+		smtc.apiErr = &fakeoracle.ServiceError{Code: 500}
+	})
+	sm.Client = serverErr.mockClient
+
+	_, err = sm.GetSecret(context.Background(), *serverErr.ref)
+	assert.Error(t, err)
+	assert.NotErrorIs(t, err, esv1.NoSecretErr)
+}
+
+func TestIsSecretNotFoundErr(t *testing.T) {
+	assert.True(t, isSecretNotFoundErr(&fakeoracle.ServiceError{Code: 404}))
+	assert.False(t, isSecretNotFoundErr(&fakeoracle.ServiceError{Code: 500}))
+	assert.False(t, isSecretNotFoundErr(errors.New("not a service error")))
+	assert.False(t, isSecretNotFoundErr(nil))
+}
+
 func ErrorContains(out error, want string) bool {
 	if out == nil {
 		return want == ""

--- a/providers/v1/oracle/oracle_test.go
+++ b/providers/v1/oracle/oracle_test.go
@@ -630,6 +630,33 @@ func TestOracleVaultGetAllSecrets(t *testing.T) {
 				s2id: []byte(s2id),
 			},
 		},
+		// A summary listing and the per-secret reads are not atomic, so a secret
+		// can be deleted in between and answer 404. That must not fail the whole
+		// find: NoSecretErr escaping here would let deletionPolicy drop every key
+		// of the Kubernetes Secret because one member went away.
+		"skips a secret that disappeared after it was listed": {
+			&VaultManagementService{
+				Client: &fakeoracle.OracleMockClient{
+					SecretBundles: map[string]secrets.SecretBundle{
+						s1id: s1bundle,
+					},
+				},
+				VaultClient: &fakeoracle.OracleMockVaultClient{
+					SecretSummaries: []vault.SecretSummary{
+						s1summary,
+						s2summary,
+					},
+				},
+			},
+			esv1.ExternalSecretFind{
+				Name: &esv1.FindName{
+					RegExp: ".*",
+				},
+			},
+			map[string][]byte{
+				s1id: []byte(s1id),
+			},
+		},
 	}
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
## Problem Statement

The Oracle provider returns the sanitised OCI SDK error when a secret is missing in the vault, not `esv1.NoSecretErr`. The ExternalSecret controller only applies `spec.target.deletionPolicy` when the read error satisfies `errors.Is(err, esv1.NoSecretErr)`, so deleting a secret in OCI Vault never propagates to the Kubernetes Secret, even though the support matrix advertises `DeletionPolicy Merge/Delete` for Oracle.

## Related Issue

Fixes #6572

## Proposed Changes

`GetSecret` now returns `esv1.NoSecretErr` when OCI answers 404, and keeps returning the sanitised error for anything else. The check lives in a new `isSecretNotFoundErr` helper that asserts `common.ServiceError` rather than `common.ServiceErrorRichInfo`, since `ServiceError` is the interface that declares `GetHTTPStatusCode` and a plain service error carries no rich info.

`getSecretBundleCode` now calls that same helper instead of repeating the assertion inline. That part is pure de-duplication: `common.IsServiceError` is the same plain type assertion the inlined code was already doing (it is not `errors.As`), so the PushSecret path is behaviourally unchanged.

Dropped the redundant `sanitizeOCISDKErr` in `GetSecretMap` as you suggested. It was a no-op in practice: `GetSecret` already sanitises, and a sanitised error is a plain `fmt.Errorf` that never satisfies the `ServiceErrorRichInfo` assertion.

On the trade-off you raised: OCI returns `NotAuthorizedOrNotFound` for both "missing" and "not permitted", so mapping 404 makes a revoked IAM policy look identical to a deletion, and under `deletionPolicy: Delete` that removes a live Secret. I mapped it anyway, as you leaned, and documented the risk in two places: the `GetSecret` doc comment, and a new "Deletion policy" section in `docs/provider/oracle-vault.md` that points at the `Retain` default for anyone who would rather keep the Secret when access is lost.

Two things I left out on purpose. Happy to fold either one into this PR if you would rather have them here:

1. `sanitizeOCISDKErr` still asserts `ServiceErrorRichInfo`, so a plain non-rich service error passes through unsanitised. That is the separate bug your note points at, and fixing it also changes error text on the PushSecret, DeleteSecret, SecretExists and GetAllSecrets paths.
2. `GetSecret` still returns `errMissingKey` when `ref.Property` is absent from a secret that does exist. A missing field is not a missing secret, and mapping it would delete a Secret over a mistyped property.

## Format

`fix(oracle): return NoSecretErr on a missing secret so deletionPolicy applies`

## AI Assistance disclosure

Did you use an script, LLM, or AI assisted development tool for this contribution?

AI assistance used: Yes

If yes provide details:

Tool(s) used: Claude Code (Opus 5)

Purpose of assistance: tracing the path from `GetSecret` to the controller's `deletionPolicy` gate, locating the in-repo precedents (the existing 404 check in `getSecretBundleCode`, the `NoSecretError` shape used by the beyondtrust provider, and the `fake.ServiceError` stub already present in the oracle test fake), and drafting the two tests and the docs section.

Parts of the contribution affected: the provider change, the two new test functions, and the docs section.

Human validation performed: ran `make check-diff` on the committed tree. That runs `make reviewable` (generate, docs, manifests, helm generate/schema/docs, lint, license check, helm tests, CRD snapshot tests, tf fmt) and then verifies the branch is clean, and it passes: golangci-lint reports 0 issues across every module including `providers/v1/oracle`, helm tests 62 passed, CRD snapshot tests 20 passed, and no generated file drifted. `make test` passes too, 90 packages ok, with `providers/v1/oracle` at 62.2% statement coverage. I also confirmed the new tests actually catch the bug rather than passing vacuously: neutralising `isSecretNotFoundErr` makes both `TestOracleVaultGetSecretNotFound` and `TestIsSecretNotFoundErr` fail, and they pass again once it is restored. Not exercised against a live OCI Vault, so the last box below is left unchecked.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
- [x] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [ ] I have tested my changes on a live environment to confirm they are working
