### PR TITLE
chore: update go version to 1.26.6

### DIFF
--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -1,6 +1,6 @@
 # This version of Dockerfile is for building without external dependencies.
 # Build a multi-platform image e.g. `docker buildx build --push --platform linux/arm64,linux/amd64 --tag external-secrets:dev --file Dockerfile.standalone .`
-FROM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
+FROM golang:1.26.6-alpine@sha256:af8d6740070b8906d12eae1c3e3ea0957fb63f492051ea05e354c38ef9fe88df AS builder
 # Add metadata
 LABEL maintainer="cncf-externalsecretsop-maintainers@lists.cncf.io" \
       description="External Secrets Operator is a Kubernetes operator that integrates external secret management systems"

--- a/apis/go.mod
+++ b/apis/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/apis
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.5-bookworm@sha256:18aedc16aa19b3fd7ded7245fc14b109e054d65d22ed53c355c899582bbb2113 AS builder
+FROM golang:1.26.6-bookworm@sha256:116d58cbd88c1297624acc6e967a060012422bacf9930927e23fb719189c6f36 AS builder
 RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.6
 
 FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets-e2e
 
-go 1.26.5
+go 1.26.6
 
 tool github.com/onsi/ginkgo/v2/ginkgo
 

--- a/generators/v1/acr/go.mod
+++ b/generators/v1/acr/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/acr
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.1

--- a/generators/v1/beyondtrustworkloadcredentials/go.mod
+++ b/generators/v1/beyondtrustworkloadcredentials/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/beyondtrustworkloadcredentials
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/cloudsmith/go.mod
+++ b/generators/v1/cloudsmith/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/cloudsmith
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/ecr/go.mod
+++ b/generators/v1/ecr/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/ecr
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.6

--- a/generators/v1/fake/go.mod
+++ b/generators/v1/fake/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/fake
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/gcr/go.mod
+++ b/generators/v1/gcr/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/gcr
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/github/go.mod
+++ b/generators/v1/github/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/github
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/gitlab/go.mod
+++ b/generators/v1/gitlab/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/gitlab
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/grafana/go.mod
+++ b/generators/v1/grafana/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/grafana
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/mfa/go.mod
+++ b/generators/v1/mfa/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/mfa
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/password/go.mod
+++ b/generators/v1/password/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/password
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/quay/go.mod
+++ b/generators/v1/quay/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/quay
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/sshkey/go.mod
+++ b/generators/v1/sshkey/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/sshkey
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/sts/go.mod
+++ b/generators/v1/sts/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/sts
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.6

--- a/generators/v1/uuid/go.mod
+++ b/generators/v1/uuid/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/uuid
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/vault/go.mod
+++ b/generators/v1/vault/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/vault
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/generators/v1/webhook/go.mod
+++ b/generators/v1/webhook/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/generators/v1/webhook
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets
 
