### PR TITLE
fix(keepersecurity): make folderID optional except when creating new records via push

### DIFF
--- a/apis/externalsecrets/v1/secretstore_keepersecurity_types.go
+++ b/apis/externalsecrets/v1/secretstore_keepersecurity_types.go
@@ -20,7 +20,9 @@ import smmeta "github.com/external-secrets/external-secrets/apis/meta/v1"
 
 // KeeperSecurityProvider Configures a store to sync secrets using Keeper Security.
 type KeeperSecurityProvider struct {
-	Auth               smmeta.SecretKeySelector `json:"authRef"`
-	FolderID           string                   `json:"folderID,omitempty"`
-	GetByTitleFallback bool                     `json:"getByTitleFallback,omitempty"`
+	Auth smmeta.SecretKeySelector `json:"authRef"`
+
+	// +optional
+	FolderID           string `json:"folderID,omitempty"`
+	GetByTitleFallback bool   `json:"getByTitleFallback,omitempty"`
 }

--- a/apis/externalsecrets/v1/secretstore_keepersecurity_types.go
+++ b/apis/externalsecrets/v1/secretstore_keepersecurity_types.go
@@ -21,6 +21,6 @@ import smmeta "github.com/external-secrets/external-secrets/apis/meta/v1"
 // KeeperSecurityProvider Configures a store to sync secrets using Keeper Security.
 type KeeperSecurityProvider struct {
 	Auth               smmeta.SecretKeySelector `json:"authRef"`
-	FolderID           string                   `json:"folderID"`
+	FolderID           string                   `json:"folderID,omitempty"`
 	GetByTitleFallback bool                     `json:"getByTitleFallback,omitempty"`
 }

--- a/config/crds/bases/external-secrets.io_clustersecretstores.yaml
+++ b/config/crds/bases/external-secrets.io_clustersecretstores.yaml
@@ -4069,7 +4069,6 @@ spec:
                         type: boolean
                     required:
                     - authRef
-                    - folderID
                     type: object
                   kubernetes:
                     description: Kubernetes configures this store to sync secrets

--- a/config/crds/bases/external-secrets.io_secretstores.yaml
+++ b/config/crds/bases/external-secrets.io_secretstores.yaml
@@ -4069,7 +4069,6 @@ spec:
                         type: boolean
                     required:
                     - authRef
-                    - folderID
                     type: object
                   kubernetes:
                     description: Kubernetes configures this store to sync secrets

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -6115,7 +6115,6 @@ spec:
                           type: boolean
                       required:
                         - authRef
-                        - folderID
                       type: object
                     kubernetes:
                       description: Kubernetes configures this store to sync secrets using a Kubernetes cluster provider
@@ -19573,7 +19572,6 @@ spec:
                           type: boolean
                       required:
                         - authRef
-                        - folderID
                       type: object
                     kubernetes:
                       description: Kubernetes configures this store to sync secrets using a Kubernetes cluster provider

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -7798,6 +7798,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 </td>
 </tr>
 <tr>

--- a/providers/v1/keepersecurity/client.go
+++ b/providers/v1/keepersecurity/client.go
@@ -51,7 +51,7 @@ const (
 	errInvalidRemoteRefKey                      = "match.remoteRef.remoteKey. Invalid format. Format should match secretName/key got %s"
 	errInvalidSecretType                        = "ESO can only push/delete records of type %s. Secret %s is type %s"
 	errFieldNotFound                            = "secret %s does not contain any custom field with label %s"
-	errKeeperSecurityMissingFolderIDForCreate   = "folderID must be set on the SecretStore to create a new Keeper security record"
+	errKeeperSecurityMissingFolderIDForCreate   = "folderID must be set on the SecretStore to create a new Keeper Security record"
 
 	externalSecretType = "externalSecrets"
 	secretType         = "secret"

--- a/providers/v1/keepersecurity/client.go
+++ b/providers/v1/keepersecurity/client.go
@@ -313,6 +313,10 @@ func (c *Client) createSecret(name, key string, value []byte) (string, error) {
 		)
 	}
 
