### PR TITLE
docs: add Quay audience snippet

### DIFF
--- a/docs/api/generator/quay.md
+++ b/docs/api/generator/quay.md
@@ -26,6 +26,8 @@ kubectl create token default -n default | cut -d '.' -f 2 | sed 's/[^=]$/&==/' |
 
 Then use the instructions [here](https://docs.projectquay.io/manage_quay.html#setting-robot-federation) to set up a robot account and federation.
 
+Starting with Red Hat Quay 3.18, robot federation supports audience validation during federated robot token exchange. Configure `spec.serviceAccountRef.audiences` to request a Kubernetes service account token whose `aud` claim matches the audience configured in Quay for the robot federation entry.
+
 ## Example Manifest
 
 ```yaml

--- a/docs/snippets/generator-quay.yaml
+++ b/docs/snippets/generator-quay.yaml
@@ -9,3 +9,5 @@ spec:
   serviceAccountRef:
     name: "default"
     namespace: "default"
+    audiences:
+      - <your-quay-federation-audience>


### PR DESCRIPTION
## Problem Statement

Just adding more docs related to Quay 3.18's new audiences field for WIF. No code changes needed - should already be supported.

## Related Issue

NA

## Proposed Changes

Just updating docs

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
design(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## AI Assistance disclosure

Did you use an script, LLM, or AI assisted development tool for this contribution?

AI assistance used: no

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
- [x] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [x] I have tested my changes on a live environment to confirm they are working
