### PR TITLE
docs(webhook): escape Go template examples with {% raw %}

### DIFF
--- a/docs/provider/webhook.md
+++ b/docs/provider/webhook.md
@@ -356,9 +356,11 @@ secrets:
       name: webhook-credentials
 ```
 
+{% raw %}
 the values are `{{ .creds.username }}` and `{{ .creds.password }}`. Referring to
 `{{ .creds }}` renders a Go map rather than a value. Note also that every key of the
 referenced secret is exposed; a `key` field on the `secretRef` does not narrow it.
+{% endraw %}
 
 #### A templated `url` is validated before templating
 


### PR DESCRIPTION
## Problem Statement

the webhook provider document(https://external-secrets.io/latest/provider/webhook/) crashes

<img width="1534" height="542" alt="27975" src="https://github.com/user-attachments/assets/74156883-11ef-4502-b788-83a8d30e8663" />

## Proposed Changes

Wrap paragraph contains Go template syntaxes with `{% raw %}` 

Tested in my local dev server as follows:
<img width="1512" height="1992" alt="8857" src="https://github.com/user-attachments/assets/e928b785-0373-49bf-8c81-f4ce8d06ae6c" />

## Format

Please ensure that your PR follows the following format for the title:
```
docs(webhook): escape Go template examples with {% raw %} - #6852
```

## AI Assistance disclosure

Did you use an script, LLM, or AI assisted development tool for this contribution?

AI assistance used: No

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
- [x] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [x] I have tested my changes on a live environment to confirm they are working
