### PR TITLE
fix: Use local GCP import for Vault modules

### DIFF
--- a/generators/v1/vault/go.mod
+++ b/generators/v1/vault/go.mod
@@ -173,3 +173,5 @@ replace (
 replace github.com/external-secrets/external-secrets/providers/v1/vault => ../../../providers/v1/vault
 
 replace github.com/external-secrets/external-secrets/providers/v1/aws => ../../../providers/v1/aws
+
+replace github.com/external-secrets/external-secrets/providers/v1/gcp => ../../../providers/v1/gcp

--- a/generators/v1/vault/go.sum
+++ b/generators/v1/vault/go.sum
@@ -73,8 +73,6 @@ github.com/evanphx/json-patch v0.5.2 h1:xVCHIVMUu1wtM/VkR9jVZ45N3FhZfYMMYGorLCR8
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
-github.com/external-secrets/external-secrets/providers/v1/gcp v0.0.0-20251104073127-4d2c8fd13e10 h1:tPYE3zcBAepYacYbhzTgZyQ/yxbXdzQqCmMsH7D54xk=
-github.com/external-secrets/external-secrets/providers/v1/gcp v0.0.0-20251104073127-4d2c8fd13e10/go.mod h1:iwajJm1aNMXI1bgCs/W5S846IfZ6lUcPiYXSyRWEDbI=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
 github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=

--- a/providers/v1/vault/go.mod
+++ b/providers/v1/vault/go.mod
@@ -173,3 +173,5 @@ replace (
 )
 
 replace github.com/external-secrets/external-secrets/providers/v1/aws => ../aws
+
+replace github.com/external-secrets/external-secrets/providers/v1/gcp => ../gcp

--- a/providers/v1/vault/go.sum
+++ b/providers/v1/vault/go.sum
@@ -73,8 +73,6 @@ github.com/evanphx/json-patch v0.5.2 h1:xVCHIVMUu1wtM/VkR9jVZ45N3FhZfYMMYGorLCR8
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
-github.com/external-secrets/external-secrets/providers/v1/gcp v0.0.0-20251104073127-4d2c8fd13e10 h1:tPYE3zcBAepYacYbhzTgZyQ/yxbXdzQqCmMsH7D54xk=
-github.com/external-secrets/external-secrets/providers/v1/gcp v0.0.0-20251104073127-4d2c8fd13e10/go.mod h1:iwajJm1aNMXI1bgCs/W5S846IfZ6lUcPiYXSyRWEDbI=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
 github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=


### PR DESCRIPTION
## Problem Statement

Incorrect gcp import in vault provider: standalone module linting is incorrectly resolving to published/pseudo versions instead of fetching the ones locally.

## Related Issue

Blocks: https://github.com/external-secrets/external-secrets/pull/6883 
Related: https://github.com/external-secrets/external-secrets/issues/6897

## Proposed Changes

Add explicit local replaces for the vault provider gcp's integration. This matches what we do for AWS.

While one could argue that we should NOT have any of those imports (complete independence), this is not the case currently and vault relies on the other modules at the moment. Should we want to guarantee isolation, it should be fixed separately.

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
design(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## AI Assistance disclosure

Did you use an script, LLM, or AI assisted development tool for this contribution?

AI assistance used: No

If yes provide details:

Tool(s) used:

Purpose of assistance:

Parts of the contribution affected:

Human validation performed:

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] My changes have reasonable test coverage
- [X] All tests pass with `make test`
- [X] I ensured my PR is ready for review with `make reviewable`
- [X] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [ ] I have tested my changes on a live environment to confirm they are working
