### PR TITLE
chore(providers): drop redundant TLS 1.2 MinVersion from clients

### DIFF
--- a/providers/v1/akeyless/akeyless.go
+++ b/providers/v1/akeyless/akeyless.go
@@ -576,8 +576,7 @@ func (a *akeylessBase) getAkeylessHTTPClient(ctx context.Context, provider *esv1
 	}
 
 	tlsConf := &tls.Config{
-		RootCAs:    caCertPool,
-		MinVersion: tls.VersionTLS12,
+		RootCAs: caCertPool,
 	}
 	client.Transport = &http.Transport{TLSClientConfig: tlsConf}
 	return client, nil

--- a/providers/v1/beyondtrustworkloadcredentials/httpclient/client.go
+++ b/providers/v1/beyondtrustworkloadcredentials/httpclient/client.go
@@ -98,8 +98,7 @@ func NewClientWithCustomCA(serverURL, token string, caBundlePEM []byte) (*Client
 		// Clone the default transport to preserve default settings like ProxyFromEnvironment
 		transport := http.DefaultTransport.(*http.Transport).Clone()
 		transport.TLSClientConfig = &tls.Config{
-			RootCAs:    roots,
-			MinVersion: tls.VersionTLS12,
+			RootCAs: roots,
 		}
 		httpClient.Transport = transport
 	}

--- a/providers/v1/bitwarden/provider.go
+++ b/providers/v1/bitwarden/provider.go
@@ -147,7 +147,7 @@ func newHTTPSClient(ctx context.Context, c client.Client, storeKind, namespace s
 	}
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12},
+		TLSClientConfig: &tls.Config{RootCAs: pool},
 	}
 
 	return &http.Client{Transport: tr, Timeout: time.Second * 10}, nil

