### PR TITLE
fix(ci): zizmor no-op blocks gates

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -10,34 +10,16 @@ permissions:
   contents: read
 
 jobs:
-  detect-noop:
-    permissions:
-      actions: write  # for fkirc/skip-duplicate-actions to skip or stop workflow runs
-      contents: read  # for fkirc/skip-duplicate-actions to read and compare commits
+  zizmor:
+    name: Run zizmor 🌈
     runs-on: ubuntu-latest
-    outputs:
-      noop: ${{ steps.noop.outputs.should_skip }}
+    permissions:
+      security-events: write
     steps:
       - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: audit
-      - name: Detect No-op Changes
-        id: noop
-        uses: fkirc/skip-duplicate-actions@b974a9395958c231af965b70070979a577efa578 # v5.3.2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          paths_ignore: '["**.md", "**.png", "**.jpg"]'
-          do_not_skip: '["workflow_dispatch", "schedule", "push"]'
-          concurrent_skipping: false
 
-  zizmor:
-    name: Run zizmor 🌈
-    runs-on: ubuntu-latest
-    needs: detect-noop
-    if: needs.detect-noop.outputs.noop != 'true'
-    permissions:
-      security-events: write
-    steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
## Problem Statement

Without this, when a commit is tested multiple times, it is not tested again.

As we require to test for merging (rightfully so), the CI will be blocked when the commit is tested multiple times.

Creating another commit should fix it.
For me, the noop job was an optimization that lead to this kind of failures.

Unless zizmor rate limits us, there is no reason to _NOT TEST_ the last commit of a PR, even if it was tested before. 

## Related Issue

This was caused when we fixed https://github.com/external-secrets/external-secrets/issues/6844 . 

## Proposed Changes

I removed the noop handling and I am now closer to the upstream recommendations.

There are indeed other ways to fix it, like keeping the noop but always run on last commit. But this seems convoluted compared to simply remove the noop check.

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
design(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## AI Assistance disclosure

Did you use an script, LLM, or AI assisted development tool for this contribution?

AI assistance used: No

If yes provide details:

Tool(s) used:

Purpose of assistance:

Parts of the contribution affected:

Human validation performed:

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
- [ ] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [ ] I have tested my changes on a live environment to confirm they are working