+	if c.folderID == "" {
+		return "", errors.New("folderID must be set on the SecretStore to create a new Keeper security record")
+	}
+	
 	uid, err := c.ksmClient.CreateSecretWithRecordData("", c.folderID, externalSecretRecord)
 	metrics.ObserveAPICall(ProviderKeeperSecurity, CallKeeperSecurityCreateSecretWithRecordData, err)
 	return uid, err

--- a/providers/v1/keepersecurity/client.go
+++ b/providers/v1/keepersecurity/client.go
@@ -51,6 +51,7 @@ const (
 	errInvalidRemoteRefKey                      = "match.remoteRef.remoteKey. Invalid format. Format should match secretName/key got %s"
 	errInvalidSecretType                        = "ESO can only push/delete records of type %s. Secret %s is type %s"
 	errFieldNotFound                            = "secret %s does not contain any custom field with label %s"
+	errKeeperSecurityMissingFolderIDForCreate   = "folderID must be set on the SecretStore to create a new Keeper security record"
 
 	externalSecretType = "externalSecrets"
 	secretType         = "secret"
@@ -314,9 +315,9 @@ func (c *Client) createSecret(name, key string, value []byte) (string, error) {
 	}
 
 	if c.folderID == "" {
-		return "", errors.New("folderID must be set on the SecretStore to create a new Keeper security record")
+		return "", errors.New(errKeeperSecurityMissingFolderIDForCreate)
 	}
-	
+
 	uid, err := c.ksmClient.CreateSecretWithRecordData("", c.folderID, externalSecretRecord)
 	metrics.ObserveAPICall(ProviderKeeperSecurity, CallKeeperSecurityCreateSecretWithRecordData, err)
 	return uid, err

--- a/providers/v1/keepersecurity/client_test.go
+++ b/providers/v1/keepersecurity/client_test.go
@@ -920,6 +920,25 @@ func TestClientPushSecret(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "Push new secret fails without folderID",
+			fields: fields{
+				ksmClient: &fake.MockKeeperClient{
+					GetSecretsByTitleFn: func(recordTitle string) (records []*ksm.Record, err error) {
+						return generateRecords()[0:0], nil
+					},
+				},
+				folderID: "",
+			},
+			args: args{
+				data: testingfake.PushSecretData{
+					SecretKey: secretKey,
+					RemoteKey: invalidRecord,
+				},
+				value: []byte("foo"),
+			},
+			wantErr: true,
+		},
+		{
 			name: "Unable to save existing valid secret",
 			fields: fields{
 				ksmClient: &fake.MockKeeperClient{

--- a/providers/v1/keepersecurity/provider.go
+++ b/providers/v1/keepersecurity/provider.go
@@ -101,7 +101,7 @@ func (p *Provider) ValidateStore(store esv1.GenericStore) (admission.Warnings, e
 	if err := esutils.ValidateSecretSelector(store, config.Auth); err != nil {
 		return nil, fmt.Errorf("error validating secret selector: %w", err)
 	}
-	
+
 	return nil, nil
 }
 

--- a/providers/v1/keepersecurity/provider.go
+++ b/providers/v1/keepersecurity/provider.go
@@ -38,7 +38,6 @@ const (
 	errKeeperSecurityNilSpec                       = "nil spec"
 	errKeeperSecurityNilSpecProvider               = "nil spec.provider"
 	errKeeperSecurityNilSpecProviderKeeperSecurity = "nil spec.provider.keepersecurity"
-	errKeeperSecurityStoreMissingFolderID          = "missing: spec.provider.keepersecurity.folderID"
 )
 
 // Provider implements the necessary NewClient() and ValidateStore() funcs for Keeper Security.
@@ -102,10 +101,7 @@ func (p *Provider) ValidateStore(store esv1.GenericStore) (admission.Warnings, e
 	if err := esutils.ValidateSecretSelector(store, config.Auth); err != nil {
 		return nil, fmt.Errorf("error validating secret selector: %w", err)
 	}
-	if config.FolderID == "" {
-		return nil, errors.New(errKeeperSecurityStoreMissingFolderID)
-	}
-
+	
 	return nil, nil
 }
 

--- a/providers/v1/keepersecurity/provider_test.go
+++ b/providers/v1/keepersecurity/provider_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright © The ESO Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keepersecurity
+
+import (
+	"testing"
+
+	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
+	smmeta "github.com/external-secrets/external-secrets/apis/meta/v1"
+)
+
+func makeKeeperSecurityStore(folderID string) *esv1.SecretStore {
+	return &esv1.SecretStore{
+		Spec: esv1.SecretStoreSpec{
+			Provider: &esv1.SecretStoreProvider{
+				KeeperSecurity: &esv1.KeeperSecurityProvider{
+					Auth:     smmeta.SecretKeySelector{Name: "keeper-creds"},
+					FolderID: folderID,
+				},
+			},
+		},
+	}
+}
+
+func TestValidateStore(t *testing.T) {
+	testCases := []struct {
+		label string
+		store *esv1.SecretStore
+	}{
+		{
+			label: "valid store without folderID",
+			store: makeKeeperSecurityStore(""),
+		},
+		{
+			label: "valid store with folderID",
+			store: makeKeeperSecurityStore(folderID),
+		},
+	}
+
+	p := Provider{}
+
+	for _, tc := range testCases {
+		t.Run(tc.label, func(t *testing.T) {
+			_, err := p.ValidateStore(tc.store)
+			if err != nil {
+				t.Errorf("ValidateStore() unexpected error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem Statement
The KeeperSecurity provider currently requires `folderID` on every `SecretStore`/`ClusterSecretStore`, including stores that are only used for reading secrets.

`folderID` is only used when Keeper needs to create a new record. Reads, updates to existing records, and deletes do not require it.

## Related Issue

Fixes #6694 

## Proposed Changes

- Added `omitempty`/optional on `folderID` in `apis/externalsecrets/v1/secretstore_keepersecurity_types.go`, allowing folderID to be an optional field.
- Added a guard before pushing secrets in `providers/v1/keepersecurity/client.go` to require a folderID in the secretstore before creating a new record.
- Moved folderID validation from store initialization to record creation, where the field is actually required

## Live Verification

Tested against a live Keeper Secrets Manager environment from a local
Kubernetes cluster.

| Scenario | folderID | Result |
| --- | --- | --- |
| `ExternalSecret.data` | omitted | PASS |
| `dataFrom.extract` | omitted | PASS |
| `dataFrom.find` | omitted | PASS |
| Push existing record | omitted | PASS |
| Push new record | omitted | PASS (expected creation error) |
| Push new record | configured | PASS |
| Delete existing record | omitted | PASS |

The expected error when creating without `folderID` is:

`folderID must be set on the SecretStore to create a new Keeper Security record`

<img width="1332" height="901" alt="image" src="https://github.com/user-attachments/assets/d0fdd3cc-e028-43ae-811c-05c3aa8db33d" />

## Format
`fix(keepersecurity): make folderID optional except when creating new records via push`

## AI Assistance disclosure

AI assistance used: Yes 

Tool(s) used: Claude Code

Purpose of assistance:
- Understanding the code flow for external secrets
- Identify edge cases for live environment tests
- Create live environment test scripts for a local Kubernetes cluster connected to a live Keeper Security environment
- Create "Push new secret fails without folderID" test in `client.go`


Parts of the contribution affected:
- apis/externalsecrets/v1/secretstore_keepersecurity_types.go
- config/crds/bases/external-secrets.io_clustersecretstores.yaml
- config/crds/bases/external-secrets.io_secretstores.yaml
- deploy/crds/bundle.yaml
- providers/v1/keepersecurity/client.go
- providers/v1/keepersecurity/provider.go
- providers/v1/keepersecurity/client_test.go

Human validation performed:
- Reproduced the issue against a live Keeper Security environment.
- Ran and reviewed the live test scenarios.
- Verified the resulting records directly in the Keeper Vault UI.
- Reviewed and understood the submitted changes.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
- [x] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [x] I have tested my changes on a live environment to confirm they are working
