### PR TITLE
feat(passbolt): support finding secrets by folder via find.path

### DIFF
--- a/docs/provider/passbolt.md
+++ b/docs/provider/passbolt.md
@@ -54,6 +54,16 @@ Instead of retrieving secrets by ID you can also use `dataFrom` to search for se
 ```
 
 
+## Finding secrets by folder
+
+Set `find.path` to the ID of a Passbolt folder to sync all secrets stored in that folder.
+You can combine it with `name.regexp` to filter the secrets in the folder by name.
+
+```yaml
+{% include 'passbolt-external-secret-findbyfolder.yaml' %}
+```
+
+
 ## Custom fields
 
 Passbolt resources can carry arbitrary custom fields beyond the standard

--- a/docs/snippets/passbolt-external-secret-findbyfolder.yaml
+++ b/docs/snippets/passbolt-external-secret-findbyfolder.yaml
@@ -1,0 +1,15 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: passbolt-folder-example
+spec:
+  refreshInterval: "1h0m0s"
+  secretStoreRef:
+    name: passbolt
+    kind: SecretStore
+  target:
+    name: passbolt-folder-example
+  dataFrom:
+    - find:
+        # Replace with the ID of an existing Passbolt folder
+        path: fdc478e2-f09b-47a6-9764-2e5d13f7fd0c

--- a/providers/v1/passbolt/passbolt.go
+++ b/providers/v1/passbolt/passbolt.go
@@ -48,17 +48,17 @@ var errPassboltCustomFieldNotFound = errors.New("custom field not found")
 const (
 	customFieldPrefix = "custom_fields."
 
-	errPassboltStoreMissingProvider                = "missing: spec.provider.passbolt"
-	errPassboltStoreMissingAuth                    = "missing: spec.provider.passbolt.auth"
-	errPassboltStoreMissingAuthPassword            = "missing: spec.provider.passbolt.auth.passwordSecretRef"
-	errPassboltStoreMissingAuthPrivateKey          = "missing: spec.provider.passbolt.auth.privateKeySecretRef"
-	errPassboltStoreMissingHost                    = "missing: spec.provider.passbolt.host"
-	errPassboltExternalSecretMissingFindNameRegExp = "missing: find.name.regexp"
-	errPassboltStoreHostSchemeNotHTTPS             = "host Url has to be https scheme"
-	errPassboltSecretPropertyInvalid               = "property must be one of name, username, uri, password, description, or " + customFieldPrefix + "<name>"
-	errPassboltCAInvalid                           = "failed to parse CA certificate for Passbolt provider"
-	errPassboltUnexpectedTransport                 = "unexpected default http transport type"
-	errNotImplemented                              = "not implemented"
+	errPassboltStoreMissingProvider            = "missing: spec.provider.passbolt"
+	errPassboltStoreMissingAuth                = "missing: spec.provider.passbolt.auth"
+	errPassboltStoreMissingAuthPassword        = "missing: spec.provider.passbolt.auth.passwordSecretRef"
+	errPassboltStoreMissingAuthPrivateKey      = "missing: spec.provider.passbolt.auth.privateKeySecretRef"
+	errPassboltStoreMissingHost                = "missing: spec.provider.passbolt.host"
+	errPassboltExternalSecretMissingFindFilter = "missing: find.path or find.name.regexp"
+	errPassboltStoreHostSchemeNotHTTPS         = "host Url has to be https scheme"
+	errPassboltSecretPropertyInvalid           = "property must be one of name, username, uri, password, description, or " + customFieldPrefix + "<name>"
+	errPassboltCAInvalid                       = "failed to parse CA certificate for Passbolt provider"
+	errPassboltUnexpectedTransport             = "unexpected default http transport type"
+	errNotImplemented                          = "not implemented"
 )
 
 // ProviderPassbolt implements the External Secrets provider interface for Passbolt.
@@ -169,20 +169,31 @@ func (provider *ProviderPassbolt) GetSecretMap(_ context.Context, _ esv1.Externa
 func (provider *ProviderPassbolt) GetAllSecrets(ctx context.Context, ref esv1.ExternalSecretFind) (map[string][]byte, error) {
 	res := make(map[string][]byte)
 
-	if ref.Name == nil || ref.Name.RegExp == "" {
-		return res, errors.New(errPassboltExternalSecretMissingFindNameRegExp)
+	hasPath := ref.Path != nil && *ref.Path != ""
+	hasName := ref.Name != nil && ref.Name.RegExp != ""
+	if !hasPath && !hasName {
+		return res, errors.New(errPassboltExternalSecretMissingFindFilter)
+	}
+
+	var nameRegexp *regexp.Regexp
+	if hasName {
+		var err error
+		nameRegexp, err = regexp.Compile(ref.Name.RegExp)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if err := assureLoggedIn(ctx, provider.client); err != nil {
 		return nil, err
 	}
 
-	resources, err := provider.client.GetResources(ctx, &api.GetResourcesOptions{})
-	if err != nil {
-		return nil, err
+	opts := &api.GetResourcesOptions{}
+	if hasPath {
+		opts.FilterHasParent = []string{*ref.Path}
 	}
 
-	nameRegexp, err := regexp.Compile(ref.Name.RegExp)
+	resources, err := provider.client.GetResources(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +209,7 @@ func (provider *ProviderPassbolt) GetAllSecrets(ctx context.Context, ref esv1.Ex
 		}
 
 		// Filter by decrypted name (works for both V4 and V5)
-		if !nameRegexp.MatchString(secret.Name) {
+		if nameRegexp != nil && !nameRegexp.MatchString(secret.Name) {
 			continue
 		}
 

--- a/providers/v1/passbolt/passbolt_test.go
+++ b/providers/v1/passbolt/passbolt_test.go
@@ -93,6 +93,52 @@ func TestValidateStore(t *testing.T) {
 	g.Expect(err).To(g.BeNil())
 }
 
+func TestGetAllSecretsFindValidation(t *testing.T) {
+	g.RegisterTestingT(t)
+
+	folderID := "fdc478e2-f09b-47a6-9764-2e5d13f7fd0c"
+
+	tests := []struct {
+		name    string
+		ref     esv1.ExternalSecretFind
+		wantErr bool
+	}{
+		{
+			name:    "neither path nor name.regexp set",
+			ref:     esv1.ExternalSecretFind{},
+			wantErr: true,
+		},
+		{
+			name:    "empty name.regexp without path",
+			ref:     esv1.ExternalSecretFind{Name: &esv1.FindName{}},
+			wantErr: true,
+		},
+		{
+			name:    "invalid name.regexp",
+			ref:     esv1.ExternalSecretFind{Name: &esv1.FindName{RegExp: "("}},
+			wantErr: true,
+		},
+		{
+			name: "invalid name.regexp combined with path",
+			ref: esv1.ExternalSecretFind{
+				Path: &folderID,
+				Name: &esv1.FindName{RegExp: "("},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &ProviderPassbolt{}
+			_, err := p.GetAllSecrets(t.Context(), tt.ref)
+			if tt.wantErr {
+				g.Expect(err).ToNot(g.BeNil())
+			}
+		})
+	}
+}
+
 func TestSecretGetProp(t *testing.T) {
 	g.RegisterTestingT(t)
 


### PR DESCRIPTION
## Problem Statement

In Passbolt, secrets are organized by folders. The Passbolt provider can only find secrets by name and regexp, so there is no way to sync just one folder

## Proposed Changes

Add support for `find.path` property in the `dataFrom[].find` field.

## AI Assistance disclosure

AI assistance used: Yes

Tool(s) used: Claude Code (Fable 5.1)

Purpose of assistance: testing, docs