--- a/providers/v1/doppler/client/client.go
+++ b/providers/v1/doppler/client/client.go
@@ -318,10 +318,7 @@ func (c *DopplerClient) performRequest(path, method string, headers headers, par
 
 	httpClient := &http.Client{Timeout: 10 * time.Second}
 
-	tlsConfig := &tls.Config{
-		MinVersion: tls.VersionTLS12,
-	}
-
+	tlsConfig := &tls.Config{}
 	if !c.VerifyTLS {
 		tlsConfig.InsecureSkipVerify = true
 	}

--- a/providers/v1/gitlab/provider.go
+++ b/providers/v1/gitlab/provider.go
@@ -112,8 +112,7 @@ func (g *gitlabBase) getClient(ctx context.Context, provider *esv1.GitlabProvide
 
 		transport := &http.Transport{
 			TLSClientConfig: &tls.Config{
-				RootCAs:    caCertPool,
-				MinVersion: tls.VersionTLS12,
+				RootCAs: caCertPool,
 			},
 		}
 

--- a/providers/v1/infisical/push_secret.go
+++ b/providers/v1/infisical/push_secret.go
@@ -441,7 +441,7 @@ func (p *Provider) lookupHTTPClient() *http.Client {
 	if p.caCertificate != "" {
 		pool := x509.NewCertPool()
 		if pool.AppendCertsFromPEM([]byte(p.caCertificate)) {
-			transport.TLSClientConfig = &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12}
+			transport.TLSClientConfig = &tls.Config{RootCAs: pool}
 		}
 	}
 	return &http.Client{Timeout: projectLookupTimeout, Transport: transport}

--- a/providers/v1/nebius/common/sdk/sdk.go
+++ b/providers/v1/nebius/common/sdk/sdk.go
@@ -34,8 +34,7 @@ import (
 // It sets up TLS configuration, including support for custom CA certificates, and gRPC dial options.
 // Returns the initialized SDK instance or an error if the setup fails.
 func NewSDK(ctx context.Context, apiDomain string, caCertificate []byte) (*gosdk.SDK, error) {
-	tlsCfg := &tls.Config{MinVersion: tls.VersionTLS12}
-
+	tlsCfg := &tls.Config{}
 	if len(caCertificate) > 0 {
 		certPool := x509.NewCertPool()
 		if !certPool.AppendCertsFromPEM(caCertificate) {

--- a/providers/v1/onboardbase/client/client.go
+++ b/providers/v1/onboardbase/client/client.go
@@ -147,12 +147,9 @@ type SecretsResponse struct {
 // NewOnboardbaseClient creates a new client for interacting with Onboardbase API.
 // It requires an API key and passcode for authentication.
 func NewOnboardbaseClient(onboardbaseAPIKey, onboardbasePasscode string) (*OnboardbaseClient, error) {
-	tlsConfig := &tls.Config{
-		MinVersion: tls.VersionTLS12,
-	}
 	httpTransport := &http.Transport{
 		DisableKeepAlives: true,
-		TLSClientConfig:   tlsConfig,
+		TLSClientConfig:   &tls.Config{},
 	}
 	client := &OnboardbaseClient{
 		OnboardbaseAPIKey:   onboardbaseAPIKey,

--- a/providers/v1/ovh/provider.go
+++ b/providers/v1/ovh/provider.go
@@ -216,10 +216,9 @@ func newHTTPClientWithMTLS(ctx context.Context, p *Provider, cl *ovhClient, clie
 		return nil, fmt.Errorf("failed to build x509 certificate: %w", err)
 	}
 
-	// Create an HTTP transport for mTLS, enforcing TLS 1.2+ and using the client certificate.
+	// Create an HTTP transport for mTLS using the client certificate.
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.TLSClientConfig = &tls.Config{
-		MinVersion:   tls.VersionTLS12,
 		Certificates: []tls.Certificate{cert},
 	}
 	// Configure custom CA for the TLS client if provided via CAProvider or CABundle.

--- a/providers/v1/passbolt/passbolt.go
+++ b/providers/v1/passbolt/passbolt.go
@@ -376,7 +376,6 @@ func buildHTTPClient(ctx context.Context, config *esv1.PassboltProvider, kube kc
 		transport.TLSClientConfig = transport.TLSClientConfig.Clone()
 	}
 	transport.TLSClientConfig.RootCAs = caCertPool
-	transport.TLSClientConfig.MinVersion = tls.VersionTLS12
 
 	return &http.Client{
 		Transport: transport,

--- a/providers/v1/passbolt/passbolt_test.go
+++ b/providers/v1/passbolt/passbolt_test.go
@@ -21,7 +21,6 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
@@ -361,7 +360,6 @@ func TestBuildHTTPClient(t *testing.T) {
 			transport, ok := client.Transport.(*http.Transport)
 			g.Expect(ok).To(g.BeTrue())
 			g.Expect(transport.TLSClientConfig).ToNot(g.BeNil())
-			g.Expect(transport.TLSClientConfig.MinVersion).To(g.Equal(uint16(tls.VersionTLS12)))
 
 			// Verify the configured pool actually contains *our* CA, not just any
 			// non-nil pool — guards against silently loading a different bundle.

--- a/providers/v1/passworddepot/passworddepot_api.go
+++ b/providers/v1/passworddepot/passworddepot_api.go
@@ -134,11 +134,9 @@ func NewAPI(ctx context.Context, baseURL, username, password, hostPort string) (
 		username: username,
 		password: password,
 	}
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12},
+	api.client = &http.Client{
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{}},
 	}
-
-	api.client = &http.Client{Transport: tr}
 	err := api.login(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to login: %w", err)

--- a/providers/v1/secretserver/provider.go
+++ b/providers/v1/secretserver/provider.go
@@ -95,8 +95,7 @@ func (p *Provider) NewClient(ctx context.Context, store esv1.GenericStore, kube 
 		}
 
 		ssConfig.TLSClientConfig = &tls.Config{
-			RootCAs:    caCertPool,
-			MinVersion: tls.VersionTLS12,
+			RootCAs: caCertPool,
 		}
 	}
 

--- a/providers/v1/webhook/pkg/webhook/webhook.go
+++ b/providers/v1/webhook/pkg/webhook/webhook.go
@@ -381,7 +381,6 @@ func (w *Webhook) GetHTTPClient(ctx context.Context, provider *Spec) (*http.Clie
 
 		tlsConf := &tls.Config{
 			RootCAs:       caCertPool,
-			MinVersion:    tls.VersionTLS12,
 			Renegotiation: tls.RenegotiateOnceAsClient,
 		}
 

--- a/providers/v1/yandex/common/sdk.go
+++ b/providers/v1/yandex/common/sdk.go
@@ -103,7 +103,7 @@ func NewIamToken(ctx context.Context, apiEndpoint string, authorizedKey *iamkey.
 }
 
 func tlsConfig(caCertificate []byte) (*tls.Config, error) {
-	config := &tls.Config{MinVersion: tls.VersionTLS12}
+	config := &tls.Config{}
 	if caCertificate != nil {
 		caCertPool := x509.NewCertPool()
 		ok := caCertPool.AppendCertsFromPEM(caCertificate)

--- a/runtime/oidc/token_manager.go
+++ b/runtime/oidc/token_manager.go
@@ -260,9 +260,7 @@ func postJSONRequestInternal(ctx context.Context, url string, requestBody any, p
 	} else {
 		transport = &http.Transport{}
 	}
-	transport.TLSClientConfig = &tls.Config{
-		MinVersion: tls.VersionTLS12,
-	}
+	transport.TLSClientConfig = &tls.Config{}
 
 	client := &http.Client{
 		Timeout:   10 * time.Second,


### PR DESCRIPTION
## Problem Statement

Removes explicit `tls.Config{MinVersion: tls.VersionTLS12}` from provider outbound HTTP/gRPC clients and `runtime/oidc` where it duplicated Go’s default minimum (TLS 1.2 since Go 1.22). No intended behavior change.

Related context: [#6726](https://github.com/external-secrets/external-secrets/issues/6726) (TLS policy initiative). This is hygiene/explicitness cleanup, not a security fix — aligns with the audit note that unset `MinVersion` is not a live exposure today.

## Related Issue

Partially addresses https://github.com/external-secrets/external-secrets/issues/6726

## Proposed Changes

- Drop redundant `MinVersion` from 14 provider sites + `runtime/oidc/token_manager.go`
- Simplify clients that only existed to set MinVersion (`onboardbase`, `passworddepot`) or only need TLS config for `InsecureSkipVerify` (`doppler`)
- Update `passbolt_test.go` to stop asserting redundant MinVersion
- What's unchanged
  - `providers/v1/cloudru/secretmanager` — explicit TLS 1.3 (stricter than default)
  - Operator serving TLS (`cmd/controller`, #6617) — separate, flag-driven policy
  - Sites that never set MinVersion (e.g. openbao, senhasegura)

## AI Assistance disclosure

Did you use an script, LLM, or AI assisted development tool for this contribution?

AI assistance used: Yes

If yes provide details:

Tool(s) used: Cursor

Purpose of assistance: The AI was used to identify and remove the redundant TLS 1.2 MinVersion setting at all places.

Parts of the contribution affected: The whole contribution is made using AI.

Human validation performed: The code changes were reviewed, and the verification was done for bitwarden provider alone.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
- [x] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [x] I have tested my changes on a live environment to confirm they are working
