### PR TITLE
fix: Reconcile sha and version

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -37,6 +37,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v3.29.5
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Problem Statement

Without this, sha is inconsistent with version.
This happened because a single sha was targetted for multiple versions in codeql.

Dependabot messed it up, and fixed it in [1]
CodeQL was particularly mentioned in [2]

Since then, other bumps passed and changed the sha without the version, so it lead to a version mismatch.

Now that dependabot is fixed, we can bump it again and no issue should arise.

[1]: https://github.com/dependabot/dependabot-core/commit/4a60b9578ff79dc4dbc38cfa047845142c1fb9d3
[2]: https://github.com/dependabot/dependabot-core/pull/13985

## Proposed Changes

Fix codeql version in comment so that dependabot can take those over in the future. 

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
design(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## AI Assistance disclosure

Did you use an script, LLM, or AI assisted development tool for this contribution?

AI assistance used: No

If yes provide details: -

Tool(s) used:

Purpose of assistance:

Parts of the contribution affected:

Human validation performed:

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
- [X] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [ ] I have tested my changes on a live environment to confirm they are working
