### PR TITLE
fix(charts): fix bug: set CRD conversion.strategy None for server-side apply

### DIFF
--- a/deploy/charts/external-secrets/tests/__snapshot__/crds_test.yaml.snap
+++ b/deploy/charts/external-secrets/tests/__snapshot__/crds_test.yaml.snap
@@ -9,6 +9,8 @@ should match snapshot of default values:
         external-secrets.io/component: controller
       name: secretstores.external-secrets.io
     spec:
+      conversion:
+        strategy: None
       group: external-secrets.io
       names:
         categories:
@@ -60,7 +62,7 @@ should match snapshot of default values:
                   description: SecretStoreSpec defines the desired state of SecretStore.
                   properties:
                     conditions:
-                      description: Used to constraint a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore
+                      description: Used to constrain a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore.
                       items:
                         description: |-
                           ClusterSecretStoreCondition describes a condition by which to choose namespaces to process ExternalSecrets in
@@ -195,8 +197,8 @@ should match snapshot of default values:
                                         audiences:
                                           description: |-
                                             Audience specifies the `aud` claim for the service account token
-                                            If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
-                                            then this audiences will be appended to the list
+                                            Some providers automatically extend the audience field based on well-known annotations for workload
+                                            identity (e.g. IRSA or GCP Workload Identity)
                                           items:
                                             type: string
                                           type: array
@@ -309,6 +311,38 @@ should match snapshot of default values:
                                           type: string
                                       type: object
                                   type: object
+                                serviceAccountRef:
+                                  description: |-
+                                    ServiceAccountRef specifies a Kubernetes ServiceAccount used for azure_ad
+                                    authentication on AKS Workload Identity. The operator obtains a federated
+                                    identity token from this ServiceAccount via the TokenRequest API instead
+                                    of using the ESO controller pod identity. Ignored for other access types.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        Some providers automatically extend the audience field based on well-known annotations for workload
+                                        identity (e.g. IRSA or GCP Workload Identity)
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
                               type: object
                             caBundle:
                               description: |-
@@ -350,99 +384,14 @@ should match snapshot of default values:
                                 - name
                                 - type
                               type: object
+                            ignoreCache:
+                              description: |-
+                                IgnoreCache bypasses the Gateway cache for secret reads when true.
+                                Only relevant when akeylessGWApiURL points to an Akeyless Gateway.
+                              type: boolean
                           required:
                             - akeylessGWApiURL
                             - authSecretRef
-                          type: object
-                        alibaba:
-                          description: Alibaba configures this store to sync secrets using Alibaba Cloud provider
-                          properties:
-                            auth:
-                              description: AlibabaAuth contains a secretRef for credentials.
-                              properties:
-                                rrsa:
-                                  description: AlibabaRRSAAuth authenticates against Alibaba using RRSA.
-                                  properties:
-                                    oidcProviderArn:
-                                      type: string
-                                    oidcTokenFilePath:
-                                      type: string
-                                    roleArn:
-                                      type: string
-                                    sessionName:
-                                      type: string
-                                  required:
-                                    - oidcProviderArn
-                                    - oidcTokenFilePath
-                                    - roleArn
-                                    - sessionName
-                                  type: object
-                                secretRef:
-                                  description: AlibabaAuthSecretRef holds secret references for Alibaba credentials.
-                                  properties:
-                                    accessKeyIDSecretRef:
-                                      description: The AccessKeyID is used for authentication
-                                      properties:
-                                        key:
-                                          description: |-
-                                            A key in the referenced Secret.
-                                            Some instances of this field may be defaulted, in others it may be required.
-                                          maxLength: 253
-                                          minLength: 1
-                                          pattern: ^[-._a-zA-Z0-9]+$
-                                          type: string
-                                        name:
-                                          description: The name of the Secret resource being referred to.
-                                          maxLength: 253
-                                          minLength: 1
-                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                          type: string
-                                        namespace:
-                                          description: |-
-                                            The namespace of the Secret resource being referred to.
-                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
-                                          maxLength: 63
-                                          minLength: 1
-                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                                          type: string
-                                      type: object
-                                    accessKeySecretSecretRef:
-                                      description: The AccessKeySecret is used for authentication
-                                      properties:
-                                        key:
-                                          description: |-
-                                            A key in the referenced Secret.
-                                            Some instances of this field may be defaulted, in others it may be required.
-                                          maxLength: 253
-                                          minLength: 1
-                                          pattern: ^[-._a-zA-Z0-9]+$
-                                          type: string
-                                        name:
-                                          description: The name of the Secret resource being referred to.
-                                          maxLength: 253
-                                          minLength: 1
-                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                          type: string
-                                        namespace:
-                                          description: |-
-                                            The namespace of the Secret resource being referred to.
-                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
-                                          maxLength: 63
-                                          minLength: 1
-                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                                          type: string
-                                      type: object
-                                  required:
-                                    - accessKeyIDSecretRef
-                                    - accessKeySecretSecretRef
-                                  type: object
-                              type: object
-                            regionID:
-                              description: Alibaba Region to be used for the provider
-                              type: string
-                          required:
-                            - auth
-                            - regionID
                           type: object
                         aws:
                           description: AWS configures this store to sync secrets using AWS Secret Manager provider
@@ -467,8 +416,8 @@ should match snapshot of default values:
                                         audiences:
                                           description: |-
                                             Audience specifies the `aud` claim for the service account token
-                                            If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
-                                            then this audiences will be appended to the list
+                                            Some providers automatically extend the audience field based on well-known annotations for workload
+                                            identity (e.g. IRSA or GCP Workload Identity)
                                           items:
                                             type: string
                                           type: array
@@ -578,6 +527,16 @@ should match snapshot of default values:
                                       type: object
                                   type: object
                               type: object
+                            customSessionTags:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                CustomSessionTags defines additional STS session tags to include when SessionTagsPolicy is Custom.
+                                These are merged with the automatically injected esoNamespace, esoStoreName, and esoStoreKind tags.
+                              type: object
+                              x-kubernetes-validations:
+                                - message: 'customSessionTags cannot contain automatically injected reserved keys: esoNamespace, esoStoreName, esoStoreKind'
+                                  rule: '!(''esoNamespace'' in self) && !(''esoStoreName'' in self) && !(''esoStoreKind'' in self)'
                             externalID:
                               description: AWS External ID set on assumed IAM roles
                               type: string
@@ -616,6 +575,7 @@ should match snapshot of default values:
                               enum:
                                 - SecretsManager
                                 - ParameterStore
+                                - CertificateManager
                               type: string
                             sessionTags:
                               description: AWS STS assume role session tags
@@ -633,6 +593,19 @@ should match snapshot of default values:
                                   - value
                                 type: object
                               type: array
+                            sessionTagsPolicy:
+                              default: None
+                              description: |-
+                                SessionTagsPolicy controls whether and how STS session tags are added when assuming roles.
+                                None (default): no tags are added.
+                                Simple: automatically adds esoNamespace (from the ExternalSecret), esoStoreName, and esoStoreKind tags.
+                                Custom: adds esoNamespace, esoStoreName, and esoStoreKind plus any tags defined in CustomSessionTags.
+                                Note: the IAM role must have sts:TagSession permission when using Simple or Custom.
+                              enum:
+                                - None
+                                - Simple
+                                - Custom
+                              type: string
                             transitiveTagKeys:
                               description: AWS STS assume role transitive session tags. Required when multiple rules are used with the provider
                               items:
@@ -760,6 +733,7 @@ should match snapshot of default values:
                                 Valid values are:
                                 - "ServicePrincipal" (default): Using a service principal (tenantId, clientId, clientSecret)
                                 - "ManagedIdentity": Using Managed Identity assigned to the pod (see aad-pod-identity)
+                                - "WorkloadIdentity": Using a Kubernetes ServiceAccount federated with Entra ID
                               enum:
                                 - ServicePrincipal
                                 - ManagedIdentity
@@ -767,8 +741,11 @@ should match snapshot of default values:
                               type: string
                             customCloudConfig:
                               description: |-
-                                CustomCloudConfig defines custom Azure Stack Hub or Azure Stack Edge endpoints.
+                                CustomCloudConfig defines custom Azure endpoints for non-standard clouds.
                                 Required when EnvironmentType is AzureStackCloud.
+                                Optional for other environment types - useful for Azure China when using Workload Identity
+                                with AKS, where the OIDC issuer (login.partner.microsoftonline.cn) differs from the
+                                standard China Cloud endpoint (login.chinacloudapi.cn).
                                 IMPORTANT: This feature REQUIRES UseAzureSDK to be set to true. Custom cloud
                                 configuration is not supported with the legacy go-autorest SDK.
                               properties:
@@ -815,8 +792,8 @@ should match snapshot of default values:
                                 audiences:
                                   description: |-
                                     Audience specifies the `aud` claim for the service account token
-                                    If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
-                                    then this audiences will be appended to the list
+                                    Some providers automatically extend the audience field based on well-known annotations for workload
+                                    identity (e.g. IRSA or GCP Workload Identity)
                                   items:
                                     type: string
                                   type: array
@@ -851,6 +828,186 @@ should match snapshot of default values:
                               type: string
                           required:
                             - vaultUrl
