### PR TITLE
fix: Unblock CI

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -2,15 +2,9 @@ name: Zizmor Actions Scanner
 
 on:
   push:
-    branches:
-      - main
-    paths:
-      - '.github/workflows/**'
+    branches: ["main"]
   pull_request:
-    branches:
-      - main
-    paths:
-      - '.github/workflows/**'
+    branches: ["**"]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Problem Statement

Without this, the PR not impacting workflows will not trigger zizmor run.

This is a problem, as zizmor is _now mandatory_ (rightfully so) in the repository.

This changes so that any commit is reviewed by zizmor. This is totally valid if something has an impact on actions but was not a change in workflows.

This also maps to the zizmor documentation for github actions [1].

[1]: https://docs.zizmor.sh/integrations/#github-actions

## Related Issue

Fixes blocked ci.

## Proposed Changes

How do you like to solve the issue and why?

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
design(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## AI Assistance disclosure

Did you use an script, LLM, or AI assisted development tool for this contribution?

AI assistance used:  No

If yes provide details:

Tool(s) used:

Purpose of assistance:

Parts of the contribution affected:

Human validation performed:

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
- [ ] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [ ] I have tested my changes on a live environment to confirm they are working
