### PR TITLE
docs(aws): clarify PushSecret resource policy permissions and removal semantics

### DIFF
--- a/docs/provider/aws-secrets-manager.md
+++ b/docs/provider/aws-secrets-manager.md
@@ -76,7 +76,7 @@ If you're planning to use `PushSecret`, ensure you also have the following permi
 }
 ```
 
-**Note:** The resource policy permissions (`GetResourcePolicy`, `PutResourcePolicy`, `DeleteResourcePolicy`) are required for PushSecret against an existing secret, regardless of whether the `resourcePolicy` metadata option is configured. `DeleteResourcePolicy` is called whenever `resourcePolicy` is absent or empty, since ESO removes any existing resource policy in that case. `GetResourcePolicy` and `PutResourcePolicy` are called when a policy is configured through `resourcePolicy`.
+**Note:** The resource policy permissions (`GetResourcePolicy`, `PutResourcePolicy`, `DeleteResourcePolicy`) are required for PushSecret against an existing secret, regardless of whether the `resourcePolicy` metadata option is configured. `DeleteResourcePolicy` is called whenever `resourcePolicy` is omitted, or configured with a `policySourceRef` that resolves to an empty policy. `GetResourcePolicy` is called whenever a non-empty policy is configured, to compare it against the current policy. `PutResourcePolicy` is called only when that comparison shows a difference — it is not called on a no-op reconcile.
 
 **Note:** The replication permissions (`ReplicateSecretToRegions`, `RemoveRegionsFromReplication`) are only required if you're using the `replicationLocations` metadata option to manage secret replication across multiple regions.
 
@@ -153,14 +153,14 @@ To control this behavior set the following provider metadata:
 - `tags` Key-value map of user-defined tags that are attached to the secret.
 - `replicationLocations` takes a list of valid AWS region names where the secret should be replicated.
 
-**Note:** ESO reconciles tags, resource policies, and replication locations according to their individual metadata semantics. Tags and replication locations are managed only when their corresponding metadata fields are configured; if those fields are omitted, existing tags or replication settings in AWS are left unchanged. Resource policies behave differently for existing secrets: when `resourcePolicy` is configured, ESO adds or updates the policy, while an absent or empty `resourcePolicy` causes any existing resource policy to be removed. This reconciliation occurs on every refresh, even when the secret value itself has not changed.
+**Note:** ESO reconciles tags, resource policies, and replication locations according to their individual metadata semantics. Tags and replication locations are managed only when their corresponding metadata fields are configured; if those fields are omitted, existing tags or replication settings in AWS are left unchanged. Resource policies behave differently for existing secrets: when `resourcePolicy` is configured, ESO adds or updates the policy, while `resourcePolicy` being omitted, or configured with a `policySourceRef` that resolves to an empty policy, causes any existing resource policy to be removed. A `resourcePolicy` block present without a `policySourceRef` (e.g. `resourcePolicy: {}`) does not delete the policy — reconciliation fails instead, since `policySourceRef` is required. This reconciliation occurs on every refresh, even when the secret value itself has not changed.
 
 !!! warning "Resource policy ownership"
     ESO treats the resource policy as owned by PushSecret once a secret is managed by ESO
-    (see `managed-by` tag). If `resourcePolicy` is omitted or empty, any existing resource
-    policy on that secret is deleted on the next reconciliation, even one applied by a
-    separate tool (Terraform, account security tooling). This runs on every reconciliation,
-    independent of whether the secret value changed.
+    (see `managed-by` tag). If `resourcePolicy` is omitted, or resolves to an empty policy,
+    any existing resource policy on that secret is deleted on the next reconciliation, even
+    one applied by a separate tool (Terraform, account security tooling). This runs on every
+    reconciliation, independent of whether the secret value changed.
 
     If a target secret already has a resource policy managed outside ESO, provide it
     explicitly through `resourcePolicy.policySourceRef` so ESO reasserts it instead of

--- a/docs/provider/aws-secrets-manager.md
+++ b/docs/provider/aws-secrets-manager.md
@@ -76,7 +76,8 @@ If you're planning to use `PushSecret`, ensure you also have the following permi
 }
 ```
 
-**Note:** The resource policy permissions (`GetResourcePolicy`, `PutResourcePolicy`, `DeleteResourcePolicy`) are only required if you're using the `resourcePolicy` metadata option to manage resource-based policies on secrets.
+**Note:** The resource policy permissions (`GetResourcePolicy`, `PutResourcePolicy`, `DeleteResourcePolicy`) are required for PushSecret against an existing secret, regardless of whether the `resourcePolicy` metadata option is configured. `DeleteResourcePolicy` is called whenever `resourcePolicy` is absent or empty, since ESO removes any existing resource policy in that case. `GetResourcePolicy` and `PutResourcePolicy` are called when a policy is configured through `resourcePolicy`.
+
 **Note:** The replication permissions (`ReplicateSecretToRegions`, `RemoveRegionsFromReplication`) are only required if you're using the `replicationLocations` metadata option to manage secret replication across multiple regions.
 
 Here's a more restrictive version of the IAM policy:
@@ -152,7 +153,18 @@ To control this behavior set the following provider metadata:
 - `tags` Key-value map of user-defined tags that are attached to the secret.
 - `replicationLocations` takes a list of valid AWS region names where the secret should be replicated.
 
