### PR TITLE
fix: Make lint ignore Go workspaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ build-%: generate ## Build binary for the specified arch
 lint: golangci-lint ## Run golangci-lint (set LINT_TARGET to run on specific module, LINT_JOBS for parallel jobs)
 	@if [ -n "$(LINT_TARGET)" ]; then \
 		$(INFO) Running golangci-lint on $(LINT_TARGET); \
-		(cd $(LINT_TARGET) && $(GOLANGCI_LINT) run ./...) || exit 1; \
+		(cd $(LINT_TARGET) && GOWORK=off $(GOLANGCI_LINT) run ./...) || exit 1; \
 		$(OK) Finished linting $(LINT_TARGET); \
 	else \
 		$(INFO) Running golangci-lint on all modules in parallel; \
@@ -171,7 +171,7 @@ lint: golangci-lint ## Run golangci-lint (set LINT_TARGET to run on specific mod
 			module="$$0"; \
 			name=$$(echo "$$module" | sed "s/[\/\.]/_/g"); \
 			echo "Linting $$module"; \
-			if (cd "$$module" && $$GOLANGCI run ./... 2>&1); then \
+			if (cd "$$module" && GOWORK=off $$GOLANGCI run ./... 2>&1); then \
 				echo "✓ $$module" > "$$TMPDIR/$$name.success"; \
 			else \
 				echo "✗ $$module" > "$$TMPDIR/$$name.failed"; \


### PR DESCRIPTION
## Problem Statement

This makes the CI and the local behaviour consistent.

## Related Issue

Fixes: #6897

## Proposed Changes

Introduce gowork=off on all lint.
Alternative was to stop isolating those packages, but it felt like it was the opposite direction compared to the initial plan for module isolation.

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
design(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## AI Assistance disclosure

Did you use an script, LLM, or AI assisted development tool for this contribution?

AI assistance used: No

If yes provide details:

Tool(s) used:

Purpose of assistance:

Parts of the contribution affected:

Human validation performed:

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] My changes have reasonable test coverage
- [X] All tests pass with `make test`
- [X] I ensured my PR is ready for review with `make reviewable`
- [X] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [ ] I have tested my changes on a live environment to confirm they are working