+                          type: object
+                        barbican:
+                          description: Barbican configures this store to sync secrets using the OpenStack Barbican provider
+                          properties:
+                            auth:
+                              description: BarbicanAuth contains the authentication information for Barbican.
+                              properties:
+                                applicationCredentialID:
+                                  description: ID of the application credential used for authentication.
+                                  maxProperties: 1
+                                  minProperties: 1
+                                  properties:
+                                    secretRef:
+                                      description: |-
+                                        SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                        In some instances, `key` is a required field.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                    value:
+                                      minLength: 1
+                                      type: string
+                                  type: object
+                                applicationCredentialSecret:
+                                  description: BarbicanProviderAppCredSecretRef defines a reference to an Application Credential Secret.
+                                  properties:
+                                    secretRef:
+                                      description: |-
+                                        SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                        In some instances, `key` is a required field.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                  required:
+                                    - secretRef
+                                  type: object
+                                authType:
+                                  default: password
+                                  description: |-
+                                    AuthType selects how Barbican authenticates.
+                                    - "password": use username and password.
+                                    - "applicationCredential": use application credential ID and secret.
+                                    Defaults to "password".
+                                  enum:
+                                    - password
+                                    - applicationCredential
+                                  type: string
+                                password:
+                                  description: BarbicanProviderPasswordRef defines a reference to a secret containing password for the Barbican provider.
+                                  properties:
+                                    secretRef:
+                                      description: |-
+                                        SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                        In some instances, `key` is a required field.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                  required:
+                                    - secretRef
+                                  type: object
+                                username:
+                                  description: Username / Password authentication fields.
+                                  maxProperties: 1
+                                  minProperties: 1
+                                  properties:
+                                    secretRef:
+                                      description: |-
+                                        SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                        In some instances, `key` is a required field.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                    value:
+                                      minLength: 1
+                                      type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-validations:
+                                - message: password auth requires both username and password
+                                  rule: (has(self.authType) && self.authType == 'applicationCredential') || (has(self.username) && has(self.password))
+                                - message: applicationCredential auth requires both applicationCredentialID and applicationCredentialSecret
+                                  rule: self.authType != 'applicationCredential' || (has(self.applicationCredentialID) && has(self.applicationCredentialSecret))
+                                - message: password auth should not include applicationCredential fields
+                                  rule: (has(self.authType) && self.authType == 'applicationCredential') || (!has(self.applicationCredentialID) && !has(self.applicationCredentialSecret))
+                                - message: applicationCredential auth should not include password fields
+                                  rule: self.authType != 'applicationCredential' || (!has(self.username) && !has(self.password))
+                            authURL:
+                              type: string
+                            domainName:
+                              type: string
+                            region:
+                              type: string
+                            tenantName:
+                              type: string
+                          required:
+                            - auth
                           type: object
                         beyondtrust:
                           description: Beyondtrust configures this store to sync secrets using Password Safe provider.
@@ -1034,6 +1191,10 @@ should match snapshot of default values:
                                 clientTimeOutSeconds:
                                   description: Timeout specifies a time limit for requests made by this Client. The timeout includes connection time, any redirects, and reading the response body. Defaults to 45 seconds.
                                   type: integer
+                                decrypt:
+                                  default: true
+                                  description: 'When true, the response includes the decrypted password. When false, the password field is omitted. This option only applies to the SECRET retrieval type. Default: true.'
+                                  type: boolean
                                 retrievalType:
                                   description: The secret retrieval type. SECRET = Secrets Safe (credential, text, file). MANAGED_ACCOUNT = Password Safe account associated with a system.
                                   type: string
@@ -1045,6 +1206,136 @@ should match snapshot of default values:
                               required:
                                 - apiUrl
                                 - verifyCA
+                              type: object
+                          required:
+                            - auth
+                            - server
+                          type: object
+                        beyondtrustworkloadcredentials:
+                          description: BeyondtrustWorkloadCredentials configures this store to sync secrets using the BeyondTrust Workload Credentials provider.
+                          properties:
+                            auth:
+                              description: |-
+                                Auth configures how the Operator authenticates with the BeyondTrust Workload Credentials API.
+                                Currently supports API key authentication via Kubernetes secret reference.
+                                For authentication setup, see: https://docs.beyondtrust.com/bt-docs/docs/secrets-api#authentication
+                              properties:
+                                apikey:
+                                  description: |-
+                                    APIKey configures API token authentication for BeyondTrust Workload Credentials.
+                                    The token is retrieved from a Kubernetes secret and used as a Bearer token for API requests.
+                                  properties:
+                                    token:
+                                      description: |-
+                                        Token references the Kubernetes secret containing the BeyondTrust Workload Credentials API token.
+                                        The secret should contain the API key used to authenticate with BeyondTrust Workload Credentials.
+                                        Create an API token in your BeyondTrust Workload Credentials console and store it in a Kubernetes secret.
+                                        For details on creating API tokens, see: https://docs.beyondtrust.com/bt-docs/docs/secrets-api#authentication
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                  required:
+                                    - token
+                                  type: object
+                              required:
+                                - apikey
+                              type: object
+                            caBundle:
+                              description: |-
+                                CABundle is a base64-encoded CA certificate used to validate the BeyondTrust Workload Credentials API TLS certificate.
+                                Use this when your BeyondTrust instance uses a self-signed certificate or internal CA.
+                                If not set, the system's trusted root certificates are used.
+                              format: byte
+                              type: string
+                            caProvider:
+                              description: |-
+                                CAProvider points to a Secret or ConfigMap containing a PEM-encoded CA certificate.
+                                This is used to validate the BeyondTrust Workload Credentials API TLS certificate.
+                                Use this as an alternative to CABundle when you want to reference an existing Kubernetes resource.
+                              properties:
+                                key:
+                                  description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the object located at the provider type.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace the Provider type is in.
+                                    Can only be defined when used in a ClusterSecretStore.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                                type:
+                                  description: The type of provider to use such as "Secret", or "ConfigMap".
+                                  enum:
+                                    - Secret
+                                    - ConfigMap
+                                  type: string
+                              required:
+                                - name
+                                - type
+                              type: object
+                            folderPath:
+                              description: |-
+                                FolderPath specifies the default folder path for secret retrieval.
+                                Secrets will be fetched from this folder unless overridden in the ExternalSecret spec.
+                                Example: "production/database" or "dev/api-keys"
+                                Leave empty to retrieve secrets from the root folder.
+                                For folder organization, see: https://docs.beyondtrust.com/bt-docs/docs/secrets-api#folders
+                              type: string
+                            server:
+                              description: |-
+                                Server configures the BeyondTrust Workload Credentials server connection details.
+                                Includes the API URL and Site ID for your BeyondTrust instance.
+                                For API reference, see: https://docs.beyondtrust.com/bt-docs/docs/secrets-api
+                              properties:
+                                apiUrl:
+                                  description: |-
+                                    APIURL is the base URL of your BeyondTrust Workload Credentials API server.
+                                    This should be the full URL to your BeyondTrust instance.
+                                    Example: https://api.beyondtrust.io/siie
+                                    For more information, see: https://docs.beyondtrust.com/bt-docs/docs/secrets-api#base-url
+                                  type: string
+                                siteId:
+                                  description: |-
+                                    SiteID is your BeyondTrust Workload Credentials site identifier (UUID format).
+                                    This identifier is unique to your BeyondTrust Workload Credentials instance.
+                                    You can find your Site ID in the BeyondTrust Workload Credentials admin console.
+                                    Example: a1b2c3d4-e5f6-4890-abcd-ef1234567890
+                                    For more information, see: https://docs.beyondtrust.com/bt-docs/docs/secrets-api
+                                  type: string
+                              required:
+                                - apiUrl
+                                - siteId
                               type: object
                           required:
                             - auth
@@ -1277,6 +1568,8 @@ should match snapshot of default values:
                           properties:
                             auth:
                               description: Defines authentication settings for connecting to Conjur.
+                              maxProperties: 1
+                              minProperties: 1
                               properties:
                                 apikey:
                                   description: Authenticates with Conjur using an API key.
@@ -1345,6 +1638,80 @@ should match snapshot of default values:
                                     - apiKeyRef
                                     - userRef
                                   type: object
+                                cert:
+                                  description: Cert enables certificate-based authentication using a client certificate and key.
+                                  properties:
+                                    account:
+                                      description: Account is the Conjur organization account name.
+                                      type: string
+                                    clientCertRef:
+                                      description: |-
+                                        ClientCertRef is a reference to a specific 'key' containing the client certificate
+                                        within a Secret resource. The certificate must be PEM-encoded.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                    clientKeyRef:
+                                      description: |-
+                                        ClientKeyRef is a reference to a specific 'key' containing the private RSA client key
+                                        within a Secret resource. The key must be PEM-encoded.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                    hostId:
+                                      description: Optional HostID for cert authentication (can be omitted when using 'spiffe' mode).
+                                      type: string
+                                    serviceID:
+                                      description: The conjur authn cert webservice id
+                                      type: string
+                                  required:
+                                    - account
+                                    - clientCertRef
+                                    - clientKeyRef
+                                    - serviceID
+                                  type: object
                                 jwt:
                                   description: Jwt enables JWT authentication using Kubernetes service account tokens.
                                   properties:
@@ -1392,8 +1759,8 @@ should match snapshot of default values:
                                         audiences:
                                           description: |-
                                             Audience specifies the `aud` claim for the service account token
-                                            If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
-                                            then this audiences will be appended to the list
+                                            Some providers automatically extend the audience field based on well-known annotations for workload
+                                            identity (e.g. IRSA or GCP Workload Identity)
                                           items:
                                             type: string
                                           type: array
