### PR TITLE
fix(azure): reject empty workload identity annotation values in new SDK path

### DIFF
--- a/providers/v1/azure/keyvault/keyvault_new_sdk.go
+++ b/providers/v1/azure/keyvault/keyvault_new_sdk.go
@@ -552,7 +552,7 @@ func buildWorkloadIdentityCredential(ctx context.Context, az *Azure, cloudConfig
 
 	// Get clientID from service account annotations
 	var clientID string
-	if val, found := sa.ObjectMeta.Annotations[AnnotationClientID]; found {
+	if val, found := sa.ObjectMeta.Annotations[AnnotationClientID]; found && val != "" {
 		clientID = val
 	} else {
 		return nil, fmt.Errorf(errMissingClient, AnnotationClientID)
@@ -562,7 +562,7 @@ func buildWorkloadIdentityCredential(ctx context.Context, az *Azure, cloudConfig
 	var tenantID string
 	if az.provider.TenantID != nil {
 		tenantID = *az.provider.TenantID
-	} else if val, found := sa.ObjectMeta.Annotations[AnnotationTenantID]; found {
+	} else if val, found := sa.ObjectMeta.Annotations[AnnotationTenantID]; found && val != "" {
 		tenantID = val
 	} else {
 		return nil, errors.New(errMissingTenant)

--- a/providers/v1/azure/keyvault/keyvault_new_sdk_test.go
+++ b/providers/v1/azure/keyvault/keyvault_new_sdk_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright © The ESO Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keyvault
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	tassert "github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
+	v1 "github.com/external-secrets/external-secrets/apis/meta/v1"
+)
+
+func TestBuildWorkloadIdentityCredential(t *testing.T) {
+	const (
+		tenantID  = "my-tenant-id"
+		clientID  = "my-client-id"
+		saName    = "az-wi"
+		namespace = "default"
+	)
+
+	authType := esv1.AzureWorkloadIdentity
+	defaultProvider := &esv1.AzureKVProvider{
+		VaultURL: &vaultURL,
+		AuthType: &authType,
+		ServiceAccountRef: &v1.ServiceAccountSelector{
+			Name: saName,
+		},
+	}
+
+	type testCase struct {
+		name       string
+		provider   *esv1.AzureKVProvider
+		k8sObjects []client.Object
+		expErr     string
+	}
+
+	for _, row := range []testCase{
+		{
+			name:     "missing clientID annotation",
+			provider: defaultProvider,
+			k8sObjects: []client.Object{
+				&corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      saName,
+						Namespace: namespace,
+					},
+				},
+			},
+			expErr: "missing clientID: either serviceAccountRef or service account annotation 'azure.workload.identity/client-id' is missing",
+		},
+		{
+			name:     "empty clientID annotation value",
+			provider: defaultProvider,
+			k8sObjects: []client.Object{
+				&corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      saName,
+						Namespace: namespace,
+						Annotations: map[string]string{
+							AnnotationClientID: "",
+							AnnotationTenantID: tenantID,
+						},
+					},
+				},
+			},
+			expErr: "missing clientID: either serviceAccountRef or service account annotation 'azure.workload.identity/client-id' is missing",
+		},
+		{
+			name:     "empty tenantID annotation value",
+			provider: defaultProvider,
+			k8sObjects: []client.Object{
+				&corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      saName,
+						Namespace: namespace,
+						Annotations: map[string]string{
+							AnnotationClientID: clientID,
+							AnnotationTenantID: "",
+						},
+					},
+				},
+			},
+			expErr: "missing tenantID in store config",
+		},
+		{
+			name:     "valid clientID and tenantID annotations",
+			provider: defaultProvider,
+			k8sObjects: []client.Object{
+				&corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      saName,
+						Namespace: namespace,
+						Annotations: map[string]string{
+							AnnotationClientID: clientID,
+							AnnotationTenantID: tenantID,
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(row.name, func(t *testing.T) {
+			store := esv1.SecretStore{
+				Spec: esv1.SecretStoreSpec{Provider: &esv1.SecretStoreProvider{
+					AzureKV: row.provider,
+				}},
+			}
+			k8sClient := clientfake.NewClientBuilder().
+				WithObjects(row.k8sObjects...).
+				Build()
+			az := &Azure{
+				store:     &store,
+				namespace: namespace,
+				crClient:  k8sClient,
+				provider:  store.Spec.Provider.AzureKV,
+			}
+
+			credential, err := buildWorkloadIdentityCredential(context.Background(), az, cloud.AzurePublic)
+			if row.expErr == "" {
+				tassert.NoError(t, err)
+				tassert.NotNil(t, credential)
+			} else {
+				tassert.EqualError(t, err, row.expErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem Statement

When `authType: WorkloadIdentity` is used together with `useAzureSDK: true` on the
`azurekv` provider, the client ID and tenant ID are read from the ServiceAccount's
`azure.workload.identity/client-id` / `tenant-id` annotations. The lookup only checked
whether the annotation *key* was present, not whether its *value* was non-empty. An
empty-valued annotation therefore silently passed through as `clientID=""` /
`tenantID=""`, and the failure only surfaced much later, deep inside the Azure SDK's
client assertion credential construction, with a confusing generic error (e.g. "invalid
tenantID. You can locate your tenantID by following the instructions listed here: ...")
instead of this provider's own clear "missing clientID/tenantID" error.

The legacy (non-SDK) auth path does not have this gap: it extracts the annotation value
the same way, but always runs a final `if clientID == ""` / `if tenantID == ""` check
afterwards regardless of how the value was sourced, catching an empty annotation there.
The new SDK path folds annotation extraction and the found-check into a single if/else
and was missing the equivalent emptiness check — this asymmetry was identified by
@alekc in the issue comments.

This does not change behavior for well-formed configurations; it only replaces a late,
unclear Azure SDK error with this provider's own clear validation error when the
workload identity annotations are present but empty.

## Related Issue

Fixes #6476

## Proposed Changes

In `buildWorkloadIdentityCredential` (`providers/v1/azure/keyvault/keyvault_new_sdk.go`),
require the annotation value to be non-empty (`found && val != ""`) for both the client
ID and tenant ID lookups, so an empty value falls through to the existing
`errMissingClient` / `errMissingTenant` error branches, matching the legacy path's
semantics exactly (same error messages).

Added `TestBuildWorkloadIdentityCredential` covering: missing clientID annotation, empty
clientID annotation value, empty tenantID annotation value, and a valid case.

Note: `make check-diff`'s docs-image build step requires `docker`, which is not
available in the sandbox this change was prepared in. The codegen portion of `make
generate` ran clean (no diff), and this change touches no API types, CRDs, docs, or helm
charts, so the docs step is not relevant here.

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
design(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## AI Assistance disclosure

Did you use an script, LLM, or AI assisted development tool for this contribution?

AI assistance used: Yes

If yes provide details:

Tool(s) used: Claude Code

Purpose of assistance: Diagnosed the reported asymmetry between the legacy and new-SDK
Azure workload identity auth paths, implemented the two-line fix, and wrote the
accompanying unit test.

Parts of the contribution affected: `providers/v1/azure/keyvault/keyvault_new_sdk.go`
and its new test file `providers/v1/azure/keyvault/keyvault_new_sdk_test.go`.

Human validation performed: Reviewed the diff against the legacy path's equivalent
function line by line, confirmed the new test fails without the fix and passes with it,
and ran `go build ./...`, `go test ./...` (azure module), and `make lint
LINT_TARGET=providers/v1/azure` locally.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [ ] All tests pass with `make test` (ran `go build ./...` / `go test ./...` scoped to the `providers/v1/azure` module instead — see Proposed Changes note)
- [ ] I ensured my PR is ready for review with `make reviewable`
- [x] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [ ] I have tested my changes on a live environment to confirm they are working

---
AI assistance: this change was drafted with Claude Code.