### PR TITLE
fix: key escaped webhook push data by the escaped remote key

### DIFF
--- a/providers/v1/webhook/pkg/webhook/webhook.go
+++ b/providers/v1/webhook/pkg/webhook/webhook.go
@@ -248,7 +248,7 @@ func (w *Webhook) PushWebhookData(ctx context.Context, provider *Spec, data []by
 	if err != nil {
 		return err
 	}
-	escapedData["remoteRef"][remoteKey.GetRemoteKey()] = url.QueryEscape(string(data))
+	escapedData["remoteRef"][url.QueryEscape(remoteKey.GetRemoteKey())] = url.QueryEscape(string(data))
 
 	rawData, err := w.GetTemplatePushData(ctx, remoteKey, provider.Secrets, false)
 	if err != nil {

--- a/providers/v1/webhook/webhook_test.go
+++ b/providers/v1/webhook/webhook_test.go
@@ -518,6 +518,22 @@ want:
   path: /api/pushsecret?id=testkey
   body: 'pre testkey value post'
   err: ''
+---
+case: url resolves pushed value when remote key needs escaping
+args:
+  url: /api/pushsecret?id={{ .remoteRef.remoteKey }}&value={{ index .remoteRef .remoteRef.remoteKey }}
+  key: prod/testkey
+  secretkey: secretkey
+  body: '{{ index .remoteRef .remoteRef.remoteKey }}'
+  pushsecret: true
+  secret:
+    name: test-secret
+    data:
+      secretkey: value
+want:
+  path: /api/pushsecret?id=prod%2Ftestkey&value=value
+  body: 'value'
+  err: ''
 `
 
 func TestWebhookPushSecret(t *testing.T) {


### PR DESCRIPTION
Fixes #6787.

On a webhook PushSecret, the escaped template map stored the pushed value under the raw remote key while the `.remoteRef.remoteKey` handle holds the URL-escaped key. So a `spec.url` template like `{{ index .remoteRef .remoteRef.remoteKey }}` missed the entry whenever the key needed escaping, and the value silently dropped out of the URL while the push reported success. The map is now keyed by the escaped key, matching the handle. QueryEscape is the identity for keys that need no escaping, so existing configs see no change.

The new test case fails on main with `value=` empty in the URL and passes with the fix.