@@ -1468,6 +1835,288 @@ should match snapshot of default values:
                             - auth
                             - url
                           type: object
+                        crd:
+                          description: |-
+                            CRD configures this store to sync secrets from arbitrary Kubernetes resources,
+                            including both custom resources (CRDs) and core API resources. Resources are
+                            selected by API group, version and kind, where group can be "" (empty string)
+                            for core resources such as ConfigMap. Reading the core v1 Secret is
+                            intentionally blocked — use the Kubernetes provider for that.
+                          properties:
+                            auth:
+                              description: |-
+                                Auth configures authentication to the Kubernetes API, same as the
+                                Kubernetes provider. Required when Server.URL is set (unless using AuthRef).
+                              maxProperties: 1
+                              minProperties: 1
+                              properties:
+                                cert:
+                                  description: has both clientCert and clientKey as secretKeySelector
+                                  properties:
+                                    clientCert:
+                                      description: |-
+                                        SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                        In some instances, `key` is a required field.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                    clientKey:
+                                      description: |-
+                                        SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                        In some instances, `key` is a required field.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                  required:
+                                    - clientCert
+                                    - clientKey
+                                  type: object
+                                serviceAccount:
+                                  description: points to a service account that should be used for authentication
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        Some providers automatically extend the audience field based on well-known annotations for workload
+                                        identity (e.g. IRSA or GCP Workload Identity)
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                token:
+                                  description: use static token to authenticate with
+                                  properties:
+                                    bearerToken:
+                                      description: |-
+                                        SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                        In some instances, `key` is a required field.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                  required:
+                                    - bearerToken
+                                  type: object
+                              type: object
+                            authRef:
+                              description: |-
+                                AuthRef references a Secret containing a kubeconfig. Same semantics as the
+                                Kubernetes provider.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            resource:
+                              description: Resource identifies the CRD by its API group, version and kind.
+                              properties:
+                                group:
+                                  description: |-
+                                    Group is the API group of the resource. Use "" (empty string) for core
+                                    Kubernetes resources such as ConfigMap; use e.g. "config.example.io"
+                                    for a CRD. The field is required to be present in the manifest — write
+                                    `group: ""` explicitly for core resources so typos fail at admission
+                                    time rather than later at discovery.
+                                  type: string
+                                kind:
+                                  description: Kind is the Kubernetes resource kind (e.g. "MyCustomResource").
+                                  minLength: 1
+                                  type: string
+                                version:
+                                  description: Version is the API version of the resource (e.g. "v1alpha1").
+                                  minLength: 1
+                                  type: string
+                              required:
+                                - group
+                                - kind
+                                - version
+                              type: object
+                            server:
+                              description: |-
+                                Server configures the Kubernetes API address and TLS trust, same as the
+                                Kubernetes provider. When omitted, the URL defaults to the in-cluster API.
+                              properties:
+                                caBundle:
+                                  description: CABundle is a base64-encoded CA certificate
+                                  format: byte
+                                  type: string
+                                caProvider:
+                                  description: 'see: https://external-secrets.io/latest/spec/#external-secrets.io/v1alpha1.CAProvider'
+                                  properties:
+                                    key:
+                                      description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the object located at the provider type.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace the Provider type is in.
+                                        Can only be defined when used in a ClusterSecretStore.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                    type:
+                                      description: The type of provider to use such as "Secret", or "ConfigMap".
+                                      enum:
+                                        - Secret
+                                        - ConfigMap
+                                      type: string
+                                  required:
+                                    - name
+                                    - type
+                                  type: object
+                                url:
+                                  default: kubernetes.default
+                                  description: configures the Kubernetes server Address.
+                                  type: string
+                              type: object
+                            whitelist:
+                              description: |-
+                                Whitelist optionally restricts which object names and requested properties
+                                are allowed to be read.
+                              properties:
+                                rules:
+                                  description: |-
+                                    Rules is a list of allow rules. If rules are set, at least one rule must
+                                    match for a request to be allowed.
+                                  items:
+                                    description: CRDProviderWhitelistRule defines a single allow rule for CRD reads.
+                                    properties:
+                                      name:
+                                        description: |-
+                                          Name is an optional regular expression matched against the bare object name.
+                                          For both SecretStore and ClusterSecretStore this is always the object name
+                                          without any namespace prefix (e.g. "my-db-spec", not "prod/my-db-spec").
+                                        type: string
+                                      namespace:
+                                        description: |-
+                                          Namespace is an optional regular expression matched against the namespace of
+                                          the object. Applies only when a ClusterSecretStore is used; it is ignored
+                                          for SecretStore (where the namespace is fixed to the store namespace).
+                                        type: string
+                                      properties:
+                                        description: |-
+                                          Properties is an optional list of regular expressions matched against
+                                          requested property keys (for example: "spec.secretValue").
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  type: array
+                              type: object
+                          required:
+                            - resource
+                          type: object
+                          x-kubernetes-validations:
+                            - message: one of auth or authRef is required
+                              rule: has(self.auth) || has(self.authRef)
+                            - message: at most one of the fields in [auth authRef] may be set
+                              rule: '[has(self.auth),has(self.authRef)].filter(x,x==true).size() <= 1'
                         delinea:
                           description: |-
                             Delinea DevOps Secrets Vault
@@ -1557,60 +2206,59 @@ should match snapshot of default values:
                             - clientSecret
                             - tenant
                           type: object
-                        device42:
-                          description: Device42 configures this store to sync secrets using the Device42 provider
-                          properties:
-                            auth:
-                              description: Auth configures how secret-manager authenticates with a Device42 instance.
-                              properties:
-                                secretRef:
-                                  description: Device42SecretRef contains the secret reference for accessing the Device42 instance.
-                                  properties:
-                                    credentials:
-                                      description: Username / Password is used for authentication.
-                                      properties:
-                                        key:
-                                          description: |-
-                                            A key in the referenced Secret.
-                                            Some instances of this field may be defaulted, in others it may be required.
-                                          maxLength: 253
-                                          minLength: 1
-                                          pattern: ^[-._a-zA-Z0-9]+$
-                                          type: string
-                                        name:
-                                          description: The name of the Secret resource being referred to.
-                                          maxLength: 253
-                                          minLength: 1
-                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                          type: string
-                                        namespace:
-                                          description: |-
-                                            The namespace of the Secret resource being referred to.
-                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
-                                          maxLength: 63
-                                          minLength: 1
-                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                                          type: string
-                                      type: object
-                                  type: object
-                              required:
-                                - secretRef
-                              type: object
-                            host:
-                              description: URL configures the Device42 instance URL.
-                              type: string
-                          required:
-                            - auth
-                            - host
-                          type: object
                         doppler:
                           description: Doppler configures this store to sync secrets using the Doppler provider
                           properties:
                             auth:
                               description: Auth configures how the Operator authenticates with the Doppler API
                               properties:
+                                oidcConfig:
+                                  description: OIDCConfig authenticates using Kubernetes ServiceAccount tokens via OIDC.
+                                  properties:
+                                    expirationSeconds:
+                                      default: 600
+                                      description: |-
+                                        ExpirationSeconds sets the ServiceAccount token validity duration.
+                                        Defaults to 10 minutes.
+                                      format: int64
+                                      type: integer
+                                    identity:
+                                      description: Identity is the Doppler Service Account Identity ID configured for OIDC authentication.
+                                      type: string
+                                    serviceAccountRef:
+                                      description: ServiceAccountRef specifies the Kubernetes ServiceAccount to use for authentication.
+                                      properties:
+                                        audiences:
+                                          description: |-
+                                            Audience specifies the `aud` claim for the service account token
+                                            Some providers automatically extend the audience field based on well-known annotations for workload
+                                            identity (e.g. IRSA or GCP Workload Identity)
+                                          items:
+                                            type: string
+                                          type: array
+                                        name:
+                                          description: The name of the ServiceAccount resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace of the resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  required:
+                                    - identity
+                                    - serviceAccountRef
+                                  type: object
                                 secretRef:
-                                  description: DopplerAuthSecretRef contains the secret reference for accessing the Doppler API.
+                                  description: SecretRef authenticates using a Doppler service token stored in a Kubernetes Secret.
                                   properties:
                                     dopplerToken:
                                       description: |-
@@ -1644,9 +2292,10 @@ should match snapshot of default values:
                                   required:
                                     - dopplerToken
                                   type: object
-                              required:
-                                - secretRef
                               type: object
+                              x-kubernetes-validations:
+                                - message: Exactly one of 'secretRef' or 'oidcConfig' must be specified
+                                  rule: (has(self.secretRef) && !has(self.oidcConfig)) || (!has(self.secretRef) && has(self.oidcConfig))
                             config:
                               description: Doppler config (required if not using a Service Token)
                               type: string
@@ -1674,6 +2323,92 @@ should match snapshot of default values:
                               type: string
                           required:
                             - auth
