### PR TITLE
fix: guarantee replaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,11 @@ build-%: generate ## Build binary for the specified arch
 		go build -tags $(PROVIDER) -o '$(OUTPUT_DIR)/external-secrets-linux-$*' main.go
 	@$(OK) go build $*
 
-lint: golangci-lint ## Run golangci-lint (set LINT_TARGET to run on specific module, LINT_JOBS for parallel jobs)
+.PHONY: provider-replaces.check
+provider-replaces.check: ## Ensure cross-provider dependencies use local replacements
+	@./hack/check-provider-replaces.sh
+
+lint: golangci-lint provider-replaces.check ## Run golangci-lint (set LINT_TARGET to run on specific module, LINT_JOBS for parallel jobs)
 	@if [ -n "$(LINT_TARGET)" ]; then \
 		$(INFO) Running golangci-lint on $(LINT_TARGET); \
 		(cd $(LINT_TARGET) && $(GOLANGCI_LINT) run ./...) || exit 1; \

--- a/hack/check-provider-replaces.sh
+++ b/hack/check-provider-replaces.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+provider_prefix="github.com/external-secrets/external-secrets/providers/v1"
+failed=0
+
+for provider_dir in providers/v1/*/; do
+    [[ -f "${provider_dir}go.mod" ]] || continue
+
+    if ! module_path=$(GOWORK=off go -C "$provider_dir" list -m -mod=readonly -f '{{.Path}}'); then
+        failed=1
+        continue
+    fi
+
+    # Load production and test imports without the workspace, which would
+    # otherwise hide missing requirements by resolving sibling modules locally.
+    if ! GOWORK=off go -C "$provider_dir" list -mod=readonly -deps -test ./... >/dev/null; then
+        failed=1
+        continue
+    fi
+
+    if ! module_graph=$(GOWORK=off go -C "$provider_dir" list -m -mod=readonly -f '{{.Path}}{{with .Replace}} => {{.Path}}{{end}}' all); then
+        failed=1
+        continue
+    fi
+
+    while read -r dependency arrow replacement; do
+        [[ -n "${dependency:-}" ]] || continue
+        [[ "$dependency" == "$module_path" ]] && continue
+        [[ "$dependency" == "$provider_prefix/"* ]] || continue
+
+        expected="../${dependency##*/}"
+        if [[ "${arrow:-}" != "=>" || "${replacement:-}" != "$expected" ]]; then
+            printf '%sgo.mod: provider dependency %s must have:\n' "$provider_dir" "$dependency" >&2
+            printf 'replace %s => %s\n' "$dependency" "$expected" >&2
+            failed=1
+        fi
+    done <<< "$module_graph"
+done
+
+exit "$failed"


### PR DESCRIPTION
## Problem Statement

Without this, it is possible to require a module that should be "replaced" by its local code base, but isn't.

This causes a change to _not be correctly tested_: The change is tested with its local released cache instead of the actual code under test that might be changed.

## Related Issue

Fixes: #6897

## Proposed Changes

This adds a check into lint process to guarantee that imports of providers from a provider will get caught if they are not replaced by their local folder.

## Format

Please ensure that your PR follows the following format for the title:
```
feat(scope): add new feature
fix(scope): fix bug
docs(scope): update documentation
chore(scope): update build tool or dependencies
ref(scope): refactor code
clean(scope): provider cleanup
test(scope): add tests
perf(scope): improve performance
design(scope): improve design
```

Where `scope` is _optionally_ one of:
- charts
- release
- testing
- security
- templating

## AI Assistance disclosure

Did you use an script, LLM, or AI assisted development tool for this contribution?

AI assistance used: Yes

If yes provide details:

Tool(s) used: codex

Purpose of assistance: writing the shell script because it abandoned my idea to have a custom linter.

Parts of the contribution affected: the script

Human validation performed: I read the script and started it on my machine. Worked on the gcp issue.

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] My changes have reasonable test coverage
- [X] All tests pass with `make test`
- [X] I ensured my PR is ready for review with `make reviewable`
- [X] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [ ] I have tested my changes on a live environment to confirm they are working
