### PR TITLE
clean: replace k8s.io/utils pointer helpers with the new builtin

### DIFF
--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -77,7 +77,6 @@ require (
 	k8s.io/apiextensions-apiserver v0.36.3
 	k8s.io/apimachinery v0.36.3
 	k8s.io/client-go v1.5.2
-	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 	sigs.k8s.io/controller-runtime v0.24.1
 	sigs.k8s.io/yaml v1.6.0
 	software.sslmate.com/src/go-pkcs12 v0.7.0
@@ -258,6 +257,7 @@ require (
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	k8s.io/streaming v0.36.3 // indirect
+	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.3 // indirect

--- a/e2e/suites/generator/grafana.go
+++ b/e2e/suites/generator/grafana.go
@@ -28,7 +28,6 @@ import (
 	// nolint
 	. "github.com/onsi/ginkgo/v2"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/utils/ptr"
 
 	"github.com/external-secrets/external-secrets-e2e/framework"
 	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
@@ -58,9 +57,9 @@ var _ = Describe("grafana generator", Label("grafana"), func() {
 	AfterEach(func() {
 		// ESO does clean up tokens, but not the service accounts.
 		accounts, err := grafanaClient.ServiceAccounts.SearchOrgServiceAccountsWithPaging(&grafanasa.SearchOrgServiceAccountsWithPagingParams{
-			Perpage: ptr.To(int64(100)),
-			Page:    ptr.To(int64(1)),
-			Query:   ptr.To(f.Namespace.Name),
+			Perpage: new(int64(100)),
+			Page:    new(int64(1)),
+			Query:   new(f.Namespace.Name),
 		})
 		Expect(err).ToNot(HaveOccurred())
 		if accounts.GetPayload().ServiceAccounts != nil && len(accounts.GetPayload().ServiceAccounts) > 0 {
@@ -141,7 +140,7 @@ var _ = Describe("grafana generator", Label("grafana"), func() {
 			Expect(string(secret.Data["token"])).ToNot(BeEmpty())
 
 			_, err := grafanaClient.Search.Search(&grafanasearch.SearchParams{
-				Query: ptr.To(""),
+				Query: new(""),
 			})
 			Expect(err).ToNot(HaveOccurred())
 			ensureExternalSecretPurgesGeneratorState(tc)
@@ -167,9 +166,9 @@ var _ = Describe("grafana generator", Label("grafana"), func() {
 
 			// ensure service accounts are cleaned up
 			saList, err := grafanaClient.ServiceAccounts.SearchOrgServiceAccountsWithPaging(&grafanasa.SearchOrgServiceAccountsWithPagingParams{
-				Perpage: ptr.To(int64(100)),
-				Page:    ptr.To(int64(1)),
-				Query:   ptr.To(f.Namespace.Name),
+				Perpage: new(int64(100)),
+				Page:    new(int64(1)),
+				Query:   new(f.Namespace.Name),
 			})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(saList.GetPayload().ServiceAccounts).To(HaveLen(1))

--- a/e2e/suites/provider/cases/azure/provider.go
+++ b/e2e/suites/provider/cases/azure/provider.go
@@ -33,7 +33,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilpointer "k8s.io/utils/pointer"
 
 	"github.com/external-secrets/external-secrets-e2e/framework"
 	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
@@ -147,7 +146,7 @@ func (s *azureProvider) CreateSecret(key string, val framework.SecretEntry) {
 			Value: &val.Value,
 			SecretAttributes: &keyvault.SecretAttributes{
 				RecoveryLevel: keyvault.Purgeable,
-				Enabled:       utilpointer.Bool(true),
+				Enabled:       new(true),
 			},
 		})
 	Expect(err).ToNot(HaveOccurred())
@@ -170,7 +169,7 @@ func (s *azureProvider) CreateKey(key string) *keyvault.JSONWebKey {
 			Kty: keyvault.RSA,
 			KeyAttributes: &keyvault.KeyAttributes{
 				RecoveryLevel: keyvault.Purgeable,
-				Enabled:       utilpointer.Bool(true),
+				Enabled:       new(true),
 			},
 		},
 	)
@@ -191,20 +190,20 @@ func (s *azureProvider) CreateCertificate(key string) {
 		keyvault.CertificateCreateParameters{
 			CertificatePolicy: &keyvault.CertificatePolicy{
 				X509CertificateProperties: &keyvault.X509CertificateProperties{
-					Subject:          utilpointer.String("CN=e2e.test"),
-					ValidityInMonths: utilpointer.Int32(42),
+					Subject:          new("CN=e2e.test"),
+					ValidityInMonths: new(int32(42)),
 				},
 				IssuerParameters: &keyvault.IssuerParameters{
-					Name: utilpointer.String("Self"),
+					Name: new("Self"),
 				},
 				Attributes: &keyvault.CertificateAttributes{
 					RecoveryLevel: keyvault.Purgeable,
-					Enabled:       utilpointer.Bool(true),
+					Enabled:       new(true),
 				},
 			},
 			CertificateAttributes: &keyvault.CertificateAttributes{
 				RecoveryLevel: keyvault.Purgeable,
-				Enabled:       utilpointer.Bool(true),
+				Enabled:       new(true),
 			},
 		},
 	)

--- a/e2e/suites/provider/cases/gcp/provider.go
+++ b/e2e/suites/provider/cases/gcp/provider.go
@@ -33,7 +33,6 @@ import (
 	"google.golang.org/api/option"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilpointer "k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/external-secrets/external-secrets-e2e/framework"
@@ -267,7 +266,7 @@ func (s *GcpProvider) CreateSpecifcSASecretStore() {
 						ClusterName:     s.clusterName,
 						ServiceAccountRef: esmeta.ServiceAccountSelector{
 							Name:      s.ServiceAccountName,
-							Namespace: utilpointer.String(s.ServiceAccountNamespace),
+							Namespace: new(s.ServiceAccountNamespace),
 						},
 					},
 				},

--- a/pkg/controllers/webhookconfig/webhookconfig_test.go
+++ b/pkg/controllers/webhookconfig/webhookconfig_test.go
@@ -26,7 +26,6 @@ import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	pointer "k8s.io/utils/ptr"
 
 	"github.com/external-secrets/external-secrets/runtime/constants"
 
@@ -256,7 +255,7 @@ func makeValidatingWebhookConfig() *admissionregistration.ValidatingWebhookConfi
 		Webhooks: []admissionregistration.ValidatingWebhook{
 			{
 				Name:                    "secretstores.external-secrets.io",
-				SideEffects:             (*admissionregistration.SideEffectClass)(pointer.To(string(admissionregistration.SideEffectClassNone))),
+				SideEffects:             new(admissionregistration.SideEffectClassNone),
 				AdmissionReviewVersions: []string{"v1"},
 				ClientConfig: admissionregistration.WebhookClientConfig{
 					CABundle: []byte("Cg=="),
@@ -269,7 +268,7 @@ func makeValidatingWebhookConfig() *admissionregistration.ValidatingWebhookConfi
 			},
 			{
 				Name:                    "clustersecretstores.external-secrets.io",
-				SideEffects:             (*admissionregistration.SideEffectClass)(pointer.To(string(admissionregistration.SideEffectClassNone))),
+				SideEffects:             new(admissionregistration.SideEffectClassNone),
 				AdmissionReviewVersions: []string{"v1"},
 				ClientConfig: admissionregistration.WebhookClientConfig{
 					CABundle: []byte("Cg=="),

--- a/providers/v1/azure/go.mod
+++ b/providers/v1/azure/go.mod
@@ -25,7 +25,6 @@ require (
 	k8s.io/apiextensions-apiserver v0.36.3
 	k8s.io/apimachinery v0.36.3
 	k8s.io/client-go v0.36.3
-	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 	sigs.k8s.io/controller-runtime v0.24.1
 	software.sslmate.com/src/go-pkcs12 v0.7.0
 )
@@ -115,6 +114,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
+	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.3 // indirect

--- a/providers/v1/azure/keyvault/keyvault_auth_test.go
+++ b/providers/v1/azure/keyvault/keyvault_auth_test.go
@@ -28,7 +28,6 @@ import (
 	tassert "github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	pointer "k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -184,13 +183,13 @@ func TestGetAuthorizorForWorkloadIdentity(t *testing.T) {
 			provider: &esv1.AzureKVProvider{
 				VaultURL: &vaultURL,
 				AuthType: &authType,
-				TenantID: pointer.To(tenantID),
+				TenantID: new(tenantID),
 				ServiceAccountRef: &v1.ServiceAccountSelector{
 					Name: saName,
 				},
 				AuthSecretRef: &esv1.AzureKVAuth{
-					ClientID: &v1.SecretKeySelector{Name: secretName, Namespace: pointer.To(namespace), Key: clientID},
-					TenantID: &v1.SecretKeySelector{Name: secretName, Namespace: pointer.To(namespace), Key: tenantID},
+					ClientID: &v1.SecretKeySelector{Name: secretName, Namespace: new(namespace), Key: clientID},
+					TenantID: &v1.SecretKeySelector{Name: secretName, Namespace: new(namespace), Key: tenantID},
 				},
 			},
 			k8sObjects: []client.Object{
@@ -222,7 +221,7 @@ func TestGetAuthorizorForWorkloadIdentity(t *testing.T) {
 			provider: &esv1.AzureKVProvider{
 				VaultURL: &vaultURL,
 				AuthType: &authType,
-				TenantID: pointer.To(tenantID),
+				TenantID: new(tenantID),
 				ServiceAccountRef: &v1.ServiceAccountSelector{
 					Name: saName,
 				},
@@ -266,8 +265,8 @@ func TestGetAuthorizorForWorkloadIdentity(t *testing.T) {
 					Name: saName,
 				},
 				AuthSecretRef: &esv1.AzureKVAuth{
-					ClientID: &v1.SecretKeySelector{Name: secretName, Namespace: pointer.To(namespace), Key: clientID},
-					TenantID: &v1.SecretKeySelector{Name: secretName, Namespace: pointer.To(namespace), Key: tenantID},
+					ClientID: &v1.SecretKeySelector{Name: secretName, Namespace: new(namespace), Key: clientID},
+					TenantID: &v1.SecretKeySelector{Name: secretName, Namespace: new(namespace), Key: tenantID},
 				},
 			},
 			k8sObjects: []client.Object{
@@ -295,12 +294,12 @@ func TestGetAuthorizorForWorkloadIdentity(t *testing.T) {
 			provider: &esv1.AzureKVProvider{
 				VaultURL: &vaultURL,
 				AuthType: &authType,
-				TenantID: pointer.To(tenantID),
+				TenantID: new(tenantID),
 				ServiceAccountRef: &v1.ServiceAccountSelector{
 					Name: saName,
 				},
 				AuthSecretRef: &esv1.AzureKVAuth{
-					ClientID: &v1.SecretKeySelector{Name: secretName, Namespace: pointer.To(namespace), Key: clientID},
+					ClientID: &v1.SecretKeySelector{Name: secretName, Namespace: new(namespace), Key: clientID},
 				},
 			},
 			k8sObjects: []client.Object{

--- a/providers/v1/azure/keyvault/keyvault_dual_sdk_test.go
+++ b/providers/v1/azure/keyvault/keyvault_dual_sdk_test.go
@@ -22,7 +22,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
@@ -63,7 +62,7 @@ func TestFeatureFlagRouting(t *testing.T) {
 			provider := &esv1.AzureKVProvider{
 				VaultURL:    new("https://test-vault.vault.azure.net/"),
 				TenantID:    new("test-tenant"),
-				AuthType:    ptr.To(esv1.AzureServicePrincipal),
+				AuthType:    new(esv1.AzureServicePrincipal),
 				UseAzureSDK: tc.useAzureSDK,
 				AuthSecretRef: &esv1.AzureKVAuth{
 					ClientID: &v1.SecretKeySelector{
@@ -132,7 +131,7 @@ func TestClientInitialization(t *testing.T) {
 			provider := &esv1.AzureKVProvider{
 				VaultURL:    new("https://test-vault.vault.azure.net/"),
 				TenantID:    new("test-tenant"),
-				AuthType:    ptr.To(esv1.AzureServicePrincipal),
+				AuthType:    new(esv1.AzureServicePrincipal),
 				UseAzureSDK: tc.useAzureSDK,
 				AuthSecretRef: &esv1.AzureKVAuth{
 					ClientID: &v1.SecretKeySelector{
@@ -210,7 +209,7 @@ func TestConfigurationValidation(t *testing.T) {
 			provider := &esv1.AzureKVProvider{
 				VaultURL:    new("https://test-vault.vault.azure.net/"),
 				TenantID:    new("test-tenant"),
-				AuthType:    ptr.To(esv1.AzureServicePrincipal),
+				AuthType:    new(esv1.AzureServicePrincipal),
 				UseAzureSDK: tc.useAzureSDK,
 				AuthSecretRef: &esv1.AzureKVAuth{
 					ClientID: &v1.SecretKeySelector{
@@ -255,7 +254,7 @@ func TestBackwardCompatibility(t *testing.T) {
 	provider := &esv1.AzureKVProvider{
 		VaultURL: new("https://test-vault.vault.azure.net/"),
 		TenantID: new("test-tenant"),
-		AuthType: ptr.To(esv1.AzureServicePrincipal),
+		AuthType: new(esv1.AzureServicePrincipal),
 		// UseAzureSDK intentionally omitted to test backward compatibility
 		AuthSecretRef: &esv1.AzureKVAuth{
 			ClientID: &v1.SecretKeySelector{
@@ -386,7 +385,7 @@ func TestAzureStackCloudConfiguration(t *testing.T) {
 			provider := &esv1.AzureKVProvider{
 				VaultURL:          new("https://test-vault.vault.azure.net/"),
 				TenantID:          new("test-tenant"),
-				AuthType:          ptr.To(esv1.AzureServicePrincipal),
+				AuthType:          new(esv1.AzureServicePrincipal),
 				UseAzureSDK:       tc.useAzureSDK,
 				EnvironmentType:   tc.envType,
 				CustomCloudConfig: tc.customConfig,

--- a/providers/v1/ibm/go.mod
+++ b/providers/v1/ibm/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	k8s.io/api v0.36.3
 	k8s.io/apimachinery v0.36.3
-	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 	sigs.k8s.io/controller-runtime v0.24.1
 )
 
@@ -104,6 +103,7 @@ require (
 	k8s.io/client-go v0.36.3 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
+	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.3 // indirect

--- a/providers/v1/ibm/provider_test.go
+++ b/providers/v1/ibm/provider_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/go-openapi/strfmt"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilpointer "k8s.io/utils/ptr"
 	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
@@ -105,7 +104,7 @@ func makeValidAPIInput() *sm.GetSecretOptions {
 
 func makeValidAPIOutput() sm.SecretIntf {
 	secret := &sm.Secret{
-		SecretType: utilpointer.To(sm.Secret_SecretType_Arbitrary),
+		SecretType: new(sm.Secret_SecretType_Arbitrary),
 		Name:       new("testyname"),
 		ID:         new(secretUUID),
 	}
@@ -223,7 +222,7 @@ func TestIBMSecretManagerGetSecret(t *testing.T) {
 	// key is passed in, output is sent back
 	setSecretString := func(smtc *secretManagerTestCase) {
 		secret := &sm.ArbitrarySecret{
-			SecretType: utilpointer.To(sm.Secret_SecretType_Arbitrary),
+			SecretType: new(sm.Secret_SecretType_Arbitrary),
 			Name:       new("testyname"),
 			ID:         new(secretUUID),
 			Payload:    &secretString,
@@ -237,7 +236,7 @@ func TestIBMSecretManagerGetSecret(t *testing.T) {
 	// good case: custom version set
 	setCustomKey := func(smtc *secretManagerTestCase) {
 		secret := &sm.ArbitrarySecret{
-			SecretType: utilpointer.To(sm.Secret_SecretType_Arbitrary),
+			SecretType: new(sm.Secret_SecretType_Arbitrary),
 			Name:       new("testyname"),
 			ID:         new(secretUUID),
 			Payload:    &secretString,
@@ -252,7 +251,7 @@ func TestIBMSecretManagerGetSecret(t *testing.T) {
 	// bad case: arbitrary type secret which is destroyed
 	badArbitSecret := func(smtc *secretManagerTestCase) {
 		secret := &sm.ArbitrarySecret{
-			SecretType: utilpointer.To(sm.Secret_SecretType_Arbitrary),
+			SecretType: new(sm.Secret_SecretType_Arbitrary),
 			Name:       new("testyname"),
 			ID:         new(secretUUID),
 		}
@@ -267,7 +266,7 @@ func TestIBMSecretManagerGetSecret(t *testing.T) {
 	secretUserPass := "username_password/" + secretUUID
 	badSecretUserPass := func(smtc *secretManagerTestCase) {
 		secret := &sm.UsernamePasswordSecret{
-			SecretType: utilpointer.To(sm.Secret_SecretType_UsernamePassword),
+			SecretType: new(sm.Secret_SecretType_UsernamePassword),
 			Name:       new("testyname"),
 			ID:         new(secretUUID),
 			Username:   &secretUsername,
@@ -284,7 +283,7 @@ func TestIBMSecretManagerGetSecret(t *testing.T) {
 	funcSetUserPass := func(secretName, property, name string) func(smtc *secretManagerTestCase) {
 		return func(smtc *secretManagerTestCase) {
 			secret := &sm.UsernamePasswordSecret{
-				SecretType: utilpointer.To(sm.Secret_SecretType_UsernamePassword),
+				SecretType: new(sm.Secret_SecretType_UsernamePassword),
 				Name:       new("testyname"),
 				ID:         new(secretUUID),
 				Username:   &secretUsername,
@@ -308,7 +307,7 @@ func TestIBMSecretManagerGetSecret(t *testing.T) {
 	funcSetSecretIam := func(secretName, name string) func(*secretManagerTestCase) {
 		return func(smtc *secretManagerTestCase) {
 			secret := &sm.IAMCredentialsSecret{
-				SecretType: utilpointer.To(sm.Secret_SecretType_IamCredentials),
+				SecretType: new(sm.Secret_SecretType_IamCredentials),
 				Name:       new("testyname"),
 				ID:         new(secretUUID),
 				ApiKey:     new(secretAPIKey),
@@ -327,14 +326,14 @@ func TestIBMSecretManagerGetSecret(t *testing.T) {
 	funcSetSecretIamNew := func(secretName, groupName, name string) func(*secretManagerTestCase) {
 		return func(smtc *secretManagerTestCase) {
 			secret := &sm.IAMCredentialsSecret{
-				SecretType: utilpointer.To(sm.Secret_SecretType_IamCredentials),
+				SecretType: new(sm.Secret_SecretType_IamCredentials),
 				Name:       new("testyname"),
 				ID:         new(secretUUID),
 				ApiKey:     new(secretAPIKey),
 			}
 			smtc.getByNameInput.Name = &secretName
 			smtc.getByNameInput.SecretGroupName = &groupName
-			smtc.getByNameInput.SecretType = utilpointer.To(sm.Secret_SecretType_IamCredentials)
+			smtc.getByNameInput.SecretType = new(sm.Secret_SecretType_IamCredentials)
 
 			smtc.name = name
 			smtc.getByNameOutput = secret
@@ -352,7 +351,7 @@ func TestIBMSecretManagerGetSecret(t *testing.T) {
 	funcSetSecretSrvCred := func(secretName, name string) func(*secretManagerTestCase) {
 		return func(smtc *secretManagerTestCase) {
 			secret := &sm.ServiceCredentialsSecret{
-				SecretType:  utilpointer.To(sm.Secret_SecretType_ServiceCredentials),
+				SecretType:  new(sm.Secret_SecretType_ServiceCredentials),
 				Name:        new("testyname"),
 				ID:          new(secretUUID),
 				Credentials: dummySrvCreds,
@@ -384,7 +383,7 @@ func TestIBMSecretManagerGetSecret(t *testing.T) {
 
 	// good case: imported_cert type with property
 	importedCert := &sm.ImportedCertificate{
-		SecretType:   utilpointer.To(sm.Secret_SecretType_ImportedCert),
+		SecretType:   new(sm.Secret_SecretType_ImportedCert),
 		Name:         new("testyname"),
 		ID:           new(secretUUID),
 		Certificate:  new(secretCertificate),
@@ -396,7 +395,7 @@ func TestIBMSecretManagerGetSecret(t *testing.T) {
 	// good case: imported_cert type without a private_key
 	importedCertNoPvtKey := func(smtc *secretManagerTestCase) {
 		secret := &sm.ImportedCertificate{
-			SecretType:  utilpointer.To(sm.Secret_SecretType_ImportedCert),
+			SecretType:  new(sm.Secret_SecretType_ImportedCert),
 			Name:        new("testyname"),
 			ID:          new(secretUUID),
 			Certificate: new(secretCertificate),
@@ -414,7 +413,7 @@ func TestIBMSecretManagerGetSecret(t *testing.T) {
 
 	// good case: public_cert type with property
 	publicCert := &sm.PublicCertificate{
-		SecretType:   utilpointer.To(sm.Secret_SecretType_PublicCert),
+		SecretType:   new(sm.Secret_SecretType_PublicCert),
 		Name:         new("testyname"),
 		ID:           new(secretUUID),
 		Certificate:  new(secretCertificate),
@@ -428,7 +427,7 @@ func TestIBMSecretManagerGetSecret(t *testing.T) {
 
 	// good case: private_cert type with property
 	privateCert := &sm.PrivateCertificate{
-		SecretType:  utilpointer.To(sm.Secret_SecretType_PublicCert),
+		SecretType:  new(sm.Secret_SecretType_PublicCert),
 		Name:        new("testyname"),
 		ID:          new(secretUUID),
 		Certificate: new(secretCertificate),
@@ -451,7 +450,7 @@ func TestIBMSecretManagerGetSecret(t *testing.T) {
 	// bad case: kv type with key which is not in payload
 	badSecretKV := func(smtc *secretManagerTestCase) {
 		secret := &sm.KVSecret{
-			SecretType: utilpointer.To(sm.Secret_SecretType_Kv),
+			SecretType: new(sm.Secret_SecretType_Kv),
 			Name:       new("testyname"),
 			ID:         new(secretUUID),
 			Data:       secretDataKV,
@@ -467,7 +466,7 @@ func TestIBMSecretManagerGetSecret(t *testing.T) {
 	// good case: kv type with property
 	setSecretKV := func(smtc *secretManagerTestCase) {
 		secret := &sm.KVSecret{
-			SecretType: utilpointer.To(sm.Secret_SecretType_Kv),
+			SecretType: new(sm.Secret_SecretType_Kv),
 			Name:       new("testyname"),
 			ID:         new(secretUUID),
 			Data:       secretDataKV,
@@ -483,7 +482,7 @@ func TestIBMSecretManagerGetSecret(t *testing.T) {
 	// good case: kv type with property, returns specific value
 	setSecretKVWithKey := func(smtc *secretManagerTestCase) {
 		secret := &sm.KVSecret{
-			SecretType: utilpointer.To(sm.Secret_SecretType_Kv),
+			SecretType: new(sm.Secret_SecretType_Kv),
 			Name:       new("testyname"),
 			ID:         new(secretUUID),
 			Data:       secretDataKVComplex,
@@ -499,7 +498,7 @@ func TestIBMSecretManagerGetSecret(t *testing.T) {
 	// good case: kv type with property and path, returns specific value
 	setSecretKVWithKeyPath := func(smtc *secretManagerTestCase) {
 		secret := &sm.KVSecret{
-			SecretType: utilpointer.To(sm.Secret_SecretType_Kv),
+			SecretType: new(sm.Secret_SecretType_Kv),
 			Name:       new("testyname"),
 			ID:         new(secretUUID),
 			Data:       secretDataKVComplex,
@@ -515,7 +514,7 @@ func TestIBMSecretManagerGetSecret(t *testing.T) {
 	// good case: kv type with property and dot, returns specific value
 	setSecretKVWithKeyDot := func(smtc *secretManagerTestCase) {
 		secret := &sm.KVSecret{
-			SecretType: utilpointer.To(sm.Secret_SecretType_Kv),
+			SecretType: new(sm.Secret_SecretType_Kv),
 			Name:       new("testyname"),
 			ID:         new(secretUUID),
 			Data:       secretDataKVComplex,
@@ -531,7 +530,7 @@ func TestIBMSecretManagerGetSecret(t *testing.T) {
 	// good case: kv type without property, returns all
 	setSecretKVWithOutKey := func(smtc *secretManagerTestCase) {
 		secret := &sm.KVSecret{
-			SecretType: utilpointer.To(sm.Secret_SecretType_Kv),
+			SecretType: new(sm.Secret_SecretType_Kv),
 			Name:       new("testyname"),
 			ID:         new(secretUUID),
 			Data:       secretDataKVComplex,
@@ -555,7 +554,7 @@ func TestIBMSecretManagerGetSecret(t *testing.T) {
 	// bad case: custom credentials type with key which is not in payload
 	badSecretCustomCredentials := func(smtc *secretManagerTestCase) {
 		secret := &sm.CustomCredentialsSecret{
-			SecretType:         utilpointer.To(sm.Secret_SecretType_CustomCredentials),
+			SecretType:         new(sm.Secret_SecretType_CustomCredentials),
 			Name:               new("testyname"),
 			ID:                 new(secretUUID),
 			CredentialsContent: customCredentialsSecretCredentialsContent,
@@ -571,7 +570,7 @@ func TestIBMSecretManagerGetSecret(t *testing.T) {
 	// good case: custom credentials type with property
 	setSecretCustomCredentials := func(smtc *secretManagerTestCase) {
 		secret := &sm.CustomCredentialsSecret{
-			SecretType:         utilpointer.To(sm.Secret_SecretType_CustomCredentials),
+			SecretType:         new(sm.Secret_SecretType_CustomCredentials),
 			Name:               new("testyname"),
 			ID:                 new(secretUUID),
 			CredentialsContent: customCredentialsSecretCredentialsContent,
@@ -587,7 +586,7 @@ func TestIBMSecretManagerGetSecret(t *testing.T) {
 	// good case: custom_credentials type with property, returns specific value
 	setSecretCustomCredentialsWithKey := func(smtc *secretManagerTestCase) {
 		secret := &sm.CustomCredentialsSecret{
-			SecretType:         utilpointer.To(sm.Secret_SecretType_CustomCredentials),
+			SecretType:         new(sm.Secret_SecretType_CustomCredentials),
 			Name:               new("testyname"),
 			ID:                 new(secretUUID),
 			CredentialsContent: customCredentialsSecretCredentialsContentComplex,
@@ -603,7 +602,7 @@ func TestIBMSecretManagerGetSecret(t *testing.T) {
 	// good case: custom_credentials type with property and path, returns specific value
 	setSecretCustomCredentialsWithKeyPath := func(smtc *secretManagerTestCase) {
 		secret := &sm.CustomCredentialsSecret{
-			SecretType:         utilpointer.To(sm.Secret_SecretType_CustomCredentials),
+			SecretType:         new(sm.Secret_SecretType_CustomCredentials),
 			Name:               new("testyname"),
 			ID:                 new(secretUUID),
 			CredentialsContent: customCredentialsSecretCredentialsContentComplex,
@@ -619,7 +618,7 @@ func TestIBMSecretManagerGetSecret(t *testing.T) {
 	// good case: custom_credentials type with property and dot, returns specific value
 	setSecretCustomCredentialsWithKeyDot := func(smtc *secretManagerTestCase) {
 		secret := &sm.CustomCredentialsSecret{
-			SecretType:         utilpointer.To(sm.Secret_SecretType_CustomCredentials),
+			SecretType:         new(sm.Secret_SecretType_CustomCredentials),
 			Name:               new("testyname"),
 			ID:                 new(secretUUID),
 			CredentialsContent: customCredentialsSecretCredentialsContentComplex,
@@ -635,7 +634,7 @@ func TestIBMSecretManagerGetSecret(t *testing.T) {
 	// good case: custom_credentials type without property, returns all
 	setSecretCustomCredentialsWithOutKey := func(smtc *secretManagerTestCase) {
 		secret := &sm.CustomCredentialsSecret{
-			SecretType:         utilpointer.To(sm.Secret_SecretType_CustomCredentials),
+			SecretType:         new(sm.Secret_SecretType_CustomCredentials),
 			Name:               new("testyname"),
 			ID:                 new(secretUUID),
 			CredentialsContent: customCredentialsSecretCredentialsContentComplex,
@@ -725,7 +724,7 @@ func TestGetSecretMap(t *testing.T) {
 		secret := &sm.ArbitrarySecret{
 			Name:       new("testyname"),
 			ID:         new(secretUUID),
-			SecretType: utilpointer.To(sm.Secret_SecretType_Arbitrary),
+			SecretType: new(sm.Secret_SecretType_Arbitrary),
 			Payload:    &payload,
 		}
 		smtc.name = "good case: arbitrary"
@@ -740,7 +739,7 @@ func TestGetSecretMap(t *testing.T) {
 		secret := &sm.UsernamePasswordSecret{
 			Name:       new("testyname"),
 			ID:         new(secretUUID),
-			SecretType: utilpointer.To(sm.Secret_SecretType_UsernamePassword),
+			SecretType: new(sm.Secret_SecretType_UsernamePassword),
 			Username:   &secretUsername,
 			Password:   &secretPassword,
 		}
@@ -757,7 +756,7 @@ func TestGetSecretMap(t *testing.T) {
 		secret := &sm.IAMCredentialsSecret{
 			Name:       new("testyname"),
 			ID:         new(secretUUID),
-			SecretType: utilpointer.To(sm.Secret_SecretType_IamCredentials),
+			SecretType: new(sm.Secret_SecretType_IamCredentials),
 			ApiKey:     new(secretAPIKey),
 		}
 		smtc.name = "good case: iam_credentials"
@@ -772,13 +771,13 @@ func TestGetSecretMap(t *testing.T) {
 		secret := &sm.IAMCredentialsSecret{
 			Name:       new("testyname"),
 			ID:         new(secretUUID),
-			SecretType: utilpointer.To(sm.Secret_SecretType_IamCredentials),
+			SecretType: new(sm.Secret_SecretType_IamCredentials),
 			ApiKey:     new(secretAPIKey),
 		}
 		smtc.name = "good case: iam_credentials by name using new mechanism"
 		smtc.getByNameInput.Name = new("testyname")
 		smtc.getByNameInput.SecretGroupName = new("groupName")
-		smtc.getByNameInput.SecretType = utilpointer.To(sm.Secret_SecretType_IamCredentials)
+		smtc.getByNameInput.SecretType = new(sm.Secret_SecretType_IamCredentials)
 
 		smtc.getByNameOutput = secret
 		smtc.apiOutput = secret
@@ -791,7 +790,7 @@ func TestGetSecretMap(t *testing.T) {
 		secret := &sm.IAMCredentialsSecret{
 			Name:       new("testyname"),
 			ID:         new(secretUUID),
-			SecretType: utilpointer.To(sm.Secret_SecretType_IamCredentials),
+			SecretType: new(sm.Secret_SecretType_IamCredentials),
 		}
 		smtc.name = "bad case: iam_credentials of a destroyed secret"
 		smtc.apiInput.ID = new(secretUUID)
@@ -817,7 +816,7 @@ func TestGetSecretMap(t *testing.T) {
 		secret := &sm.ServiceCredentialsSecret{
 			Name:        new("testyname"),
 			ID:          new(secretUUID),
-			SecretType:  utilpointer.To(sm.Secret_SecretType_IamCredentials),
+			SecretType:  new(sm.Secret_SecretType_IamCredentials),
 			Credentials: dummySrvCreds,
 		}
 		smtc.name = "good case: service_credentials"
@@ -829,7 +828,7 @@ func TestGetSecretMap(t *testing.T) {
 
 	// good case: imported_cert
 	importedCert := &sm.ImportedCertificate{
-		SecretType:   utilpointer.To(sm.Secret_SecretType_ImportedCert),
+		SecretType:   new(sm.Secret_SecretType_ImportedCert),
 		Name:         new("testyname"),
 		ID:           new(secretUUID),
 		Certificate:  new(secretCertificate),
@@ -840,7 +839,7 @@ func TestGetSecretMap(t *testing.T) {
 
 	// good case: public_cert
 	publicCert := &sm.PublicCertificate{
-		SecretType:   utilpointer.To(sm.Secret_SecretType_PublicCert),
+		SecretType:   new(sm.Secret_SecretType_PublicCert),
 		Name:         new("testyname"),
 		ID:           new(secretUUID),
 		Certificate:  new(secretCertificate),
@@ -854,7 +853,7 @@ func TestGetSecretMap(t *testing.T) {
 		secret := &sm.PrivateCertificate{
 			Name:        new("testyname"),
 			ID:          new(secretUUID),
-			SecretType:  utilpointer.To(sm.Secret_SecretType_PrivateCert),
+			SecretType:  new(sm.Secret_SecretType_PrivateCert),
 			Certificate: &secretCertificate,
 			PrivateKey:  &secretPrivateKey,
 		}
@@ -1203,7 +1202,7 @@ func TestGetSecretMap(t *testing.T) {
 		secret := &sm.KVSecret{
 			Name:       new("testyname"),
 			ID:         new(secretUUID),
-			SecretType: utilpointer.To(sm.Secret_SecretType_Kv),
+			SecretType: new(sm.Secret_SecretType_Kv),
 			Data:       secretComplex,
 		}
 		smtc.name = "good case: kv, no property, return entire payload as key:value pairs"
@@ -1220,7 +1219,7 @@ func TestGetSecretMap(t *testing.T) {
 		secret := &sm.KVSecret{
 			Name:       new("d5deb37a-7883-4fe2-a5e7-3c15420adc76"),
 			ID:         new(secretUUID),
-			SecretType: utilpointer.To(sm.Secret_SecretType_Kv),
+			SecretType: new(sm.Secret_SecretType_Kv),
 			Data:       secretComplex,
 		}
 		smtc.name = "good case: kv, with property"
@@ -1236,7 +1235,7 @@ func TestGetSecretMap(t *testing.T) {
 		secret := &sm.KVSecret{
 			Name:       new(secretUUID),
 			ID:         new(secretUUID),
-			SecretType: utilpointer.To(sm.Secret_SecretType_Kv),
+			SecretType: new(sm.Secret_SecretType_Kv),
 			Data:       secretComplex,
 		}
 		smtc.name = "good case: kv, with property and path"
@@ -1253,7 +1252,7 @@ func TestGetSecretMap(t *testing.T) {
 		secret := &sm.KVSecret{
 			Name:       new("testyname"),
 			ID:         new(secretUUID),
-			SecretType: utilpointer.To(sm.Secret_SecretType_Kv),
+			SecretType: new(sm.Secret_SecretType_Kv),
 			Data:       secretComplex,
 		}
 		smtc.name = "bad case: kv, with property and path"
@@ -1270,7 +1269,7 @@ func TestGetSecretMap(t *testing.T) {
 		secret := &sm.CustomCredentialsSecret{
 			Name:               new("testyname"),
 			ID:                 new(secretUUID),
-			SecretType:         utilpointer.To(sm.Secret_SecretType_CustomCredentials),
+			SecretType:         new(sm.Secret_SecretType_CustomCredentials),
 			CredentialsContent: secretComplex,
 		}
 		smtc.name = "good case: custom_credentials, no property, return entire payload as key:value pairs"
@@ -1287,7 +1286,7 @@ func TestGetSecretMap(t *testing.T) {
 		secret := &sm.CustomCredentialsSecret{
 			Name:               new("d5deb37a-7883-4fe2-a5e7-3c15420adc76"),
 			ID:                 new(secretUUID),
-			SecretType:         utilpointer.To(sm.Secret_SecretType_CustomCredentials),
+			SecretType:         new(sm.Secret_SecretType_CustomCredentials),
 			CredentialsContent: secretComplex,
 		}
 		smtc.name = "good case: custom_credentials, with property"
@@ -1303,7 +1302,7 @@ func TestGetSecretMap(t *testing.T) {
 		secret := &sm.CustomCredentialsSecret{
 			Name:               new(secretUUID),
 			ID:                 new(secretUUID),
-			SecretType:         utilpointer.To(sm.Secret_SecretType_CustomCredentials),
+			SecretType:         new(sm.Secret_SecretType_CustomCredentials),
 			CredentialsContent: secretComplex,
 		}
 		smtc.name = "good case: custom_credentials, with property and path"
@@ -1320,7 +1319,7 @@ func TestGetSecretMap(t *testing.T) {
 		secret := &sm.CustomCredentialsSecret{
 			Name:               new("testyname"),
 			ID:                 new(secretUUID),
-			SecretType:         utilpointer.To(sm.Secret_SecretType_CustomCredentials),
+			SecretType:         new(sm.Secret_SecretType_CustomCredentials),
 			CredentialsContent: secretComplex,
 		}
 		smtc.name = "bad case: custom_credentials, with property and path"


### PR DESCRIPTION
## Problem Statement

Go 1.26 gave `new` an expression form, so `new(x)` allocates, stores `x` and returns the pointer. That makes the pointer-taking helpers in `k8s.io/utils/ptr` and `k8s.io/utils/pointer` redundant, and the tree is already inconsistent about it: 47 files use the builtin form, seven still call the helpers. `k8s.io/utils/pointer` is deprecated upstream on top of that.

## Related Issue

None, there is no issue for this one.

## Proposed Changes

74 call sites across seven files become `new(...)`, which drops the import with them; no behaviour change, and `k8s.io/utils/pointer` is now gone from the tree entirely. Two sites needed more than a textual swap: `utilpointer.Int32(42)` becomes `new(int32(42))` because `new(42)` would be a `*int`, and the two `SideEffects` fixtures in `webhookconfig_test.go` drop their `(*admissionregistration.SideEffectClass)(...)` cast because `new` on the typed constant already yields the pointer type. `ptr.Deref` has no builtin equivalent so it stays, as do `aws.String`, `aws.Bool` and the `smithy-go` `ptr.To*` family.

## AI Assistance disclosure

AI assistance used: Yes

Tool(s) used: Claude Code, Opus 5.

Purpose of assistance: found the call sites and applied the rewrite.

Parts of the contribution affected: all of the diff.

Human validation performed: read the diff, ran `make test` and `make reviewable`.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
- [x] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [ ] I have tested my changes on a live environment to confirm they are working

Nothing to exercise live: no runtime behaviour changes, and the three converted e2e files are harness code needing provider credentials.