-**Note:** ESO treats the PushSecret as the **source of truth** for tags, resource policy, and replication locations. When any of these resources are specified in `metadata`, they will be added or updated, and resources NOT specified but existing will be removed from AWS. This synchronization happens on every reconciliation, even when the secret value hasn't changed.
+**Note:** ESO reconciles tags, resource policies, and replication locations according to their individual metadata semantics. Tags and replication locations are managed only when their corresponding metadata fields are configured; if those fields are omitted, existing tags or replication settings in AWS are left unchanged. Resource policies behave differently for existing secrets: when `resourcePolicy` is configured, ESO adds or updates the policy, while an absent or empty `resourcePolicy` causes any existing resource policy to be removed. This reconciliation occurs on every refresh, even when the secret value itself has not changed.
+
+!!! warning "Resource policy ownership"
+    ESO treats the resource policy as owned by PushSecret once a secret is managed by ESO
+    (see `managed-by` tag). If `resourcePolicy` is omitted or empty, any existing resource
+    policy on that secret is deleted on the next reconciliation, even one applied by a
+    separate tool (Terraform, account security tooling). This runs on every reconciliation,
+    independent of whether the secret value changed.
+
+    If a target secret already has a resource policy managed outside ESO, provide it
+    explicitly through `resourcePolicy.policySourceRef` so ESO reasserts it instead of
+    deleting it.
 
 - `resourcePolicy` Attach a resource-based policy to the secret for cross-account access or advanced access control.
   - `blockPublicPolicy` (optional) - Set to `true` to validate that the policy doesn't grant public access before applying. Defaults to AWS behavior.
@@ -232,8 +244,6 @@ data:
       ]
     }
 ```
-
-**Note:** The resource policy is synchronized on every reconciliation, even when the secret value hasn't changed. If the `resourcePolicy` field is removed from metadata, the existing policy will be deleted from the secret.
 
 ##### Location Replication
 


### PR DESCRIPTION
## Problem Statement

`docs/provider/aws-secrets-manager.md` contradicts PushSecret's actual behavior against AWS Secrets Manager in two places:

1. It states the resource-policy IAM permissions (`GetResourcePolicy`, `PutResourcePolicy`, `DeleteResourcePolicy`) are only needed if you opt into the `resourcePolicy` metadata option. In practice `manageResourcePolicy` calls `DeleteResourcePolicy` on every reconcile of an existing secret regardless of whether `resourcePolicy` is set, so a PushSecret user following the docs' minimal IAM policy hits `AccessDeniedException` the first time they push to an existing secret.
2. It states that tags, resource policy, and replication locations are all removed from AWS when omitted from `metadata`. Only resource policy actually behaves this way, `patchTags` and `manageRegionReplication` both early-return when their field is absent, leaving existing AWS state untouched.

## Related Issue

Fixes #6806

## Proposed Changes

- Correct the IAM permissions note: the three resource-policy actions are required for PushSecret against an existing secret, independent of whether `resourcePolicy` is configured (matches the already-existing "restrictive policy" example, which already bundles all three).
- Correct the omission-semantics note: only `resourcePolicy` is removed from AWS when omitted; `tags` and `replicationLocations` are left unchanged when omitted, matching the guard clauses in `patchTags` and `manageRegionReplication`.
- Promote the resource-policy synchronization note out of a trailing note (after the YAML example) into a `!!! warning "Resource policy ownership"` admonition placed right after the `resourcePolicy` field description, so it's visible before a reader commits to using the option. Added explicit guidance for the case where a resource policy is managed by a tool outside ESO (e.g. Terraform): declare it via `resourcePolicy.policySourceRef` so ESO reasserts it instead of deleting it.

## AI Assistance disclosure

Did you use an script, LLM, or AI assisted development tool for this contribution?

AI assistance used: Yes

Tool(s) used: Claude Code

Purpose of assistance: Walked through the PushSecret reconcile call path to locate `manageResourcePolicy` and its sibling guarded functions. Used it to verify, call-site by call-site, which AWS SDK methods are reached under which metadata conditions, cross-checked against `secretsmanager_test.go`.

Parts of the contribution affected: docs/provider/aws-secrets-manager.md

Human validation performed:

- I read the reconcile call path myself and confirmed the guard clauses in `patchTags` and `manageRegionReplication` in the actual source before accepting that they matched the maintainer's description.
- My first draft of the IAM permissions note incorrectly grouped `GetResourcePolicy` under "always required" alongside `DeleteResourcePolicy`. Claude grepped every call site of `GetResourcePolicy`/`PutResourcePolicy`/`DeleteResourcePolicy` in `secretsmanager.go` and showed `GetResourcePolicy` is only reached when `resourcePolicy` is configured; I rewrote the note based on that.
- Claude then flagged that this corrected, more granular wording didn't match the maintainer's own disposition in #6806 ("the three resource-policy actions are always required, not conditional"). I decided to align the final wording with the maintainer's stated intent rather than keep the technically narrower phrasing, since the maintainer's disposition is what a reviewer will hold the PR to.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage — N/A, documentation-only change; no code behavior was modified
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
- [x] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [ ] I have tested my changes on a live environment to confirm they are working
