### PR TITLE
docs: add ovhcloud secret manager in the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ secret management systems like [AWS Secrets
 Manager](https://aws.amazon.com/secrets-manager/), [HashiCorp
 Vault](https://www.vaultproject.io/), [Google Secrets
 Manager](https://cloud.google.com/secret-manager), [Azure Key
-Vault](https://azure.microsoft.com/en-us/services/key-vault/), [IBM Cloud Secrets Manager](https://www.ibm.com/cloud/secrets-manager), [Akeyless](https://akeyless.io), [CyberArk Secrets Manager](https://www.cyberark.com/products/secrets-management/), [Pulumi ESC](https://www.pulumi.com/product/esc/) and many more. The
+Vault](https://azure.microsoft.com/en-us/services/key-vault/), [IBM Cloud Secrets Manager](https://www.ibm.com/cloud/secrets-manager), [Akeyless](https://akeyless.io), [CyberArk Secrets Manager](https://www.cyberark.com/products/secrets-management/), [OVHcloud Secret Manager](https://www.ovhcloud.com/en/identity-security-operations/secret-manager/), [Pulumi ESC](https://www.pulumi.com/product/esc/) and many more. The
 operator reads information from external APIs and automatically injects the
 values into a [Kubernetes
 Secret](https://kubernetes.io/docs/concepts/configuration/secret/).


### PR DESCRIPTION

## Proposed Changes

It can be useful to know the major secret manager cloud provider compatibility so I added OVHcloud in the list.
I hope it's OK for you.

## AI Assistance disclosure

AI assistance used: No

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