-go 1.26.5
+go 1.26.6
 
 replace (
 	github.com/external-secrets/external-secrets/apis => ./apis

--- a/providers/v1/akeyless/go.mod
+++ b/providers/v1/akeyless/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/akeyless
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.1

--- a/providers/v1/aws/go.mod
+++ b/providers/v1/aws/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/aws
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.6

--- a/providers/v1/azure/go.mod
+++ b/providers/v1/azure/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/azure
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible

--- a/providers/v1/barbican/go.mod
+++ b/providers/v1/barbican/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/barbican
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/beyondtrust/go.mod
+++ b/providers/v1/beyondtrust/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/beyondtrust
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/BeyondTrust/go-client-library-passwordsafe v1.3.0

--- a/providers/v1/beyondtrustworkloadcredentials/go.mod
+++ b/providers/v1/beyondtrustworkloadcredentials/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/beyondtrustworkloadcredentials
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/bitwarden/go.mod
+++ b/providers/v1/bitwarden/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/bitwarden
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/chef/go.mod
+++ b/providers/v1/chef/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/chef
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/cloudru/go.mod
+++ b/providers/v1/cloudru/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/cloudru
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/cloudru-tech/iam-sdk v1.0.4

--- a/providers/v1/conjur/go.mod
+++ b/providers/v1/conjur/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/conjur
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/cyberark/conjur-api-go v0.14.1

--- a/providers/v1/crd/go.mod
+++ b/providers/v1/crd/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/crd
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/delinea/go.mod
+++ b/providers/v1/delinea/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/delinea
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/DelineaXPM/dsv-sdk-go/v2 v2.2.0

--- a/providers/v1/doppler/go.mod
+++ b/providers/v1/doppler/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/doppler
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/dvls/go.mod
+++ b/providers/v1/dvls/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/dvls
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/Devolutions/go-dvls v0.19.1

--- a/providers/v1/fake/go.mod
+++ b/providers/v1/fake/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/fake
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/fortanix/go.mod
+++ b/providers/v1/fortanix/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/fortanix
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/gcp/go.mod
+++ b/providers/v1/gcp/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/gcp
 
-go 1.26.5
+go 1.26.6
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0

--- a/providers/v1/github/go.mod
+++ b/providers/v1/github/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/github
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.17.0

--- a/providers/v1/gitlab/go.mod
+++ b/providers/v1/gitlab/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/gitlab
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/ibm/go.mod
+++ b/providers/v1/ibm/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/ibm
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/IBM/go-sdk-core/v5 v5.21.0

--- a/providers/v1/infisical/go.mod
+++ b/providers/v1/infisical/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/infisical
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/keepersecurity/go.mod
+++ b/providers/v1/keepersecurity/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/keepersecurity
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/kubernetes/go.mod
+++ b/providers/v1/kubernetes/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/kubernetes
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/nebius/go.mod
+++ b/providers/v1/nebius/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/nebius
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/ngrok/go.mod
+++ b/providers/v1/ngrok/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/ngrok
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/onboardbase/go.mod
+++ b/providers/v1/onboardbase/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/onboardbase
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/Onboardbase/go-cryptojs-aes-decrypt v0.0.0-20230430095000-27c0d3a9016d

--- a/providers/v1/onepassword/go.mod
+++ b/providers/v1/onepassword/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/onepassword
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/1Password/connect-sdk-go v1.5.3

--- a/providers/v1/onepasswordsdk/go.mod
+++ b/providers/v1/onepasswordsdk/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/onepasswordsdk
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/1password/onepassword-sdk-go v0.4.1

--- a/providers/v1/openbao/go.mod
+++ b/providers/v1/openbao/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/openbao
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/oracle/go.mod
+++ b/providers/v1/oracle/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/oracle
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/ovh/go.mod
+++ b/providers/v1/ovh/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/ovh
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/passbolt/go.mod
+++ b/providers/v1/passbolt/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/passbolt
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/passworddepot/go.mod
+++ b/providers/v1/passworddepot/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/passworddepot
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/previder/go.mod
+++ b/providers/v1/previder/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/previder
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/pulumi/go.mod
+++ b/providers/v1/pulumi/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/pulumi
 
-go 1.26.5
+go 1.26.6
 
 require (
 	dario.cat/mergo v1.0.2

--- a/providers/v1/scaleway/go.mod
+++ b/providers/v1/scaleway/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/scaleway
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/secretserver/go.mod
+++ b/providers/v1/secretserver/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/secretserver
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/DelineaXPM/tss-sdk-go/v3 v3.0.2

--- a/providers/v1/senhasegura/go.mod
+++ b/providers/v1/senhasegura/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/senhasegura
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/vault/go.mod
+++ b/providers/v1/vault/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/vault
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.6

--- a/providers/v1/volcengine/go.mod
+++ b/providers/v1/volcengine/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/volcengine
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/providers/v1/webhook/go.mod
+++ b/providers/v1/webhook/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/webhook
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358

--- a/providers/v1/yandex/go.mod
+++ b/providers/v1/yandex/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/providers/v1/yandex
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/external-secrets/external-secrets/apis v0.0.0

--- a/runtime/go.mod
+++ b/runtime/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets/runtime
 
-go 1.26.5
+go 1.26.6
 
 require (
 	dario.cat/mergo v1.0.2

--- a/tilt.debug.dockerfile
+++ b/tilt.debug.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.5@sha256:2005724102f45917a63e9d092fc0e4ea56ea575048ce147caad5f5f61502c365
+FROM golang:1.26.6@sha256:640a234f4bea3e399c056b7b8f9c667c4939befae8db2f14e9785e16eccd4205
 WORKDIR /
 COPY ./bin/external-secrets /external-secrets
 COPY ./bin/dlv /dlv


### PR DESCRIPTION
## Problem Statement

Go 1.26.5 carries eight HIGH severity stdlib advisories. Trivy flags them on every image build, so `publish-artifacts` fails on `main` and on every open PR regardless of content. The scanned binary reports `Total: 8 (HIGH: 8, CRITICAL: 0)`, all against `stdlib` at v1.26.5; the UBI base layer itself is clean.

CVE-2026-33818 (encoding/asn1 DoS), CVE-2026-39821 (x/net/idna privilege escalation), CVE-2026-46600 (x/net/dns/dnsmessage DoS), CVE-2026-56853 (net/http unencrypted HTTP/2), CVE-2026-56858 (html/template XSS), CVE-2026-56859 (encoding/xml DoS), CVE-2026-56860 (net/url DoS), CVE-2026-56862 (crypto/tls DoS). All are fixed in 1.26.6, which is the floor on this line since CVE-2026-46600 is not fixed in 1.25.13.

## Related Issue

None. Found while the trivy gate failed an unrelated PR.

## Proposed Changes

Bumps the `go` directive from 1.26.5 to 1.26.6 in the root module and all 62 submodules, and the three `golang` base image pins in `Dockerfile.standalone`, `e2e/Dockerfile` and `tilt.debug.dockerfile`. Those pins carry both a tag and an `@sha256` digest, and docker resolves by digest, so bumping the tag alone would keep pulling the vulnerable image; both are updated, with the new digests resolved via `docker buildx imagetools inspect`.

The two `hack/tools` modules stay on 1.26.4. They are build-time only, excluded from the workspace by the `go-work` target, and not compiled into the scanned image, which is also how the 1.26.5 bump left them.

No `toolchain` directives exist and every workflow uses `go-version-file: go.mod`, so the root bump drives CI on its own.

## AI Assistance disclosure

AI assistance used: Yes

Used to cross-check the advisory list against the trivy output and to sweep the version pins; the change itself is mechanical and verified by hand.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
- [x] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [ ] I have tested my changes on a live environment to confirm they are working
