### PR TITLE
feat(ci): route pull requests by derived review state

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -48,6 +48,13 @@ Parts of the contribution affected:
 
 Human validation performed:
 
+## Review process
+
+Review runs in two stages: automated review first, then a maintainer. If an automated reviewer
+raises findings, this pull request stays with you until they are resolved, and a comment will
+appear explaining what is outstanding. A `review/*` label tracks where it sits. See
+[how review is routed](https://external-secrets.io/latest/contributing/process/#how-review-is-routed).
+
 ## Checklist
 
 - [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)

--- a/.github/scripts/resolve-prs-test.js
+++ b/.github/scripts/resolve-prs-test.js
@@ -1,0 +1,204 @@
+/**
+ * Tests for resolve-prs.js.
+ *
+ * The fork cases matter most. listPullRequestsAssociatedWithCommit returns an
+ * empty array for pull requests from forks, with no error to distinguish that
+ * from "no such pull request", so this module matches against the open pull
+ * request list instead. These tests pin that.
+ *
+ * Run with: node .github/scripts/resolve-prs-test.js
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import resolvePullRequests, { pullRequestsForSha, pullRequestsForBranch } from './resolve-prs.js';
+
+// Two forks and one same-repo branch, mirroring the real mix on this repository.
+const OPEN = [
+  { number: 6856, head: { sha: 'aaa111', ref: 'feat/routing', repo: { full_name: 'alekc/fork-external-secrets' } } },
+  { number: 6855, head: { sha: 'bbb222', ref: 'make-license.check', repo: { full_name: 'dronenb/external-secrets' } } },
+  { number: 6842, head: { sha: 'ccc333', ref: 'chore/bump', repo: { full_name: 'external-secrets/external-secrets' } } },
+];
+
+function harness({ open = OPEN } = {}) {
+  const warnings = [];
+  const infos = [];
+  const core = { warning: (m) => warnings.push(m), info: (m) => infos.push(m) };
+  const github = {
+    paginate: async () => open,
+    rest: { pulls: { list: () => {} } },
+  };
+  return { core, github, warnings, infos };
+}
+
+const ctx = (eventName, payload = {}) => ({
+  eventName,
+  repo: { owner: 'external-secrets', repo: 'external-secrets' },
+  payload,
+});
+
+for (const event of ['pull_request_target', 'pull_request_review', 'pull_request_review_comment']) {
+  test(`${event} resolves to the pull request in its payload`, async () => {
+    const { core, github } = harness();
+    const numbers = await resolvePullRequests({
+      core, github, context: ctx(event, { pull_request: { number: 6856 } }),
+    });
+    assert.deepEqual(numbers, [6856]);
+  });
+}
+
+test('a pull request event without a number warns instead of throwing', async () => {
+  const { core, github, warnings } = harness();
+  assert.deepEqual(await resolvePullRequests({ core, github, context: ctx('pull_request_target', {}) }), []);
+  assert.equal(warnings.length, 1);
+});
+
+// --- workflow_run, the relay from Review Signal -----------------------------
+
+test('workflow_run resolves a FORK pull request by head repo and branch', async () => {
+  const { core, github } = harness();
+  const numbers = await resolvePullRequests({
+    core,
+    github,
+    context: ctx('workflow_run', {
+      workflow_run: {
+        head_branch: 'feat/routing',
+        head_repository: { full_name: 'alekc/fork-external-secrets' },
+        pull_requests: [],
+      },
+    }),
+  });
+  assert.deepEqual(numbers, [6856], 'fork pull requests must still be found');
+});
+
+test('workflow_run does not confuse the same branch name on a different fork', async () => {
+  const open = [
+    { number: 1, head: { sha: 'x', ref: 'shared', repo: { full_name: 'alice/fork' } } },
+    { number: 2, head: { sha: 'y', ref: 'shared', repo: { full_name: 'bob/fork' } } },
+  ];
+  const { core, github } = harness({ open });
+  const numbers = await resolvePullRequests({
+    core,
+    github,
+    context: ctx('workflow_run', {
+      workflow_run: { head_branch: 'shared', head_repository: { full_name: 'bob/fork' } },
+    }),
+  });
+  assert.deepEqual(numbers, [2]);
+});
+
+test('workflow_run without a branch or head repository warns', async () => {
+  const { core, github, warnings } = harness();
+  assert.deepEqual(
+    await resolvePullRequests({ core, github, context: ctx('workflow_run', { workflow_run: {} }) }),
+    [],
+  );
+  assert.equal(warnings.length, 1);
+});
+
+test('workflow_run for a branch with no open pull request resolves to nothing', async () => {
+  const { core, github, infos } = harness();
+  const numbers = await resolvePullRequests({
+    core,
+    github,
+    context: ctx('workflow_run', {
+      workflow_run: { head_branch: 'gone', head_repository: { full_name: 'alekc/fork-external-secrets' } },
+    }),
+  });
+  assert.deepEqual(numbers, []);
+  assert.match(infos.join(' '), /matches no open pull request/);
+});
+
+// --- check_suite and friends, resolved by head SHA -------------------------
+
+test('check_suite resolves a fork pull request by head SHA', async () => {
+  const { core, github } = harness();
+  const numbers = await resolvePullRequests({
+    core, github, context: ctx('check_suite', { check_suite: { head_sha: 'bbb222', pull_requests: [] } }),
+  });
+  assert.deepEqual(numbers, [6855]);
+});
+
+test('check_run and status also resolve by SHA', async () => {
+  const { core, github } = harness();
+  assert.deepEqual(
+    await resolvePullRequests({
+      core, github, context: ctx('check_run', { check_run: { check_suite: { head_sha: 'ccc333' } } }),
+    }),
+    [6842],
+  );
+  assert.deepEqual(
+    await resolvePullRequests({ core, github, context: ctx('status', { sha: 'aaa111' }) }),
+    [6856],
+  );
+});
+
+test('a SHA event with no SHA warns and resolves to nothing', async () => {
+  const { core, github, warnings } = harness();
+  assert.deepEqual(await resolvePullRequests({ core, github, context: ctx('check_suite', {}) }), []);
+  assert.equal(warnings.length, 1);
+});
+
+test('an unknown SHA resolves to nothing rather than everything', async () => {
+  const { core, github } = harness();
+  assert.deepEqual(
+    await resolvePullRequests({ core, github, context: ctx('check_suite', { check_suite: { head_sha: 'nope' } }) }),
+    [],
+  );
+});
+
+test('the SHA and branch helpers are exported and usable directly', async () => {
+  const { github } = harness();
+  assert.deepEqual(await pullRequestsForSha(github, 'o', 'r', 'aaa111'), [6856]);
+  assert.deepEqual(
+    await pullRequestsForBranch(github, 'o', 'r', 'dronenb/external-secrets', 'make-license.check'),
+    [6855],
+  );
+});
+
+// --- sweeps and manual dispatch --------------------------------------------
+
+test('a scheduled run sweeps every open pull request', async () => {
+  const { core, github } = harness();
+  assert.deepEqual(await resolvePullRequests({ core, github, context: ctx('schedule') }), [6856, 6855, 6842]);
+});
+
+test('workflow_dispatch with a number evaluates just that pull request', async () => {
+  const { core, github } = harness();
+  assert.deepEqual(
+    await resolvePullRequests({ core, github, context: ctx('workflow_dispatch', { inputs: { pr: '6613' } }) }),
+    [6613],
+  );
+});
+
+test('workflow_dispatch tolerates surrounding whitespace', async () => {
+  const { core, github } = harness();
+  assert.deepEqual(
+    await resolvePullRequests({ core, github, context: ctx('workflow_dispatch', { inputs: { pr: '  42  ' } }) }),
+    [42],
+  );
+});
+
+test('workflow_dispatch with a blank input sweeps everything', async () => {
+  const { core, github } = harness();
+  assert.deepEqual(
+    await resolvePullRequests({ core, github, context: ctx('workflow_dispatch', { inputs: { pr: '   ' } }) }),
+    [6856, 6855, 6842],
+  );
+});
+
+test('workflow_dispatch rejects a non-numeric input rather than querying NaN', async () => {
+  const { core, github } = harness();
+  await assert.rejects(
+    () => resolvePullRequests({ core, github, context: ctx('workflow_dispatch', { inputs: { pr: 'main' } }) }),
+    /Invalid pr input/,
+  );
+});
+
+test('an absent payload does not blow up', async () => {
+  const { core, github } = harness();
+  assert.deepEqual(
+    await resolvePullRequests({ core, github, context: { eventName: 'schedule', repo: { owner: 'o', repo: 'r' } } }),
+    [6856, 6855, 6842],
+  );
+});

--- a/.github/scripts/resolve-prs-test.js
+++ b/.github/scripts/resolve-prs-test.js
@@ -11,7 +11,11 @@
 
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import resolvePullRequests, { pullRequestsForSha, pullRequestsForBranch } from './resolve-prs.js';
+import resolvePullRequests, { pullRequestsForSha, pullRequestsForBranch, SWEEP_TARGET } from './resolve-prs.js';
+
+// resolvePullRequests returns { numbers, targets }; most tests care about numbers.
+const numbersOf = async (args) => (await resolvePullRequests(args)).numbers;
+const targetsOf = async (args) => (await resolvePullRequests(args)).targets;
 
 // Two forks and one same-repo branch, mirroring the real mix on this repository.
 const OPEN = [
@@ -40,7 +44,7 @@ const ctx = (eventName, payload = {}) => ({
 for (const event of ['pull_request_target', 'pull_request_review', 'pull_request_review_comment']) {
   test(`${event} resolves to the pull request in its payload`, async () => {
     const { core, github } = harness();
-    const numbers = await resolvePullRequests({
+    const numbers = await numbersOf({
       core, github, context: ctx(event, { pull_request: { number: 6856 } }),
     });
     assert.deepEqual(numbers, [6856]);
@@ -49,7 +53,7 @@ for (const event of ['pull_request_target', 'pull_request_review', 'pull_request
 
 test('a pull request event without a number warns instead of throwing', async () => {
   const { core, github, warnings } = harness();
-  assert.deepEqual(await resolvePullRequests({ core, github, context: ctx('pull_request_target', {}) }), []);
+  assert.deepEqual(await numbersOf({ core, github, context: ctx('pull_request_target', {}) }), []);
   assert.equal(warnings.length, 1);
 });
 
@@ -57,7 +61,7 @@ test('a pull request event without a number warns instead of throwing', async ()
 
 test('workflow_run resolves a FORK pull request by head repo and branch', async () => {
   const { core, github } = harness();
-  const numbers = await resolvePullRequests({
+  const numbers = await numbersOf({
     core,
     github,
     context: ctx('workflow_run', {
@@ -77,7 +81,7 @@ test('workflow_run does not confuse the same branch name on a different fork', a
     { number: 2, head: { sha: 'y', ref: 'shared', repo: { full_name: 'bob/fork' } } },
   ];
   const { core, github } = harness({ open });
-  const numbers = await resolvePullRequests({
+  const numbers = await numbersOf({
     core,
     github,
     context: ctx('workflow_run', {
@@ -90,7 +94,7 @@ test('workflow_run does not confuse the same branch name on a different fork', a
 test('workflow_run without a branch or head repository warns', async () => {
   const { core, github, warnings } = harness();
   assert.deepEqual(
-    await resolvePullRequests({ core, github, context: ctx('workflow_run', { workflow_run: {} }) }),
+    await numbersOf({ core, github, context: ctx('workflow_run', { workflow_run: {} }) }),
     [],
   );
   assert.equal(warnings.length, 1);
@@ -98,7 +102,7 @@ test('workflow_run without a branch or head repository warns', async () => {
 
 test('workflow_run for a branch with no open pull request resolves to nothing', async () => {
   const { core, github, infos } = harness();
-  const numbers = await resolvePullRequests({
+  const numbers = await numbersOf({
     core,
     github,
     context: ctx('workflow_run', {
@@ -113,7 +117,7 @@ test('workflow_run for a branch with no open pull request resolves to nothing', 
 
 test('check_suite resolves a fork pull request by head SHA', async () => {
   const { core, github } = harness();
-  const numbers = await resolvePullRequests({
+  const numbers = await numbersOf({
     core, github, context: ctx('check_suite', { check_suite: { head_sha: 'bbb222', pull_requests: [] } }),
   });
   assert.deepEqual(numbers, [6855]);
@@ -122,27 +126,27 @@ test('check_suite resolves a fork pull request by head SHA', async () => {
 test('check_run and status also resolve by SHA', async () => {
   const { core, github } = harness();
   assert.deepEqual(
-    await resolvePullRequests({
+    await numbersOf({
       core, github, context: ctx('check_run', { check_run: { check_suite: { head_sha: 'ccc333' } } }),
     }),
     [6842],
   );
   assert.deepEqual(
-    await resolvePullRequests({ core, github, context: ctx('status', { sha: 'aaa111' }) }),
+    await numbersOf({ core, github, context: ctx('status', { sha: 'aaa111' }) }),
     [6856],
   );
 });
 
 test('a SHA event with no SHA warns and resolves to nothing', async () => {
   const { core, github, warnings } = harness();
-  assert.deepEqual(await resolvePullRequests({ core, github, context: ctx('check_suite', {}) }), []);
+  assert.deepEqual(await numbersOf({ core, github, context: ctx('check_suite', {}) }), []);
   assert.equal(warnings.length, 1);
 });
 
 test('an unknown SHA resolves to nothing rather than everything', async () => {
   const { core, github } = harness();
   assert.deepEqual(
-    await resolvePullRequests({ core, github, context: ctx('check_suite', { check_suite: { head_sha: 'nope' } }) }),
+    await numbersOf({ core, github, context: ctx('check_suite', { check_suite: { head_sha: 'nope' } }) }),
     [],
   );
 });
@@ -160,13 +164,13 @@ test('the SHA and branch helpers are exported and usable directly', async () => 
 
 test('a scheduled run sweeps every open pull request', async () => {
   const { core, github } = harness();
-  assert.deepEqual(await resolvePullRequests({ core, github, context: ctx('schedule') }), [6856, 6855, 6842]);
+  assert.deepEqual(await numbersOf({ core, github, context: ctx('schedule') }), [6856, 6855, 6842]);
 });
 
 test('workflow_dispatch with a number evaluates just that pull request', async () => {
   const { core, github } = harness();
   assert.deepEqual(
-    await resolvePullRequests({ core, github, context: ctx('workflow_dispatch', { inputs: { pr: '6613' } }) }),
+    await numbersOf({ core, github, context: ctx('workflow_dispatch', { inputs: { pr: '6613' } }) }),
     [6613],
   );
 });
@@ -174,7 +178,7 @@ test('workflow_dispatch with a number evaluates just that pull request', async (
 test('workflow_dispatch tolerates surrounding whitespace', async () => {
   const { core, github } = harness();
   assert.deepEqual(
-    await resolvePullRequests({ core, github, context: ctx('workflow_dispatch', { inputs: { pr: '  42  ' } }) }),
+    await numbersOf({ core, github, context: ctx('workflow_dispatch', { inputs: { pr: '  42  ' } }) }),
     [42],
   );
 });
@@ -182,7 +186,7 @@ test('workflow_dispatch tolerates surrounding whitespace', async () => {
 test('workflow_dispatch with a blank input sweeps everything', async () => {
   const { core, github } = harness();
   assert.deepEqual(
-    await resolvePullRequests({ core, github, context: ctx('workflow_dispatch', { inputs: { pr: '   ' } }) }),
+    await numbersOf({ core, github, context: ctx('workflow_dispatch', { inputs: { pr: '   ' } }) }),
     [6856, 6855, 6842],
   );
 });
@@ -198,7 +202,72 @@ test('workflow_dispatch rejects a non-numeric input rather than querying NaN', a
 test('an absent payload does not blow up', async () => {
   const { core, github } = harness();
   assert.deepEqual(
-    await resolvePullRequests({ core, github, context: { eventName: 'schedule', repo: { owner: 'o', repo: 'r' } } }),
+    await numbersOf({ core, github, context: { eventName: 'schedule', repo: { owner: 'o', repo: 'r' } } }),
     [6856, 6855, 6842],
+  );
+});
+
+// --- targets drive the job matrix and the concurrency group ----------------
+
+test('an event resolves to per-pull-request targets, one job each', async () => {
+  const { core, github } = harness();
+  const targets = await targetsOf({
+    core, github, context: ctx('pull_request_target', { pull_request: { number: 6857 } }),
+  });
+  assert.deepEqual(targets, ['6857'], 'the group becomes review-state-6857');
+});
+
+test('a check_suite matching two pull requests yields two targets', async () => {
+  const open = [
+    { number: 10, head: { sha: 'dup', ref: 'a', repo: { full_name: 'x/y' } } },
+    { number: 11, head: { sha: 'dup', ref: 'b', repo: { full_name: 'x/z' } } },
+  ];
+  const { core, github } = harness({ open });
+  const targets = await targetsOf({
+    core, github, context: ctx('check_suite', { check_suite: { head_sha: 'dup' } }),
+  });
+  assert.deepEqual(targets, ['10', '11'], 'each gets its own group, not a shared one');
+});
+
+test('a sweep collapses to one sentinel target rather than one job per PR', async () => {
+  const { core, github } = harness();
+  const out = await resolvePullRequests({ core, github, context: ctx('schedule') });
+  assert.deepEqual(out.targets, [SWEEP_TARGET]);
+  assert.equal(out.numbers.length, 3, 'but it still carries every pull request to evaluate');
+});
+
+test('the sweep sentinel cannot be mistaken for a pull request number', () => {
+  assert.ok(!/^\d+$/.test(SWEEP_TARGET), 'it becomes part of a concurrency group name');
+});
+
+test('nothing to do yields no targets, so the matrix job is skipped', async () => {
+  const { core, github } = harness({ open: [] });
+  const out = await resolvePullRequests({ core, github, context: ctx('schedule') });
+  assert.deepEqual(out.targets, []);
+  assert.deepEqual(out.numbers, []);
+});
+
+test('check_run prefers its own head_sha over the nested check_suite', async () => {
+  const { core, github } = harness();
+  assert.deepEqual(
+    await numbersOf({
+      core,
+      github,
+      context: ctx('check_run', {
+        check_run: { head_sha: 'aaa111', check_suite: { head_sha: 'bbb222' } },
+      }),
+    }),
+    [6856],
+    'the direct head_sha wins',
+  );
+});
+
+test('check_run still falls back to the nested check_suite head_sha', async () => {
+  const { core, github } = harness();
+  assert.deepEqual(
+    await numbersOf({
+      core, github, context: ctx('check_run', { check_run: { check_suite: { head_sha: 'ccc333' } } }),
+    }),
+    [6842],
   );
 });

--- a/.github/scripts/resolve-prs.js
+++ b/.github/scripts/resolve-prs.js
@@ -1,0 +1,117 @@
+/**
+ * Works out which pull requests a Review State run should evaluate.
+ *
+ * Split out of the workflow so the fork handling below can be tested: getting
+ * it wrong fails silently, as an empty list rather than an error.
+ */
+
+// Events that name their pull request directly in the payload.
+const DIRECT_EVENTS = new Set([
+  'pull_request_target',
+  'pull_request_review',
+  'pull_request_review_comment',
+  'pull_request',
+]);
+
+// Events that identify a pull request only by the commit they ran against.
+const SHA_EVENTS = new Set(['check_suite', 'check_run', 'status']);
+
+async function listOpenPullRequests(github, owner, repo) {
+  return github.paginate(github.rest.pulls.list, {
+    owner, repo, state: 'open', per_page: 100,
+  });
+}
+
+function headShaFor(event, payload) {
+  if (event === 'check_suite') return (payload.check_suite || {}).head_sha;
+  if (event === 'check_run') return ((payload.check_run || {}).check_suite || {}).head_sha;
+  if (event === 'status') return payload.sha;
+  return undefined;
+}
+
+/**
+ * Maps a head commit back to its open pull requests by matching against the
+ * open pull request list.
+ *
+ * The obvious call, listPullRequestsAssociatedWithCommit, returns an empty
+ * array for pull requests from forks, which is most of our traffic, and gives
+ * no error to distinguish that from "no such pull request". Matching head SHAs
+ * has no fork special case.
+ */
+export async function pullRequestsForSha(github, owner, repo, sha) {
+  const open = await listOpenPullRequests(github, owner, repo);
+  return open.filter((p) => p.head && p.head.sha === sha).map((p) => p.number);
+}
+
+/**
+ * Maps a workflow_run back to its pull request by head repository and branch.
+ *
+ * Not by head SHA: for review events GITHUB_SHA is the merge commit rather
+ * than the pull request head, so the SHA would not match. A head branch is
+ * unique per repository, so the pair identifies exactly one open pull request.
+ */
+export async function pullRequestsForBranch(github, owner, repo, headRepo, headRef) {
+  const open = await listOpenPullRequests(github, owner, repo);
+  return open
+    .filter((p) => p.head
+      && p.head.ref === headRef
+      && p.head.repo
+      && p.head.repo.full_name === headRepo)
+    .map((p) => p.number);
+}
+
+export default async function resolvePullRequests({ core, github, context }) {
+  const owner = context.repo.owner;
+  const repo = context.repo.repo;
+  const event = context.eventName;
+  const payload = context.payload || {};
+
+  if (DIRECT_EVENTS.has(event)) {
+    const number = payload.pull_request && payload.pull_request.number;
+    if (!number) {
+      core.warning(`${event} carried no pull request number`);
+      return [];
+    }
+    return [number];
+  }
+
+  if (event === 'workflow_run') {
+    const wr = payload.workflow_run || {};
+    const headRepo = (wr.head_repository || {}).full_name;
+    if (!wr.head_branch || !headRepo) {
+      core.warning('workflow_run carried no head branch or head repository');
+      return [];
+    }
+    const numbers = await pullRequestsForBranch(github, owner, repo, headRepo, wr.head_branch);
+    if (numbers.length === 0) {
+      core.info(`workflow_run: ${headRepo}:${wr.head_branch} matches no open pull request`);
+    }
+    return numbers;
+  }
+
+  if (SHA_EVENTS.has(event)) {
+    const sha = headShaFor(event, payload);
+    if (!sha) {
+      core.warning(`${event} carried no head SHA`);
+      return [];
+    }
+    const numbers = await pullRequestsForSha(github, owner, repo, sha);
+    if (numbers.length === 0) {
+      core.info(`${event}: head SHA ${sha} matches no open pull request`);
+    }
+    return numbers;
+  }
+
+  const requested = ((payload.inputs && payload.inputs.pr) || '').trim();
+  if (requested) {
+    // Reject anything that is not a plain pull request number rather than
+    // querying NaN and reporting a confusing not-found.
+    if (!/^\d+$/.test(requested)) {
+      throw new Error(`Invalid pr input: ${JSON.stringify(requested)}. Expected a number.`);
+    }
+    return [Number(requested)];
+  }
+
+  const open = await listOpenPullRequests(github, owner, repo);
+  return open.map((p) => p.number);
+}

--- a/.github/scripts/resolve-prs.js
+++ b/.github/scripts/resolve-prs.js
@@ -3,7 +3,17 @@
  *
  * Split out of the workflow so the fork handling below can be tested: getting
  * it wrong fails silently, as an empty list rather than an error.
+ *
+ * Returns { numbers, targets }. `targets` drives a job matrix so that each
+ * event-driven run gets its own per-pull-request concurrency group, which is
+ * the only way to serialise writes: a workflow-level group is evaluated before
+ * the pull request number is known. A sweep collapses to the single sentinel
+ * SWEEP_TARGET so it stays one job rather than one job per pull request.
  */
+
+// Must not collide with a pull request number, since it becomes part of a
+// concurrency group name.
+export const SWEEP_TARGET = 'all';
 
 // Events that name their pull request directly in the payload.
 const DIRECT_EVENTS = new Set([
@@ -24,7 +34,12 @@ async function listOpenPullRequests(github, owner, repo) {
 
 function headShaFor(event, payload) {
   if (event === 'check_suite') return (payload.check_suite || {}).head_sha;
-  if (event === 'check_run') return ((payload.check_run || {}).check_suite || {}).head_sha;
+  // check_run carries head_sha directly; the nested check_suite is a fallback
+  // for payload shapes that omit it.
+  if (event === 'check_run') {
+    const cr = payload.check_run || {};
+    return cr.head_sha || (cr.check_suite || {}).head_sha;
+  }
   if (event === 'status') return payload.sha;
   return undefined;
 }
@@ -60,6 +75,9 @@ export async function pullRequestsForBranch(github, owner, repo, headRepo, headR
     .map((p) => p.number);
 }
 
+const forPullRequests = (numbers) => ({ numbers, targets: numbers.map(String) });
+const forSweep = (numbers) => ({ numbers, targets: numbers.length > 0 ? [SWEEP_TARGET] : [] });
+
 export default async function resolvePullRequests({ core, github, context }) {
   const owner = context.repo.owner;
   const repo = context.repo.repo;
@@ -70,9 +88,9 @@ export default async function resolvePullRequests({ core, github, context }) {
     const number = payload.pull_request && payload.pull_request.number;
     if (!number) {
       core.warning(`${event} carried no pull request number`);
-      return [];
+      return forPullRequests([]);
     }
-    return [number];
+    return forPullRequests([number]);
   }
 
   if (event === 'workflow_run') {
@@ -80,26 +98,26 @@ export default async function resolvePullRequests({ core, github, context }) {
     const headRepo = (wr.head_repository || {}).full_name;
     if (!wr.head_branch || !headRepo) {
       core.warning('workflow_run carried no head branch or head repository');
-      return [];
+      return forPullRequests([]);
     }
     const numbers = await pullRequestsForBranch(github, owner, repo, headRepo, wr.head_branch);
     if (numbers.length === 0) {
       core.info(`workflow_run: ${headRepo}:${wr.head_branch} matches no open pull request`);
     }
-    return numbers;
+    return forPullRequests(numbers);
   }
 
   if (SHA_EVENTS.has(event)) {
     const sha = headShaFor(event, payload);
     if (!sha) {
       core.warning(`${event} carried no head SHA`);
-      return [];
+      return forPullRequests([]);
     }
     const numbers = await pullRequestsForSha(github, owner, repo, sha);
     if (numbers.length === 0) {
       core.info(`${event}: head SHA ${sha} matches no open pull request`);
     }
-    return numbers;
+    return forPullRequests(numbers);
   }
 
   const requested = ((payload.inputs && payload.inputs.pr) || '').trim();
@@ -109,9 +127,10 @@ export default async function resolvePullRequests({ core, github, context }) {
     if (!/^\d+$/.test(requested)) {
       throw new Error(`Invalid pr input: ${JSON.stringify(requested)}. Expected a number.`);
     }
-    return [Number(requested)];
+    return forPullRequests([Number(requested)]);
   }
 
+  // A sweep is one job over every open pull request, not one job each.
   const open = await listOpenPullRequests(github, owner, repo);
-  return open.map((p) => p.number);
+  return forSweep(open.map((p) => p.number));
 }

--- a/.github/scripts/review-state-cli.js
+++ b/.github/scripts/review-state-cli.js
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+/**
+ * Local dry run for the review state router.
+ *
+ * Reads the live repository and prints the label each open pull request would
+ * get. It cannot write: the client's mutating methods throw, so a plumbing bug
+ * surfaces as a crash here instead of a change to a real pull request.
+ *
+ * Usage:
+ *   node .github/scripts/review-state-cli.js
+ *   node .github/scripts/review-state-cli.js --pr 6613 --pr 6851
+ *   node .github/scripts/review-state-cli.js --repo owner/name --json
+ *
+ * Auth: GH_TOKEN or GITHUB_TOKEN, otherwise `gh auth token` is used.
+ */
+
+import { execFileSync } from 'node:child_process';
+import run from './review-state.js';
+
+const API = 'https://api.github.com';
+
+function parseArgs(argv) {
+  const args = { repo: 'external-secrets/external-secrets', prs: [], json: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === '--pr') args.prs.push(Number(argv[++i]));
+    else if (a === '--repo') args.repo = argv[++i];
+    else if (a === '--json') args.json = true;
+    else if (a === '--help' || a === '-h') args.help = true;
+    else throw new Error(`Unknown argument: ${a}`);
+  }
+  return args;
+}
+
+function token() {
+  if (process.env.GH_TOKEN) return process.env.GH_TOKEN;
+  if (process.env.GITHUB_TOKEN) return process.env.GITHUB_TOKEN;
+  try {
+    return execFileSync('gh', ['auth', 'token'], { encoding: 'utf8' }).trim();
+  } catch {
+    throw new Error('No token. Set GH_TOKEN, or run `gh auth login`.');
+  }
+}
+
+function makeClient(auth) {
+  const headers = {
+    authorization: `Bearer ${auth}`,
+    accept: 'application/vnd.github+json',
+    'user-agent': 'eso-review-state-cli',
+  };
+
+  async function request(path, { method = 'GET', body } = {}) {
+    const res = await fetch(path.startsWith('http') ? path : `${API}${path}`, {
+      method,
+      headers: body ? { ...headers, 'content-type': 'application/json' } : headers,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    if (!res.ok) {
+      const error = new Error(`${method} ${path} -> ${res.status} ${await res.text()}`);
+      error.status = res.status;
+      throw error;
+    }
+    return res.json();
+  }
+
+  // Anything that would mutate the repository is deliberately unavailable, so
+  // "dry run" is enforced by the client rather than by remembering a flag.
+  const readOnly = (name) => () => {
+    throw new Error(`${name} is not available in the local dry run`);
+  };
+
+  const endpoint = (template) => {
+    const fn = async (params) => {
+      const query = new URLSearchParams();
+      const path = template.replace(/\{(\w+)\}/g, (_, k) => encodeURIComponent(params[k]));
+      for (const [k, v] of Object.entries(params)) {
+        if (!template.includes(`{${k}}`) && k !== 'owner' && k !== 'repo') query.set(k, v);
+      }
+      const qs = query.toString();
+      return { data: await request(qs ? `${path}?${qs}` : path) };
+    };
+    fn.__template = template;
+    return fn;
+  };
+
+  const github = {
+    graphql: async (query, variables) => {
+      const out = await request('/graphql', { method: 'POST', body: { query, variables } });
+      if (out.errors) throw new Error(`GraphQL: ${JSON.stringify(out.errors)}`);
+      return out.data;
+    },
+    paginate: async (fn, params) => {
+      const all = [];
+      for (let page = 1; ; page += 1) {
+        const { data } = await fn({ ...params, page });
+        if (!Array.isArray(data) || data.length === 0) break;
+        all.push(...data);
+        if (data.length < (params.per_page || 30)) break;
+      }
+      return all;
+    },
+    rest: {
+      issues: {
+        listComments: endpoint('/repos/{owner}/{repo}/issues/{issue_number}/comments'),
+        listLabelsForRepo: endpoint('/repos/{owner}/{repo}/labels'),
+        addLabels: readOnly('addLabels'),
+        removeLabel: readOnly('removeLabel'),
+        createComment: readOnly('createComment'),
+        updateComment: readOnly('updateComment'),
+      },
+      pulls: { list: endpoint('/repos/{owner}/{repo}/pulls') },
+    },
+  };
+  return github;
+}
+
+const core = {
+  info: (m) => process.stderr.write(`  ${m}\n`),
+  warning: (m) => process.stderr.write(`  WARN ${m}\n`),
+  error: (m) => process.stderr.write(`  ERROR ${m}\n`),
+  setFailed: (m) => process.stderr.write(`  FAILED ${m}\n`),
+};
+
+function table(results) {
+  const rows = results.map((r) => ({
+    pr: `#${r.number}`,
+    state: r.state.replace('review/', ''),
+    now: (r.current.filter((l) => l.startsWith('review/'))[0] || '-').replace('review/', ''),
+    appr: `${r.approvals}/${r.required}`,
+    bots: String(r.botFindingsOpen),
+    comment: r.commentAction,
+  }));
+  const cols = ['pr', 'state', 'now', 'appr', 'bots', 'comment'];
+  const width = {};
+  for (const c of cols) width[c] = Math.max(c.length, ...rows.map((r) => r[c].length));
+  const line = (r) => cols.map((c) => String(r[c]).padEnd(width[c])).join('  ');
+  const out = [line(Object.fromEntries(cols.map((c) => [c, c.toUpperCase()])))];
+  out.push(cols.map((c) => '-'.repeat(width[c])).join('  '));
+  for (const r of rows) out.push(line(r));
+  return out.join('\n');
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write(`${new URL(import.meta.url).pathname}\n`
+      + '  --pr N     evaluate one pull request, repeatable\n'
+      + '  --repo O/R target repository\n'
+      + '  --json     machine readable output\n');
+    return;
+  }
+
+  const [owner, repo] = args.repo.split('/');
+  if (!owner || !repo) throw new Error(`--repo must be owner/name, got ${args.repo}`);
+
+  const github = makeClient(token());
+  const context = { repo: { owner, repo }, eventName: 'workflow_dispatch', payload: {} };
+
+  let numbers = args.prs;
+  if (numbers.length === 0) {
+    const open = await github.paginate(github.rest.pulls.list, {
+      owner, repo, state: 'open', per_page: 100,
+    });
+    numbers = open.map((p) => p.number);
+    core.info(`sweeping ${numbers.length} open pull requests`);
+  }
+
+  const results = await run({ core, github, context, numbers, dryRun: true });
+
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify(results, null, 2)}\n`);
+    return;
+  }
+  process.stdout.write(`\n${table(results)}\n\n`);
+  const counts = results.reduce((acc, r) => {
+    acc[r.state] = (acc[r.state] || 0) + 1;
+    return acc;
+  }, {});
+  for (const [state, n] of Object.entries(counts).sort((a, b) => b[1] - a[1])) {
+    process.stdout.write(`  ${String(n).padStart(3)}  ${state}\n`);
+  }
+  const changes = results.filter((r) => r.labelChange.added || r.labelChange.removed.length);
+  process.stdout.write(`\n  ${changes.length} of ${results.length} would change label\n`);
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error.message}\n`);
+  process.exit(1);
+});

--- a/.github/scripts/review-state-cli.js
+++ b/.github/scripts/review-state-cli.js
@@ -23,11 +23,22 @@ function parseArgs(argv) {
   const args = { repo: 'external-secrets/external-secrets', prs: [], json: false };
   for (let i = 0; i < argv.length; i += 1) {
     const a = argv[i];
-    if (a === '--pr') args.prs.push(Number(argv[++i]));
-    else if (a === '--repo') args.repo = argv[++i];
-    else if (a === '--json') args.json = true;
-    else if (a === '--help' || a === '-h') args.help = true;
-    else throw new Error(`Unknown argument: ${a}`);
+    if (a === '--pr') {
+      const raw = argv[++i];
+      const number = Number(raw);
+      if (!Number.isSafeInteger(number) || number <= 0) {
+        throw new Error(`--pr needs a positive pull request number, got ${JSON.stringify(raw)}`);
+      }
+      args.prs.push(number);
+    } else if (a === '--repo') {
+      args.repo = argv[++i];
+    } else if (a === '--json') {
+      args.json = true;
+    } else if (a === '--help' || a === '-h') {
+      args.help = true;
+    } else {
+      throw new Error(`Unknown argument: ${a}`);
+    }
   }
   return args;
 }
@@ -103,6 +114,7 @@ function makeClient(auth) {
       issues: {
         listComments: endpoint('/repos/{owner}/{repo}/issues/{issue_number}/comments'),
         listLabelsForRepo: endpoint('/repos/{owner}/{repo}/labels'),
+        listLabelsOnIssue: endpoint('/repos/{owner}/{repo}/issues/{issue_number}/labels'),
         addLabels: readOnly('addLabels'),
         removeLabel: readOnly('removeLabel'),
         createComment: readOnly('createComment'),
@@ -150,8 +162,11 @@ async function main() {
     return;
   }
 
-  const [owner, repo] = args.repo.split('/');
-  if (!owner || !repo) throw new Error(`--repo must be owner/name, got ${args.repo}`);
+  const parts = (args.repo || '').split('/');
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    throw new Error(`--repo must be exactly owner/name, got ${JSON.stringify(args.repo)}`);
+  }
+  const [owner, repo] = parts;
 
   const github = makeClient(token());
   const context = { repo: { owner, repo }, eventName: 'workflow_dispatch', payload: {} };

--- a/.github/scripts/review-state-test.js
+++ b/.github/scripts/review-state-test.js
@@ -11,7 +11,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import run, {
   classify, isBot, effectiveVerdicts, gateComment, clearedComment, STATE, ALL_STATES,
-  fetchPullRequest, syncLabels, syncComment,
+  fetchPullRequest, syncLabels, syncComment, deconflictSweep,
 } from './review-state.js';
 
 // run() checks that every state label exists before touching anything.
@@ -799,4 +799,156 @@ test('a single run creating a comment does not delete it again', async () => {
   });
   assert.equal(action, 'created');
   assert.equal(calls.deleteComment.length, 0, 'nothing to dedupe');
+});
+
+// ---------------------------------------------------------------------------
+// End-of-sweep deconfliction. Only the sweep cleans up, and only by
+// withdrawing its own state, which is what makes zero unreachable.
+// ---------------------------------------------------------------------------
+
+test('a sweep withdraws its own state when an event left one too', async () => {
+  const repo = sharedRepo([STATE.CI_RED, STATE.IN_REVIEW, 'size/l']);
+  const core = fakeCore();
+  const out = await deconflictSweep(
+    repo.github, 'o', 'r', [{ number: 1, label: STATE.IN_REVIEW }], core,
+  );
+  assert.deepEqual(repo.reviewLabels(), [STATE.CI_RED], "the event's state stands");
+  assert.deepEqual(out, [{ number: 1, label: STATE.IN_REVIEW, action: 'yielded' }]);
+  assert.ok(repo.state.has('size/l'), 'unrelated labels untouched');
+});
+
+test('a sweep leaves a single state alone', async () => {
+  const repo = sharedRepo([STATE.IN_REVIEW]);
+  const out = await deconflictSweep(
+    repo.github, 'o', 'r', [{ number: 1, label: STATE.IN_REVIEW }], fakeCore(),
+  );
+  assert.deepEqual(repo.reviewLabels(), [STATE.IN_REVIEW]);
+  assert.deepEqual(out, [], 'nothing to deconflict');
+});
+
+test('a sweep does nothing when its own state is already gone', async () => {
+  // An event ran after the sweep's write and replaced its label outright.
+  const repo = sharedRepo([STATE.CI_RED, STATE.READY_TO_MERGE]);
+  const out = await deconflictSweep(
+    repo.github, 'o', 'r', [{ number: 1, label: STATE.IN_REVIEW }], fakeCore(),
+  );
+  assert.equal(repo.reviewLabels().length, 2, 'not ours to resolve, next run converges');
+  assert.deepEqual(out, []);
+});
+
+test('a sweep never leaves a pull request with no state at all', async () => {
+  const repo = sharedRepo([STATE.CI_RED, STATE.IN_REVIEW]);
+  // The other state vanishes between our read and our removal.
+  const realRemove = repo.github.rest.issues.removeLabel;
+  repo.github.rest.issues.removeLabel = async (p) => {
+    repo.state.delete(STATE.CI_RED);
+    return realRemove(p);
+  };
+  const core = fakeCore();
+  const out = await deconflictSweep(
+    repo.github, 'o', 'r', [{ number: 1, label: STATE.IN_REVIEW }], core,
+  );
+  assert.deepEqual(repo.reviewLabels(), [STATE.IN_REVIEW], 'put back rather than left empty');
+  assert.equal(out[0].action, 'restored');
+  assert.match(core.warnings.join(' '), /put it back/);
+});
+
+test('a sweep will not withdraw the maintainer override', async () => {
+  const repo = sharedRepo([STATE.IN_REVIEW, 'review/bots-overridden']);
+  const out = await deconflictSweep(
+    repo.github, 'o', 'r', [{ number: 1, label: STATE.IN_REVIEW }], fakeCore(),
+  );
+  assert.ok(repo.state.has('review/bots-overridden'), 'the override is not derived state');
+  assert.deepEqual(out, [], 'the override does not count as a competing state');
+});
+
+test('the whole race resolves to exactly one state, the event side', async () => {
+  const repo = sharedRepo(['review/needs-review', 'size/l']);
+  // An event run and a sweep run overlap on the same pull request.
+  await Promise.all([
+    syncLabels(repo.github, 'o', 'r', 1, ['review/needs-review'], STATE.CI_RED),
+    syncLabels(repo.github, 'o', 'r', 1, ['review/needs-review'], STATE.IN_REVIEW),
+  ]);
+  assert.equal(repo.reviewLabels().length, 2, 'the race does leave two');
+  // Then the sweep's end-of-cycle pass runs.
+  await deconflictSweep(repo.github, 'o', 'r', [{ number: 1, label: STATE.IN_REVIEW }], fakeCore());
+  assert.deepEqual(repo.reviewLabels(), [STATE.CI_RED], 'one state, the event wins');
+});
+
+test('an event-driven run never deconflicts, which is what keeps zero unreachable', async () => {
+  // A competing state appears only AFTER this run has written its own, which is
+  // the real shape of the race: syncLabels cannot have cleaned it up already.
+  // If an event run deconflicted, it would withdraw its own label here and,
+  // with the other side doing the same, the pull request would end with none.
+  const build = () => {
+    const state = new Set();
+    const calls = { removeLabel: [] };
+    let reads = 0;
+    const listComments = () => {};
+    listComments.__kind = 'comments';
+    const listLabelsForRepo = () => {};
+    listLabelsForRepo.__kind = 'repoLabels';
+    return {
+      state,
+      calls,
+      github: {
+        graphql: async () => graphqlPr(),
+        paginate: async (fn) => (fn.__kind === 'repoLabels'
+          ? ALL_STATES.map((name) => ({ name })) : []),
+        rest: {
+          issues: {
+            listComments,
+            listLabelsForRepo,
+            listLabelsOnIssue: async () => {
+              reads += 1;
+              // Reads 1 and 2 belong to syncLabels; from read 3 on, an
+              // overlapping run has landed its own state.
+              if (reads >= 3) state.add(STATE.CI_RED);
+              return { data: [...state].map((name) => ({ name })) };
+            },
+            addLabels: async (p) => { p.labels.forEach((l) => state.add(l)); },
+            removeLabel: async (p) => { calls.removeLabel.push(p.name); state.delete(p.name); },
+            createComment: async () => ({ data: { id: 1 } }),
+            updateComment: async () => {},
+            deleteComment: async () => {},
+          },
+        },
+      },
+    };
+  };
+
+  const asEvent = build();
+  await run({
+    core: fakeCore(),
+    github: asEvent.github,
+    context: { repo: { owner: 'o', repo: 'r' } },
+    numbers: [42],
+    sweep: false,
+  });
+  assert.ok(
+    asEvent.state.has(STATE.NEEDS_2ND_APPROVAL),
+    'an event run must never withdraw the label it just applied',
+  );
+  assert.ok(
+    !asEvent.calls.removeLabel.includes(STATE.NEEDS_2ND_APPROVAL),
+    'and must not even try',
+  );
+
+  const asSweep = build();
+  await run({
+    core: fakeCore(),
+    github: asSweep.github,
+    context: { repo: { owner: 'o', repo: 'r' } },
+    numbers: [42],
+    sweep: true,
+  });
+  assert.ok(
+    asSweep.calls.removeLabel.includes(STATE.NEEDS_2ND_APPROVAL),
+    'a sweep yields the state it applied when an overlapping run left one',
+  );
+  assert.deepEqual(
+    [...asSweep.state].filter((l) => ALL_STATES.includes(l)),
+    [STATE.CI_RED],
+    'exactly one state survives, the event side',
+  );
 });

--- a/.github/scripts/review-state-test.js
+++ b/.github/scripts/review-state-test.js
@@ -33,6 +33,20 @@ function pr(overrides = {}) {
 }
 
 const review = (author, state, submittedAt) => ({ author, state, submittedAt });
+
+// Captures what the workflow reported, so tests can assert on it.
+function fakeCore() {
+  const warnings = [];
+  const errors = [];
+  return {
+    warnings,
+    errors,
+    info: () => {},
+    warning: (m) => warnings.push(m),
+    error: (m) => errors.push(m),
+    setFailed: (m) => errors.push(m),
+  };
+}
 const botThread = (o = {}) => ({ author: 'coderabbitai', isResolved: false, isOutdated: false, ...o });
 const humanThread = (o = {}) => ({ author: 'someone', isResolved: false, isOutdated: false, ...o });
 
@@ -313,25 +327,50 @@ test('the guidance comment carries a marker and pluralises', () => {
 // ---------------------------------------------------------------------------
 
 function fakeGithub({ graphql, comments = [], removeLabelError, liveLabels } = {}) {
-  const calls = { addLabels: [], removeLabel: [], createComment: [], updateComment: [] };
+  const calls = {
+    addLabels: [], removeLabel: [], createComment: [], updateComment: [], deleteComment: [],
+    labelReads: 0,
+  };
   const listComments = () => {};
   listComments.__kind = 'comments';
+
+  // `liveLabels` as an array of arrays models another run changing labels
+  // mid-flight: each read returns the next entry. As a flat array it seeds a
+  // mutable set, so a removal is actually reflected in the next read the way
+  // the real API would.
+  const scripted = Array.isArray(liveLabels) && Array.isArray(liveLabels[0]);
+  const state = new Set(scripted ? [] : (liveLabels || []));
+
   const github = {
     graphql: async () => graphql,
     paginate: async (fn) => (fn.__kind === 'comments' ? comments : []),
     rest: {
       issues: {
         listComments,
-        // syncLabels re-reads before writing; default to whatever the caller
-        // passed as `current` unless a test overrides the live state.
-        listLabelsOnIssue: async () => ({ data: (liveLabels || []).map((name) => ({ name })) }),
-        addLabels: async (p) => { calls.addLabels.push(p); },
+        listLabelsOnIssue: async () => {
+          const answer = scripted
+            ? (liveLabels[Math.min(calls.labelReads, liveLabels.length - 1)] || [])
+            : [...state];
+          calls.labelReads += 1;
+          return { data: answer.map((name) => ({ name })) };
+        },
+        addLabels: async (p) => { calls.addLabels.push(p); p.labels.forEach((l) => state.add(l)); },
         removeLabel: async (p) => {
           calls.removeLabel.push(p);
           if (removeLabelError) throw removeLabelError;
+          state.delete(p.name);
         },
-        createComment: async (p) => { calls.createComment.push(p); },
+        createComment: async (p) => {
+          calls.createComment.push(p);
+          // Derived from the shared comment list, not a per-client counter, so
+          // two clients writing to one pull request get distinct ids the way
+          // the real API guarantees.
+          const created = { id: 1001 + comments.length, body: p.body, user: { type: 'Bot' } };
+          comments.push(created);
+          return { data: created };
+        },
         updateComment: async (p) => { calls.updateComment.push(p); },
+        deleteComment: async (p) => { calls.deleteComment.push(p); },
       },
     },
   };
@@ -418,16 +457,15 @@ test('fetchPullRequest treats a missing check rollup as no CI rather than failur
 });
 
 test('fetchPullRequest reports both connections when both are truncated', async () => {
-  const warnings = [];
-  const core = { warning: (m) => warnings.push(m) };
+  const core = fakeCore();
   const g = graphqlPr();
   g.repository.pullRequest.reviews.pageInfo.hasNextPage = true;
   g.repository.pullRequest.reviewThreads.pageInfo.hasPreviousPage = true;
   const { github } = fakeGithub({ graphql: g });
   const p = await fetchPullRequest(github, 'o', 'r', 42, core);
   assert.deepEqual(p.truncated, ['reviews', 'reviewThreads']);
-  assert.equal(warnings.length, 1);
-  assert.match(warnings[0], /reviews and reviewThreads/);
+  assert.equal(core.warnings.length, 1);
+  assert.match(core.warnings[0], /reviews and reviewThreads/);
 });
 
 test('syncLabels adds the desired label and strips only stale review states', async () => {
@@ -463,7 +501,7 @@ test('syncLabels tolerates a 404 but rethrows a permissions failure', async () =
 });
 
 test('syncLabels writes nothing in a dry run but still reports the change', async () => {
-  const { github, calls } = fakeGithub();
+  const { github, calls } = fakeGithub({ liveLabels: ['review/needs-review', 'size/l'] });
   const res = await syncLabels(
     github, 'o', 'r', 1, ['review/needs-review'], STATE.IN_REVIEW, { dryRun: true },
   );
@@ -471,6 +509,17 @@ test('syncLabels writes nothing in a dry run but still reports the change', asyn
   assert.equal(res.applied, false);
   assert.equal(res.added, STATE.IN_REVIEW);
   assert.deepEqual(res.removed, ['review/needs-review']);
+});
+
+test('a dry run reports from a live read, not the classification snapshot', async () => {
+  // The snapshot says needs-review, but the pull request has moved on since.
+  const { github, calls } = fakeGithub({ liveLabels: ['review/draft'] });
+  const res = await syncLabels(
+    github, 'o', 'r', 1, ['review/needs-review'], STATE.IN_REVIEW, { dryRun: true },
+  );
+  assert.deepEqual(res.removed, ['review/draft'], 'reports what is actually on the pull request');
+  assert.equal(calls.labelReads, 1, 'it reads');
+  assert.equal(calls.removeLabel.length + calls.addLabels.length, 0, 'but never writes');
 });
 
 test('syncComment stays silent on a clean pull request', async () => {
@@ -537,14 +586,13 @@ test('syncComment writes nothing in a dry run', async () => {
 // ---------------------------------------------------------------------------
 
 test('truncated data is flagged so the caller can refuse to write', async () => {
-  const warnings = [];
-  const core = { warning: (m) => warnings.push(m) };
+  const core = fakeCore();
   const g = graphqlPr();
   g.repository.pullRequest.reviewThreads.pageInfo.hasPreviousPage = true;
   const { github } = fakeGithub({ graphql: g });
   const p = await fetchPullRequest(github, 'o', 'r', 42, core);
   assert.deepEqual(p.truncated, ['reviewThreads']);
-  assert.match(warnings[0], /skipping rather than/);
+  assert.match(core.warnings[0], /skipping rather than/);
 });
 
 test('complete data carries no truncation flag', async () => {
@@ -584,7 +632,6 @@ test('the gate comment tells contributors to resolve, not merely reply', () => {
 
 test('run() refuses to write a label when the data is truncated', async () => {
   const calls = { addLabels: [], removeLabel: [], createComment: [], updateComment: [] };
-  const warnings = [];
   const listComments = () => {};
   listComments.__kind = 'comments';
   const listLabelsForRepo = () => {};
@@ -610,9 +657,7 @@ test('run() refuses to write a label when the data is truncated', async () => {
       },
     },
   };
-  const core = {
-    info: () => {}, warning: (m) => warnings.push(m), error: () => {}, setFailed: () => {},
-  };
+  const core = fakeCore();
 
   const results = await run({
     core, github, context: { repo: { owner: 'o', repo: 'r' } }, numbers: [42],
@@ -622,7 +667,7 @@ test('run() refuses to write a label when the data is truncated', async () => {
   assert.equal(calls.addLabels.length, 0, 'no label written');
   assert.equal(calls.removeLabel.length, 0, 'no label removed');
   assert.equal(calls.createComment.length, 0, 'no comment written');
-  assert.match(warnings.join(' '), /truncated data/);
+  assert.match(core.warnings.join(' '), /truncated data/);
 });
 
 test('run() does write when the data is complete', async () => {
@@ -648,10 +693,110 @@ test('run() does write when the data is complete', async () => {
       },
     },
   };
-  const core = { info: () => {}, warning: () => {}, error: () => {}, setFailed: () => {} };
+  const core = fakeCore();
   const results = await run({
     core, github, context: { repo: { owner: 'o', repo: 'r' } }, numbers: [42],
   });
   assert.equal(results.length, 1, 'the control case still produces a result');
   assert.deepEqual(calls.addLabels[0].labels, [STATE.NEEDS_2ND_APPROVAL]);
+});
+
+// A shared mutable label store driven by two concurrent syncLabels calls. The
+// earlier canned-sequence tests could not catch the zero-label bug, because
+// only one side of the race actually ran.
+function sharedRepo(initial) {
+  const state = new Set(initial);
+  const github = {
+    rest: {
+      issues: {
+        listLabelsOnIssue: async () => ({ data: [...state].map((name) => ({ name })) }),
+        addLabels: async (p) => { p.labels.forEach((l) => state.add(l)); },
+        removeLabel: async (p) => {
+          if (!state.has(p.name)) {
+            throw Object.assign(new Error('not found'), { status: 404 });
+          }
+          state.delete(p.name);
+        },
+      },
+    },
+  };
+  return { github, state, reviewLabels: () => [...state].filter((l) => l.startsWith('review/')) };
+}
+
+test('two concurrent runs never strip a pull request of every review label', async () => {
+  const repo = sharedRepo(['review/needs-review', 'size/l']);
+  await Promise.all([
+    syncLabels(repo.github, 'o', 'r', 1, ['review/needs-review'], STATE.CI_RED),
+    syncLabels(repo.github, 'o', 'r', 1, ['review/needs-review'], STATE.IN_REVIEW),
+  ]);
+  const surviving = repo.reviewLabels();
+  assert.notEqual(
+    surviving.length, 0,
+    'zero labels would silently drop the pull request out of the queue',
+  );
+  assert.ok(repo.state.has('size/l'), 'unrelated labels are untouched');
+});
+
+test('a two-label race converges on the next run', async () => {
+  const repo = sharedRepo(['review/needs-review', 'size/l']);
+  await Promise.all([
+    syncLabels(repo.github, 'o', 'r', 1, ['review/needs-review'], STATE.CI_RED),
+    syncLabels(repo.github, 'o', 'r', 1, ['review/needs-review'], STATE.IN_REVIEW),
+  ]);
+  await syncLabels(repo.github, 'o', 'r', 1, repo.reviewLabels(), STATE.CI_RED);
+  assert.deepEqual(repo.reviewLabels(), [STATE.CI_RED]);
+});
+
+test('the verification pass restores a label a concurrent run deleted', async () => {
+  const repo = sharedRepo([STATE.IN_REVIEW]);
+  // Between our add and our verification read, something removes our label.
+  const realRead = repo.github.rest.issues.listLabelsOnIssue;
+  let reads = 0;
+  repo.github.rest.issues.listLabelsOnIssue = async () => {
+    reads += 1;
+    if (reads === 2) repo.state.delete(STATE.CI_RED);
+    return realRead();
+  };
+  const res = await syncLabels(repo.github, 'o', 'r', 1, [STATE.IN_REVIEW], STATE.CI_RED);
+  assert.equal(res.restored, true, 'the deletion is noticed and undone');
+  assert.ok(repo.state.has(STATE.CI_RED));
+});
+
+test('a sequential run still lands exactly one label', async () => {
+  const repo = sharedRepo(['review/needs-review', 'review/draft', 'size/l']);
+  await syncLabels(repo.github, 'o', 'r', 1, ['review/needs-review'], STATE.READY_TO_MERGE);
+  assert.deepEqual(repo.reviewLabels(), [STATE.READY_TO_MERGE]);
+  assert.ok(repo.state.has('size/l'));
+});
+
+test('two concurrent runs do not leave two guidance comments', async () => {
+  // Both runs see no marker comment, so both create one. The later creator
+  // must clean up after itself rather than orphaning a duplicate.
+  const shared = [];
+  const make = () => fakeGithub({ comments: shared });
+  const a = make();
+  const b = make();
+  const gate = { state: STATE.BOT_FINDINGS_OPEN, botFindingsOpen: 2 };
+  const [ra, rb] = await Promise.all([
+    syncComment(a.github, 'o', 'r', 1, gate),
+    syncComment(b.github, 'o', 'r', 1, gate),
+  ]);
+
+  const markers = shared.filter((c) => c.body.includes('<!-- eso-review-routing -->'));
+  const deleted = [...a.calls.deleteComment, ...b.calls.deleteComment].map((c) => c.comment_id);
+  const surviving = markers.filter((c) => !deleted.includes(c.id));
+  assert.equal(surviving.length, 1, 'exactly one guidance comment survives');
+  assert.ok(
+    [ra, rb].includes('created-then-deduped'),
+    'the loser reports that it cleaned up',
+  );
+});
+
+test('a single run creating a comment does not delete it again', async () => {
+  const { github, calls } = fakeGithub({ comments: [] });
+  const action = await syncComment(github, 'o', 'r', 1, {
+    state: STATE.BOT_FINDINGS_OPEN, botFindingsOpen: 1,
+  });
+  assert.equal(action, 'created');
+  assert.equal(calls.deleteComment.length, 0, 'nothing to dedupe');
 });

--- a/.github/scripts/review-state-test.js
+++ b/.github/scripts/review-state-test.js
@@ -1,0 +1,525 @@
+/**
+ * Tests for review-state.js.
+ *
+ * Imports the real functions rather than duplicating them, so the ordered
+ * evaluation cannot drift away from what the workflow actually runs.
+ *
+ * Run with: node .github/scripts/review-state-test.js
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  classify, isBot, effectiveVerdicts, gateComment, clearedComment, STATE,
+  fetchPullRequest, syncLabels, syncComment,
+} from './review-state.js';
+
+function pr(overrides = {}) {
+  return {
+    number: 1,
+    isDraft: false,
+    reviewDecision: null,
+    author: 'contributor',
+    labels: [],
+    assignees: [],
+    reviews: [],
+    threads: [],
+    ciState: 'SUCCESS',
+    ...overrides,
+  };
+}
+
+const review = (author, state, submittedAt) => ({ author, state, submittedAt });
+const botThread = (o = {}) => ({ author: 'coderabbitai', isResolved: false, isOutdated: false, ...o });
+const humanThread = (o = {}) => ({ author: 'someone', isResolved: false, isOutdated: false, ...o });
+
+// ---------------------------------------------------------------------------
+// Effective verdicts. This is the fix for latestReviews losing a verdict as
+// soon as its author comments again, so it gets the most attention.
+// ---------------------------------------------------------------------------
+
+test('a comment after requesting changes does not erase the request', () => {
+  const v = effectiveVerdicts([
+    review('Skarlso', 'CHANGES_REQUESTED', '2026-07-09T10:00:00Z'),
+    review('Skarlso', 'COMMENTED', '2026-07-09T11:00:00Z'),
+  ]);
+  assert.equal(v.get('Skarlso'), 'CHANGES_REQUESTED');
+});
+
+test('a comment after approving does not erase the approval', () => {
+  const v = effectiveVerdicts([
+    review('Skarlso', 'APPROVED', '2026-07-09T10:00:00Z'),
+    review('Skarlso', 'COMMENTED', '2026-07-09T11:00:00Z'),
+  ]);
+  assert.equal(v.get('Skarlso'), 'APPROVED');
+});
+
+test('a later verdict does replace an earlier one', () => {
+  const v = effectiveVerdicts([
+    review('Skarlso', 'CHANGES_REQUESTED', '2026-07-09T10:00:00Z'),
+    review('Skarlso', 'APPROVED', '2026-07-10T10:00:00Z'),
+  ]);
+  assert.equal(v.get('Skarlso'), 'APPROVED');
+});
+
+test('a dismissed approval stops counting', () => {
+  const v = effectiveVerdicts([
+    review('Skarlso', 'APPROVED', '2026-07-09T10:00:00Z'),
+    review('Skarlso', 'DISMISSED', '2026-07-10T10:00:00Z'),
+  ]);
+  assert.equal(v.get('Skarlso'), 'DISMISSED');
+});
+
+test('verdicts are ordered by submission time, not array order', () => {
+  const v = effectiveVerdicts([
+    review('Skarlso', 'APPROVED', '2026-07-10T10:00:00Z'),
+    review('Skarlso', 'CHANGES_REQUESTED', '2026-07-09T10:00:00Z'),
+  ]);
+  assert.equal(v.get('Skarlso'), 'APPROVED', 'the later timestamp wins');
+});
+
+test('bots and the pull request author are excluded from verdicts', () => {
+  const v = effectiveVerdicts([
+    review('coderabbitai', 'APPROVED', '2026-07-09T10:00:00Z'),
+    review('contributor', 'APPROVED', '2026-07-09T11:00:00Z'),
+    review('Skarlso', 'APPROVED', '2026-07-09T12:00:00Z'),
+  ], { excludeAuthor: 'contributor' });
+  assert.deepEqual([...v.keys()], ['Skarlso']);
+});
+
+// ---------------------------------------------------------------------------
+// The real PR that exposed the bug: external-secrets#6613. reviewDecision is
+// CHANGES_REQUESTED, but the reviewer commented after requesting changes.
+// ---------------------------------------------------------------------------
+
+test('regression, external-secrets#6613 routes to changes-requested', () => {
+  const p = pr({
+    number: 6613,
+    reviewDecision: 'CHANGES_REQUESTED',
+    author: 'someone-else',
+    reviews: [
+      review('evrardj-roche', 'CHANGES_REQUESTED', '2026-07-09T08:00:00Z'),
+      review('evrardj-roche', 'COMMENTED', '2026-07-09T09:00:00Z'),
+      review('Skarlso', 'COMMENTED', '2026-07-09T10:00:00Z'),
+      review('coderabbitai', 'COMMENTED', '2026-07-09T11:00:00Z'),
+    ],
+    threads: [botThread(), botThread()],
+  });
+  assert.equal(classify(p).state, STATE.CHANGES_REQUESTED);
+});
+
+test('reviewDecision alone is enough, even without a matching review row', () => {
+  const p = pr({ reviewDecision: 'CHANGES_REQUESTED', reviews: [] });
+  assert.equal(classify(p).state, STATE.CHANGES_REQUESTED);
+});
+
+test('per-author verdicts alone are enough when reviewDecision is null', () => {
+  const p = pr({
+    reviewDecision: null,
+    reviews: [review('Skarlso', 'CHANGES_REQUESTED', '2026-07-09T10:00:00Z')],
+  });
+  assert.equal(classify(p).state, STATE.CHANGES_REQUESTED);
+});
+
+// ---------------------------------------------------------------------------
+// Bots
+// ---------------------------------------------------------------------------
+
+test('bot detection covers plain and [bot] suffixed logins', () => {
+  assert.equal(isBot('coderabbitai'), true);
+  assert.equal(isBot('coderabbitai[bot]'), true);
+  assert.equal(isBot('some-new-bot[bot]'), true, 'unknown [bot] accounts still count as bots');
+  assert.equal(isBot('Skarlso'), false);
+  assert.equal(isBot(null), false);
+});
+
+test('a bot approval never satisfies the threshold', () => {
+  const p = pr({ reviews: [review('coderabbitai', 'APPROVED', '2026-07-09T10:00:00Z')] });
+  const r = classify(p);
+  assert.equal(r.approvals, 0);
+  assert.notEqual(r.state, STATE.READY_TO_MERGE);
+});
+
+test('a bot changes-requested review does not park the pull request with the author', () => {
+  const p = pr({ reviews: [review('github-advanced-security', 'CHANGES_REQUESTED', '2026-07-09T10:00:00Z')] });
+  assert.notEqual(classify(p).state, STATE.CHANGES_REQUESTED);
+});
+
+// ---------------------------------------------------------------------------
+// The bot gate
+// ---------------------------------------------------------------------------
+
+test('a fresh pull request with nothing on it needs review', () => {
+  assert.equal(classify(pr()).state, STATE.NEEDS_REVIEW);
+});
+
+test('unresolved bot findings gate before a human is involved', () => {
+  const r = classify(pr({ threads: [botThread(), botThread()] }));
+  assert.equal(r.state, STATE.BOT_FINDINGS_OPEN);
+  assert.equal(r.botFindingsOpen, 2);
+});
+
+test('resolved bot threads do not gate', () => {
+  assert.equal(classify(pr({ threads: [botThread({ isResolved: true })] })).state, STATE.NEEDS_REVIEW);
+});
+
+test('outdated bot threads do not gate, because the author already pushed over them', () => {
+  assert.equal(classify(pr({ threads: [botThread({ isOutdated: true })] })).state, STATE.NEEDS_REVIEW);
+});
+
+test('human threads never gate', () => {
+  assert.equal(classify(pr({ threads: [humanThread()] })).state, STATE.NEEDS_REVIEW);
+});
+
+test('the override label pushes a pull request past the gate', () => {
+  const p = pr({ threads: [botThread()], labels: ['review/bots-overridden'] });
+  assert.equal(classify(p).state, STATE.NEEDS_REVIEW);
+});
+
+test('the gate sits below in-review, so a reviewer is never interrupted', () => {
+  const p = pr({ threads: [botThread()], reviews: [review('Skarlso', 'COMMENTED', '2026-07-09T10:00:00Z')] });
+  assert.equal(classify(p).state, STATE.IN_REVIEW);
+});
+
+// ---------------------------------------------------------------------------
+// Engagement, including the author exclusion
+// ---------------------------------------------------------------------------
+
+test('an assignee alone counts as a claim', () => {
+  assert.equal(classify(pr({ assignees: ['moolen'] })).state, STATE.IN_REVIEW);
+});
+
+test('the author commenting on their own diff does not count as engagement', () => {
+  const p = pr({
+    author: 'contributor',
+    threads: [botThread()],
+    reviews: [review('contributor', 'COMMENTED', '2026-07-09T10:00:00Z')],
+  });
+  assert.equal(classify(p).state, STATE.BOT_FINDINGS_OPEN, 'the author cannot clear their own gate');
+});
+
+test('someone else commenting does count as engagement', () => {
+  const p = pr({
+    author: 'contributor',
+    threads: [botThread()],
+    reviews: [review('Skarlso', 'COMMENTED', '2026-07-09T10:00:00Z')],
+  });
+  assert.equal(classify(p).state, STATE.IN_REVIEW);
+});
+
+// ---------------------------------------------------------------------------
+// Approval thresholds. Each asserts `required` explicitly, so removing a size
+// label from LARGE_LABELS fails a test rather than passing silently.
+// ---------------------------------------------------------------------------
+
+test('one human approval merges a small change', () => {
+  const p = pr({ reviews: [review('Skarlso', 'APPROVED', '2026-07-09T10:00:00Z')], labels: ['size/s'] });
+  const r = classify(p);
+  assert.equal(r.required, 1);
+  assert.equal(r.state, STATE.READY_TO_MERGE);
+});
+
+test('size/l needs a second approval', () => {
+  const p = pr({ reviews: [review('Skarlso', 'APPROVED', '2026-07-09T10:00:00Z')], labels: ['size/l'] });
+  const r = classify(p);
+  assert.equal(r.required, 2);
+  assert.equal(r.state, STATE.NEEDS_2ND_APPROVAL);
+});
+
+test('size/xl needs a second approval too', () => {
+  const p = pr({ reviews: [review('Skarlso', 'APPROVED', '2026-07-09T10:00:00Z')], labels: ['size/xl'] });
+  const r = classify(p);
+  assert.equal(r.required, 2, 'size/xl must be in LARGE_LABELS');
+  assert.equal(r.state, STATE.NEEDS_2ND_APPROVAL);
+});
+
+test('two human approvals clear a large change', () => {
+  const p = pr({
+    labels: ['size/xl'],
+    reviews: [
+      review('Skarlso', 'APPROVED', '2026-07-09T10:00:00Z'),
+      review('gusfcarvalho', 'APPROVED', '2026-07-09T11:00:00Z'),
+    ],
+  });
+  const r = classify(p);
+  assert.equal(r.required, 2);
+  assert.equal(r.approvals, 2);
+  assert.equal(r.state, STATE.READY_TO_MERGE);
+});
+
+test('the same person approving twice is still one approval', () => {
+  const p = pr({
+    labels: ['size/l'],
+    reviews: [
+      review('Skarlso', 'APPROVED', '2026-07-09T10:00:00Z'),
+      review('Skarlso', 'APPROVED', '2026-07-10T10:00:00Z'),
+    ],
+  });
+  assert.equal(classify(p).approvals, 1);
+});
+
+// ---------------------------------------------------------------------------
+// Precedence and CI
+// ---------------------------------------------------------------------------
+
+test('draft outranks everything, including failing CI and open findings', () => {
+  const p = pr({
+    isDraft: true,
+    ciState: 'FAILURE',
+    threads: [botThread()],
+    reviewDecision: 'CHANGES_REQUESTED',
+  });
+  assert.equal(classify(p).state, STATE.DRAFT);
+});
+
+test('changes requested outranks failing CI', () => {
+  const p = pr({ ciState: 'FAILURE', reviewDecision: 'CHANGES_REQUESTED' });
+  assert.equal(classify(p).state, STATE.CHANGES_REQUESTED);
+});
+
+test('failing CI outranks an approval', () => {
+  const p = pr({ ciState: 'FAILURE', reviews: [review('Skarlso', 'APPROVED', '2026-07-09T10:00:00Z')] });
+  assert.equal(classify(p).state, STATE.CI_RED);
+});
+
+test('a crashed check reports ERROR and still counts as red', () => {
+  const p = pr({ ciState: 'ERROR', reviews: [review('Skarlso', 'APPROVED', '2026-07-09T10:00:00Z')] });
+  assert.equal(classify(p).state, STATE.CI_RED, 'ERROR must not fall through to ready-to-merge');
+});
+
+test('pending, expected and absent CI are not treated as failing', () => {
+  for (const ciState of ['PENDING', 'EXPECTED', null]) {
+    assert.equal(classify(pr({ ciState })).state, STATE.NEEDS_REVIEW, `ciState=${ciState}`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Comments
+// ---------------------------------------------------------------------------
+
+test('the guidance comment carries a marker and pluralises', () => {
+  assert.match(gateComment(1), /<!-- eso-review-routing -->/);
+  assert.match(gateComment(1), /\*\*1 open item\*\*/);
+  assert.match(gateComment(3), /\*\*3 open items\*\*/);
+  assert.match(clearedComment(STATE.NEEDS_REVIEW), /<!-- eso-review-routing -->/);
+  assert.match(clearedComment(STATE.NEEDS_REVIEW), /human review queue/);
+});
+
+// ---------------------------------------------------------------------------
+// Data plumbing and write paths, against a fake Octokit.
+// ---------------------------------------------------------------------------
+
+function fakeGithub({ graphql, comments = [], removeLabelError } = {}) {
+  const calls = { addLabels: [], removeLabel: [], createComment: [], updateComment: [] };
+  const listComments = () => {};
+  listComments.__kind = 'comments';
+  const github = {
+    graphql: async () => graphql,
+    paginate: async (fn) => (fn.__kind === 'comments' ? comments : []),
+    rest: {
+      issues: {
+        listComments,
+        addLabels: async (p) => { calls.addLabels.push(p); },
+        removeLabel: async (p) => {
+          calls.removeLabel.push(p);
+          if (removeLabelError) throw removeLabelError;
+        },
+        createComment: async (p) => { calls.createComment.push(p); },
+        updateComment: async (p) => { calls.updateComment.push(p); },
+      },
+    },
+  };
+  return { github, calls };
+}
+
+const graphqlPr = (overrides = {}) => ({
+  repository: {
+    pullRequest: {
+      number: 42,
+      isDraft: false,
+      reviewDecision: 'REVIEW_REQUIRED',
+      author: { login: 'contributor' },
+      labels: { nodes: [{ name: 'size/l' }] },
+      assignees: { nodes: [{ login: 'moolen' }] },
+      reviews: {
+        totalCount: 1,
+        pageInfo: { hasNextPage: false },
+        nodes: [{ author: { login: 'Skarlso' }, state: 'APPROVED', submittedAt: '2026-07-09T10:00:00Z' }],
+      },
+      reviewThreads: {
+        totalCount: 1,
+        pageInfo: { hasPreviousPage: false },
+        nodes: [{ isResolved: false, isOutdated: false, comments: { nodes: [{ author: { login: 'coderabbitai' } }] } }],
+      },
+      commits: { nodes: [{ commit: { statusCheckRollup: { state: 'SUCCESS' } } }] },
+      ...overrides,
+    },
+  },
+});
+
+test('fetchPullRequest maps a full response onto the classifier shape', async () => {
+  const { github } = fakeGithub({ graphql: graphqlPr() });
+  const p = await fetchPullRequest(github, 'o', 'r', 42);
+  assert.deepEqual(p, {
+    number: 42,
+    isDraft: false,
+    reviewDecision: 'REVIEW_REQUIRED',
+    author: 'contributor',
+    labels: ['size/l'],
+    assignees: ['moolen'],
+    reviews: [{ author: 'Skarlso', state: 'APPROVED', submittedAt: '2026-07-09T10:00:00Z' }],
+    threads: [{ author: 'coderabbitai', isResolved: false, isOutdated: false }],
+    ciState: 'SUCCESS',
+  });
+  assert.equal(classify(p).state, STATE.NEEDS_2ND_APPROVAL);
+});
+
+test('fetchPullRequest returns null when the pull request is missing', async () => {
+  const { github } = fakeGithub({ graphql: { repository: { pullRequest: null } } });
+  assert.equal(await fetchPullRequest(github, 'o', 'r', 999), null);
+});
+
+test('fetchPullRequest survives a thread with no comments', async () => {
+  const g = graphqlPr();
+  g.repository.pullRequest.reviewThreads.nodes = [
+    { isResolved: false, isOutdated: false, comments: { nodes: [] } },
+  ];
+  const { github } = fakeGithub({ graphql: g });
+  const p = await fetchPullRequest(github, 'o', 'r', 42);
+  assert.equal(p.threads[0].author, null);
+  assert.equal(classify(p).botFindingsOpen, 0, 'an authorless thread cannot gate');
+});
+
+test('fetchPullRequest survives deleted users and a missing author', async () => {
+  const g = graphqlPr();
+  g.repository.pullRequest.author = null;
+  g.repository.pullRequest.reviews.nodes = [{ author: null, state: 'APPROVED', submittedAt: 'x' }];
+  const { github } = fakeGithub({ graphql: g });
+  const p = await fetchPullRequest(github, 'o', 'r', 42);
+  assert.equal(p.author, null);
+  assert.equal(p.reviews[0].author, null);
+  assert.equal(classify(p).approvals, 0, 'an authorless review cannot be attributed');
+});
+
+test('fetchPullRequest treats a missing check rollup as no CI rather than failure', async () => {
+  const g = graphqlPr();
+  g.repository.pullRequest.commits.nodes = [{ commit: {} }];
+  const { github } = fakeGithub({ graphql: g });
+  const p = await fetchPullRequest(github, 'o', 'r', 42);
+  assert.equal(p.ciState, null);
+  assert.notEqual(classify(p).state, STATE.CI_RED);
+});
+
+test('fetchPullRequest warns when reviews or threads are truncated', async () => {
+  const warnings = [];
+  const core = { warning: (m) => warnings.push(m) };
+  const g = graphqlPr();
+  g.repository.pullRequest.reviews.pageInfo.hasNextPage = true;
+  g.repository.pullRequest.reviewThreads.pageInfo.hasPreviousPage = true;
+  const { github } = fakeGithub({ graphql: g });
+  await fetchPullRequest(github, 'o', 'r', 42, core);
+  assert.equal(warnings.length, 2);
+  assert.match(warnings[0], /more than 100 reviews/);
+  assert.match(warnings[1], /more than 100 review threads/);
+});
+
+test('syncLabels adds the desired label and strips only stale review states', async () => {
+  const { github, calls } = fakeGithub();
+  const res = await syncLabels(github, 'o', 'r', 1, ['review/needs-review', 'size/l'], STATE.IN_REVIEW);
+  assert.deepEqual(calls.removeLabel.map((c) => c.name), ['review/needs-review']);
+  assert.deepEqual(calls.addLabels[0].labels, [STATE.IN_REVIEW]);
+  assert.equal(res.applied, true);
+});
+
+test('syncLabels is a no-op when the label is already correct', async () => {
+  const { github, calls } = fakeGithub();
+  await syncLabels(github, 'o', 'r', 1, [STATE.IN_REVIEW, 'size/s'], STATE.IN_REVIEW);
+  assert.equal(calls.removeLabel.length + calls.addLabels.length, 0);
+});
+
+test('syncLabels never touches the override label', async () => {
+  const { github, calls } = fakeGithub();
+  await syncLabels(github, 'o', 'r', 1, ['review/bots-overridden'], STATE.NEEDS_REVIEW);
+  assert.equal(calls.removeLabel.length, 0, 'the override is a human decision, not derived state');
+});
+
+test('syncLabels tolerates a 404 but rethrows a permissions failure', async () => {
+  const gone = Object.assign(new Error('Label does not exist'), { status: 404 });
+  await syncLabels(fakeGithub({ removeLabelError: gone }).github, 'o', 'r', 1, ['review/needs-review'], STATE.IN_REVIEW);
+
+  const denied = Object.assign(new Error('Resource not accessible by integration'), { status: 403 });
+  await assert.rejects(
+    () => syncLabels(fakeGithub({ removeLabelError: denied }).github, 'o', 'r', 1, ['review/needs-review'], STATE.IN_REVIEW),
+    /not accessible/,
+  );
+});
+
+test('syncLabels writes nothing in a dry run but still reports the change', async () => {
+  const { github, calls } = fakeGithub();
+  const res = await syncLabels(
+    github, 'o', 'r', 1, ['review/needs-review'], STATE.IN_REVIEW, { dryRun: true },
+  );
+  assert.equal(calls.removeLabel.length + calls.addLabels.length, 0, 'dry run must not write');
+  assert.equal(res.applied, false);
+  assert.equal(res.added, STATE.IN_REVIEW);
+  assert.deepEqual(res.removed, ['review/needs-review']);
+});
+
+test('syncComment stays silent on a clean pull request', async () => {
+  const { github, calls } = fakeGithub({ comments: [] });
+  const action = await syncComment(github, 'o', 'r', 1, { state: STATE.NEEDS_REVIEW, botFindingsOpen: 0 });
+  assert.equal(action, 'none');
+  assert.equal(calls.createComment.length, 0, 'never introduce itself unprompted');
+});
+
+test('syncComment posts once when the gate first closes', async () => {
+  const { github, calls } = fakeGithub({ comments: [] });
+  const action = await syncComment(github, 'o', 'r', 1, { state: STATE.BOT_FINDINGS_OPEN, botFindingsOpen: 3 });
+  assert.equal(action, 'created');
+  assert.match(calls.createComment[0].body, /3 open items/);
+});
+
+test('syncComment edits its own comment rather than posting a second', async () => {
+  const { github, calls } = fakeGithub({ comments: [{ id: 7, body: gateComment(3) }] });
+  const action = await syncComment(github, 'o', 'r', 1, { state: STATE.BOT_FINDINGS_OPEN, botFindingsOpen: 1 });
+  assert.equal(action, 'updated');
+  assert.equal(calls.createComment.length, 0);
+  assert.equal(calls.updateComment[0].comment_id, 7);
+});
+
+test('syncComment rewrites to the cleared text once the gate opens', async () => {
+  const { github, calls } = fakeGithub({ comments: [{ id: 7, body: gateComment(2) }] });
+  const action = await syncComment(github, 'o', 'r', 1, { state: STATE.NEEDS_REVIEW, botFindingsOpen: 0 });
+  assert.equal(action, 'updated');
+  assert.match(calls.updateComment[0].body, /human review queue/);
+});
+
+test('syncComment does not rewrite an identical body', async () => {
+  const { github, calls } = fakeGithub({ comments: [{ id: 7, body: gateComment(2) }] });
+  const action = await syncComment(github, 'o', 'r', 1, { state: STATE.BOT_FINDINGS_OPEN, botFindingsOpen: 2 });
+  assert.equal(action, 'unchanged');
+  assert.equal(calls.updateComment.length, 0, 'no needless notification');
+});
+
+test('syncComment ignores comments from other authors', async () => {
+  const { github, calls } = fakeGithub({ comments: [{ id: 1, body: 'unrelated' }, { id: 2, body: null }] });
+  const action = await syncComment(github, 'o', 'r', 1, { state: STATE.BOT_FINDINGS_OPEN, botFindingsOpen: 1 });
+  assert.equal(action, 'created');
+  assert.equal(calls.updateComment.length, 0);
+});
+
+test('syncComment writes nothing in a dry run', async () => {
+  const clean = fakeGithub({ comments: [] });
+  assert.equal(
+    await syncComment(clean.github, 'o', 'r', 1, { state: STATE.BOT_FINDINGS_OPEN, botFindingsOpen: 1 }, { dryRun: true }),
+    'would-create',
+  );
+  assert.equal(clean.calls.createComment.length, 0, 'dry run must not write');
+
+  const existing = fakeGithub({ comments: [{ id: 7, body: gateComment(9) }] });
+  assert.equal(
+    await syncComment(existing.github, 'o', 'r', 1, { state: STATE.BOT_FINDINGS_OPEN, botFindingsOpen: 1 }, { dryRun: true }),
+    'would-update',
+  );
+  assert.equal(existing.calls.updateComment.length, 0, 'dry run must not write');
+});

--- a/.github/scripts/review-state-test.js
+++ b/.github/scripts/review-state-test.js
@@ -9,10 +9,13 @@
 
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import {
-  classify, isBot, effectiveVerdicts, gateComment, clearedComment, STATE,
+import run, {
+  classify, isBot, effectiveVerdicts, gateComment, clearedComment, STATE, ALL_STATES,
   fetchPullRequest, syncLabels, syncComment,
 } from './review-state.js';
+
+// run() checks that every state label exists before touching anything.
+const ALL_STATES_FOR_TEST = ALL_STATES;
 
 function pr(overrides = {}) {
   return {
@@ -309,7 +312,7 @@ test('the guidance comment carries a marker and pluralises', () => {
 // Data plumbing and write paths, against a fake Octokit.
 // ---------------------------------------------------------------------------
 
-function fakeGithub({ graphql, comments = [], removeLabelError } = {}) {
+function fakeGithub({ graphql, comments = [], removeLabelError, liveLabels } = {}) {
   const calls = { addLabels: [], removeLabel: [], createComment: [], updateComment: [] };
   const listComments = () => {};
   listComments.__kind = 'comments';
@@ -319,6 +322,9 @@ function fakeGithub({ graphql, comments = [], removeLabelError } = {}) {
     rest: {
       issues: {
         listComments,
+        // syncLabels re-reads before writing; default to whatever the caller
+        // passed as `current` unless a test overrides the live state.
+        listLabelsOnIssue: async () => ({ data: (liveLabels || []).map((name) => ({ name })) }),
         addLabels: async (p) => { calls.addLabels.push(p); },
         removeLabel: async (p) => {
           calls.removeLabel.push(p);
@@ -361,6 +367,7 @@ test('fetchPullRequest maps a full response onto the classifier shape', async ()
   const { github } = fakeGithub({ graphql: graphqlPr() });
   const p = await fetchPullRequest(github, 'o', 'r', 42);
   assert.deepEqual(p, {
+    truncated: null,
     number: 42,
     isDraft: false,
     reviewDecision: 'REVIEW_REQUIRED',
@@ -410,21 +417,21 @@ test('fetchPullRequest treats a missing check rollup as no CI rather than failur
   assert.notEqual(classify(p).state, STATE.CI_RED);
 });
 
-test('fetchPullRequest warns when reviews or threads are truncated', async () => {
+test('fetchPullRequest reports both connections when both are truncated', async () => {
   const warnings = [];
   const core = { warning: (m) => warnings.push(m) };
   const g = graphqlPr();
   g.repository.pullRequest.reviews.pageInfo.hasNextPage = true;
   g.repository.pullRequest.reviewThreads.pageInfo.hasPreviousPage = true;
   const { github } = fakeGithub({ graphql: g });
-  await fetchPullRequest(github, 'o', 'r', 42, core);
-  assert.equal(warnings.length, 2);
-  assert.match(warnings[0], /more than 100 reviews/);
-  assert.match(warnings[1], /more than 100 review threads/);
+  const p = await fetchPullRequest(github, 'o', 'r', 42, core);
+  assert.deepEqual(p.truncated, ['reviews', 'reviewThreads']);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /reviews and reviewThreads/);
 });
 
 test('syncLabels adds the desired label and strips only stale review states', async () => {
-  const { github, calls } = fakeGithub();
+  const { github, calls } = fakeGithub({ liveLabels: ['review/needs-review', 'size/l'] });
   const res = await syncLabels(github, 'o', 'r', 1, ['review/needs-review', 'size/l'], STATE.IN_REVIEW);
   assert.deepEqual(calls.removeLabel.map((c) => c.name), ['review/needs-review']);
   assert.deepEqual(calls.addLabels[0].labels, [STATE.IN_REVIEW]);
@@ -432,24 +439,25 @@ test('syncLabels adds the desired label and strips only stale review states', as
 });
 
 test('syncLabels is a no-op when the label is already correct', async () => {
-  const { github, calls } = fakeGithub();
+  const { github, calls } = fakeGithub({ liveLabels: [STATE.IN_REVIEW, 'size/s'] });
   await syncLabels(github, 'o', 'r', 1, [STATE.IN_REVIEW, 'size/s'], STATE.IN_REVIEW);
   assert.equal(calls.removeLabel.length + calls.addLabels.length, 0);
 });
 
 test('syncLabels never touches the override label', async () => {
-  const { github, calls } = fakeGithub();
+  const { github, calls } = fakeGithub({ liveLabels: ['review/bots-overridden'] });
   await syncLabels(github, 'o', 'r', 1, ['review/bots-overridden'], STATE.NEEDS_REVIEW);
   assert.equal(calls.removeLabel.length, 0, 'the override is a human decision, not derived state');
 });
 
 test('syncLabels tolerates a 404 but rethrows a permissions failure', async () => {
+  const live = ['review/needs-review'];
   const gone = Object.assign(new Error('Label does not exist'), { status: 404 });
-  await syncLabels(fakeGithub({ removeLabelError: gone }).github, 'o', 'r', 1, ['review/needs-review'], STATE.IN_REVIEW);
+  await syncLabels(fakeGithub({ removeLabelError: gone, liveLabels: live }).github, 'o', 'r', 1, live, STATE.IN_REVIEW);
 
   const denied = Object.assign(new Error('Resource not accessible by integration'), { status: 403 });
   await assert.rejects(
-    () => syncLabels(fakeGithub({ removeLabelError: denied }).github, 'o', 'r', 1, ['review/needs-review'], STATE.IN_REVIEW),
+    () => syncLabels(fakeGithub({ removeLabelError: denied, liveLabels: live }).github, 'o', 'r', 1, live, STATE.IN_REVIEW),
     /not accessible/,
   );
 });
@@ -480,7 +488,7 @@ test('syncComment posts once when the gate first closes', async () => {
 });
 
 test('syncComment edits its own comment rather than posting a second', async () => {
-  const { github, calls } = fakeGithub({ comments: [{ id: 7, body: gateComment(3) }] });
+  const { github, calls } = fakeGithub({ comments: [{ id: 7, body: gateComment(3), user: { type: 'Bot' } }] });
   const action = await syncComment(github, 'o', 'r', 1, { state: STATE.BOT_FINDINGS_OPEN, botFindingsOpen: 1 });
   assert.equal(action, 'updated');
   assert.equal(calls.createComment.length, 0);
@@ -488,21 +496,21 @@ test('syncComment edits its own comment rather than posting a second', async () 
 });
 
 test('syncComment rewrites to the cleared text once the gate opens', async () => {
-  const { github, calls } = fakeGithub({ comments: [{ id: 7, body: gateComment(2) }] });
+  const { github, calls } = fakeGithub({ comments: [{ id: 7, body: gateComment(2), user: { type: 'Bot' } }] });
   const action = await syncComment(github, 'o', 'r', 1, { state: STATE.NEEDS_REVIEW, botFindingsOpen: 0 });
   assert.equal(action, 'updated');
   assert.match(calls.updateComment[0].body, /human review queue/);
 });
 
 test('syncComment does not rewrite an identical body', async () => {
-  const { github, calls } = fakeGithub({ comments: [{ id: 7, body: gateComment(2) }] });
+  const { github, calls } = fakeGithub({ comments: [{ id: 7, body: gateComment(2), user: { type: 'Bot' } }] });
   const action = await syncComment(github, 'o', 'r', 1, { state: STATE.BOT_FINDINGS_OPEN, botFindingsOpen: 2 });
   assert.equal(action, 'unchanged');
   assert.equal(calls.updateComment.length, 0, 'no needless notification');
 });
 
 test('syncComment ignores comments from other authors', async () => {
-  const { github, calls } = fakeGithub({ comments: [{ id: 1, body: 'unrelated' }, { id: 2, body: null }] });
+  const { github, calls } = fakeGithub({ comments: [{ id: 1, body: 'unrelated', user: { type: 'User' } }, { id: 2, body: null, user: { type: 'Bot' } }] });
   const action = await syncComment(github, 'o', 'r', 1, { state: STATE.BOT_FINDINGS_OPEN, botFindingsOpen: 1 });
   assert.equal(action, 'created');
   assert.equal(calls.updateComment.length, 0);
@@ -516,10 +524,134 @@ test('syncComment writes nothing in a dry run', async () => {
   );
   assert.equal(clean.calls.createComment.length, 0, 'dry run must not write');
 
-  const existing = fakeGithub({ comments: [{ id: 7, body: gateComment(9) }] });
+  const existing = fakeGithub({ comments: [{ id: 7, body: gateComment(9), user: { type: 'Bot' } }] });
   assert.equal(
     await syncComment(existing.github, 'o', 'r', 1, { state: STATE.BOT_FINDINGS_OPEN, botFindingsOpen: 1 }, { dryRun: true }),
     'would-update',
   );
   assert.equal(existing.calls.updateComment.length, 0, 'dry run must not write');
+});
+
+// ---------------------------------------------------------------------------
+// Fixes from review of the first version.
+// ---------------------------------------------------------------------------
+
+test('truncated data is flagged so the caller can refuse to write', async () => {
+  const warnings = [];
+  const core = { warning: (m) => warnings.push(m) };
+  const g = graphqlPr();
+  g.repository.pullRequest.reviewThreads.pageInfo.hasPreviousPage = true;
+  const { github } = fakeGithub({ graphql: g });
+  const p = await fetchPullRequest(github, 'o', 'r', 42, core);
+  assert.deepEqual(p.truncated, ['reviewThreads']);
+  assert.match(warnings[0], /skipping rather than/);
+});
+
+test('complete data carries no truncation flag', async () => {
+  const { github } = fakeGithub({ graphql: graphqlPr() });
+  const p = await fetchPullRequest(github, 'o', 'r', 42);
+  assert.equal(p.truncated, null);
+});
+
+test('syncLabels writes against a fresh read, not the stale snapshot', async () => {
+  // Another run relabelled this pull request after we classified it. The stale
+  // snapshot says needs-review; the live state says in-review.
+  const { github, calls } = fakeGithub({ liveLabels: ['review/in-review', 'size/l'] });
+  await syncLabels(github, 'o', 'r', 1, ['review/needs-review'], STATE.CI_RED);
+  assert.deepEqual(
+    calls.removeLabel.map((c) => c.name),
+    ['review/in-review'],
+    'removes what is actually there, not what we last saw',
+  );
+});
+
+test('a human cannot capture the guidance comment slot with the marker', async () => {
+  const { github, calls } = fakeGithub({
+    comments: [{ id: 99, body: `spoof ${gateComment(1)}`, user: { type: 'User' } }],
+  });
+  const action = await syncComment(github, 'o', 'r', 1, { state: STATE.BOT_FINDINGS_OPEN, botFindingsOpen: 1 });
+  assert.equal(action, 'created', 'the workflow posts its own rather than editing a human comment');
+  assert.equal(calls.updateComment.length, 0);
+});
+
+test('the gate comment tells contributors to resolve, not merely reply', () => {
+  const body = gateComment(2);
+  assert.match(body, /Resolve conversation/);
+  assert.match(body, /a reply on its own/i);
+  assert.match(body, /review\/bots-overridden/);
+  assert.doesNotMatch(body, /leave it open/i, 'the old text promised an open reply was enough');
+});
+
+test('run() refuses to write a label when the data is truncated', async () => {
+  const calls = { addLabels: [], removeLabel: [], createComment: [], updateComment: [] };
+  const warnings = [];
+  const listComments = () => {};
+  listComments.__kind = 'comments';
+  const listLabelsForRepo = () => {};
+  listLabelsForRepo.__kind = 'repoLabels';
+
+  const g = graphqlPr();
+  g.repository.pullRequest.reviewThreads.pageInfo.hasPreviousPage = true;
+
+  const github = {
+    graphql: async () => g,
+    paginate: async (fn) => (fn.__kind === 'repoLabels'
+      ? [...ALL_STATES_FOR_TEST].map((name) => ({ name }))
+      : []),
+    rest: {
+      issues: {
+        listComments,
+        listLabelsForRepo,
+        listLabelsOnIssue: async () => ({ data: [] }),
+        addLabels: async (p) => { calls.addLabels.push(p); },
+        removeLabel: async (p) => { calls.removeLabel.push(p); },
+        createComment: async (p) => { calls.createComment.push(p); },
+        updateComment: async (p) => { calls.updateComment.push(p); },
+      },
+    },
+  };
+  const core = {
+    info: () => {}, warning: (m) => warnings.push(m), error: () => {}, setFailed: () => {},
+  };
+
+  const results = await run({
+    core, github, context: { repo: { owner: 'o', repo: 'r' } }, numbers: [42],
+  });
+
+  assert.deepEqual(results, [], 'a truncated pull request produces no result');
+  assert.equal(calls.addLabels.length, 0, 'no label written');
+  assert.equal(calls.removeLabel.length, 0, 'no label removed');
+  assert.equal(calls.createComment.length, 0, 'no comment written');
+  assert.match(warnings.join(' '), /truncated data/);
+});
+
+test('run() does write when the data is complete', async () => {
+  const calls = { addLabels: [] };
+  const listComments = () => {};
+  listComments.__kind = 'comments';
+  const listLabelsForRepo = () => {};
+  listLabelsForRepo.__kind = 'repoLabels';
+  const github = {
+    graphql: async () => graphqlPr(),
+    paginate: async (fn) => (fn.__kind === 'repoLabels'
+      ? [...ALL_STATES_FOR_TEST].map((name) => ({ name }))
+      : []),
+    rest: {
+      issues: {
+        listComments,
+        listLabelsForRepo,
+        listLabelsOnIssue: async () => ({ data: [] }),
+        addLabels: async (p) => { calls.addLabels.push(p); },
+        removeLabel: async () => {},
+        createComment: async () => {},
+        updateComment: async () => {},
+      },
+    },
+  };
+  const core = { info: () => {}, warning: () => {}, error: () => {}, setFailed: () => {} };
+  const results = await run({
+    core, github, context: { repo: { owner: 'o', repo: 'r' } }, numbers: [42],
+  });
+  assert.equal(results.length, 1, 'the control case still produces a result');
+  assert.deepEqual(calls.addLabels[0].labels, [STATE.NEEDS_2ND_APPROVAL]);
 });

--- a/.github/scripts/review-state.js
+++ b/.github/scripts/review-state.js
@@ -123,12 +123,16 @@ export function gateComment(count) {
     `Automated review has flagged ${items} on this pull request.`,
     '',
     'Review here runs in two stages: automated review first, then a maintainer.',
-    'This pull request moves into the human review queue once the automated',
-    'comments are addressed, either by pushing a fix or by replying in the thread.',
+    'This pull request moves into the human review queue once every automated',
+    'comment above is resolved.',
     '',
-    'You can resolve a thread yourself with **Resolve conversation**. If you think a',
-    'finding is wrong, say so in the thread and leave it open; a maintainer will',
-    'judge it. You are not expected to change code you disagree with.',
+    'Push a fix, or reply in the thread if you disagree with a finding, then mark it',
+    '**Resolve conversation**. Resolving is what moves this along: a reply on its own',
+    'leaves the thread open and the pull request here.',
+    '',
+    'You are not expected to change code you disagree with. If a finding is wrong and',
+    'you would rather a maintainer decided, say so and ask for the',
+    '`review/bots-overridden` label, which skips this stage entirely.',
     '',
     `Status: \`${STATE.BOT_FINDINGS_OPEN}\``,
   ].join('\n');
@@ -177,17 +181,21 @@ export async function fetchPullRequest(github, owner, repo, number, core) {
   const pr = data.repository && data.repository.pullRequest;
   if (!pr) return null;
 
-  // Truncation would silently change the derived state, so say so loudly.
-  if (core) {
-    if (pr.reviews.pageInfo.hasNextPage) {
-      core.warning(`PR #${number}: more than 100 reviews, verdicts may be incomplete`);
-    }
-    if (pr.reviewThreads.pageInfo.hasPreviousPage) {
-      core.warning(`PR #${number}: more than 100 review threads, oldest were dropped`);
-    }
+  // Truncated data would derive a state from an incomplete picture, so the
+  // caller must skip the pull request rather than write a label it cannot
+  // stand behind.
+  const truncated = [];
+  if (pr.reviews.pageInfo.hasNextPage) truncated.push('reviews');
+  if (pr.reviewThreads.pageInfo.hasPreviousPage) truncated.push('reviewThreads');
+  if (truncated.length > 0 && core) {
+    core.warning(
+      `PR #${number}: more than 100 ${truncated.join(' and ')}, skipping rather than `
+      + 'deriving a state from incomplete data',
+    );
   }
 
   return {
+    truncated: truncated.length > 0 ? truncated : null,
     number: pr.number,
     isDraft: pr.isDraft,
     reviewDecision: pr.reviewDecision,
@@ -209,9 +217,22 @@ export async function fetchPullRequest(github, owner, repo, number, core) {
 }
 
 export async function syncLabels(github, owner, repo, number, current, desired, { dryRun } = {}) {
-  const stale = current.filter((l) => ALL_STATES.includes(l) && l !== desired);
-  const missing = current.includes(desired) ? null : desired;
-  if (dryRun) return { added: missing, removed: stale, applied: false };
+  if (dryRun) {
+    const stale = current.filter((l) => ALL_STATES.includes(l) && l !== desired);
+    return { added: current.includes(desired) ? null : desired, removed: stale, applied: false };
+  }
+
+  // Re-read rather than trusting the classification-time snapshot. Runs for the
+  // same pull request cannot be fully serialised, because the concurrency group
+  // is evaluated before the pull request number is known for workflow_run and
+  // check_suite. Reading here shrinks the window to the read-write gap, and any
+  // residue is corrected by the next run, which removes every stale state.
+  const fresh = await github.rest.issues.listLabelsOnIssue({
+    owner, repo, issue_number: number, per_page: 100,
+  });
+  const live = fresh.data.map((l) => l.name);
+  const stale = live.filter((l) => ALL_STATES.includes(l) && l !== desired);
+  const missing = live.includes(desired) ? null : desired;
 
   for (const name of stale) {
     try {
@@ -235,7 +256,15 @@ export async function syncComment(github, owner, repo, number, result, { dryRun 
   const comments = await github.paginate(github.rest.issues.listComments, {
     owner, repo, issue_number: number, per_page: 100,
   });
-  const existing = comments.find((c) => c.body && c.body.includes(COMMENT_MARKER));
+  // Require the marker AND a bot author. The marker is public, so a human
+  // could otherwise post one and capture the slot, leaving this workflow
+  // trying to edit a comment it does not own and the guidance never shown.
+  const existing = comments.find(
+    (c) => c.body
+      && c.body.includes(COMMENT_MARKER)
+      && c.user
+      && c.user.type === 'Bot',
+  );
   const gated = result.state === STATE.BOT_FINDINGS_OPEN;
 
   // Never open the conversation unprompted: the comment appears only when
@@ -283,11 +312,16 @@ export default async function run({ core, github, context, numbers, dryRun = fal
   // still turn the run red rather than passing quietly.
   const results = [];
   const failures = [];
+  const skipped = [];
   for (const number of numbers) {
     try {
       const pr = await fetchPullRequest(github, owner, repo, number, core);
       if (!pr) {
         core.info(`PR #${number}: not found, skipping`);
+        continue;
+      }
+      if (pr.truncated) {
+        skipped.push(number);
         continue;
       }
       const result = classify(pr);
@@ -308,6 +342,9 @@ export default async function run({ core, github, context, numbers, dryRun = fal
       failures.push(number);
       core.error(`PR #${number}: ${error.message}`);
     }
+  }
+  if (skipped.length > 0) {
+    core.warning(`Skipped ${skipped.length} pull request(s) with truncated data: ${skipped.join(', ')}`);
   }
   if (failures.length > 0) {
     core.setFailed(`Failed to evaluate ${failures.length} pull request(s): ${failures.join(', ')}`);

--- a/.github/scripts/review-state.js
+++ b/.github/scripts/review-state.js
@@ -1,0 +1,316 @@
+/**
+ * Review state router.
+ *
+ * Derives one review/* label per open pull request from facts GitHub already
+ * knows, so "which PR should I review, and has anyone looked at it" is a query
+ * rather than a read of every comment thread. See design/015-review-routing.md.
+ */
+
+// Accounts whose review activity never counts as human coverage. They gate
+// (see BOT_FINDINGS_OPEN) but can never approve a change through.
+export const BOTS = new Set([
+  'coderabbitai',
+  'github-advanced-security',
+  'copilot-pull-request-reviewer',
+  'dependabot',
+  'eso-service-account-app',
+]);
+
+export const STATE = {
+  DRAFT: 'review/draft',
+  CHANGES_REQUESTED: 'review/changes-requested',
+  CI_RED: 'review/ci-red',
+  BOT_FINDINGS_OPEN: 'review/bot-findings-open',
+  NEEDS_REVIEW: 'review/needs-review',
+  IN_REVIEW: 'review/in-review',
+  NEEDS_2ND_APPROVAL: 'review/needs-2nd-approval',
+  READY_TO_MERGE: 'review/ready-to-merge',
+};
+
+export const ALL_STATES = Object.values(STATE);
+
+// Applied by a maintainer to push a pull request past the bot gate: false
+// positives, a newcomer stuck on nitpicks, or a bot outage.
+export const OVERRIDE_LABEL = 'review/bots-overridden';
+
+// Changes this size need two human approvals, per docs/contributing/process.md.
+const LARGE_LABELS = new Set(['size/l', 'size/xl']);
+
+// Review states that express a verdict. COMMENTED and PENDING do not, so they
+// must never overwrite one: that is the difference between this and GitHub's
+// latestReviews field, which returns the last SUBMISSION per author and so
+// silently loses a changes-requested as soon as its author comments again.
+const VERDICTS = new Set(['APPROVED', 'CHANGES_REQUESTED', 'DISMISSED']);
+
+// A crashed runner reports ERROR, not FAILURE. Both mean CI is not green.
+const CI_RED_STATES = new Set(['FAILURE', 'ERROR']);
+
+const COMMENT_MARKER = '<!-- eso-review-routing -->';
+
+export function isBot(login) {
+  return BOTS.has(login) || (typeof login === 'string' && login.endsWith('[bot]'));
+}
+
+/**
+ * Each reviewer's standing verdict: their most recent APPROVED,
+ * CHANGES_REQUESTED or DISMISSED, ignoring anything that expressed no verdict.
+ */
+export function effectiveVerdicts(reviews, { excludeAuthor } = {}) {
+  const byAuthor = new Map();
+  const ordered = [...reviews].sort(
+    (a, b) => String(a.submittedAt || '').localeCompare(String(b.submittedAt || '')),
+  );
+  for (const r of ordered) {
+    const login = r.author;
+    if (!login || isBot(login) || login === excludeAuthor) continue;
+    if (!VERDICTS.has(r.state)) continue;
+    byAuthor.set(login, r.state);
+  }
+  return byAuthor;
+}
+
+/**
+ * Decide the review state. Ordered evaluation, first match wins: conditions
+ * overlap constantly, so the order below is the specification, not a detail.
+ */
+export function classify(pr) {
+  const labels = new Set(pr.labels || []);
+  const verdicts = effectiveVerdicts(pr.reviews || [], { excludeAuthor: pr.author });
+  const approvals = [...verdicts.values()].filter((v) => v === 'APPROVED').length;
+  const required = [...LARGE_LABELS].some((l) => labels.has(l)) ? 2 : 1;
+
+  // Trust GitHub's own reviewDecision when it says changes are requested, and
+  // fall back to the per-author verdicts so the signal survives a repo where
+  // reviewDecision is null (no review policy configured).
+  const changesRequested = pr.reviewDecision === 'CHANGES_REQUESTED'
+    || [...verdicts.values()].includes('CHANGES_REQUESTED');
+
+  // Only bot threads that are unresolved AND still current gate the pull
+  // request. An outdated thread means the author already pushed over the
+  // flagged line, so counting it would trap someone who did respond.
+  const botFindingsOpen = (pr.threads || []).filter(
+    (t) => isBot(t.author) && !t.isResolved && !t.isOutdated,
+  ).length;
+
+  // The author commenting on their own diff is not someone else reviewing it.
+  const others = (pr.reviews || []).filter(
+    (r) => r.author && !isBot(r.author) && r.author !== pr.author,
+  );
+  const humanEngaged = others.length > 0 || (pr.assignees || []).length > 0;
+
+  const verdict = (state) => ({ state, botFindingsOpen, approvals, required });
+
+  if (pr.isDraft) return verdict(STATE.DRAFT);
+  if (changesRequested) return verdict(STATE.CHANGES_REQUESTED);
+  if (CI_RED_STATES.has(pr.ciState)) return verdict(STATE.CI_RED);
+  if (approvals >= required) return verdict(STATE.READY_TO_MERGE);
+  if (approvals >= 1) return verdict(STATE.NEEDS_2ND_APPROVAL);
+
+  // The gate sits below IN_REVIEW on purpose. Once a human is engaged their
+  // judgement supersedes the bot, and a card must not be pulled out from
+  // under a reviewer mid-read by a fresh nitpick.
+  if (humanEngaged) return verdict(STATE.IN_REVIEW);
+  if (botFindingsOpen > 0 && !labels.has(OVERRIDE_LABEL)) {
+    return verdict(STATE.BOT_FINDINGS_OPEN);
+  }
+  return verdict(STATE.NEEDS_REVIEW);
+}
+
+export function gateComment(count) {
+  const items = count === 1 ? '**1 open item**' : `**${count} open items**`;
+  return [
+    COMMENT_MARKER,
+    `Automated review has flagged ${items} on this pull request.`,
+    '',
+    'Review here runs in two stages: automated review first, then a maintainer.',
+    'This pull request moves into the human review queue once the automated',
+    'comments are addressed, either by pushing a fix or by replying in the thread.',
+    '',
+    'You can resolve a thread yourself with **Resolve conversation**. If you think a',
+    'finding is wrong, say so in the thread and leave it open; a maintainer will',
+    'judge it. You are not expected to change code you disagree with.',
+    '',
+    `Status: \`${STATE.BOT_FINDINGS_OPEN}\``,
+  ].join('\n');
+}
+
+export function clearedComment(state) {
+  return [
+    COMMENT_MARKER,
+    'Automated review is clear. This pull request is now in the human review queue.',
+    '',
+    `Status: \`${state}\``,
+  ].join('\n');
+}
+
+// reviewThreads takes `last` so truncation drops the OLDEST threads. Taking
+// `first` would drop the newest, which is exactly what a freshness-sensitive
+// gate needs to see.
+const PR_QUERY = `
+query($owner:String!, $repo:String!, $number:Int!) {
+  repository(owner:$owner, name:$repo) {
+    pullRequest(number:$number) {
+      number isDraft reviewDecision
+      author{login}
+      labels(first:100){nodes{name}}
+      assignees(first:10){nodes{login}}
+      reviews(first:100){
+        totalCount
+        pageInfo{hasNextPage}
+        nodes{author{login} state submittedAt}
+      }
+      reviewThreads(last:100){
+        totalCount
+        pageInfo{hasPreviousPage}
+        nodes{
+          isResolved isOutdated
+          comments(first:1){nodes{author{login}}}
+        }
+      }
+      commits(last:1){nodes{commit{statusCheckRollup{state}}}}
+    }
+  }
+}`;
+
+export async function fetchPullRequest(github, owner, repo, number, core) {
+  const data = await github.graphql(PR_QUERY, { owner, repo, number });
+  const pr = data.repository && data.repository.pullRequest;
+  if (!pr) return null;
+
+  // Truncation would silently change the derived state, so say so loudly.
+  if (core) {
+    if (pr.reviews.pageInfo.hasNextPage) {
+      core.warning(`PR #${number}: more than 100 reviews, verdicts may be incomplete`);
+    }
+    if (pr.reviewThreads.pageInfo.hasPreviousPage) {
+      core.warning(`PR #${number}: more than 100 review threads, oldest were dropped`);
+    }
+  }
+
+  return {
+    number: pr.number,
+    isDraft: pr.isDraft,
+    reviewDecision: pr.reviewDecision,
+    author: pr.author ? pr.author.login : null,
+    labels: pr.labels.nodes.map((l) => l.name),
+    assignees: pr.assignees.nodes.map((a) => a.login),
+    reviews: pr.reviews.nodes.map((r) => ({
+      author: r.author ? r.author.login : null,
+      state: r.state,
+      submittedAt: r.submittedAt,
+    })),
+    threads: pr.reviewThreads.nodes.map((t) => ({
+      author: t.comments.nodes[0] ? (t.comments.nodes[0].author || {}).login ?? null : null,
+      isResolved: t.isResolved,
+      isOutdated: t.isOutdated,
+    })),
+    ciState: (((pr.commits.nodes[0] || {}).commit || {}).statusCheckRollup || {}).state ?? null,
+  };
+}
+
+export async function syncLabels(github, owner, repo, number, current, desired, { dryRun } = {}) {
+  const stale = current.filter((l) => ALL_STATES.includes(l) && l !== desired);
+  const missing = current.includes(desired) ? null : desired;
+  if (dryRun) return { added: missing, removed: stale, applied: false };
+
+  for (const name of stale) {
+    try {
+      await github.rest.issues.removeLabel({ owner, repo, issue_number: number, name });
+    } catch (error) {
+      // A label already gone is fine. Anything else, a permissions problem or
+      // a rate limit, must surface: swallowing it leaves stale labels behind
+      // while the run still reports success.
+      if (error.status !== 404) throw error;
+    }
+  }
+  if (missing) {
+    await github.rest.issues.addLabels({
+      owner, repo, issue_number: number, labels: [desired],
+    });
+  }
+  return { added: missing, removed: stale, applied: true };
+}
+
+export async function syncComment(github, owner, repo, number, result, { dryRun } = {}) {
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner, repo, issue_number: number, per_page: 100,
+  });
+  const existing = comments.find((c) => c.body && c.body.includes(COMMENT_MARKER));
+  const gated = result.state === STATE.BOT_FINDINGS_OPEN;
+
+  // Never open the conversation unprompted: the comment appears only when
+  // there is something to act on, which is also why it cannot post before
+  // the async bot review has produced findings.
+  if (!gated && !existing) return 'none';
+
+  const body = gated ? gateComment(result.botFindingsOpen) : clearedComment(result.state);
+  if (existing) {
+    if (existing.body.trim() === body.trim()) return 'unchanged';
+    if (dryRun) return 'would-update';
+    await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+    return 'updated';
+  }
+  if (dryRun) return 'would-create';
+  await github.rest.issues.createComment({ owner, repo, issue_number: number, body });
+  return 'created';
+}
+
+/**
+ * Evaluates every pull request in `numbers` and reconciles its label and
+ * guidance comment. With `dryRun` it only reports what it would change.
+ */
+export default async function run({ core, github, context, numbers, dryRun = false }) {
+  const owner = context.repo.owner;
+  const repo = context.repo.repo;
+
+  // Fail loudly rather than silently mislabelling: a missing label would make
+  // the board look calm while pull requests pile up unrouted.
+  const repoLabels = await github.paginate(github.rest.issues.listLabelsForRepo, {
+    owner, repo, per_page: 100,
+  });
+  const known = new Set(repoLabels.map((l) => l.name));
+  const missing = ALL_STATES.filter((l) => !known.has(l));
+  if (missing.length > 0) {
+    const message = `Missing required labels in ${owner}/${repo}: ${missing.join(', ')}. `
+      + 'Create them before enabling this workflow.';
+    if (dryRun) core.warning(message);
+    else { core.setFailed(message); return []; }
+  }
+
+  if (dryRun) core.info('DRY RUN: no labels or comments will be written');
+
+  // One bad pull request must not abandon the rest of a sweep, but it must
+  // still turn the run red rather than passing quietly.
+  const results = [];
+  const failures = [];
+  for (const number of numbers) {
+    try {
+      const pr = await fetchPullRequest(github, owner, repo, number, core);
+      if (!pr) {
+        core.info(`PR #${number}: not found, skipping`);
+        continue;
+      }
+      const result = classify(pr);
+      const labelChange = await syncLabels(
+        github, owner, repo, number, pr.labels, result.state, { dryRun },
+      );
+      const commentAction = await syncComment(github, owner, repo, number, result, { dryRun });
+      results.push({ number, ...result, labelChange, commentAction, current: pr.labels });
+      core.info(
+        `PR #${number}: ${result.state} `
+        + `(approvals ${result.approvals}/${result.required}, `
+        + `bot findings ${result.botFindingsOpen}, ci ${pr.ciState ?? 'none'}, `
+        + `decision ${pr.reviewDecision ?? 'none'}, draft ${pr.isDraft}) `
+        + `labels[+${labelChange.added ?? '-'} -${labelChange.removed.join(',') || '-'}] `
+        + `comment[${commentAction}]`,
+      );
+    } catch (error) {
+      failures.push(number);
+      core.error(`PR #${number}: ${error.message}`);
+    }
+  }
+  if (failures.length > 0) {
+    core.setFailed(`Failed to evaluate ${failures.length} pull request(s): ${failures.join(', ')}`);
+  }
+  return results;
+}

--- a/.github/scripts/review-state.js
+++ b/.github/scripts/review-state.js
@@ -217,54 +217,94 @@ export async function fetchPullRequest(github, owner, repo, number, core) {
 }
 
 export async function syncLabels(github, owner, repo, number, current, desired, { dryRun } = {}) {
+  const readLive = async () => {
+    const fresh = await github.rest.issues.listLabelsOnIssue({
+      owner, repo, issue_number: number, per_page: 100,
+    });
+    return fresh.data.map((l) => l.name);
+  };
+
+  // A dry run reads live as well: reporting from the classification-time
+  // snapshot would describe a pull request that may already have moved on,
+  // which is exactly what the live path re-reads to avoid.
   if (dryRun) {
-    const stale = current.filter((l) => ALL_STATES.includes(l) && l !== desired);
-    return { added: current.includes(desired) ? null : desired, removed: stale, applied: false };
+    const live = await readLive();
+    return {
+      added: live.includes(desired) ? null : desired,
+      removed: live.filter((l) => ALL_STATES.includes(l) && l !== desired),
+      restored: false,
+      applied: false,
+    };
   }
 
-  // Re-read rather than trusting the classification-time snapshot. Runs for the
-  // same pull request cannot be fully serialised, because the concurrency group
-  // is evaluated before the pull request number is known for workflow_run and
-  // check_suite. Reading here shrinks the window to the read-write gap, and any
-  // residue is corrected by the next run, which removes every stale state.
-  const fresh = await github.rest.issues.listLabelsOnIssue({
-    owner, repo, issue_number: number, per_page: 100,
-  });
-  const live = fresh.data.map((l) => l.name);
-  const stale = live.filter((l) => ALL_STATES.includes(l) && l !== desired);
-  const missing = live.includes(desired) ? null : desired;
-
-  for (const name of stale) {
-    try {
-      await github.rest.issues.removeLabel({ owner, repo, issue_number: number, name });
-    } catch (error) {
-      // A label already gone is fine. Anything else, a permissions problem or
-      // a rate limit, must surface: swallowing it leaves stale labels behind
-      // while the run still reports success.
-      if (error.status !== 404) throw error;
+  const removeStale = async (labels) => {
+    const stale = labels.filter((l) => ALL_STATES.includes(l) && l !== desired);
+    for (const name of stale) {
+      try {
+        await github.rest.issues.removeLabel({ owner, repo, issue_number: number, name });
+      } catch (error) {
+        // A label already gone is fine. Anything else, a permissions problem or
+        // a rate limit, must surface: swallowing it leaves stale labels behind
+        // while the run still reports success.
+        if (error.status !== 404) throw error;
+      }
     }
-  }
+    return stale;
+  };
+
+  // Read live rather than trusting the classification-time snapshot: another
+  // run may have relabelled this pull request since we classified it.
+  const live = await readLive();
+  const removed = await removeStale(live);
+  const missing = live.includes(desired) ? null : desired;
   if (missing) {
     await github.rest.issues.addLabels({
       owner, repo, issue_number: number, labels: [desired],
     });
   }
-  return { added: missing, removed: stale, applied: true };
+
+  // The write is not atomic and cannot be: a sweep and an event-driven run for
+  // the same pull request sit in different concurrency groups by design.
+  //
+  // This pass therefore only ever ADDS. An earlier version also removed labels
+  // it did not expect, which converged two racing runs to ZERO labels: each
+  // stripped the other's state and neither re-added its own, so the pull
+  // request silently left the queue. Two labels for one cycle is visible and
+  // self-corrects on the next run; none is invisible.
+  const after = await readLive();
+  const restored = !after.includes(desired);
+  if (restored) {
+    await github.rest.issues.addLabels({
+      owner, repo, issue_number: number, labels: [desired],
+    });
+  }
+
+  return {
+    added: missing || (restored ? desired : null),
+    removed,
+    restored,
+    applied: true,
+  };
 }
 
 export async function syncComment(github, owner, repo, number, result, { dryRun } = {}) {
-  const comments = await github.paginate(github.rest.issues.listComments, {
-    owner, repo, issue_number: number, per_page: 100,
-  });
   // Require the marker AND a bot author. The marker is public, so a human
   // could otherwise post one and capture the slot, leaving this workflow
   // trying to edit a comment it does not own and the guidance never shown.
-  const existing = comments.find(
-    (c) => c.body
-      && c.body.includes(COMMENT_MARKER)
-      && c.user
-      && c.user.type === 'Bot',
-  );
+  const findMarkers = async () => {
+    const comments = await github.paginate(github.rest.issues.listComments, {
+      owner, repo, issue_number: number, per_page: 100,
+    });
+    return comments.filter(
+      (c) => c.body
+        && c.body.includes(COMMENT_MARKER)
+        && c.user
+        && c.user.type === 'Bot',
+    );
+  };
+
+  const markers = await findMarkers();
+  const existing = markers[0];
   const gated = result.state === STATE.BOT_FINDINGS_OPEN;
 
   // Never open the conversation unprompted: the comment appears only when
@@ -280,7 +320,24 @@ export async function syncComment(github, owner, repo, number, result, { dryRun 
     return 'updated';
   }
   if (dryRun) return 'would-create';
-  await github.rest.issues.createComment({ owner, repo, issue_number: number, body });
+
+  const created = await github.rest.issues.createComment({
+    owner, repo, issue_number: number, body,
+  });
+
+  // Creating is the one write here that cannot be made idempotent by reading
+  // first: a concurrent run may create its own between our read and our write.
+  // Keep the earliest and drop ours, so a pull request never accumulates two
+  // guidance comments that nothing would ever clean up.
+  const after = await findMarkers();
+  if (after.length > 1) {
+    const earliest = after.reduce((a, b) => (a.id < b.id ? a : b));
+    const mine = created && created.data && created.data.id;
+    if (mine && mine !== earliest.id) {
+      await github.rest.issues.deleteComment({ owner, repo, comment_id: mine });
+      return 'created-then-deduped';
+    }
+  }
   return 'created';
 }
 
@@ -336,6 +393,7 @@ export default async function run({ core, github, context, numbers, dryRun = fal
         + `bot findings ${result.botFindingsOpen}, ci ${pr.ciState ?? 'none'}, `
         + `decision ${pr.reviewDecision ?? 'none'}, draft ${pr.isDraft}) `
         + `labels[+${labelChange.added ?? '-'} -${labelChange.removed.join(',') || '-'}] `
+        + (labelChange.restored ? 'RACED(label was deleted under us, restored) ' : '')
         + `comment[${commentAction}]`,
       );
     } catch (error) {

--- a/.github/scripts/review-state.js
+++ b/.github/scripts/review-state.js
@@ -342,10 +342,61 @@ export async function syncComment(github, owner, repo, number, result, { dryRun 
 }
 
 /**
+ * End-of-sweep deconfliction.
+ *
+ * A sweep and an event-driven run for one pull request sit in different
+ * concurrency groups by design, so both can write and leave two states. Only
+ * the sweep cleans that up, and only ever by withdrawing the label it applied
+ * itself. That asymmetry is the point: when both sides cleaned up, each
+ * removed the other's state and neither re-added its own, leaving the pull
+ * request with none at all.
+ *
+ * The event's state wins, which is the right precedence: it was raised by an
+ * actual change, while a sweep is a backstop.
+ */
+export async function deconflictSweep(github, owner, repo, applied, core) {
+  const outcomes = [];
+  for (const { number, label } of applied) {
+    const read = async () => {
+      const r = await github.rest.issues.listLabelsOnIssue({
+        owner, repo, issue_number: number, per_page: 100,
+      });
+      return r.data.map((l) => l.name).filter((n) => ALL_STATES.includes(n));
+    };
+
+    const live = await read();
+    // Nothing to yield unless an overlapping run left its own state next to ours.
+    if (live.length < 2 || !live.includes(label)) continue;
+
+    try {
+      await github.rest.issues.removeLabel({ owner, repo, issue_number: number, name: label });
+    } catch (error) {
+      if (error.status !== 404) throw error;
+    }
+
+    // A sweep must never be the reason a pull request carries no state at all.
+    const after = await read();
+    if (after.length === 0) {
+      await github.rest.issues.addLabels({
+        owner, repo, issue_number: number, labels: [label],
+      });
+      core.warning(`PR #${number}: withdrew ${label} but nothing remained, put it back`);
+      outcomes.push({ number, label, action: 'restored' });
+    } else {
+      core.info(`PR #${number}: withdrew sweep state ${label}, event state ${after.join(',')} stands`);
+      outcomes.push({ number, label, action: 'yielded' });
+    }
+  }
+  return outcomes;
+}
+
+/**
  * Evaluates every pull request in `numbers` and reconciles its label and
  * guidance comment. With `dryRun` it only reports what it would change.
  */
-export default async function run({ core, github, context, numbers, dryRun = false }) {
+export default async function run({
+  core, github, context, numbers, dryRun = false, sweep = false,
+}) {
   const owner = context.repo.owner;
   const repo = context.repo.repo;
 
@@ -370,6 +421,7 @@ export default async function run({ core, github, context, numbers, dryRun = fal
   const results = [];
   const failures = [];
   const skipped = [];
+  const applied = [];
   for (const number of numbers) {
     try {
       const pr = await fetchPullRequest(github, owner, repo, number, core);
@@ -387,6 +439,7 @@ export default async function run({ core, github, context, numbers, dryRun = fal
       );
       const commentAction = await syncComment(github, owner, repo, number, result, { dryRun });
       results.push({ number, ...result, labelChange, commentAction, current: pr.labels });
+      if (labelChange.added) applied.push({ number, label: labelChange.added });
       core.info(
         `PR #${number}: ${result.state} `
         + `(approvals ${result.approvals}/${result.required}, `
@@ -401,6 +454,16 @@ export default async function run({ core, github, context, numbers, dryRun = fal
       core.error(`PR #${number}: ${error.message}`);
     }
   }
+  // Deferred to the end of the cycle on purpose: by now the event-driven runs
+  // that overlapped these pull requests have almost certainly finished, so this
+  // sees settled state instead of racing what it is trying to repair.
+  if (sweep && !dryRun && applied.length > 0) {
+    const outcomes = await deconflictSweep(github, owner, repo, applied, core);
+    if (outcomes.length > 0) {
+      core.info(`deconflicted ${outcomes.length} pull request(s) after overlapping writes`);
+    }
+  }
+
   if (skipped.length > 0) {
     core.warning(`Skipped ${skipped.length} pull request(s) with truncated data: ${skipped.join(', ')}`);
   }

--- a/.github/workflows/review-signal.yml
+++ b/.github/workflows/review-signal.yml
@@ -1,0 +1,24 @@
+# Relay so that review activity can reach a privileged workflow.
+#
+# pull_request_review runs the workflow from the pull request's merge commit
+# with a read-only token and no secrets, so it cannot label anything itself.
+# Its only job is to complete, which fires workflow_run for Review State,
+# and that runs from the default branch with a write token.
+#
+# It therefore holds no permissions and touches nothing: a fork can change
+# this file in its own pull request, and the worst it gains is a runner.
+name: Review Signal
+
+on:
+  pull_request_review:
+    types: [submitted, dismissed, edited]
+
+permissions: {}
+
+jobs:
+  signal:
+    name: Relay review activity
+    runs-on: ubuntu-latest
+    steps:
+      - name: Note the review
+        run: echo "Review activity recorded. Review State will pick this up."

--- a/.github/workflows/review-state.yml
+++ b/.github/workflows/review-state.yml
@@ -1,0 +1,95 @@
+# Derives one review/* label per open pull request.
+# See design/015-review-routing.md for the rationale.
+#
+# Only triggers that run from the default branch with a write token appear
+# here. Review activity arrives indirectly via workflow_run on Review Signal,
+# because pull_request_review itself is read-only for pull requests from forks.
+name: Review State
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, labeled, unlabeled]
+  workflow_run:
+    workflows: [Review Signal]
+    types: [completed]
+  check_suite:
+    types: [completed]
+  schedule:
+    # Backstop only: events above carry the load. Every six hours keeps the
+    # full sweep well inside the hourly API budget shared with other workflows.
+    - cron: '17 */6 * * *'
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: 'Pull request number to evaluate. Leave empty to sweep all open PRs.'
+        required: false
+        type: string
+      dry_run:
+        description: 'Report what would change without writing labels or comments.'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  # Keyed on the pull request wherever one is known, so runs for the same pull
+  # request serialise. syncLabels is read-then-write and not atomic.
+  group: review-state-${{ github.event.pull_request.number || github.event.workflow_run.head_branch || github.event.check_suite.head_sha || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  review-state:
+    name: Derive review state
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read        # for reading .github/scripts
+      pull-requests: write  # for labelling pull requests
+      issues: write         # for the guidance comment
+    # Labels this workflow applies itself must not trigger it again. Events
+    # raised by GITHUB_TOKEN do not start new runs, so this is belt and braces
+    # against a future switch to an App token. The override label is exempt:
+    # applying it is precisely a request to re-evaluate.
+    if: >-
+      github.event_name != 'pull_request_target'
+      || !contains(fromJSON('["labeled", "unlabeled"]'), github.event.action)
+      || !startsWith(github.event.label.name, 'review/')
+      || github.event.label.name == 'review/bots-overridden'
+    steps:
+      # Never check out pull request code here: pull_request_target and the
+      # workflow_run handler run against the base repo with a writable token.
+      - name: Checkout scripts from the base ref
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: .github/scripts
+          persist-credentials: false
+
+      - name: Resolve which pull requests to evaluate
+        id: resolve
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { default: resolve } = await import(
+              `${process.env.GITHUB_WORKSPACE}/.github/scripts/resolve-prs.js`
+            );
+            const numbers = await resolve({ core, github, context });
+            core.info(`evaluating ${numbers.length} pull request(s): ${numbers.join(', ') || 'none'}`);
+            core.setOutput('numbers', JSON.stringify(numbers));
+
+      - name: Apply review state
+        if: steps.resolve.outputs.numbers != '[]'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBERS: ${{ steps.resolve.outputs.numbers }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        with:
+          script: |
+            const { default: run } = await import(
+              `${process.env.GITHUB_WORKSPACE}/.github/scripts/review-state.js`
+            );
+            await run({
+              core, github, context,
+              numbers: JSON.parse(process.env.PR_NUMBERS),
+              dryRun: process.env.DRY_RUN === 'true',
+            });

--- a/.github/workflows/review-state.yml
+++ b/.github/workflows/review-state.yml
@@ -6,7 +6,12 @@
 # because pull_request_review itself is read-only for pull requests from forks.
 name: Review State
 
-on:
+# zizmor flags pull_request_target and workflow_run as dangerous triggers on
+# sight. Both are used here in their documented safe form: the checkout takes
+# the base ref with no `ref:` and a sparse path, so no pull request code is ever
+# fetched or executed, and nothing interpolates attacker-controlled text.
+# See the security notes in design/015-review-routing.md.
+on: # zizmor: ignore[dangerous-triggers] base-ref checkout only, no PR code is executed
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, labeled, unlabeled]
   workflow_run:

--- a/.github/workflows/review-state.yml
+++ b/.github/workflows/review-state.yml
@@ -38,20 +38,12 @@ on: # zizmor: ignore[dangerous-triggers] base-ref checkout only, no PR code is e
 permissions:
   contents: read
 
-concurrency:
-  # Keyed on the pull request wherever one is known, so runs for the same pull
-  # request serialise. syncLabels is read-then-write and not atomic.
-  group: review-state-${{ github.event.pull_request.number || github.event.workflow_run.head_branch || github.event.check_suite.head_sha || github.run_id }}
-  cancel-in-progress: false
-
 jobs:
-  review-state:
-    name: Derive review state
+  resolve:
+    name: Resolve targets
     runs-on: ubuntu-latest
     permissions:
-      contents: read        # for reading .github/scripts
-      pull-requests: write  # for labelling pull requests
-      issues: write         # for the guidance comment
+      contents: read
     # Labels this workflow applies itself must not trigger it again. Events
     # raised by GITHUB_TOKEN do not start new runs, so this is belt and braces
     # against a future switch to an App token. The override label is exempt:
@@ -61,6 +53,9 @@ jobs:
       || !contains(fromJSON('["labeled", "unlabeled"]'), github.event.action)
       || !startsWith(github.event.label.name, 'review/')
       || github.event.label.name == 'review/bots-overridden'
+    outputs:
+      targets: ${{ steps.resolve.outputs.targets }}
+      numbers: ${{ steps.resolve.outputs.numbers }}
     steps:
       # Never check out pull request code here: pull_request_target and the
       # workflow_run handler run against the base repo with a writable token.
@@ -78,23 +73,81 @@ jobs:
             const { default: resolve } = await import(
               `${process.env.GITHUB_WORKSPACE}/.github/scripts/resolve-prs.js`
             );
-            const numbers = await resolve({ core, github, context });
-            core.info(`evaluating ${numbers.length} pull request(s): ${numbers.join(', ') || 'none'}`);
+            const { numbers, targets } = await resolve({ core, github, context });
+            core.info(`targets: ${targets.join(', ') || 'none'} (${numbers.length} pull request(s))`);
+            core.setOutput('targets', JSON.stringify(targets));
             core.setOutput('numbers', JSON.stringify(numbers));
 
+  apply:
+    name: Apply review state
+    needs: resolve
+    # The result check is load-bearing, not defensive noise. A custom `if:`
+    # drops the implicit success() gate, and a skipped or failed job reports
+    # empty outputs, so targets would be '' rather than '[]'. That passes a
+    # bare inequality check and then crashes fromJSON at matrix expansion.
+    # resolve skips by design whenever this workflow's own label write, or a
+    # maintainer editing a review/* label by hand, raised the event.
+    if: needs.resolve.result == 'success' && needs.resolve.outputs.targets != '[]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read        # for reading .github/scripts
+      pull-requests: write  # for labelling pull requests
+      issues: write         # for the guidance comment
+    strategy:
+      # One job per target. An event resolves to a single pull request, so it
+      # gets its own group below and its writes serialise against other events
+      # for the same pull request. A sweep resolves to one sentinel target, so
+      # it stays a single job rather than one per open pull request.
+      matrix:
+        target: ${{ fromJSON(needs.resolve.outputs.targets) }}
+      fail-fast: false
+    concurrency:
+      # matrix is only available at job level, which is the whole reason the
+      # workflow is split in two: a workflow-level group is evaluated before
+      # the pull request number is known for workflow_run and check_suite.
+      group: ${{ github.workflow }}-${{ matrix.target }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout scripts from the base ref
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: .github/scripts
+          persist-credentials: false
+
       - name: Apply review state
-        if: steps.resolve.outputs.numbers != '[]'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          PR_NUMBERS: ${{ steps.resolve.outputs.numbers }}
+          TARGET: ${{ matrix.target }}
+          ALL_NUMBERS: ${{ needs.resolve.outputs.numbers }}
           DRY_RUN: ${{ inputs.dry_run }}
         with:
           script: |
             const { default: run } = await import(
               `${process.env.GITHUB_WORKSPACE}/.github/scripts/review-state.js`
             );
+            const { SWEEP_TARGET } = await import(
+              `${process.env.GITHUB_WORKSPACE}/.github/scripts/resolve-prs.js`
+            );
+            const target = process.env.TARGET;
+            let numbers;
+            if (target === SWEEP_TARGET) {
+              // resolve guarantees a non-empty list alongside the sentinel, so
+              // failing loudly here names a broken invariant rather than
+              // surfacing a bare SyntaxError from a partial re-run.
+              try {
+                numbers = JSON.parse(process.env.ALL_NUMBERS || 'null');
+              } catch (error) {
+                core.setFailed(`ALL_NUMBERS is not valid JSON: ${error.message}`);
+                return;
+              }
+              if (!Array.isArray(numbers) || numbers.length === 0) {
+                core.setFailed(`Sweep target carried no pull requests: ${process.env.ALL_NUMBERS}`);
+                return;
+              }
+            } else {
+              numbers = [Number(target)];
+            }
             await run({
-              core, github, context,
-              numbers: JSON.parse(process.env.PR_NUMBERS),
+              core, github, context, numbers,
               dryRun: process.env.DRY_RUN === 'true',
             });

--- a/.github/workflows/review-state.yml
+++ b/.github/workflows/review-state.yml
@@ -150,4 +150,7 @@ jobs:
             await run({
               core, github, context, numbers,
               dryRun: process.env.DRY_RUN === 'true',
+              // Only a sweep deconflicts, and only by withdrawing its own
+              // state, so two cleaning runs can never strip a pull request.
+              sweep: target === SWEEP_TARGET,
             });

--- a/.github/workflows/scripts-test.yml
+++ b/.github/workflows/scripts-test.yml
@@ -1,0 +1,48 @@
+# Runs the unit tests for the Node scripts under .github/scripts.
+#
+# These tests existed before this workflow but nothing executed them, so a
+# broken helper would only have surfaced in production on a live pull request.
+name: Scripts Test
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/scripts/**'
+      - '.github/workflows/scripts-test.yml'
+  pull_request:
+    paths:
+      - '.github/scripts/**'
+      - '.github/workflows/scripts-test.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Node script tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+
+      # node --test exits 0 when its glob matches nothing, so a rename would
+      # turn CI green having run no tests at all. Count the files first.
+      - name: Check test files are discoverable
+        run: |
+          count=$(ls .github/scripts/*-test.js 2>/dev/null | wc -l | tr -d ' ')
+          echo "found $count test file(s)"
+          if [ "$count" -lt 3 ]; then
+            echo "::error::expected at least 3 test files under .github/scripts, found $count"
+            exit 1
+          fi
+
+      - name: Run tests
+        run: node --test '.github/scripts/**/*-test.js'

--- a/.github/workflows/scripts-test.yml
+++ b/.github/workflows/scripts-test.yml
@@ -34,10 +34,11 @@ jobs:
           node-version: '22'
 
       # node --test exits 0 when its glob matches nothing, so a rename would
-      # turn CI green having run no tests at all. Count the files first.
+      # turn CI green having run no tests at all. Count first, recursively, so
+      # the guard covers the same set as the glob below.
       - name: Check test files are discoverable
         run: |
-          count=$(ls .github/scripts/*-test.js 2>/dev/null | wc -l | tr -d ' ')
+          count=$(find .github/scripts -type f -name '*-test.js' -printf '.' | wc -c | tr -d ' ')
           echo "found $count test file(s)"
           if [ "$count" -lt 3 ]; then
             echo "::error::expected at least 3 test files under .github/scripts, found $count"

--- a/design/015-review-routing.md
+++ b/design/015-review-routing.md
@@ -31,20 +31,21 @@ there is actually something to address.
 
 ### The problem, measured
 
-Across the 78 open pull requests, formal review state looks like this:
+Across the 81 open pull requests, human review state looks like this:
 
-| Review state                  | PRs |
+| Human review state            | PRs |
 | ----------------------------- | --: |
-| Commented only, no verdict    |  47 |
-| No review at all              |  15 |
-| Changes requested             |  13 |
-| Approved                      |   3 |
+| No human review at all        |  39 |
+| Commented on, but no verdict  |  24 |
+| Changes requested             |  14 |
+| Approved                      |   4 |
 
-(Effective current review per reviewer, not cumulative review events. Buckets are
-mutually exclusive, with changes-requested taking precedence over approved.)
+(Buckets are mutually exclusive, counting only non-bot reviewers, with
+changes-requested taking precedence over approved.)
 
-That first row is the whole problem. Those 47 pull requests have activity but no answer,
-so the reconstruction cost is paid again by each person who opens one.
+**63 of 81 pull requests carry no human verdict.** Some have never been looked at; others
+have comments but no answer to "is this covered". Either way the reconstruction cost is
+paid again by each person who opens one.
 
 Worse, the activity is mostly not human. Sorted by effective reviews on open pull
 requests, the top reviewer is a bot:
@@ -61,7 +62,7 @@ requests, the top reviewer is a bot:
 | moolen                        |       2 | maintainer              |
 | knelasevero                   |       1 | maintainer              |
 
-**24 of 78 open pull requests carry reviews from bots only.** In the GitHub UI they look
+**24 of the 81 carry reviews from bots only.** In the GitHub UI they look
 reviewed. No human has formed a view on any of them. Any signal that does not distinguish
 bots from humans is worse than no signal, because it is confidently wrong.
 
@@ -71,11 +72,11 @@ are clean** and genuinely need a human. Today both groups look identical.
 
 Meanwhile every native routing mechanism is switched off:
 
-- 67 of 78 pull requests have no requested reviewer.
+- 69 of 81 pull requests have no requested reviewer.
 - Zero carry the `lgtm` label.
-- 8 have an assignee, though `docs/contributing/process.md` names the assignee as the
+- 11 have an assignee, though `docs/contributing/process.md` names the assignee as the
   mechanism that tracks who owns a pull request's lifecycle.
-- 60 of 78 have had no maintainer review at all.
+- 63 of 81 have had no maintainer review at all.
 
 ### Root cause
 
@@ -91,7 +92,7 @@ docs/CODEOWNERS          absent
 
 So all fifty-odd path-to-team mappings are inert: no automatic review requests, nothing in
 anyone's "awaiting your review" filter, no per-team sign-off state in the sidebar. One
-file extension explains why 67 of 78 pull requests have no reviewer attached.
+file extension explains why 69 of 81 pull requests have no reviewer attached.
 
 The encouraging part is that the hard logic already exists.
 `.github/scripts/lgtm-processor.js` parses that file, maps changed files to reviewer
@@ -204,31 +205,31 @@ Eight columns in two lanes. The lane split is the central claim of this proposal
 half of what currently sits in one undifferentiated list is not a maintainer's problem at
 all.
 
-Counts are the real distribution of today's 78 open pull requests under the rules below.
+Counts are the real distribution of today's 81 open pull requests under the rules below.
 
-**Maintainer's queue, waiting on us: 32 PRs**
+**Maintainer's queue, waiting on us: 33 PRs**
 
 | Column                 | PRs | Entry condition                                                     |
 | ---------------------- | --: | ------------------------------------------------------------------- |
-| `👀 In Review`         |  16 | A human other than the author has engaged, or someone self-assigned. |
-| `📥 Needs Review`      |  15 | No human review yet, and automated review is clear. Front of the queue. |
-| `🥈 Needs 2nd Approval`|   1 | One human approval on a `size/l` or larger change.                  |
-| `🚀 Ready to Merge`    |   0 | Approval threshold met, CI green. Needs a merge, not a review.      |
+| `👀 In Review`         | 17 | A human other than the author has engaged, or someone self-assigned. |
+| `📥 Needs Review`      | 13 | No human review yet, and automated review is clear. Front of the queue. |
+| `🥈 Needs 2nd Approval`| 1 | One human approval on a `size/l` or larger change.                  |
+| `🚀 Ready to Merge`    | 2 | Approval threshold met, CI green. Needs a merge, not a review.      |
 
 **Author's court, waiting on the contributor: 48 PRs**
 
 | Column                 | PRs | Entry condition                                                     |
 | ---------------------- | --: | ------------------------------------------------------------------- |
-| `✋ Changes Requested` |  19 | A human asked for changes. Returns to the queue when author pushes. |
-| `📝 Draft`             |  14 | Author has said it is not ready. We take them at their word.        |
-| `🔴 CI Red`            |  10 | Checks failing, including crashed runs. Not worth a human read yet.  |
-| `🤖 Bot Findings Open` |   5 | Automated review has unresolved findings. First line of defence.    |
+| `✋ Changes Requested` | 20 | A human asked for changes. Returns to the queue when author pushes. |
+| `📝 Draft`             | 13 | Author has said it is not ready. We take them at their word.        |
+| `🔴 CI Red`            | 11 | Checks failing, including crashed runs. Not worth a human read yet.  |
+| `🤖 Bot Findings Open` | 4 | Automated review has unresolved findings. First line of defence.    |
 
-Counts come from a live dry run against the 80 open pull requests
-(`node .github/scripts/review-state-cli.js`), not from an estimate.
+Counts come from a live dry run against the 81 open pull requests
+(`node .github/scripts/review-state-cli.js`) on 2026-08-20, not from an estimate.
 
 **`✋ Changes Requested` is 19 rather than 13** because of the `reviewDecision` fix described
-above. Six pull requests (#6082, #6526, #6589, #6613, #6784, #6817) have a standing
+above. Six pull requests (#6082, #6526, #6589, #6613, #6784, #6817) had a standing
 changes-requested that the naive reading of `latestReviews` had erased, so they were sitting in
 the maintainer queue while the ball was actually with their author.
 
@@ -349,8 +350,8 @@ Actions before the workflow is allowed to write.
 
 ### Contributor guidance
 
-A gate nobody explains is just an unexplained delay, and 5 of the 9 pull requests this rule
-would currently divert are from first-time contributors. So the workflow tells the author
+A gate nobody explains is just an unexplained delay, and every one of the 4 pull requests
+this rule currently diverts is from a first-time contributor. So the workflow tells the author
 what is happening, on the pull request itself.
 
 **Timing solves itself.** The comment is posted when a pull request first enters
@@ -372,9 +373,13 @@ Draft text, in the gate state:
 > request moves into the human review queue once the automated comments are addressed, either
 > by pushing a fix or by replying in the thread.
 >
-> You can resolve a thread yourself with **Resolve conversation**. If you think a finding is
-> wrong, say so in the thread and leave it open; a maintainer will judge it. You are not
-> expected to change code you disagree with.
+> Push a fix, or reply in the thread if you disagree with a finding, then mark it
+> **Resolve conversation**. Resolving is what moves this along: a reply on its own leaves the
+> thread open and the pull request here.
+>
+> You are not expected to change code you disagree with. If a finding is wrong and you would
+> rather a maintainer decided, say so and ask for the `review/bots-overridden` label, which
+> skips this stage entirely.
 >
 > Status: `🤖 Bot Findings Open`
 
@@ -427,8 +432,8 @@ remembering anything.
 
 ## Drawbacks
 
-- **Day one will look worse than today feels.** 26 pull requests land in
-  `📥 Needs Review` and `🚀 Ready to Merge` holds one. That is not a regression, it is the
+- **Day one will look worse than today feels.** 33 pull requests land in the maintainer lane
+  and only 2 are actually ready to merge. That is not a regression, it is the
   existing backlog with the reconstruction cost stripped out. Anyone expecting the board
   to look reassuring will be disappointed.
 - **Renaming CODEOWNERS produces a notification burst** as pull requests update and teams
@@ -441,15 +446,15 @@ remembering anything.
   practice the human queue is fed by CodeRabbit's judgment. If it becomes noisy, the queue
   starves, and nobody would notice quickly because a starved queue looks like a calm one.
   Worth watching the size of `🤖 Bot Findings Open` as a signal in its own right.
-- **It lands hardest on newcomers.** 5 of the 9 pull requests the gate currently diverts are
-  from first-time contributors, and one open pull request carries 19 unresolved bot threads.
+- **It lands hardest on newcomers.** All 4 pull requests the gate currently diverts are from
+  first-time contributors, and one open pull request carries 19 unresolved bot threads.
   The guidance comment and the override exist for this, but the honest read is that we are
   asking newcomers to clear a bot before a human engages. Open question Q4.
 - **Authors can resolve their own threads.** GitHub permits it, which is what makes the gate
   actionable rather than a dead end. It also means an author can resolve without fixing to
   jump the queue. Acceptable, since a human still reviews afterwards and the thread history
   stays visible, but it means the gate is a routing hint and not an enforcement mechanism.
-- **Two approvals is aspirational today.** 38 of 78 open pull requests are `size/l` or
+- **Two approvals is aspirational today.** 38 of 81 open pull requests are `size/l` or
   larger, and exactly one of those 38 carries a human approval. Encoding the rule will
   show a persistently populated `🥈 Needs 2nd Approval` column. That is honest, and it is
   also a standing argument for either resourcing the rule or relaxing it.
@@ -541,8 +546,8 @@ a decision.
 
 **Q4. Should the bot gate apply to first-time contributors?**
 
-5 of the 9 pull requests the gate currently diverts are from first-time contributors, and the
-worst case is a pull request with 19 unresolved bot threads. Exempting newcomers would give
+All 4 pull requests the gate currently diverts are from first-time contributors, and the worst
+case is a pull request with 19 unresolved bot threads. Exempting newcomers would give
 them a human sooner, but it aims the exemption at exactly the pull requests where automated
 review earns its keep, and it puts the noisiest changes straight onto a maintainer. My
 position: apply it uniformly, rely on the guidance comment to make it navigable, and use
@@ -553,15 +558,15 @@ newcomers who then go quiet, which is the signal that the gate has become a wall
 
 | Alternative                                       | Why not                                                                                                                                                                                                 |
 | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Branch protection with required reviews           | Would hard-block the entire queue overnight: 60 of 78 open pull requests have no maintainer review. Worth revisiting once the queue is healthy, not as the mechanism for getting it there.                |
-| Weekly digest to Slack or a tracking issue        | Answers "has this been reviewed" but not "is somebody on it right now", and adds a channel to maintain. The board answers both and already contains all 78 pull requests.                                 |
+| Branch protection with required reviews           | Would hard-block the entire queue overnight: 63 of 81 open pull requests have no maintainer review. Worth revisiting once the queue is healthy, not as the mechanism for getting it there.                |
+| Weekly digest to Slack or a tracking issue        | Answers "has this been reviewed" but not "is somebody on it right now", and adds a channel to maintain. The board answers both and already contains every open pull request.                                 |
 | Saved GitHub searches only, no board field        | Cheapest option and a genuine fallback if the project token does not materialise, but a list of filtered searches is not a transition path. No sense of a card moving, no claim signal.                    |
 | Extend `lgtm` into a fuller command set           | Keeps state in comments, which is where it is unqueryable today, and requires a human to type something. The current `lgtm` label sits at zero uses, which is the evidence against.                       |
 | A custom dashboard                                | Something else to host, authenticate, and keep alive. Labels plus a board view reach most of the value with nothing running.                                                                              |
 
 ---
 
-Figures come from the 78 open pull requests and 258 board items as of 2026-08-19, read
+Figures come from the 81 open pull requests and 258 board items as of 2026-08-20, read
 through the GitHub GraphQL API. The column counts in the board section are produced by
 running the ordered evaluation above against that snapshot, so they are what the board
 would actually show on the day this lands.

--- a/design/015-review-routing.md
+++ b/design/015-review-routing.md
@@ -171,6 +171,33 @@ gain nothing but a runner.
 `review-state.yml` therefore listens only to triggers that are trusted: `pull_request_target`,
 `workflow_run`, `check_suite`, `schedule`, and `workflow_dispatch`.
 
+### Serialising writes for one pull request
+
+A workflow-level `concurrency` group cannot serialise this, because it is evaluated before the
+pull request number is known for `workflow_run` and `check_suite`. Keying on branch or SHA there
+produces a *different* group for the same pull request rather than the same one, which is worse
+than no grouping at all.
+
+Job-level `concurrency` can see `needs` and `matrix`, so the workflow is two jobs. `resolve`
+works out what to evaluate and emits both a list of pull request numbers and a list of matrix
+targets. `apply` fans out over those targets with `concurrency: review-state-${{ matrix.target }}`.
+
+An event resolves to one pull request, so it becomes one job in a group named for that pull
+request, and concurrent events for the same pull request queue behind each other. A sweep
+resolves to the single sentinel target `all`, so it stays one job over every open pull request
+rather than eighty-one jobs, and two sweeps cannot overlap.
+
+The residual case is a sweep overlapping an event run for the same pull request, since their
+groups differ. `syncLabels` verifies after writing and restores its own label if a racing run
+removed it.
+
+That verification pass deliberately only ever **adds**. An earlier version also removed labels it
+did not expect, which converged two racing runs to *zero* labels: each stripped the other's state
+and neither re-added its own, so the pull request silently left the queue. Two labels for one
+cycle is visible and self-corrects on the next run; none is invisible. `syncComment` has the same
+exposure on creation, which cannot be made idempotent by reading first, so the later creator
+detects the duplicate and deletes its own comment.
+
 ### Layer 3: mirror the label to the board
 
 The same workflow writes a new `Review` single-select field via
@@ -359,6 +386,12 @@ what is happening, on the pull request itself.
 produced findings. There is no need to guess how long CodeRabbit takes, and no risk of
 posting "wait for the bot" on a pull request the bot then passes clean. A contributor whose
 change is clean never sees a gate message at all.
+
+**The gate only applies before a human engages.** Once a maintainer reviews or self-assigns,
+the pull request moves to `👀 In Review` even with automated findings still open, because human
+judgement supersedes the bot. This is the same ordering rule as the transition logic above, but
+it needs saying in contributor-facing terms too: a maintainer looking early does not leave a
+contributor stuck behind a bot.
 
 **One comment, edited, never repeated.** The workflow finds its own previous comment by a
 hidden marker and edits it in place rather than posting again, so a pull request that cycles

--- a/design/015-review-routing.md
+++ b/design/015-review-routing.md
@@ -1,0 +1,567 @@
+```yaml
+---
+title: Review Routing for Maintainers
+version: v1
+authors: Alexander Chernov
+creation-date: 2026-08-19
+status: draft
+---
+```
+
+# Review Routing for Maintainers
+
+## Summary
+
+Review state on `external-secrets/external-secrets` is not recorded anywhere you can
+query. It exists only as prose in comment threads, so every maintainer who opens a pull
+request pays the cost of reconstructing it: has a human looked at this, did they reach a
+verdict, is someone already on it, does it need a second approval.
+
+This proposal derives review state from facts GitHub already knows, writes it to a
+single-select field on the Maintainer Queue board (org project #3), and groups a board
+view by it. The result is a kanban that nobody has to move cards on. Everything is
+computed; the only manual act is claiming a pull request by assigning yourself.
+
+Review runs in two stages. Automated review is the first line of defence: while a bot has
+unresolved findings, the pull request sits with its author and never reaches the human
+queue. Contributors are told this in a comment on the pull request itself, posted only once
+there is actually something to address.
+
+## Motivation
+
+### The problem, measured
+
+Across the 78 open pull requests, formal review state looks like this:
+
+| Review state                  | PRs |
+| ----------------------------- | --: |
+| Commented only, no verdict    |  47 |
+| No review at all              |  15 |
+| Changes requested             |  13 |
+| Approved                      |   3 |
+
+(Effective current review per reviewer, not cumulative review events. Buckets are
+mutually exclusive, with changes-requested taking precedence over approved.)
+
+That first row is the whole problem. Those 47 pull requests have activity but no answer,
+so the reconstruction cost is paid again by each person who opens one.
+
+Worse, the activity is mostly not human. Sorted by effective reviews on open pull
+requests, the top reviewer is a bot:
+
+| Reviewer                      | Reviews | Kind                    |
+| ----------------------------- | ------: | ----------------------- |
+| coderabbitai                  |      56 | bot                     |
+| evrardj-roche                 |      29 | human, not a maintainer |
+| alekc                         |      11 | human                   |
+| Skarlso                       |      11 | maintainer              |
+| gusfcarvalho                  |       6 | maintainer              |
+| github-advanced-security      |       5 | bot                     |
+| copilot-pull-request-reviewer |       2 | bot                     |
+| moolen                        |       2 | maintainer              |
+| knelasevero                   |       1 | maintainer              |
+
+**24 of 78 open pull requests carry reviews from bots only.** In the GitHub UI they look
+reviewed. No human has formed a view on any of them. Any signal that does not distinguish
+bots from humans is worse than no signal, because it is confidently wrong.
+
+Splitting those 24 by whether the bot still has outstanding findings is what makes them
+actionable: **10 have unresolved bot findings** and belong with their author, while **14
+are clean** and genuinely need a human. Today both groups look identical.
+
+Meanwhile every native routing mechanism is switched off:
+
+- 67 of 78 pull requests have no requested reviewer.
+- Zero carry the `lgtm` label.
+- 8 have an assignee, though `docs/contributing/process.md` names the assignee as the
+  mechanism that tracks who owns a pull request's lifecycle.
+- 60 of 78 have had no maintainer review at all.
+
+### Root cause
+
+Our CODEOWNERS file sits at a path GitHub does not read. Both copies are named
+`CODEOWNERS.md`, and GitHub only honours `CODEOWNERS` with no extension at the repository
+root, in `.github/`, or in `docs/`. None of those exist:
+
+```
+CODEOWNERS               absent
+.github/CODEOWNERS       absent
+docs/CODEOWNERS          absent
+```
+
+So all fifty-odd path-to-team mappings are inert: no automatic review requests, nothing in
+anyone's "awaiting your review" filter, no per-team sign-off state in the sidebar. One
+file extension explains why 67 of 78 pull requests have no reviewer attached.
+
+The encouraging part is that the hard logic already exists.
+`.github/scripts/lgtm-processor.js` parses that file, maps changed files to reviewer
+teams, checks team membership, and computes exactly which areas are covered and which are
+not. It then writes the answer into a prose comment and discards it, and only when
+somebody types `/lgtm`. We have already built the expensive part. It just needs somewhere
+durable to put the result.
+
+### Goals
+
+- Make "which pull request should I review next" answerable without reading comment threads.
+- Make "has another maintainer already reviewed or claimed this" visible at a glance.
+- Separate work that is genuinely ours from work waiting on the contributor.
+- Add no step that depends on anyone remembering to do it.
+
+### Non-Goals
+
+- Enforcing review policy. This proposal changes visibility, not merge gating.
+- Enabling branch protection or required reviews (see Alternatives).
+- Reworking the `Maintainer Queue` priority classification, which is a separate concern.
+- Any new service to host or keep alive.
+
+## Proposal
+
+Three layers, each independently useful. If a later layer stalls, the earlier ones keep
+working.
+
+### Layer 1: make CODEOWNERS real
+
+Config only, one pull request. **Raised as #6853.** Moving the file to
+`.github/CODEOWNERS` restores native review requests and the per-reviewer "awaiting your
+review" filter.
+
+A plain rename would not have worked, and this is worth knowing before reviewing that PR.
+Precedence is last-match-wins and the project-wide `*` line sat at the bottom of the file,
+so the moment GitHub started reading it the maintainers teams would have owned every path
+and every area rule would have been dead. The default now comes first.
+
+Auditing the file against the tree and the org team list turned up more:
+
+- The two copies had already drifted. `.github/CODEOWNERS.md` carried the corrected
+  `providers/v1/ovh/` path while the root copy still had `pkg/provider/v1/ovh/`, and
+  `lgtm-processor.js` read the stale one. #6853 collapses to a single canonical file and
+  retargets `lgtm.yml` and `lgtm-processor.js`, rather than keeping two that can drift.
+- Five referenced reviewer teams do not exist (dvls, nebius, ngrok, ovh, volcengine).
+  GitHub reports unknown owners as errors and ignores those lines, so a rename would have
+  surfaced five syntax errors immediately. Those paths now fall through to
+  `providers-reviewers`.
+- `scripts/`, `build/` and `test/` do not exist in this repository at all.
+- `docs-maintainers` and `provider-openbao-reviewers` already exist as teams with matching
+  directories and were simply never wired up. Both are now mapped.
+- `deploy/` gets no entry after all, because there is no charts reviewer team to point it
+  at. Creating one is worth doing separately, given the chart review volume.
+
+### Layer 2: compute review state into labels
+
+One workflow. It evaluates the rules in the Behavior section, applies exactly one
+`review/*` label, and maintains the contributor-facing comment described under Contributor
+guidance. Labels rather than a board field alone, for two reasons: the state
+becomes visible on the pull request itself and in ordinary GitHub search, and it keeps
+working if project write access is ever unavailable.
+
+Triggers are constrained by something worth stating plainly, because it shaped the whole
+design: **`pull_request_review` cannot label a pull request from a fork.** GitHub runs that
+event's workflow from the pull request's own merge commit, so it gets a read-only token and no
+secrets. An App token cannot rescue it either, since secrets are not passed at all. And
+`pull_request_review_thread` is not a valid Actions trigger, so thread resolution cannot be
+observed directly at all.
+
+So review activity reaches us in two stages. `review-signal.yml` fires on
+`pull_request_review`, holds `permissions: {}`, and does nothing but complete. Its completion
+raises `workflow_run` for `review-state.yml`, which runs from the default branch with a write
+token. The relay is deliberately inert: a fork can rewrite it in their own pull request and
+gain nothing but a runner.
+
+`review-state.yml` therefore listens only to triggers that are trusted: `pull_request_target`,
+`workflow_run`, `check_suite`, `schedule`, and `workflow_dispatch`.
+
+### Layer 3: mirror the label to the board
+
+The same workflow writes a new `Review` single-select field via
+`updateProjectV2ItemFieldValue`, and a pull-request-only board view (`is:pr -is:closed`)
+groups by it.
+
+A dedicated field rather than reusing `Status`, because the board also carries 180 issues
+for which review columns are meaningless, and because the built-in workflows already drive
+`Status` (Todo on add, Done on close and merge) and would fight a custom pipeline.
+
+**Prerequisite:** `GITHUB_TOKEN` cannot write org projects. The natural candidate is the
+App already behind `LGTM_APP_ID` and `LGTM_PRIVATE_KEY`, but it needs
+`organization_projects: write`. Someone with org admin needs to confirm or grant this.
+Layers 1 and 2 do not depend on it.
+
+### Resolving a pull request from an event
+
+Two events name a pull request only indirectly, and the obvious API call for it does not work.
+`listPullRequestsAssociatedWithCommit` returns an **empty array for pull requests from forks**,
+with no error to distinguish that from "no such pull request". Measured on this repository: it
+resolves same-repo pull requests correctly and returns nothing for every fork one, which is
+most of our traffic.
+
+So both cases match against the open pull request list instead. `check_suite` matches on head
+SHA. `workflow_run` matches on head repository plus head branch, not SHA, because for review
+events `GITHUB_SHA` is the merge commit rather than the pull request head. A head branch is
+unique per repository, so the pair identifies exactly one open pull request.
+
+### The board
+
+Eight columns in two lanes. The lane split is the central claim of this proposal: more than
+half of what currently sits in one undifferentiated list is not a maintainer's problem at
+all.
+
+Counts are the real distribution of today's 78 open pull requests under the rules below.
+
+**Maintainer's queue, waiting on us: 32 PRs**
+
+| Column                 | PRs | Entry condition                                                     |
+| ---------------------- | --: | ------------------------------------------------------------------- |
+| `👀 In Review`         |  16 | A human other than the author has engaged, or someone self-assigned. |
+| `📥 Needs Review`      |  15 | No human review yet, and automated review is clear. Front of the queue. |
+| `🥈 Needs 2nd Approval`|   1 | One human approval on a `size/l` or larger change.                  |
+| `🚀 Ready to Merge`    |   0 | Approval threshold met, CI green. Needs a merge, not a review.      |
+
+**Author's court, waiting on the contributor: 48 PRs**
+
+| Column                 | PRs | Entry condition                                                     |
+| ---------------------- | --: | ------------------------------------------------------------------- |
+| `✋ Changes Requested` |  19 | A human asked for changes. Returns to the queue when author pushes. |
+| `📝 Draft`             |  14 | Author has said it is not ready. We take them at their word.        |
+| `🔴 CI Red`            |  10 | Checks failing, including crashed runs. Not worth a human read yet.  |
+| `🤖 Bot Findings Open` |   5 | Automated review has unresolved findings. First line of defence.    |
+
+Counts come from a live dry run against the 80 open pull requests
+(`node .github/scripts/review-state-cli.js`), not from an estimate.
+
+**`✋ Changes Requested` is 19 rather than 13** because of the `reviewDecision` fix described
+above. Six pull requests (#6082, #6526, #6589, #6613, #6784, #6817) have a standing
+changes-requested that the naive reading of `latestReviews` had erased, so they were sitting in
+the maintainer queue while the ball was actually with their author.
+
+Merging is the exit. The built-in "Pull request merged" workflow sets `Status` to Done,
+and auto-archive removes the item after its two week grace window. That path is already
+wired and needs no new work.
+
+## Behavior
+
+### Transition logic
+
+Conditions overlap constantly. A draft can have failing CI and a changes-requested review
+at the same time. So the rules are an **ordered evaluation with first match winning**, not
+a set of independent tests. Order is the specification.
+
+```
+# definitions
+BOTS      = {coderabbitai, github-advanced-security,
+             copilot-pull-request-reviewer, dependabot,
+             eso-service-account-app}
+# Each reviewer's standing verdict: their most recent APPROVED,
+# CHANGES_REQUESTED or DISMISSED. COMMENTED and PENDING express no verdict and
+# must never overwrite one. This is why latestReviews is the WRONG input: it
+# returns the last SUBMISSION per author, so a reviewer who requests changes
+# and then comments again silently loses the request.
+verdicts  = last verdict per author, excluding bots and the PR author
+approvals = count(v == APPROVED for v in verdicts)
+required  = 2 if labels & {size/l, size/xl} else 1
+
+# GitHub's own reviewDecision is authoritative; the per-author verdicts are the
+# fallback for a repository with no review policy configured.
+changesRequested = reviewDecision == CHANGES_REQUESTED
+                   or CHANGES_REQUESTED in verdicts
+
+# A crashed runner reports ERROR, not FAILURE. Both mean CI is not green.
+ciRed     = ciState in {FAILURE, ERROR}
+
+# The author commenting on their own diff is not someone else reviewing it.
+engaged   = any non-bot review by someone other than the author
+            or the PR has an assignee
+
+# the bot gate: threads opened by a bot, still unresolved, still relevant.
+# isOutdated means the author already pushed over the flagged line, so the
+# finding may well be moot and must not trap the pull request.
+botOpen   = count(t for t in reviewThreads
+                  if t.firstComment.author in BOTS
+                  and not t.isResolved
+                  and not t.isOutdated)
+override  = "review/bots-overridden" in labels
+
+# ordered evaluation, first match wins
+if isDraft                                 -> 📝 Draft
+if changesRequested                        -> ✋ Changes Requested
+if ciRed                                   -> 🔴 CI Red
+if approvals >= required                   -> 🚀 Ready to Merge
+if approvals >= 1                          -> 🥈 Needs 2nd Approval
+if engaged                                 -> 👀 In Review
+if botOpen > 0 and not override            -> 🤖 Bot Findings Open
+else                                       -> 📥 Needs Review
+```
+
+### Local dry run
+
+`review-state-cli.js` runs the same classifier against the live repository and prints the label
+each pull request would get, without writing anything. Its client's mutating methods throw, so
+dry run is enforced by the code rather than by remembering a flag.
+
+```
+node .github/scripts/review-state-cli.js            # sweep every open PR
+node .github/scripts/review-state-cli.js --pr 6613  # one pull request
+node .github/scripts/review-state-cli.js --json     # machine readable
+```
+
+`workflow_dispatch` also takes a `dry_run` input, so the same report can be produced from
+Actions before the workflow is allowed to write.
+
+### Why this order
+
+- **Draft outranks everything.** The author has explicitly said it is not ready, and that
+  statement should not be second-guessed by CI or by a stale review.
+- **Changes Requested outranks CI Red.** Both put the ball in the author's court, so
+  routing is unaffected either way, but "a human asked for changes" tells the author more
+  than "checks are failing" and is the more useful label to carry.
+- **Ready to Merge outranks Needs 2nd Approval.** Otherwise a single-approval change on a
+  small pull request would sit in a column asking for a second reviewer it does not need.
+- **The bot gate sits below `👀 In Review`, deliberately.** Once a human has engaged or
+  claimed a pull request, human judgment supersedes the bot and the card must not be yanked
+  out from under a reviewer mid-read. The gate only diverts pull requests nobody has touched
+  yet, which is exactly what "should not move into needing a human review" means.
+- **The gate ignores outdated threads.** Of 86 unresolved bot threads, 73 are still current
+  and 13 are outdated. An outdated thread means the author already pushed over the flagged
+  line, so counting those would trap pull requests whose authors had in fact responded.
+- **Needs Review is the fallback,** not a computed state. Anything we cannot classify
+  lands at the front of the queue rather than disappearing. Failing loudly beats failing
+  silently. Note this means a bot that never runs cannot block anything: no threads, no
+  gate, so a CodeRabbit outage degrades to today's behaviour rather than stalling the queue.
+
+### What counts as a review
+
+- **Bots gate, they never satisfy.** Automated review is the first line of defence: while a
+  bot has unresolved current findings, the pull request sits in `🤖 Bot Findings Open` and
+  never reaches the human queue. A bot approval, equally, never counts toward the approval
+  threshold. Both halves matter: bots can hold a pull request back, and they can never wave
+  one through.
+- **Which bots actually gate.** Of 327 bot-opened threads on open pull requests,
+  coderabbitai opened 301 (70 unresolved and current), github-advanced-security 21 (3), and
+  copilot-pull-request-reviewer 5 (0). In practice this gate means "CodeRabbit is satisfied",
+  which is worth saying out loud rather than pretending it is bot-agnostic.
+- **Maintainers can override.** The `review/bots-overridden` label forces a pull request
+  past the gate, for false positives, for a newcomer stuck on nitpicks, or for a bot
+  outage. Consistent with the existing `/lgtm` dispatcher, this is worth exposing as a
+  slash command too.
+- **Effective state, not history.** Counting `latestReviews` rather than all reviews means
+  an approval that the same person later superseded with a comment stops counting,
+  automatically.
+- **Two approvals for `size/l` and above,** one otherwise, matching the rule already
+  written down in `process.md`.
+
+### Contributor guidance
+
+A gate nobody explains is just an unexplained delay, and 5 of the 9 pull requests this rule
+would currently divert are from first-time contributors. So the workflow tells the author
+what is happening, on the pull request itself.
+
+**Timing solves itself.** The comment is posted when a pull request first enters
+`🤖 Bot Findings Open`, which by definition cannot happen before automated review has
+produced findings. There is no need to guess how long CodeRabbit takes, and no risk of
+posting "wait for the bot" on a pull request the bot then passes clean. A contributor whose
+change is clean never sees a gate message at all.
+
+**One comment, edited, never repeated.** The workflow finds its own previous comment by a
+hidden marker and edits it in place rather than posting again, so a pull request that cycles
+through the gate three times still has exactly one comment. When the findings clear, the
+same comment is rewritten to say so.
+
+Draft text, in the gate state:
+
+> Automated review has flagged **3 open items** on this pull request.
+>
+> Review here runs in two stages. Automated review comes first, then a maintainer. This pull
+> request moves into the human review queue once the automated comments are addressed, either
+> by pushing a fix or by replying in the thread.
+>
+> You can resolve a thread yourself with **Resolve conversation**. If you think a finding is
+> wrong, say so in the thread and leave it open; a maintainer will judge it. You are not
+> expected to change code you disagree with.
+>
+> Status: `🤖 Bot Findings Open`
+
+And once it clears:
+
+> Automated review is clear. This pull request is now in the human review queue.
+>
+> Status: `📥 Needs Review`
+
+Expectations should also be set before a contributor opens a pull request at all, so a short
+paragraph describing the two-stage flow belongs in `.github/pull_request_template.md` and in
+`docs/contributing/process.md` alongside the existing review rules.
+
+### Worked examples
+
+| Situation                                                                  | Column                  | Why                                                        |
+| -------------------------------------------------------------------------- | ----------------------- | ---------------------------------------------------------- |
+| New provider PR, `size/l`, coderabbitai left 4 unresolved comments, CI green | `🤖 Bot Findings Open`  | Automated review is the first stage; author addresses these |
+| Author resolves all 4 threads                                              | `📥 Needs Review`       | Gate clear, and the guidance comment is rewritten to say so |
+| Author pushes a fix but forgets to resolve the threads                     | `📥 Needs Review`       | The threads go outdated, and outdated threads do not gate   |
+| Same PR, Skarlso approves                                                  | `🥈 Needs 2nd Approval` | One human approval against a required two                  |
+| Same PR, gusfcarvalho also approves                                        | `🚀 Ready to Merge`     | Threshold met, CI still green                              |
+| Author pushes a new commit                                                 | recomputed              | See open question Q1 on approval staleness                 |
+| `size/xs` docs typo fix, one approval                                      | `🚀 Ready to Merge`     | `required` is 1 below `size/l`                             |
+| Draft with failing CI and an old changes-requested review                   | `📝 Draft`              | Draft wins the ordering                                    |
+| Maintainer assigns themselves, has not reviewed yet                        | `👀 In Review`          | Assignment is the claim signal, so nobody duplicates work  |
+| Maintainer already reviewing when CodeRabbit opens a new thread             | `👀 In Review`          | The gate sits below In Review, so nothing is yanked back    |
+| CodeRabbit finding is a false positive, maintainer labels `review/bots-overridden` | `📥 Needs Review` | Override skips the gate without resolving anything falsely  |
+| CodeRabbit never ran on the pull request                                    | `📥 Needs Review`       | No threads means no gate; an outage cannot stall the queue  |
+
+### Automated versus manual
+
+Worth being explicit, because this is the part that decides whether the system survives
+contact with a busy month.
+
+**Automated:** intake to the board, every column assignment, the transition on every
+review and every push, the exit on merge, and archiving afterwards.
+
+**Manual, two things.** Assigning yourself to claim a pull request, which is optional since
+engaging with a review moves the card anyway, and exists only so two maintainers do not spend
+the same evening on the same pull request. And applying `review/bots-overridden` when a bot
+finding does not deserve to hold a change back.
+
+Resolving bot threads is the contributor's, not ours, which is the point of the gate.
+
+This is a deliberate constraint rather than a nice property. The `Maintainer Queue`
+classification on this same board was real work by real maintainers, and it stopped in
+July because it depended on people remembering. Nothing in this proposal depends on anyone
+remembering anything.
+
+## Drawbacks
+
+- **Day one will look worse than today feels.** 26 pull requests land in
+  `📥 Needs Review` and `🚀 Ready to Merge` holds one. That is not a regression, it is the
+  existing backlog with the reconstruction cost stripped out. Anyone expecting the board
+  to look reassuring will be disappointed.
+- **Renaming CODEOWNERS produces a notification burst** as pull requests update and teams
+  get requested. There is no blocking risk, since the repository has no rulesets and no
+  branch protection, but inboxes will notice.
+- **The bot list needs maintaining.** A new review bot silently counts as human coverage
+  until someone adds it. Keeping the list in the workflow file rather than a secret makes
+  the omission visible in review.
+- **The gate makes CodeRabbit load-bearing.** It opened 301 of 327 bot threads, so in
+  practice the human queue is fed by CodeRabbit's judgment. If it becomes noisy, the queue
+  starves, and nobody would notice quickly because a starved queue looks like a calm one.
+  Worth watching the size of `🤖 Bot Findings Open` as a signal in its own right.
+- **It lands hardest on newcomers.** 5 of the 9 pull requests the gate currently diverts are
+  from first-time contributors, and one open pull request carries 19 unresolved bot threads.
+  The guidance comment and the override exist for this, but the honest read is that we are
+  asking newcomers to clear a bot before a human engages. Open question Q4.
+- **Authors can resolve their own threads.** GitHub permits it, which is what makes the gate
+  actionable rather than a dead end. It also means an author can resolve without fixing to
+  jump the queue. Acceptable, since a human still reviews afterwards and the thread history
+  stays visible, but it means the gate is a routing hint and not an enforcement mechanism.
+- **Two approvals is aspirational today.** 38 of 78 open pull requests are `size/l` or
+  larger, and exactly one of those 38 carries a human approval. Encoding the rule will
+  show a persistently populated `🥈 Needs 2nd Approval` column. That is honest, and it is
+  also a standing argument for either resourcing the rule or relaxing it.
+- **A third field on the board.** `Status`, `Maintainer Queue`, and now `Review`.
+  Justified because they answer different questions (pipeline position, priority and
+  category, review coverage) but it is more surface to keep coherent.
+- **Thread resolution is not promptly observable.** There is no Actions trigger for it. In
+  practice resolving usually accompanies a push, which both fires `pull_request_target` and
+  makes the threads outdated, so the common path is prompt. Resolving without pushing waits for
+  the next sweep.
+- **`check_suite` never fires for our own CI.** GitHub suppresses it for check suites created by
+  Actions, to prevent recursion. It fires only for the non-Actions integrations (dco,
+  sonarqubecloud, github-advanced-security, codecov), whose runs happen to re-query the full
+  pull request state as a side effect. That is incidental, not guaranteed, so CI transitions can
+  lag until the sweep.
+- **Truncation is possible on very long pull requests.** Reviews and threads are fetched 100 at
+  a time. Threads use `last:100` so the newest are kept, and both cases log a warning rather
+  than silently deriving the wrong state. One open pull request is already at 68 threads.
+
+## What this design got wrong the first time
+
+Recorded because the mistakes are instructive, and because a reviewer will otherwise ask why
+the shape is unusual.
+
+- `pull_request_review_thread` was used as a trigger. It is not a valid Actions event, and one
+  invalid key invalidates the whole workflow file, so the first version never ran at all: zero
+  jobs, on every trigger.
+- `latestReviews` was used to derive verdicts. It returns the last submission per author, not
+  each author's standing verdict, and it was erasing a changes-requested on six live pull
+  requests.
+- `listPullRequestsAssociatedWithCommit` was used to map a commit to its pull request. It
+  returns an empty array for forks.
+- Only `FAILURE` was treated as red CI, missing `ERROR`.
+- The test suite passed while `size/xl` was silently removed from the two-approval rule. Every
+  rule in this document is now mutation-tested: deliberately breaking it has to fail a test.
+
+## Acceptance Criteria
+
+- Layer 1 merged, and a subsequent pull request shows automatic team review requests.
+- Layer 2 applies exactly one `review/*` label per open pull request, and the label
+  changes within one workflow run of a review being submitted or a commit being pushed.
+- Resolving the last open bot thread moves a pull request out of `🤖 Bot Findings Open`
+  without any human action, and the guidance comment is rewritten rather than duplicated.
+- A pull request with no bot activity at all is never gated.
+- Layer 3 has the `Review` field populated for every open pull request on the board, with
+  the pull-request-only view grouped by it.
+- **Rollback:** each layer is independently revertable. Layer 1 is a file rename. Layer 2
+  is deleting a workflow plus the `review/*` labels. Layer 3 is deleting one field and one
+  view. No layer leaves state behind that blocks anything.
+- **Observability:** the workflow logs the derived state and the inputs it used
+  (approval count, required count, CI rollup, draft flag) so a wrong column can be
+  diagnosed from the run log alone rather than by re-deriving it by hand.
+- **Failure modes to watch:** a new review bot not in `BOTS` inflating coverage; the App
+  token losing project write and silently failing the Layer 3 step; label and field drifting
+  apart if the two writes are not in the same job; the guidance comment posting more than
+  once because the marker lookup failed; and a growing `🤖 Bot Findings Open` column, which
+  reads as a quiet queue but means contributors are stuck.
+
+## Open Questions
+
+Four things that should not be decided unilaterally.
+
+**Q1. Should an approval survive a subsequent push?**
+
+GitHub keeps approvals valid across pushes when no branch protection dismisses them, and
+we have none. But `lgtm-remove-on-update.yml` already strips the `lgtm` label on
+synchronize, so the repository has effectively answered "no" once already. Consistency
+argues for invalidating approvals given before the current head commit. Strictness argues
+the other way, since it means a rebase costs a re-approval. My position: match the
+existing `lgtm` behaviour and invalidate, because a silently stale approval is the failure
+mode that actually hurts.
+
+**Q2. Should coverage require the right team, or just a human?**
+
+The strict reading of `OWNERS.md` is that a reviewer approves within their specialty, and
+`lgtm-processor.js` already does the team-membership checks needed to enforce it. The cost
+is a team-membership API call per reviewer per area, which is noticeably heavier. My
+position: ship with "any non-bot human" first, add team awareness as a follow-up once the
+pipeline is proven, since the simple version already fixes the 24 bot-only pull requests.
+
+**Q3. Should the board stay private?**
+
+Not strictly part of this proposal, but adjacent. Project #3 is private while project #2
+is public. Whatever we decide for review routing, the `🎯 Free for All` and
+`⚡ Easy Wins` buckets identify 65 open items of delegatable work that contributors cannot
+see, and 42 of those carry neither `good first issue` nor `help wanted`. Given
+`burnout-mitigation.md` is explicitly about growing the contributor pool, that seems worth
+a decision.
+
+**Q4. Should the bot gate apply to first-time contributors?**
+
+5 of the 9 pull requests the gate currently diverts are from first-time contributors, and the
+worst case is a pull request with 19 unresolved bot threads. Exempting newcomers would give
+them a human sooner, but it aims the exemption at exactly the pull requests where automated
+review earns its keep, and it puts the noisiest changes straight onto a maintainer. My
+position: apply it uniformly, rely on the guidance comment to make it navigable, and use
+`review/bots-overridden` when someone is clearly stuck. Revisit if the column fills with
+newcomers who then go quiet, which is the signal that the gate has become a wall.
+
+## Alternatives
+
+| Alternative                                       | Why not                                                                                                                                                                                                 |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Branch protection with required reviews           | Would hard-block the entire queue overnight: 60 of 78 open pull requests have no maintainer review. Worth revisiting once the queue is healthy, not as the mechanism for getting it there.                |
+| Weekly digest to Slack or a tracking issue        | Answers "has this been reviewed" but not "is somebody on it right now", and adds a channel to maintain. The board answers both and already contains all 78 pull requests.                                 |
+| Saved GitHub searches only, no board field        | Cheapest option and a genuine fallback if the project token does not materialise, but a list of filtered searches is not a transition path. No sense of a card moving, no claim signal.                    |
+| Extend `lgtm` into a fuller command set           | Keeps state in comments, which is where it is unqueryable today, and requires a human to type something. The current `lgtm` label sits at zero uses, which is the evidence against.                       |
+| A custom dashboard                                | Something else to host, authenticate, and keep alive. Labels plus a board view reach most of the value with nothing running.                                                                              |
+
+---
+
+Figures come from the 78 open pull requests and 258 board items as of 2026-08-19, read
+through the GitHub GraphQL API. The column counts in the board section are produced by
+running the ordered evaluation above against that snapshot, so they are what the board
+would actually show on the day this lands.

--- a/design/015-review-routing.md
+++ b/design/015-review-routing.md
@@ -193,10 +193,22 @@ removed it.
 
 That verification pass deliberately only ever **adds**. An earlier version also removed labels it
 did not expect, which converged two racing runs to *zero* labels: each stripped the other's state
-and neither re-added its own, so the pull request silently left the queue. Two labels for one
-cycle is visible and self-corrects on the next run; none is invisible. `syncComment` has the same
-exposure on creation, which cannot be made idempotent by reading first, so the later creator
+and neither re-added its own, so the pull request silently left the queue. `syncComment` has the
+same exposure on creation, which cannot be made idempotent by reading first, so the later creator
 detects the duplicate and deletes its own comment.
+
+An overlap therefore leaves two states, which the sweep resolves at the end of its cycle.
+**Only the sweep cleans up, and only ever by withdrawing the label it applied itself.** That
+asymmetry is what makes zero unreachable: when both sides cleaned up they removed each other's
+state, whereas one side withdrawing its own can only ever reduce two to one. The event's state
+wins, which is the right precedence, since it was raised by an actual change while a sweep is a
+backstop.
+
+Deferring it to the end of the cycle matters too: by then the overlapping event runs have almost
+certainly finished, so the pass sees settled state rather than racing what it is repairing. It
+refuses to act when its own label is already gone, ignores `review/bots-overridden` because that
+is a human decision rather than derived state, and restores its label if withdrawing it would
+have left the pull request with none.
 
 ### Layer 3: mirror the label to the board
 

--- a/docs/contributing/process.md
+++ b/docs/contributing/process.md
@@ -80,6 +80,11 @@ You do not need to watch for this. When there is something to address, a comment
 the pull request explaining what is outstanding, and it is updated in place once the queue
 picks your change up.
 
+There is one exception worth knowing: the automated stage only applies before a human gets
+involved. Once a maintainer reviews or assigns themselves, their judgement takes over and the
+pull request moves to `review/in-review` even if automated findings are still open. So a
+maintainer engaging early does not leave your pull request stuck behind a bot.
+
 A `review/*` label tracks where each pull request sits, and it is derived automatically. The
 ones that mean the ball is with the author are `review/draft`, `review/ci-red`,
 `review/changes-requested`, and `review/bot-findings-open`. The rest mean it is with us.

--- a/docs/contributing/process.md
+++ b/docs/contributing/process.md
@@ -68,10 +68,13 @@ of code in this project.
 Review runs in two stages: automated review first, then a maintainer.
 
 While an automated reviewer still has unresolved findings on your pull request, it stays with
-you rather than entering the maintainer queue. Address them by pushing a fix, or by replying
-in the thread if you think a finding is wrong, and resolve the conversation. You do not need
-to change code you disagree with; say so in the thread and a maintainer will judge it. A
-maintainer can also apply `review/bots-overridden` to skip the gate entirely.
+you rather than entering the maintainer queue. Push a fix, or reply in the thread if you
+disagree with a finding, then mark the conversation resolved. Resolving is what moves the pull
+request along: a reply on its own leaves the thread open, and the pull request where it is.
+
+You are not expected to change code you disagree with. If a finding is wrong and you would
+rather a maintainer decided, say so in the thread and ask for the `review/bots-overridden`
+label, which skips this stage entirely.
 
 You do not need to watch for this. When there is something to address, a comment appears on
 the pull request explaining what is outstanding, and it is updated in place once the queue

--- a/docs/contributing/process.md
+++ b/docs/contributing/process.md
@@ -63,6 +63,24 @@ Pull requests that are labelled with _size/l_ and above _MUST_ have at least **T
 approvers for it to be merged. Please respect this policy to ensure the quality
 of code in this project.
 
+### How review is routed
+
+Review runs in two stages: automated review first, then a maintainer.
+
+While an automated reviewer still has unresolved findings on your pull request, it stays with
+you rather than entering the maintainer queue. Address them by pushing a fix, or by replying
+in the thread if you think a finding is wrong, and resolve the conversation. You do not need
+to change code you disagree with; say so in the thread and a maintainer will judge it. A
+maintainer can also apply `review/bots-overridden` to skip the gate entirely.
+
+You do not need to watch for this. When there is something to address, a comment appears on
+the pull request explaining what is outstanding, and it is updated in place once the queue
+picks your change up.
+
+A `review/*` label tracks where each pull request sits, and it is derived automatically. The
+ones that mean the ball is with the author are `review/draft`, `review/ci-red`,
+`review/changes-requested`, and `review/bot-findings-open`. The rest mean it is with us.
+
 ### Triggering e2e tests
 
 We have an extensive set of e2e tests that test the integration with *real* cloud provider APIs.


### PR DESCRIPTION
## Problem Statement

Review state only exists as prose in comment threads, so working out whether a pull request needs attention means reading it. Of the 81 open pull requests, 63 carry no human verdict at all: 39 have never been reviewed by a human, and 24 have comments but no answer to "is this covered". 63 have had no maintainer review. The most active reviewer is a bot: coderabbitai has 57 effective reviews against 11 for the busiest maintainer, and 24 pull requests carry reviews from bots only, which looks identical to having been reviewed.

Reading that state back out of the API is also not as simple as it looks. `latestReviews` returns each author's last review *submission* rather than their standing verdict, so a reviewer who requests changes and then comments again appears to have withdrawn the request. Six open pull requests are in that position right now (#6082, #6526, #6589, #6613, #6784, #6817): all have a standing changes-requested, all currently look like they are waiting on a maintainer, and all are actually waiting on their author.

## Related Issue

None. Design doc included as `design/015-review-routing.md`.

## Proposed Changes

A workflow derives exactly one `review/*` label per open pull request from draft flag, each reviewer's standing verdict, check rollup, size labels, assignees and unresolved bot threads. Ordered evaluation, first match wins, with `review/needs-review` as the fallback so anything unclassifiable surfaces at the front of the queue rather than vanishing. Nothing is moved by hand.

Automated review is the first stage. While a bot has findings that are unresolved and not outdated, the pull request carries `review/bot-findings-open` and stays with its author. The gate sits below `review/in-review`, so a card is never pulled from under a reviewer who has already engaged; outdated threads are ignored, since the author has already pushed over the flagged line; and a bot that never runs leaves no threads, so an outage degrades to today's behaviour rather than stalling the queue. `review/bots-overridden` skips the gate.

Contributors get one comment when a pull request first enters the gate, edited in place when it clears. The timing needs no logic: producing findings is what triggers the comment, so it cannot fire before the async bot review has run, and a clean pull request never sees one.

## Why this is two workflows

The unusual part, and the bit worth reviewing.

`pull_request_review` cannot label a pull request from a fork. GitHub runs it from the pull request's merge commit, so it gets a read-only token and no secrets, which also rules out an App token. And `pull_request_review_thread` is not a valid Actions trigger at all.

So `review-signal.yml` fires on `pull_request_review`, holds `permissions: {}` and does nothing but complete. That raises `workflow_run` for `review-state.yml`, which runs from the default branch with a write token. The relay is deliberately inert: a fork can rewrite it and gain a runner, nothing else.

Worth knowing if you maintain this later: `listPullRequestsAssociatedWithCommit` returns an empty array for fork pull requests, with no error distinguishing that from "no such pull request". Both `check_suite` and `workflow_run` match against the open pull request list instead, on head SHA and on head repository plus branch respectively, since for review events `GITHUB_SHA` is the merge commit rather than the pull request head.

## Verification

`node --test '.github/scripts/**/*-test.js'` passes, 79 cases. Nothing previously ran the pre-existing lgtm tests at all; `scripts-test.yml` fixes that and guards against `node --test` exiting 0 when its glob matches nothing.

Every rule is mutation-tested: breaking `size/xl`, `ERROR`, the author exclusion, `reviewDecision`, `isOutdated`, the verdict set, the gate's position, the truncation skip or the comment-author check each fails a test. That is worth stating because the first attempt at the truncation skip turned out not to be pinned by anything, and only mutating it revealed that. Every workflow in the repo was also validated against the official workflow schema, which is worth doing because an unrecognised trigger key invalidates a whole workflow file and GitHub reports it only as a run with zero jobs.

A live dry run over all 81 open pull requests gives 20 changes-requested, 17 in-review, 13 needs-review, 13 draft, 11 ci-red, 4 bot-findings-open, 2 ready-to-merge and 1 needs-2nd-approval. That is 33 waiting on us against 48 waiting on a contributor, which is the argument for the two lanes. Expect it to look worse than the backlog currently feels; it is the same backlog with the reconstruction cost removed.

Worth flagging from that run: all 4 pull requests the bot gate currently diverts are from first-time contributors. The guidance comment and the `review/bots-overridden` escape hatch exist for exactly that, but it is the sharp edge of this design and open question Q4 in the design doc is about whether to keep it uniform.

To see it yourself without writing anything, `node .github/scripts/review-state-cli.js`. The client's mutating methods throw, so dry run is enforced by code rather than a flag. `workflow_dispatch` also takes a `dry_run` input.

## Two details in the classifier worth a look

Each reviewer's verdict is derived from their full review history, taking the most recent `APPROVED`, `CHANGES_REQUESTED` or `DISMISSED` and ignoring plain comments, then cross-checked against GitHub's own `reviewDecision`. That is what fixes the six misrouted pull requests above, and it fixes it in both directions: an approval followed by a comment is no longer lost either.

Red CI covers `ERROR` as well as `FAILURE`. `ERROR` is what a crashed runner reports, and treating only `FAILURE` as red lets a pull request with genuinely broken CI reach `review/ready-to-merge`.

## Not in this PR

The nine `review/*` labels already exist, so the fail-fast guard is satisfied and nothing else is needed to enable this.

Mirroring the label onto the Maintainer Queue board as a `Review` field needs an App token with `organization_projects: write`, which is unconfirmed. Labels stand on their own.

The design doc raises four open questions I would rather not settle alone: whether an approval survives a push, whether coverage should require the right reviewer team, whether the board stays private, and whether the bot gate should apply to first-time contributors.

## Review feedback

The second commit addresses review of the first. The guidance comment had contradicted the gate it describes, telling contributors a reply was enough while an unresolved thread still gated; it now says resolving is what moves the pull request along. Label writes re-read state immediately beforehand, because runs for one pull request cannot be fully serialised when the concurrency group is evaluated before the pull request number is known. Truncated data now skips rather than producing a label. The guidance comment requires a bot author as well as its marker, since the marker alone is forgeable by anyone who can comment.

zizmor flags `pull_request_target` and `workflow_run` on sight. Both are used in their documented safe form, so the finding is suppressed inline with the justification next to it, verified against zizmor 1.29.0 locally.

## Security notes

No pull request code is checked out or executed: the checkout is `sparse-checkout: .github/scripts` from the base ref with `persist-credentials: false`. The GraphQL query never fetches title, body or branch name, and the comment interpolates only an integer, so no attacker-controlled text reaches the process or the output. The two `${{ }}` uses are numeric ids in the concurrency key and the pull request list passed via `env:`.

The workflow applies `review/*` labels and `labeled` is one of its triggers. `GITHUB_TOKEN`-raised events do not start new runs so it cannot loop today, and a job-level condition skips self-applied labels so it stays safe under an App token. `review/bots-overridden` is exempt, since applying it is a request to re-evaluate.

## AI Assistance disclosure

AI assistance used: Yes

Claude Code, to gather the review statistics, draft the workflows, scripts and tests, and write this description. The ordering rules, the two-stage split and the gate design are mine, and I verified the classifier against real pull request data.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
- [x] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [x] I have tested my changes on a live environment to confirm they are working

No Go code changed, so `make test` and `make reviewable` say nothing about this diff; the JS suite covering the new scripts passes. The live-environment box reflects the dry-run CLI exercising the real classifier against all 81 open pull requests through the API.
