### PR TITLE
docs: set Orphan on ClusterExternalSecret fan-out example

### DIFF
--- a/docs/api/clusterexternalsecret.md
+++ b/docs/api/clusterexternalsecret.md
@@ -42,6 +42,16 @@ use the [Kubernetes provider](../provider/kubernetes.md) to fan that
 {% include 'cluster-external-secret-fanout.yaml' %}
 ```
 
+!!! warning "Fan-out targets and `creationPolicy`"
+    Omitting `spec.externalSecretSpec.target.creationPolicy` defaults to `Owner`.
+    The ClusterExternalSecret owns the per-namespace ExternalSecrets. Replacing
+    the CES (GitOps prune+recreate, delete+apply) deletes those objects, and
+    Kubernetes garbage-collects the fanned-out Secrets via `ownerReference`.
+    `deletionPolicy: Retain` does not prevent that — Retain is the provider-side
+    axis. For copies that must stay mounted across CES replacement, set
+    `creationPolicy: Orphan` or `CreateOrMerge`. See
+    [Lifecycle: ownership & deletion](../guides/ownership-deletion-policy.md).
+
 The `ServiceAccount` and RBAC for the Kubernetes provider store are the same
 as described in the [Kubernetes provider docs](../provider/kubernetes.md).
 

--- a/docs/api/clusterexternalsecret.md
+++ b/docs/api/clusterexternalsecret.md
@@ -44,12 +44,14 @@ use the [Kubernetes provider](../provider/kubernetes.md) to fan that
 
 !!! warning "Fan-out targets and `creationPolicy`"
     Omitting `spec.externalSecretSpec.target.creationPolicy` defaults to `Owner`.
-    The ClusterExternalSecret owns the per-namespace ExternalSecrets. Replacing
-    the CES (GitOps prune+recreate, delete+apply) deletes those objects, and
-    Kubernetes garbage-collects the fanned-out Secrets via `ownerReference`.
-    `deletionPolicy: Retain` does not prevent that — Retain is the provider-side
-    axis. For copies that must stay mounted across CES replacement, set
-    `creationPolicy: Orphan` or `CreateOrMerge`. See
+    The ClusterExternalSecret owns and deletes per-namespace ExternalSecrets
+    when the CES is replaced or a namespace stops matching `namespaceSelectors`.
+    With `Owner`, Kubernetes also garbage-collects the fanned-out Secrets via
+    `ownerReference`. `deletionPolicy: Retain` does not prevent that — Retain is
+    the provider-side axis. `Orphan` and `CreateOrMerge` preserve those Secrets,
+    which avoids disruption during CES replacement but also means removing a
+    namespace from the selector does not revoke its copy; delete stale copies
+    manually. See
     [Lifecycle: ownership & deletion](../guides/ownership-deletion-policy.md).
 
 The `ServiceAccount` and RBAC for the Kubernetes provider store are the same

--- a/docs/api/clusterexternalsecret.md
+++ b/docs/api/clusterexternalsecret.md
@@ -38,21 +38,26 @@ use the [Kubernetes provider](../provider/kubernetes.md) to fan that
 
 ![Fan-out pattern: only the source ExternalSecret polls the provider](../pictures/diagrams-ces-fanout-pattern.png)
 
-```yaml
-{% include 'cluster-external-secret-fanout.yaml' %}
-```
-
 !!! warning "Fan-out targets and `creationPolicy`"
     Omitting `spec.externalSecretSpec.target.creationPolicy` defaults to `Owner`.
     The ClusterExternalSecret owns and deletes per-namespace ExternalSecrets
     when the CES is replaced or a namespace stops matching `namespaceSelectors`.
     With `Owner`, Kubernetes also garbage-collects the fanned-out Secrets via
     `ownerReference`. `deletionPolicy: Retain` does not prevent that — Retain is
-    the provider-side axis. `Orphan` and `CreateOrMerge` preserve those Secrets,
-    which avoids disruption during CES replacement but also means removing a
-    namespace from the selector does not revoke its copy; delete stale copies
-    manually. See
+    the provider-side axis.
+
+    No combination gives both properties. `Owner` (or `Orphan` + `Delete`)
+    revokes the copy when a namespace is de-selected, but CES replacement
+    also drops the Secret. `Orphan` / `CreateOrMerge` + `Retain` survives
+    replacement, but the de-selected namespace keeps a stale, unrefreshed
+    copy. Use `Orphan` when a mount gap hurts (CA bundles, wildcard TLS).
+    Keep `Owner` for credentials that must disappear when the namespace is
+    unlabelled. The snippet below is a CA bundle, so it sets `Orphan`. See
     [Lifecycle: ownership & deletion](../guides/ownership-deletion-policy.md).
+
+```yaml
+{% include 'cluster-external-secret-fanout.yaml' %}
+```
 
 The `ServiceAccount` and RBAC for the Kubernetes provider store are the same
 as described in the [Kubernetes provider docs](../provider/kubernetes.md).

--- a/docs/api/clusterexternalsecret.md
+++ b/docs/api/clusterexternalsecret.md
@@ -45,8 +45,7 @@ use the [Kubernetes provider](../provider/kubernetes.md) to fan that
     With `Owner`, Kubernetes also garbage-collects the fanned-out Secrets via
     `ownerReference`. `deletionPolicy: Retain` does not prevent that — Retain is
     the provider-side axis.
-
-    No combination gives both properties. `Owner` (or `Orphan` + `Delete`)
+    No combination gives both properties. `Owner`
     revokes the copy when a namespace is de-selected, but CES replacement
     also drops the Secret. `Orphan` / `CreateOrMerge` + `Retain` survives
     replacement, but the de-selected namespace keeps a stale, unrefreshed

--- a/docs/snippets/cluster-external-secret-fanout.yaml
+++ b/docs/snippets/cluster-external-secret-fanout.yaml
@@ -53,6 +53,10 @@ spec:
       kind: ClusterSecretStore
     target:
       name: shared-credentials
+      # Orphan: replacing the CES deletes child ExternalSecrets. Owner would
+      # garbage-collect these copies via ownerReference. Retain (deletionPolicy)
+      # does not prevent Kubernetes GC.
+      creationPolicy: Orphan
     dataFrom:
     - extract:
         key: shared-credentials

--- a/docs/snippets/cluster-external-secret-fanout.yaml
+++ b/docs/snippets/cluster-external-secret-fanout.yaml
@@ -53,9 +53,9 @@ spec:
       kind: ClusterSecretStore
     target:
       name: shared-credentials
-      # Orphan: replacing the CES deletes child ExternalSecrets. Owner would
-      # garbage-collect these copies via ownerReference. Retain (deletionPolicy)
-      # does not prevent Kubernetes GC.
+      # Orphan keeps the copied Secret when its child ExternalSecret is deleted.
+      # This protects CES replacement, but also leaves the copy behind when its
+      # namespace stops matching; remove stale copies manually.
       creationPolicy: Orphan
     dataFrom:
     - extract:

--- a/docs/snippets/cluster-external-secret-fanout.yaml
+++ b/docs/snippets/cluster-external-secret-fanout.yaml
@@ -3,7 +3,7 @@
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: shared-credentials
+  name: shared-ca-bundle
   namespace: eso-fanout-source
 spec:
   refreshInterval: "1h"
@@ -11,16 +11,16 @@ spec:
     name: my-upstream-store
     kind: ClusterSecretStore
   target:
-    name: shared-credentials
+    name: shared-ca-bundle
   dataFrom:
   - extract:
-      key: path/to/shared-credentials
+      key: path/to/shared-ca-bundle
 ---
 # Step 2: ClusterSecretStore reads the source Secret via the Kubernetes provider.
 apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
-  name: shared-credentials-store
+  name: shared-ca-bundle-store
 spec:
   provider:
     kubernetes:
@@ -40,24 +40,25 @@ spec:
 apiVersion: external-secrets.io/v1
 kind: ClusterExternalSecret
 metadata:
-  name: shared-credentials
+  name: shared-ca-bundle
 spec:
-  externalSecretName: shared-credentials
+  externalSecretName: shared-ca-bundle
   namespaceSelectors:
   - matchLabels:
-      shared-credentials: "true"
+      shared-ca-bundle: "true"
   externalSecretSpec:
     refreshInterval: "1h"
     secretStoreRef:
-      name: shared-credentials-store
+      name: shared-ca-bundle-store
       kind: ClusterSecretStore
     target:
-      name: shared-credentials
+      name: shared-ca-bundle
       # Orphan keeps the copied Secret when its child ExternalSecret is deleted.
-      # This protects CES replacement, but also leaves the copy behind when its
-      # namespace stops matching; remove stale copies manually.
+      # This protects CES replacement. A de-selected namespace keeps a stale
+      # copy; remove those manually. Do not copy this onto credentials that
+      # must be revoked when the namespace label is dropped.
       creationPolicy: Orphan
     dataFrom:
     - extract:
-        key: shared-credentials
+        key: shared-ca-bundle
 {% endraw %}


### PR DESCRIPTION
Fixes https://github.com/external-secrets/external-secrets/issues/6884

The recommended CES fan-out snippet omitted `target.creationPolicy`, so it inherited `Owner`. Replacing the ClusterExternalSecret deletes child ExternalSecrets and Kubernetes GC's the copies. `deletionPolicy: Retain` is provider-side and does not stop that.

Set `creationPolicy: Orphan` on the fan-out example and add a warning on the ClusterExternalSecret page. CRD default is unchanged.
