### PR TITLE
fix: doc builds may set different user/group ownership on git repo objects

### DIFF
--- a/hack/api-docs/Makefile
+++ b/hack/api-docs/Makefile
@@ -67,6 +67,7 @@ build: image generate $(SOURCES)
 	    $(GIT_MOUNT) \
 		--sig-proxy=true \
 		--rm \
+		--user $(UID):$(GID) \
 		--env "GIT_COMMITTER_NAME=$(shell git config user.name)" \
 		--env "GIT_COMMITTER_EMAIL=$(shell git config user.email)" \
 		--env "GITHUB_TOKEN=$(GITHUB_TOKEN)" \


### PR DESCRIPTION
## Problem Statement

Without this, builds are done with the docker user. We do not change ownership, so it means git objects files are edited as root.

This leads to follow up issues in the repo like:
"insufficient permission for adding an object to repository database .git/objects".

## Related Issue

Partial-Fixes: #6900

## Proposed Changes

Editing docker command for make docs.

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
design(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## AI Assistance disclosure

Did you use an script, LLM, or AI assisted development tool for this contribution?

AI assistance used: No

If yes provide details:

Tool(s) used:

Purpose of assistance:

Parts of the contribution affected:

Human validation performed:

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
- [ ] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [ ] I have tested my changes on a live environment to confirm they are working