+                          type: object
+                        dvls:
+                          description: DVLS configures this store to sync secrets using Devolutions Server provider
+                          properties:
+                            auth:
+                              description: Auth defines the authentication method to use.
+                              properties:
+                                secretRef:
+                                  description: SecretRef contains the Application ID and Application Secret for authentication.
+                                  properties:
+                                    appId:
+                                      description: AppID is the reference to the secret containing the Application ID.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                    appSecret:
+                                      description: AppSecret is the reference to the secret containing the Application Secret.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                  required:
+                                    - appId
+                                    - appSecret
+                                  type: object
+                              required:
+                                - secretRef
+                              type: object
+                            insecure:
+                              description: |-
+                                Insecure allows connecting to DVLS over plain HTTP.
+                                This is NOT RECOMMENDED for production use.
+                                Set to true only if you understand the security implications.
+                              type: boolean
+                            serverUrl:
+                              description: ServerURL is the DVLS instance URL (e.g., https://dvls.example.com).
+                              type: string
+                            vault:
+                              description: |-
+                                Vault is the name or UUID of the vault to fetch secrets from.
+                                When omitted, the vault must be specified in the secret key using the legacy format "<vault-id>/<entry-id>".
+                              type: string
+                          required:
+                            - auth
+                            - serverUrl
                           type: object
                         fake:
                           description: Fake configures a store with static key/value pairs
@@ -1796,8 +2531,8 @@ should match snapshot of default values:
                                         audiences:
                                           description: |-
                                             Audience specifies the `aud` claim for the service account token
-                                            If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
-                                            then this audiences will be appended to the list
+                                            Some providers automatically extend the audience field based on well-known annotations for workload
+                                            identity (e.g. IRSA or GCP Workload Identity)
                                           items:
                                             type: string
                                           type: array
@@ -1903,6 +2638,18 @@ should match snapshot of default values:
                                         credential_source.url in the provided credConfig. This field is merely to double-check the external token source
                                         URL is having the expected value.
                                       type: string
+                                    gcpServiceAccountEmail:
+                                      description: |-
+                                        GCPServiceAccountEmail is the email of the Google Cloud service account to impersonate
+                                        after Workload Identity Federation. Use this to grant access through the service account's
+                                        IAM bindings (for example roles/secretmanager.secretAccessor). When set, it overrides
+                                        service_account_impersonation_url in the external account JSON from credConfig;
+                                        when serviceAccountRef is set, it also overrides the "iam.gke.io/gcp-service-account" annotation
+                                        on that ServiceAccount.
+                                      example: my-gsa@my-project.iam.gserviceaccount.com
+                                      minLength: 1
+                                      pattern: ^.*@.*\.iam\.gserviceaccount\.com$
+                                      type: string
                                     serviceAccountRef:
                                       description: |-
                                         serviceAccountRef is the reference to the kubernetes ServiceAccount to be used for obtaining the tokens,
@@ -1911,8 +2658,8 @@ should match snapshot of default values:
                                         audiences:
                                           description: |-
                                             Audience specifies the `aud` claim for the service account token
-                                            If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
-                                            then this audiences will be appended to the list
+                                            Some providers automatically extend the audience field based on well-known annotations for workload
+                                            identity (e.g. IRSA or GCP Workload Identity)
                                           items:
                                             type: string
                                           type: array
@@ -1953,7 +2700,7 @@ should match snapshot of default values:
                           type: object
                         github:
                           description: |-
-                            Github configures this store to push GitHub Action secrets using GitHub API provider.
+                            Github configures this store to push GitHub Actions or Dependabot secrets using the GitHub API provider.
                             Note: This provider only supports write operations (PushSecret) and cannot fetch secrets from GitHub
                           properties:
                             appID:
@@ -2001,11 +2748,30 @@ should match snapshot of default values:
                               description: installationID specifies the Github APP installation that will be used to authenticate the client
                               format: int64
                               type: integer
+                            orgSecretVisibility:
+                              description: |-
+                                orgSecretVisibility controls the visibility of organization secrets pushed via PushSecret.
+                                Valid values are "all" or "private".
+                                When unset, new secrets are created with visibility "all" and existing secrets preserve
+                                whatever visibility they already have in GitHub.
+                              enum:
+                                - all
+                                - private
+                              type: string
                             organization:
                               description: organization will be used to fetch secrets from the Github organization
                               type: string
                             repository:
                               description: repository will be used to fetch secrets from the Github repository within an organization
+                              type: string
+                            secretType:
+                              default: Actions
+                              description: |-
+                                secretType specifies which GitHub secret service to use.
+                                Defaults to Actions for backwards compatibility.
+                              enum:
+                                - Actions
+                                - Dependabot
                               type: string
                             uploadURL:
                               description: Upload URL for enterprise instances. Default to URL.
@@ -2020,6 +2786,9 @@ should match snapshot of default values:
                             - installationID
                             - organization
                           type: object
+                          x-kubernetes-validations:
+                            - message: Dependabot secrets do not support environments
+                              rule: self.secretType != 'Dependabot' || !has(self.environment) || size(self.environment) == 0
                         gitlab:
                           description: GitLab configures this store to sync secrets using GitLab Variables provider
                           properties:
@@ -2901,6 +3670,48 @@ should match snapshot of default values:
                                     - clientSecret
                                   type: object
                               type: object
+                            caBundle:
+                              description: |-
+                                CABundle is a PEM-encoded CA certificate bundle used to validate
+                                the Infisical server's TLS certificate. Mutually exclusive with CAProvider.
+                              format: byte
+                              type: string
+                            caProvider:
+                              description: |-
+                                CAProvider is a reference to a Secret or ConfigMap that contains a CA certificate.
+                                The certificate is used to validate the Infisical server's TLS certificate.
+                                Mutually exclusive with CABundle.
+                              properties:
+                                key:
+                                  description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the object located at the provider type.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace the Provider type is in.
+                                    Can only be defined when used in a ClusterSecretStore.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                                type:
+                                  description: The type of provider to use such as "Secret", or "ConfigMap".
+                                  enum:
+                                    - Secret
+                                    - ConfigMap
+                                  type: string
+                              required:
+                                - name
+                                - type
+                              type: object
                             hostAPI:
                               default: https://app.infisical.com/api
                               description: HostAPI specifies the base URL of the Infisical API. If not provided, it defaults to "https://app.infisical.com/api".
@@ -2915,6 +3726,11 @@ should match snapshot of default values:
                                   default: true
                                   description: ExpandSecretReferences indicates whether secret references should be expanded. Defaults to true if not provided.
                                   type: boolean
+                                organizationSlug:
+                                  description: |-
+                                    OrganizationSlug is the optional slug that identifies the organization that will be used
+                                    during authentication. Useful for sub-organization setups
+                                  type: string
                                 projectSlug:
                                   description: ProjectSlug is the required slug identifier for the project.
                                   type: string
@@ -2967,6 +3783,8 @@ should match snapshot of default values:
                               type: object
                             folderID:
                               type: string
+                            getByTitleFallback:
+                              type: boolean
                           required:
                             - authRef
                             - folderID
@@ -3038,6 +3856,9 @@ should match snapshot of default values:
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                       type: object
+                                  required:
+                                    - clientCert
+                                    - clientKey
                                   type: object
                                 serviceAccount:
                                   description: points to a service account that should be used for authentication
@@ -3045,8 +3866,8 @@ should match snapshot of default values:
                                     audiences:
                                       description: |-
                                         Audience specifies the `aud` claim for the service account token
-                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
-                                        then this audiences will be appended to the list
+                                        Some providers automatically extend the audience field based on well-known annotations for workload
+                                        identity (e.g. IRSA or GCP Workload Identity)
                                       items:
                                         type: string
                                       type: array
@@ -3098,6 +3919,8 @@ should match snapshot of default values:
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                       type: object
+                                  required:
+                                    - bearerToken
                                   type: object
                               type: object
                             authRef:
@@ -3141,7 +3964,7 @@ should match snapshot of default values:
                                   format: byte
                                   type: string
                                 caProvider:
-                                  description: 'see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider'
+                                  description: 'see: https://external-secrets.io/latest/spec/#external-secrets.io/v1alpha1.CAProvider'
                                   properties:
                                     key:
                                       description: The key where the CA certificate can be found in the Secret or ConfigMap.
@@ -3178,6 +4001,166 @@ should match snapshot of default values:
                                   description: configures the Kubernetes server Address.
                                   type: string
                               type: object
+                          type: object
+                        nebiusmysterybox:
+                          description: NebiusMysterybox configures this store to sync secrets using NebiusMysterybox provider
+                          properties:
+                            apiDomain:
+                              description: NebiusMysterybox API endpoint
+                              type: string
+                            auth:
+                              description: Auth defines parameters to authenticate in MysteryBox
+                              properties:
+                                serviceAccountCredsSecretRef:
+                                  description: |-
+                                    ServiceAccountCreds references a Kubernetes Secret key that contains a JSON
+                                    document with service account credentials used to get an IAM token.
+
+                                    Expected JSON structure:
+                                    {
+                                      "subject-credentials": {
+                                        "alg": "RS256",
+                                        "private-key": "-----BEGIN PRIVATE KEY-----\n<private-key>\n-----END PRIVATE KEY-----\n",
+                                        "kid": "<public-key-id>",
+                                        "iss": "<issuer-service-account-id>",
+                                        "sub": "<subject-service-account-id>"
+                                      }
+                                    }
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                tokenSecretRef:
+                                  description: Token authenticates with Nebius Mysterybox by presenting a token.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                workloadIdentity:
+                                  description: WorkloadIdentity defines configuration for workload identity authentication to Nebius IAM.
+                                  properties:
+                                    iamServiceAccountID:
+                                      description: |-
+                                        IAMServiceAccountID is the Nebius IAM service account identifier that the
+                                        federated Kubernetes service account should impersonate during token exchange.
+                                      example: serviceaccount-e00example
+                                      minLength: 1
+                                      pattern: ^serviceaccount-[a-z][a-z0-9]{2}
+                                      type: string
+                                    serviceAccountRef:
+                                      description: |-
+                                        ServiceAccountRef references a Kubernetes ServiceAccount used to request a
+                                        temporary JWT via the TokenRequest API. The JWT is then exchanged for a
+                                        Nebius IAM token using workload federation.
+                                      properties:
+                                        audiences:
+                                          description: |-
+                                            Audience specifies the `aud` claim for the service account token
+                                            Some providers automatically extend the audience field based on well-known annotations for workload
+                                            identity (e.g. IRSA or GCP Workload Identity)
+                                          items:
+                                            type: string
+                                          type: array
+                                        name:
+                                          description: The name of the ServiceAccount resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace of the resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  required:
+                                    - iamServiceAccountID
+                                    - serviceAccountRef
+                                  type: object
+                              type: object
+                              x-kubernetes-validations:
+                                - message: exactly one of serviceAccountCredsSecretRef, tokenSecretRef, or workloadIdentity must be set
+                                  rule: '(has(self.serviceAccountCredsSecretRef) && has(self.serviceAccountCredsSecretRef.name) && size(self.serviceAccountCredsSecretRef.name) > 0 ? 1 : 0) + (has(self.tokenSecretRef) && has(self.tokenSecretRef.name) && size(self.tokenSecretRef.name) > 0 ? 1 : 0) + (has(self.workloadIdentity) ? 1 : 0) == 1'
+                            caProvider:
+                              description: The provider for the CA bundle to use to validate NebiusMysterybox server certificate.
+                              properties:
+                                certSecretRef:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                          required:
+                            - apiDomain
+                            - auth
                           type: object
                         ngrok:
                           description: Ngrok configures this store to sync secrets using the ngrok provider.
@@ -3406,6 +4389,34 @@ should match snapshot of default values:
                               required:
                                 - serviceAccountSecretRef
                               type: object
+                            cache:
+                              description: |-
+                                Cache configures client-side caching for read operations (GetSecret, GetSecretMap).
+                                When enabled, secrets are cached with the specified TTL.
+                                Write operations (PushSecret, DeleteSecret) automatically invalidate relevant cache entries.
+                                If omitted, caching is disabled (default).
+                                cache: {} is a valid option to set.
+                              properties:
+                                maxSize:
+                                  default: 100
+                                  description: |-
+                                    MaxSize is the maximum number of secrets to cache.
+                                    When the cache is full, least-recently-used entries are evicted.
+                                  minimum: 1
+                                  type: integer
+                                ttl:
+                                  default: 5m
+                                  description: |-
+                                    TTL is the time-to-live for cached secrets.
+                                    Format: duration string (e.g., "5m", "1h", "30s")
+                                  type: string
+                              type: object
+                            environment:
+                              description: |-
+                                Environment defines the 1Password Environment ID to read variables from.
+                                Environments are read-only: PushSecret, DeleteSecret, and SecretExists return an error when set.
+                                Mutually exclusive with Vault.
+                              type: string
                             integrationInfo:
                               description: |-
                                 IntegrationInfo specifies the name and version of the integration built using the 1Password Go SDK.
@@ -3421,12 +4432,362 @@ should match snapshot of default values:
                                   type: string
                               type: object
                             vault:
-                              description: Vault defines the vault's name or uuid to access. Do NOT add op:// prefix. This will be done automatically.
+                              description: |-
+                                Vault defines the vault's name or uuid to access. Do NOT add op:// prefix. This will be done automatically.
+                                Mutually exclusive with Environment.
                               type: string
                           required:
                             - auth
-                            - vault
                           type: object
+                          x-kubernetes-validations:
+                            - message: at most one of the fields in [vault environment] may be set
+                              rule: '[has(self.vault),has(self.environment)].filter(x,x==true).size() <= 1'
+                        openBao:
+                          description: OpenBao configures this store to sync secrets using the OpenBao provider.
+                          properties:
+                            auth:
+                              description: Auth configures how secret-manager authenticates with the OpenBao server.
+                              properties:
+                                appRole:
+                                  description: |-
+                                    AppRole authenticates with OpenBao using the [App Role auth mechanism],
+                                    with the role and secret stored in a Kubernetes Secret resource.
+
+                                    [App Role auth mechanism]: https://openbao.org/docs/auth/approle/
+                                  properties:
+                                    path:
+                                      default: approle
+                                      description: |-
+                                        Path where the App Role authentication backend is mounted
+                                        in OpenBao, e.g: "approle"
+                                      type: string
+                                    roleId:
+                                      description: |-
+                                        RoleID configured in the App Role authentication backend when setting
+                                        up the authentication backend in OpenBao.
+                                      minLength: 1
+                                      type: string
+                                    roleRef:
+                                      description: |-
+                                        Reference to a key in a Secret that contains the App Role ID used
+                                        to authenticate with OpenBao.
+                                        The `key` field must be specified and denotes which entry within the Secret
+                                        resource is used as the app role id.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                    secretRef:
+                                      description: |-
+                                        Reference to a key in a Secret that contains the App Role secret used
+                                        to authenticate with OpenBao.
+                                        The `key` field must be specified and denotes which entry within the Secret
+                                        resource is used as the app role secret.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                  required:
+                                    - path
+                                    - secretRef
+                                  type: object
+                                  x-kubernetes-validations:
+                                    - message: exactly one of the fields in [roleId roleRef] must be set
+                                      rule: '[has(self.roleId),has(self.roleRef)].filter(x,x==true).size() == 1'
+                                kubernetes:
+                                  description: |-
+                                    Kubernetes authenticates with OpenBao by passing a ServiceAccount
+                                    token to the [Kubernetes auth mechanism].
+
+                                    [Kubernetes auth mechanism]: https://openbao.org/docs/auth/kubernetes/
+                                  properties:
+                                    path:
+                                      default: kubernetes
+                                      description: |-
+                                        Path where the Kubernetes authentication backend is mounted in OpenBao, e.g:
+                                        "kubernetes"
+                                      type: string
+                                    role:
+                                      description: |-
+                                        A required field containing the OpenBao Role to assume. A Role binds a
+                                        Kubernetes ServiceAccount with a set of OpenBao policies.
+                                      minLength: 1
+                                      type: string
+                                    secretRef:
+                                      description: |-
+                                        Optional secret field containing a Kubernetes ServiceAccount JWT used
+                                        for authenticating with OpenBao. If a name is specified without a key,
+                                        `token` is the default.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                    serviceAccountRef:
+                                      description: |-
+                                        Optional service account field containing the name of a Kubernetes ServiceAccount.
+                                        If the service account is specified, a token will be requested from the Kubernetes
+                                        TokenRequest API for authenticating with OpenBao.
+                                        Any configured audiences will be passed to the TokenRequest as-is.
+                                      properties:
+                                        audiences:
+                                          description: |-
+                                            Audience specifies the `aud` claim for the service account token
+                                            Some providers automatically extend the audience field based on well-known annotations for workload
+                                            identity (e.g. IRSA or GCP Workload Identity)
+                                          items:
+                                            type: string
+                                          type: array
+                                        name:
+                                          description: The name of the ServiceAccount resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace of the resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  required:
+                                    - path
+                                    - role
+                                  type: object
+                                  x-kubernetes-validations:
+                                    - message: exactly one of the fields in [serviceAccountRef secretRef] must be set
+                                      rule: '[has(self.serviceAccountRef),has(self.secretRef)].filter(x,x==true).size() == 1'
+                                namespace:
+                                  description: |-
+                                    Name of the [OpenBao Namespace] to authenticate to. This can be different
+                                    than the namespace your secret is in. Namespaces is a set of features
+                                    within OpenBao that allows OpenBao environments to support secure
+                                    multi-tenancy. e.g: "ns1". This will default to OpenBao.Namespace field
+                                    if set, or empty otherwise
+
+                                    [OpenBao Namespace]: https://openbao.org/docs/concepts/namespaces/
+                                  type: string
+                                tokenSecretRef:
+                                  description: TokenSecretRef authenticates with OpenBao by presenting a token.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                userPass:
+                                  description: UserPass authenticates with OpenBao by passing a username/password pair
+                                  properties:
+                                    path:
+                                      default: userpass
+                                      description: |-
+                                        Path where the UserPassword authentication backend is mounted
+                                        in OpenBao, e.g: "userpass"
+                                      type: string
+                                    secretRef:
+                                      description: |-
+                                        SecretRef to a key in a Secret resource containing password for the user
+                                        used to authenticate with OpenBao using the [UserPass authentication
+                                        method]
+
+                                        [UserPass authentication method]: https://openbao.org/docs/auth/userpass/
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                    username:
+                                      description: |-
+                                        Username is a username used to authenticate using the [UserPass
+                                        authentication method]
+
+                                        [UserPass authentication method]: https://openbao.org/docs/auth/userpass/
+                                      type: string
+                                  required:
+                                    - path
+                                    - username
+                                  type: object
+                              type: object
+                              x-kubernetes-validations:
+                                - message: exactly one of the fields in [appRole tokenSecretRef userPass kubernetes] must be set
+                                  rule: '[has(self.appRole),has(self.tokenSecretRef),has(self.userPass),has(self.kubernetes)].filter(x,x==true).size() == 1'
+                            caBundle:
+                              description: |-
+                                PEM encoded CA bundle used to validate the OpenBao server certificate. If
+                                this and `caProvider` are not set the system root certificates are used
+                                to validate the TLS connection.
+                              format: byte
+                              type: string
+                            caProvider:
+                              description: |-
+                                The provider for the CA bundle to use to validate OpenBao server
+                                certificate. If this and `caBundle` are not set the system root
+                                certificates are used to validate the TLS connection.
+                              properties:
+                                key:
+                                  description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the object located at the provider type.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace the Provider type is in.
+                                    Can only be defined when used in a ClusterSecretStore.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                                type:
+                                  description: The type of provider to use such as "Secret", or "ConfigMap".
+                                  enum:
+                                    - Secret
+                                    - ConfigMap
+                                  type: string
+                              required:
+                                - name
+                                - type
+                              type: object
+                            namespace:
+                              description: |-
+                                Name of the [OpenBao Namespace]. Namespaces is a set of features within
+                                OpenBao that allows OpenBao environments to support secure multi-tenancy.
+                                e.g: "ns1".
+
+                                [OpenBao Namespace]: https://openbao.org/docs/concepts/namespaces/
+                              type: string
+                            path:
+                              description: |-
+                                Path is the mount path of the OpenBao KV backend endpoint, e.g:
+                                "secret". The v2 KV secret engine version specific "/data" path suffix
+                                for fetching secrets from OpenBao is optional and will be appended
+                                if not present in specified path.
+                              type: string
+                            server:
+                              description: 'Server is the connection address for the OpenBao server, e.g: `https://openbao.example.com:8200`.'
+                              type: string
+                            version:
+                              default: v2
+                              description: |-
+                                Version is the OpenBao KV secret engine version. This can be either "v1" or
+                                "v2". Version defaults to "v2".
+                              enum:
+                                - v1
+                                - v2
+                              type: string
+                          required:
+                            - server
+                          type: object
+                          x-kubernetes-validations:
+                            - message: at most one of the fields in [caBundle caProvider] may be set
+                              rule: '[has(self.caBundle),has(self.caProvider)].filter(x,x==true).size() <= 1'
                         oracle:
                           description: Oracle configures this store to sync secrets using Oracle Vault provider
                           properties:
@@ -3537,8 +4898,8 @@ should match snapshot of default values:
                                 audiences:
                                   description: |-
                                     Audience specifies the `aud` claim for the service account token
-                                    If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
-                                    then this audiences will be appended to the list
+                                    Some providers automatically extend the audience field based on well-known annotations for workload
+                                    identity (e.g. IRSA or GCP Workload Identity)
                                   items:
                                     type: string
                                   type: array
@@ -3565,6 +4926,168 @@ should match snapshot of default values:
                           required:
                             - region
                             - vault
+                          type: object
+                        ovh:
+                          description: OVHcloud configures this store to sync secrets using the OVHcloud provider.
+                          properties:
+                            auth:
+                              description: Authentication method (mtls or token).
+                              properties:
+                                mtls:
+                                  description: OvhClientMTLS defines the configuration required to authenticate to OVHcloud's Secret Manager using mTLS.
+                                  properties:
+                                    caBundle:
+                                      format: byte
+                                      type: string
+                                    caProvider:
+                                      description: |-
+                                        CAProvider provides a custom certificate authority for accessing the provider's store.
+                                        The CAProvider points to a Secret or ConfigMap resource that contains a PEM-encoded certificate.
+                                      properties:
+                                        key:
+                                          description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the object located at the provider type.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace the Provider type is in.
+                                            Can only be defined when used in a ClusterSecretStore.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                        type:
+                                          description: The type of provider to use such as "Secret", or "ConfigMap".
+                                          enum:
+                                            - Secret
+                                            - ConfigMap
+                                          type: string
+                                      required:
+                                        - name
+                                        - type
+                                      type: object
+                                    certSecretRef:
+                                      description: |-
+                                        SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                        In some instances, `key` is a required field.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                    keySecretRef:
+                                      description: |-
+                                        SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                        In some instances, `key` is a required field.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                  required:
+                                    - certSecretRef
+                                    - keySecretRef
+                                  type: object
+                                token:
+                                  description: OvhClientToken defines the configuration required to authenticate to OVHcloud's Secret Manager using a token.
+                                  properties:
+                                    tokenSecretRef:
+                                      description: |-
+                                        SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                        In some instances, `key` is a required field.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                  required:
+                                    - tokenSecretRef
+                                  type: object
+                              type: object
+                            casRequired:
+                              description: 'Enables or disables check-and-set (CAS) (default: false).'
+                              type: boolean
+                            okmsTimeout:
+                              default: 30
+                              description: 'Setup a timeout in seconds when requests to the KMS are made (default: 30).'
+                              format: int32
+                              minimum: 1
+                              type: integer
+                            okmsid:
+                              description: specifies the OKMS ID.
+                              type: string
+                            server:
+                              description: specifies the OKMS server endpoint.
+                              type: string
+                          required:
+                            - auth
+                            - okmsid
+                            - server
                           type: object
                         passbolt:
                           description: |-
@@ -3633,6 +5156,46 @@ should match snapshot of default values:
                               required:
                                 - passwordSecretRef
                                 - privateKeySecretRef
+                              type: object
+                            caBundle:
+                              description: |-
+                                PEM encoded CA bundle used to validate Passbolt server certificate. Only used
+                                if the Host URL is using HTTPS protocol. If not set the system root certificates
+                                are used to validate the TLS connection.
+                              format: byte
+                              type: string
+                            caProvider:
+                              description: The provider for the CA bundle to use to validate Passbolt server certificate.
+                              properties:
+                                key:
+                                  description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the object located at the provider type.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace the Provider type is in.
+                                    Can only be defined when used in a ClusterSecretStore.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                                type:
+                                  description: The type of provider to use such as "Secret", or "ConfigMap".
+                                  enum:
+                                    - Secret
+                                    - ConfigMap
+                                  type: string
+                              required:
+                                - name
+                                - type
                               type: object
                             host:
                               description: Host defines the Passbolt Server to connect to
@@ -3739,7 +5302,10 @@ should match snapshot of default values:
                           description: Pulumi configures this store to sync secrets using the Pulumi provider
                           properties:
                             accessToken:
-                              description: AccessToken is the access tokens to sign in to the Pulumi Cloud Console.
+                              description: |-
+                                AccessToken is the access tokens to sign in to the Pulumi Cloud Console.
+
+                                Deprecated: Use auth.accessToken instead.
                               properties:
                                 secretRef:
                                   description: SecretRef is a reference to a secret containing the Pulumi API token.
@@ -3772,6 +5338,91 @@ should match snapshot of default values:
                               default: https://api.pulumi.com/api/esc
                               description: APIURL is the URL of the Pulumi API.
                               type: string
+                            auth:
+                              description: |-
+                                Auth configures how the Operator authenticates with the Pulumi API.
+                                Either auth or the deprecated accessToken field must be specified.
+                              properties:
+                                accessToken:
+                                  description: AccessToken authenticates using a Pulumi access token stored in a Kubernetes Secret.
+                                  properties:
+                                    secretRef:
+                                      description: SecretRef is a reference to a secret containing the Pulumi API token.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                  type: object
+                                oidcConfig:
+                                  description: OIDCConfig authenticates using Kubernetes ServiceAccount tokens via OIDC.
+                                  properties:
+                                    expirationSeconds:
+                                      default: 600
+                                      description: |-
+                                        ExpirationSeconds sets the token validity duration for service account and OIDC token.
+                                        Defaults to 10 minutes.
+                                      format: int64
+                                      minimum: 600
+                                      type: integer
+                                    organization:
+                                      description: Organization is the name of the Pulumi organization configured for OIDC authentication.
+                                      type: string
+                                    serviceAccountRef:
+                                      description: ServiceAccountRef specifies the Kubernetes ServiceAccount to use for authentication.
+                                      properties:
+                                        audiences:
+                                          description: |-
+                                            Audience specifies the `aud` claim for the service account token
+                                            Some providers automatically extend the audience field based on well-known annotations for workload
+                                            identity (e.g. IRSA or GCP Workload Identity)
+                                          items:
+                                            type: string
+                                          type: array
+                                        name:
+                                          description: The name of the ServiceAccount resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace of the resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  required:
+                                    - organization
+                                    - serviceAccountRef
+                                  type: object
+                              type: object
+                              x-kubernetes-validations:
+                                - message: Exactly one of 'accessToken' or 'oidcConfig' must be specified
+                                  rule: (has(self.accessToken) && !has(self.oidcConfig)) || (!has(self.accessToken) && has(self.oidcConfig))
                             environment:
                               description: |-
                                 Environment are YAML documents composed of static key-value pairs, programmatic expressions,
@@ -3788,13 +5439,15 @@ should match snapshot of default values:
                               description: Project is the name of the Pulumi ESC project the environment belongs to.
                               type: string
                           required:
-                            - accessToken
                             - environment
                             - organization
                             - project
                           type: object
+                          x-kubernetes-validations:
+                            - message: Exactly one of 'auth' or deprecated 'accessToken' must be specified
+                              rule: (has(self.auth) && !has(self.accessToken)) || (!has(self.auth) && has(self.accessToken))
                         scaleway:
-                          description: Scaleway
+                          description: Scaleway configures this store to sync secrets using the Scaleway provider.
                           properties:
                             accessKey:
                               description: AccessKey is the non-secret part of the api key.
@@ -3922,11 +5575,18 @@ should match snapshot of default values:
                                 - name
                                 - type
                               type: object
+                            disableSiteIDValidation:
+                              description: |-
+                                DisableSiteIDValidation permits a missing site ID for new secrets.
+                                The provider sends 0 if no site ID is set.
+                              type: boolean
                             domain:
                               description: Domain is the secret server domain.
                               type: string
                             password:
-                              description: Password is the secret server account password.
+                              description: |-
+                                Password is the secret server account password.
+                                Required unless Token is set.
                               properties:
                                 secretRef:
                                   description: SecretRef references a key in a secret that will be used as value.
@@ -3956,15 +5616,29 @@ should match snapshot of default values:
                                   type: object
                                 value:
                                   description: Value can be specified directly to set a value without using a secret.
+                                  minLength: 1
                                   type: string
                               type: object
+                              x-kubernetes-validations:
+                                - message: exactly one of value or secretRef must be set
+                                  rule: has(self.value) != has(self.secretRef)
                             serverURL:
                               description: |-
                                 ServerURL
                                 URL to your secret server installation
                               type: string
-                            username:
-                              description: Username is the secret server account username.
+                            siteId:
+                              description: |-
+                                SiteID is the ID of the Secret Server site for new secrets.
+                                PushSecret metadata can override this value for one secret.
+                                The provider uses 1 if this field is not set.
+                              minimum: 1
+                              type: integer
+                            token:
+                              description: |-
+                                Token is an access token used to authenticate to the secret server,
+                                as an alternative to Username and Password. When set, Username and
+                                Password are not required and are ignored.
                               properties:
                                 secretRef:
                                   description: SecretRef references a key in a secret that will be used as value.
@@ -3994,13 +5668,57 @@ should match snapshot of default values:
                                   type: object
                                 value:
                                   description: Value can be specified directly to set a value without using a secret.
+                                  minLength: 1
                                   type: string
                               type: object
+                              x-kubernetes-validations:
+                                - message: exactly one of value or secretRef must be set
+                                  rule: has(self.value) != has(self.secretRef)
+                            username:
+                              description: |-
+                                Username is the secret server account username.
+                                Required unless Token is set.
+                              properties:
+                                secretRef:
+                                  description: SecretRef references a key in a secret that will be used as value.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                value:
+                                  description: Value can be specified directly to set a value without using a secret.
+                                  minLength: 1
+                                  type: string
+                              type: object
+                              x-kubernetes-validations:
+                                - message: exactly one of value or secretRef must be set
+                                  rule: has(self.value) != has(self.secretRef)
                           required:
-                            - password
                             - serverURL
-                            - username
                           type: object
+                          x-kubernetes-validations:
+                            - message: either token, or both username and password, must be set
+                              rule: has(self.token) || (has(self.username) && has(self.password))
                         senhasegura:
                           description: Senhasegura configures this store to sync secrets using senhasegura provider
                           properties:
@@ -4057,7 +5775,7 @@ should match snapshot of default values:
                             - url
                           type: object
                         vault:
-                          description: Vault configures this store to sync secrets using Hashi provider
+                          description: Vault configures this store to sync secrets using the HashiCorp Vault provider.
                           properties:
                             auth:
                               description: Auth configures how secret-manager authenticates with the Vault server.
@@ -4209,6 +5927,9 @@ should match snapshot of default values:
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                       type: object
+                                    vaultRole:
+                                      description: VaultRole specifies the Vault role to use for TLS certificate authentication.
+                                      type: string
                                   type: object
                                 gcp:
                                   description: |-
@@ -4264,8 +5985,8 @@ should match snapshot of default values:
                                         audiences:
                                           description: |-
                                             Audience specifies the `aud` claim for the service account token
-                                            If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
-                                            then this audiences will be appended to the list
+                                            Some providers automatically extend the audience field based on well-known annotations for workload
+                                            identity (e.g. IRSA or GCP Workload Identity)
                                           items:
                                             type: string
                                           type: array
@@ -4310,8 +6031,8 @@ should match snapshot of default values:
                                             audiences:
                                               description: |-
                                                 Audience specifies the `aud` claim for the service account token
-                                                If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
-                                                then this audiences will be appended to the list
+                                                Some providers automatically extend the audience field based on well-known annotations for workload
+                                                identity (e.g. IRSA or GCP Workload Identity)
                                               items:
                                                 type: string
                                               type: array
@@ -4355,8 +6076,8 @@ should match snapshot of default values:
                                             audiences:
                                               description: |-
                                                 Audience specifies the `aud` claim for the service account token
-                                                If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
-                                                then this audiences will be appended to the list
+                                                Some providers automatically extend the audience field based on well-known annotations for workload
+                                                identity (e.g. IRSA or GCP Workload Identity)
                                               items:
                                                 type: string
                                               type: array
@@ -4496,6 +6217,7 @@ should match snapshot of default values:
                                             Optional audiences field that will be used to request a temporary Kubernetes service
                                             account token for the service account referenced by `serviceAccountRef`.
                                             Defaults to a single audience `vault` it not specified.
+
                                             Deprecated: use serviceAccountRef.Audiences instead
                                           items:
                                             type: string
@@ -4505,6 +6227,7 @@ should match snapshot of default values:
                                             Optional expiration time in seconds that will be used to request a temporary
                                             Kubernetes service account token for the service account referenced by
                                             `serviceAccountRef`.
+
                                             Deprecated: this will be removed in the future.
                                             Defaults to 10 minutes.
                                           format: int64
@@ -4515,8 +6238,8 @@ should match snapshot of default values:
                                             audiences:
                                               description: |-
                                                 Audience specifies the `aud` claim for the service account token
-                                                If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
-                                                then this audiences will be appended to the list
+                                                Some providers automatically extend the audience field based on well-known annotations for workload
+                                                identity (e.g. IRSA or GCP Workload Identity)
                                               items:
                                                 type: string
                                               type: array
@@ -4638,8 +6361,8 @@ should match snapshot of default values:
                                         audiences:
                                           description: |-
                                             Audience specifies the `aud` claim for the service account token
-                                            If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
-                                            then this audiences will be appended to the list
+                                            Some providers automatically extend the audience field based on well-known annotations for workload
+                                            identity (e.g. IRSA or GCP Workload Identity)
                                           items:
                                             type: string
                                           type: array
@@ -5423,10 +7146,16 @@ should match snapshot of default values:
                           type: object
                       type: object
                     refreshInterval:
-                      description: Used to configure store refresh interval in seconds. Empty or 0 will default to the controller config.
-                      type: integer
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: |-
+                        Used to configure store refresh interval. Accepts either an integer number
+                        of seconds (legacy) or a Go duration string such as "1h" or "5m". Empty or
+                        0 will default to the controller config.
+                      x-kubernetes-int-or-string: true
                     retrySettings:
-                      description: Used to configure http retries if failed
+                      description: Used to configure HTTP retries on failures.
                       properties:
                         maxRetries:
                           format: int32
@@ -5510,7 +7239,7 @@ should match snapshot of default values:
                   description: SecretStoreSpec defines the desired state of SecretStore.
                   properties:
                     conditions:
-                      description: Used to constraint a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore
+                      description: Used to constrain a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore.
                       items:
                         description: |-
                           ClusterSecretStoreCondition describes a condition by which to choose namespaces to process ExternalSecrets in
@@ -5645,8 +7374,8 @@ should match snapshot of default values:
                                         audiences:
                                           description: |-
                                             Audience specifies the `aud` claim for the service account token
-                                            If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
-                                            then this audiences will be appended to the list
+                                            Some providers automatically extend the audience field based on well-known annotations for workload
+                                            identity (e.g. IRSA or GCP Workload Identity)
                                           items:
                                             type: string
                                           type: array
@@ -5917,8 +7646,8 @@ should match snapshot of default values:
                                         audiences:
                                           description: |-
                                             Audience specifies the `aud` claim for the service account token
-                                            If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
-                                            then this audiences will be appended to the list
+                                            Some providers automatically extend the audience field based on well-known annotations for workload
+                                            identity (e.g. IRSA or GCP Workload Identity)
                                           items:
                                             type: string
                                           type: array
@@ -6237,8 +7966,8 @@ should match snapshot of default values:
                                 audiences:
                                   description: |-
                                     Audience specifies the `aud` claim for the service account token
-                                    If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
-                                    then this audiences will be appended to the list
+                                    Some providers automatically extend the audience field based on well-known annotations for workload
+                                    identity (e.g. IRSA or GCP Workload Identity)
                                   items:
                                     type: string
                                   type: array
@@ -6450,6 +8179,10 @@ should match snapshot of default values:
                                 clientTimeOutSeconds:
                                   description: Timeout specifies a time limit for requests made by this Client. The timeout includes connection time, any redirects, and reading the response body. Defaults to 45 seconds.
                                   type: integer
+                                decrypt:
+                                  default: true
+                                  description: 'When true, the response includes the decrypted password. When false, the password field is omitted. This option only applies to the SECRET retrieval type. Default: true.'
+                                  type: boolean
                                 retrievalType:
                                   description: The secret retrieval type. SECRET = Secrets Safe (credential, text, file). MANAGED_ACCOUNT = Password Safe account associated with a system.
                                   type: string
@@ -6808,8 +8541,8 @@ should match snapshot of default values:
                                         audiences:
                                           description: |-
                                             Audience specifies the `aud` claim for the service account token
-                                            If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
-                                            then this audiences will be appended to the list
+                                            Some providers automatically extend the audience field based on well-known annotations for workload
+                                            identity (e.g. IRSA or GCP Workload Identity)
                                           items:
                                             type: string
                                           type: array
@@ -7209,8 +8942,8 @@ should match snapshot of default values:
                                         audiences:
                                           description: |-
                                             Audience specifies the `aud` claim for the service account token
-                                            If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
-                                            then this audiences will be appended to the list
+                                            Some providers automatically extend the audience field based on well-known annotations for workload
+                                            identity (e.g. IRSA or GCP Workload Identity)
                                           items:
                                             type: string
                                           type: array
@@ -7243,7 +8976,7 @@ should match snapshot of default values:
                               type: string
                           type: object
                         github:
-                          description: Github configures this store to push Github Action secrets using Github API provider
+                          description: Github configures this store to push GitHub Actions secrets using the GitHub API provider.
                           properties:
                             appID:
                               description: appID specifies the Github APP that will be used to authenticate the client
@@ -7680,8 +9413,8 @@ should match snapshot of default values:
                                     audiences:
                                       description: |-
                                         Audience specifies the `aud` claim for the service account token
-                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
-                                        then this audiences will be appended to the list
+                                        Some providers automatically extend the audience field based on well-known annotations for workload
+                                        identity (e.g. IRSA or GCP Workload Identity)
                                       items:
                                         type: string
                                       type: array
@@ -8060,8 +9793,8 @@ should match snapshot of default values:
                                 audiences:
                                   description: |-
                                     Audience specifies the `aud` claim for the service account token
-                                    If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
-                                    then this audiences will be appended to the list
+                                    Some providers automatically extend the audience field based on well-known annotations for workload
+                                    identity (e.g. IRSA or GCP Workload Identity)
                                   items:
                                     type: string
                                   type: array
@@ -8311,7 +10044,7 @@ should match snapshot of default values:
                             - project
                           type: object
                         scaleway:
-                          description: Scaleway
+                          description: Scaleway configures this store to sync secrets using the Scaleway provider.
                           properties:
                             accessKey:
                               description: AccessKey is the non-secret part of the api key.
@@ -8531,7 +10264,7 @@ should match snapshot of default values:
                             - url
                           type: object
                         vault:
-                          description: Vault configures this store to sync secrets using Hashi provider
+                          description: Vault configures this store to sync secrets using the HashiCorp Vault provider.
                           properties:
                             auth:
                               description: Auth configures how secret-manager authenticates with the Vault server.
@@ -8695,8 +10428,8 @@ should match snapshot of default values:
                                             audiences:
                                               description: |-
                                                 Audience specifies the `aud` claim for the service account token
-                                                If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
-                                                then this audiences will be appended to the list
+                                                Some providers automatically extend the audience field based on well-known annotations for workload
+                                                identity (e.g. IRSA or GCP Workload Identity)
                                               items:
                                                 type: string
                                               type: array
@@ -8836,6 +10569,7 @@ should match snapshot of default values:
                                             Optional audiences field that will be used to request a temporary Kubernetes service
                                             account token for the service account referenced by `serviceAccountRef`.
                                             Defaults to a single audience `vault` it not specified.
+
                                             Deprecated: use serviceAccountRef.Audiences instead
                                           items:
                                             type: string
@@ -8845,6 +10579,7 @@ should match snapshot of default values:
                                             Optional expiration time in seconds that will be used to request a temporary
                                             Kubernetes service account token for the service account referenced by
                                             `serviceAccountRef`.
+
                                             Deprecated: this will be removed in the future.
                                             Defaults to 10 minutes.
                                           format: int64
@@ -8855,8 +10590,8 @@ should match snapshot of default values:
                                             audiences:
                                               description: |-
                                                 Audience specifies the `aud` claim for the service account token
-                                                If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
-                                                then this audiences will be appended to the list
+                                                Some providers automatically extend the audience field based on well-known annotations for workload
+                                                identity (e.g. IRSA or GCP Workload Identity)
                                               items:
                                                 type: string
                                               type: array
@@ -8978,8 +10713,8 @@ should match snapshot of default values:
                                         audiences:
                                           description: |-
                                             Audience specifies the `aud` claim for the service account token
-                                            If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
-                                            then this audiences will be appended to the list
+                                            Some providers automatically extend the audience field based on well-known annotations for workload
+                                            identity (e.g. IRSA or GCP Workload Identity)
                                           items:
                                             type: string
                                           type: array
@@ -9617,7 +11352,7 @@ should match snapshot of default values:
                       description: Used to configure store refresh interval in seconds. Empty or 0 will default to the controller config.
                       type: integer
                     retrySettings:
-                      description: Used to configure http retries if failed
+                      description: Used to configure HTTP retries on failures.
                       properties:
                         maxRetries:
                           description: MaxRetries is the maximum number of retry attempts.

--- a/deploy/charts/external-secrets/tests/crds_test.yaml
+++ b/deploy/charts/external-secrets/tests/crds_test.yaml
@@ -5,12 +5,13 @@ tests:
   - it: should match snapshot of default values
     asserts:
       - matchSnapshot: {}
-  - it: should disable conversion webhook
+  - it: should set conversion strategy to None when conversion webhook is disabled
     set:
       crds.conversion.enabled: false
     asserts:
-      - isNull:
-          path: spec.conversion
+      - equal:
+          path: spec.conversion.strategy
+          value: None
 
   - it: should add annotations
     set:

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -71,7 +71,8 @@ crds:
   createPushSecret: true
   annotations: {}
   conversion:
-    # -- Conversion is disabled by default as we stopped supporting v1alpha1.
+    # -- Conversion webhook is disabled by default as we stopped supporting v1alpha1.
+    # Helm CRD templates always set `spec.conversion.strategy: None` so installs using server-side apply (`helm upgrade --server-side`) succeed.
     enabled: false
   # -- If true, enable v1beta1 API version serving for ExternalSecret, ClusterExternalSecret, SecretStore, and ClusterSecretStore CRDs.
   # v1beta1 is deprecated. Only enable this for backward compatibility if you have existing v1beta1 resources.

--- a/hack/helm.generate.sh
+++ b/hack/helm.generate.sh
@@ -19,6 +19,10 @@ yq e -Ns "\"${HELM_DIR}/templates/crds/\" + .spec.names.singular" ${BUNDLE_DIR}/
 for i in "${HELM_DIR}"/templates/crds/*.yml; do
   export CRDS_FLAG_NAME="create$(yq e '.spec.names.kind' "${i}")"
   cp "$i" "$i.bkp"
+
+  # Server-side apply requires an explicit conversion strategy. Client-side apply treated a missing spec.conversion as None; SSA does not (see #4673).
+  yq e '.spec.conversion.strategy = "None"' -i "$i.bkp"
+
   if [[ "${CRDS_FLAG_NAME}" == *"ExternalSecret"* || "${CRDS_FLAG_NAME}" == *"SecretStore"* ]]; then
     yq e '(.spec.versions[] | select(.name == "v1alpha1")) |= ("{{- if .Values.crds.conversion.enabled }}\n \(.)\n {{- end }}")' -i "$i.bkp" || true
     $SEDPRG -i '/- |-/d' "$i.bkp"


### PR DESCRIPTION
## Problem Statement

Helm installs of External Secrets Operator fail when using **server-side apply** (`helm upgrade --server-side`) because rendered CRD manifests omit `spec.conversion.strategy`.

Client-side apply (default Helm behavior) implicitly treats a missing `spec.conversion` as `strategy: None`. Server-side apply does not, and the API server rejects the CRD with:

```
CustomResourceDefinition [...] is invalid: spec.conversion.strategy: Required value
```

#4673 fixed this for the static `deploy/crds/bundle.yaml` path, but the Helm chart generator was intentionally left unchanged at the time. That leaves SSA-based GitOps/CI pipelines broken when `installCRDs: true` (the default) is set in the helm values.

## Related Issue

- #4673 — documented the same error for Helm; fixed bundle only
- #4675 — removed conversion webhook from bundle
- #4662 — 0.16 upgrade thread with conversion webhook removal
- #5244 — recommends SSA for the whole chart since v0.19.0 (large CRDs)

## Proposed Changes

This change updates `hack/helm.generate.sh` to set `spec.conversion.strategy: None` on every generated Helm CRD template via `yq`, matching the post-#4675 bundle behavior (no conversion webhook). Adding the following snippet to the helm CRDs:

```yaml
spec:
  conversion:
    strategy: None
```
This was added within the helm chart build.

## AI Assistance disclosure

AI assistance used: Yes, Cursor

If yes provide details: AI wrote the code that fixes the problem. Verified manually.

Tool(s) used: Cursor

Purpose of assistance: Change the code, the test for the build of the helm chart was executed manually and verified myself.

Parts of the contribution affected: Helm and tests for helm.

Human validation performed: Manual build of the helm chart and checked if the conersion strategy is built inside. then tried to apply the helm chart with `--server-side=true`.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
- [x] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [x] I have tested my changes on a live environment to confirm they are working