### PR TITLE
feat: allow specifying namespace for grafana dashboard ConfigMap

### DIFF
--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -161,6 +161,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | grafanaDashboard.annotations | object | `{}` | Annotations that ConfigMaps can have to get configured in Grafana, See: sidecar.dashboards.folderAnnotation for specifying the dashboard folder. https://github.com/grafana/helm-charts/tree/main/charts/grafana |
 | grafanaDashboard.enabled | bool | `false` | If true creates a Grafana dashboard. |
 | grafanaDashboard.extraLabels | object | `{}` | Extra labels to add to the Grafana dashboard ConfigMap. |
+| grafanaDashboard.namespace | string | `""` | Namespace where the dashboard ConfigMap should be created. Resolution order: grafanaDashboard.namespace, then namespaceOverride, then the release namespace. |
 | grafanaDashboard.sidecarLabel | string | `"grafana_dashboard"` | Label that ConfigMaps should have to be loaded as dashboards. |
 | grafanaDashboard.sidecarLabelValue | string | `"1"` | Label value that ConfigMaps should have to be loaded as dashboards. |
 | hostAliases | list | `[]` | Specifies `hostAliases` to deployment |

--- a/deploy/charts/external-secrets/templates/grafana-dashboard.yaml
+++ b/deploy/charts/external-secrets/templates/grafana-dashboard.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "external-secrets.fullname" . }}-dashboard
-  namespace: {{ include "external-secrets.namespace" . }}
+  namespace: {{ .Values.grafanaDashboard.namespace | default (include "external-secrets.namespace" .) | quote }}
   labels:
     {{ .Values.grafanaDashboard.sidecarLabel }}: {{ .Values.grafanaDashboard.sidecarLabelValue | quote }}
     {{- include "external-secrets.labels" . | nindent 4 }}

--- a/deploy/charts/external-secrets/tests/grafana_dashboard_test.yaml
+++ b/deploy/charts/external-secrets/tests/grafana_dashboard_test.yaml
@@ -92,3 +92,43 @@ tests:
           count: 1
       - exists:
           path: data["external-secrets.json"]
+  - it: should default namespace to release namespace
+    set:
+      grafanaDashboard.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+  - it: should override namespace
+    set:
+      grafanaDashboard.enabled: true
+      grafanaDashboard.namespace: monitoring
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.namespace
+          value: monitoring
+  - it: should use namespaceOverride when grafanaDashboard.namespace is unset
+    set:
+      grafanaDashboard.enabled: true
+      namespaceOverride: override-ns
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.namespace
+          value: override-ns
+  - it: should prefer grafanaDashboard.namespace over namespaceOverride
+    set:
+      grafanaDashboard.enabled: true
+      grafanaDashboard.namespace: monitoring
+      namespaceOverride: override-ns
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.namespace
+          value: monitoring

--- a/deploy/charts/external-secrets/values.schema.json
+++ b/deploy/charts/external-secrets/values.schema.json
@@ -558,6 +558,9 @@
                 "extraLabels": {
                     "type": "object"
                 },
+                "namespace": {
+                    "type": "string"
+                },
                 "sidecarLabel": {
                     "type": "string"
                 },

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -389,6 +389,10 @@ grafanaDashboard:
   # -- If true creates a Grafana dashboard.
   enabled: false
 
+  # -- Namespace where the dashboard ConfigMap should be created.
+  # Resolution order: grafanaDashboard.namespace, then namespaceOverride, then the release namespace.
+  namespace: ""
+
   # -- Label that ConfigMaps should have to be loaded as dashboards.
   sidecarLabel: "grafana_dashboard"
 


### PR DESCRIPTION
## Problem Statement

`grafanaDashboard.enabled: true` creates the dashboard ConfigMap in the chart's namespace (`namespaceOverride`). With grafana-operator, a GrafanaDashboard can only read `configMapRef` from its own namespace, so the JSON had to be copied manually into the Grafana namespace.

## Related Issue

Fixes #6919

## Proposed Changes

Add a `namespace` value on `grafanaDashboard`, mirroring `serviceMonitor.namespace`, so the ConfigMap can be created in a namespace other than the chart's:

```yaml
grafanaDashboard:
  enabled: true
  namespace: monitoring
```

Precedence when rendering the ConfigMap namespace:

1. `grafanaDashboard.namespace`
2. `namespaceOverride` (global)
3. `.Release.Namespace`

Unset behavior is unchanged thanks to the existing `external-secrets.namespace` helper.

Changes:

- `templates/grafana-dashboard.yaml`: resolve namespace from `.Values.grafanaDashboard.namespace | default (include "external-secrets.namespace" .)`
- `values.yaml`: add `grafanaDashboard.namespace`
- `tests/grafana_dashboard_test.yaml`: add cases for default and overridden namespace
- `values.schema.json`, `README.md`: regenerated

## Format

```
feat(charts): allow specifying namespace for the grafana dashboard ConfigMap
```

## AI Assistance disclosure

AI assistance used: Yes

Tool(s) used: opencode (deepseek-v4-pro)

Purpose of assistance: Implement the helm chart change, regenerate values.schema.json and README.md, and add helm-unittest coverage.

Parts of the contribution affected: deploy/charts/external-secrets/{values.yaml, templates/grafana-dashboard.yaml, tests/grafana_dashboard_test.yaml, values.schema.json, README.md}

Human validation performed: Reviewed the diff; the affected grafana_dashboard_test.yaml suite passes locally (9/9).

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test` (helm chart tests only; `make test` Go suite N/A for this change)
- [x] I ensured my PR is ready for review with `make reviewable`
- [x] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [x] I have tested my changes on a live environment to confirm they are working