### PR TITLE
fix: bump Makefile license-eye image to 0.9.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ update-deps: ## Update dependencies across all modules (root, apis, runtime, e2e
 
 .PHONY: license.check
 license.check:
-	$(DOCKER) run --rm -u $(shell id -u) -v $(shell pwd):/github/workspace apache/skywalking-eyes:0.6.0 header check
+	$(DOCKER) run --rm -u $(shell id -u) -v $(shell pwd):/github/workspace docker.io/apache/skywalking-eyes:0.9.0@sha256:b503ab18f5b29d7e04abe05668faf42f1023f9347b095d97592a5208102588ef header check
 
 # ====================================================================================
 # Golang


### PR DESCRIPTION
## Problem Statement

`make license.check` crashes on Apple Silicon: the tagged `0.8.0` image ships an `x86-64` binary for `linux/arm64` (see #6854). Rebuilding `license-eye` from source via `go run`/`go install` fixes the arch issue, but pulls in ~30 transitive Go dependencies, several of which are flagged by CI's Dependency Review check, so that approach regresses on security tooling.

## Related Issue

Fixes #6854

## Proposed Changes

- Point `make license.check` at the newly released `0.9.0` image, which already contains the `linux/arm64` fix, pinned by digest (`sha256:80c44d9274...f62291`) for reproducibility.

## Format

```
fix: bump Makefile license-eye image to 0.9.0
```

## AI Assistance disclosure

Did you use an script, LLM, or AI assisted development tool for this contribution?

AI assistance used: No

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
- [x] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [x] I have tested my changes on a live environment to confirm they are working