### PR TITLE
fix(pulumi): preserve environment definition on PushSecret

### DIFF
--- a/docs/provider/pulumi.md
+++ b/docs/provider/pulumi.md
@@ -182,6 +182,8 @@ spec:
 
 This will then push the secret to the Pulumi service. If the secret already exists, it will be updated.
 
+Only the pushed key is written. The rest of the environment definition (`imports`, `pulumiConfig`, `environmentVariables`, `files` and any `fn::` expressions) is left unchanged. The pushed value is stored as a plain literal; it is not wrapped in `fn::secret`.
+
 ## Limitations
 
 Currently, the Pulumi provider only supports nested objects up to a depth of 1. Any nested objects beyond this depth will be stored as a string with the JSON representation.

--- a/providers/v1/pulumi/go.mod
+++ b/providers/v1/pulumi/go.mod
@@ -12,6 +12,7 @@ require (
 	k8s.io/api v0.36.3
 	k8s.io/client-go v0.36.3
 	sigs.k8s.io/controller-runtime v0.24.1
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -91,7 +92,6 @@ require (
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.3 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 	software.sslmate.com/src/go-pkcs12 v0.7.0 // indirect
 )
 

--- a/providers/v1/pulumi/pulumi.go
+++ b/providers/v1/pulumi/pulumi.go
@@ -117,22 +117,27 @@ func (c *client) PushSecret(ctx context.Context, secret *corev1.Secret, data esv
 	}
 	value := secret.Data[secretKey]
 
-	updatePayload := &esc.EnvironmentDefinition{
-		Values: &esc.EnvironmentDefinitionValues{
-			AdditionalProperties: map[string]any{
-				data.GetRemoteKey(): string(value),
-			},
-		},
-	}
-	_, oldValues, err := c.escClient.OpenAndReadEnvironment(authCtx, c.organization, c.project, c.environment)
+	// Merge into the raw environment definition rather than the opened
+	// (resolved) environment, so imports, pulumiConfig, environmentVariables,
+	// files and fn:: expressions are written back untouched.
+	definition, _, err := c.escClient.GetEnvironment(authCtx, c.organization, c.project, c.environment)
 	if err != nil {
 		return fmt.Errorf(errReadEnvironment, err)
 	}
-	updatePayload.Values.AdditionalProperties = createSubmaps(updatePayload.Values.AdditionalProperties)
-	if err := mergo.Merge(&updatePayload.Values.AdditionalProperties, oldValues); err != nil {
+	if definition == nil {
+		definition = &esc.EnvironmentDefinition{}
+	}
+	if definition.Values == nil {
+		definition.Values = &esc.EnvironmentDefinitionValues{}
+	}
+	values := createSubmaps(map[string]any{
+		data.GetRemoteKey(): string(value),
+	})
+	if err := mergo.Merge(&values, definition.Values.AdditionalProperties); err != nil {
 		return fmt.Errorf(errPushSecrets, err)
 	}
-	_, err = c.escClient.UpdateEnvironment(authCtx, c.organization, c.project, c.environment, updatePayload)
+	definition.Values.AdditionalProperties = values
+	_, err = c.escClient.UpdateEnvironment(authCtx, c.organization, c.project, c.environment, definition)
 	if err != nil {
 		return fmt.Errorf(errPushSecrets, err)
 	}

--- a/providers/v1/pulumi/pulumi_test.go
+++ b/providers/v1/pulumi/pulumi_test.go
@@ -466,6 +466,41 @@ func TestPushSecret(t *testing.T) {
 	assert.Equal(t, want, patched)
 }
 
+func TestPushSecretEmptyEnvironment(t *testing.T) {
+	// A brand-new environment has an empty definition (no values block yet),
+	// so definition.Values is nil after GetEnvironment.
+	var patched map[string]any
+	client := newTestClient(t, "", "/environments/foo/default/bar", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add(contentType, contentTypeValue)
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = w.Write([]byte(`{}`))
+		case http.MethodPatch:
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.NoError(t, yaml.Unmarshal(body, &patched))
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+
+	err := client.PushSecret(context.TODO(), &corev1.Secret{
+		Data: map[string][]byte{"token": []byte("new-token")},
+	}, testingfake.PushSecretData{SecretKey: "token", RemoteKey: "app.token"})
+	require.NoError(t, err)
+	require.NotNil(t, patched, "expected UpdateEnvironment to be called")
+
+	want := map[string]any{
+		"values": map[string]any{
+			"app": map[string]any{
+				"token": "new-token",
+			},
+		},
+	}
+	assert.Equal(t, want, patched)
+}
+
 func TestCreateSubmaps(t *testing.T) {
 	input := map[string]any{
 		"a.b.c": 1,

--- a/providers/v1/pulumi/pulumi_test.go
+++ b/providers/v1/pulumi/pulumi_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -27,8 +28,11 @@ import (
 	esc "github.com/pulumi/esc-sdk/sdk/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/yaml"
 
 	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
+	testingfake "github.com/external-secrets/external-secrets/runtime/testing/fake"
 )
 
 // Constants for content type and value.
@@ -363,6 +367,103 @@ func TestGetSecretMap(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPushSecret(t *testing.T) {
+	definition := map[string]any{
+		"imports": []any{"base-env"},
+		"values": map[string]any{
+			"pulumiConfig": map[string]any{
+				"aws:region": "us-west-2",
+			},
+			"environmentVariables": map[string]any{
+				"AWS_REGION": "${aws.region}",
+			},
+			"files": map[string]any{
+				"KUBECONFIG": "${kubeconfig}",
+			},
+			"aws": map[string]any{
+				"login": map[string]any{
+					"fn::open::aws-login": map[string]any{
+						"oidc": map[string]any{
+							"roleArn": "arn:aws:iam::123456789012:role/esc",
+						},
+					},
+				},
+			},
+			"db": map[string]any{
+				"password": map[string]any{
+					"fn::secret": map[string]any{
+						"ciphertext": "ZXNjeAAAAAE=",
+					},
+				},
+			},
+			"app": map[string]any{
+				"token": map[string]any{
+					"fn::secret": "old-token",
+				},
+				"url": "https://app.example.com",
+			},
+		},
+	}
+
+	var patched map[string]any
+	client := newTestClient(t, "", "/environments/foo/default/bar", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add(contentType, contentTypeValue)
+		switch r.Method {
+		case http.MethodGet:
+			require.NoError(t, json.NewEncoder(w).Encode(definition))
+		case http.MethodPatch:
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.NoError(t, yaml.Unmarshal(body, &patched))
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+
+	err := client.PushSecret(context.TODO(), &corev1.Secret{
+		Data: map[string][]byte{"token": []byte("new-token")},
+	}, testingfake.PushSecretData{SecretKey: "token", RemoteKey: "app.token"})
+	require.NoError(t, err)
+	require.NotNil(t, patched, "expected UpdateEnvironment to be called")
+
+	want := map[string]any{
+		"imports": []any{"base-env"},
+		"values": map[string]any{
+			"pulumiConfig": map[string]any{
+				"aws:region": "us-west-2",
+			},
+			"environmentVariables": map[string]any{
+				"AWS_REGION": "${aws.region}",
+			},
+			"files": map[string]any{
+				"KUBECONFIG": "${kubeconfig}",
+			},
+			"aws": map[string]any{
+				"login": map[string]any{
+					"fn::open::aws-login": map[string]any{
+						"oidc": map[string]any{
+							"roleArn": "arn:aws:iam::123456789012:role/esc",
+						},
+					},
+				},
+			},
+			"db": map[string]any{
+				"password": map[string]any{
+					"fn::secret": map[string]any{
+						"ciphertext": "ZXNjeAAAAAE=",
+					},
+				},
+			},
+			"app": map[string]any{
+				"token": "new-token",
+				"url":   "https://app.example.com",
+			},
+		},
+	}
+	assert.Equal(t, want, patched)
 }
 
 func TestCreateSubmaps(t *testing.T) {


### PR DESCRIPTION
## Problem Statement

`PushSecret` on the Pulumi ESC provider rewrites the whole environment definition from the *resolved* environment. A single-key push drops the environment's `imports:`, `pulumiConfig:`, `environmentVariables:` and `files:` blocks, and any `fn::secret` / `fn::open::*` / `${...}` content is written back as resolved literals (dynamic credentials frozen, encrypted values stored in plaintext). Any environment that is more than a flat list of literal key/value pairs is damaged by one push.

Root cause, `providers/v1/pulumi/pulumi.go:120-135` (`PushSecret`, on `main` at dbfbd9889):

- the merge base comes from `escClient.OpenAndReadEnvironment`, which opens the environment and returns the *resolved* property values, not the definition;
- the update payload is a fresh `esc.EnvironmentDefinition` that only populates `Values.AdditionalProperties`, so `Imports`, `Values.PulumiConfig`, `Values.EnvironmentVariables` and `Values.Files` are always sent empty and `UpdateEnvironment` replaces the stored definition with that truncated payload.

## Related Issue

Fixes #6748

## Proposed Changes

- Read the merge base with `escClient.GetEnvironment`, which returns the raw `*esc.EnvironmentDefinition` (the same type `UpdateEnvironment` consumes), instead of `OpenAndReadEnvironment`.
- Merge the pushed key (still expanded through `createSubmaps`, so dotted remote keys keep working) into `definition.Values.AdditionalProperties` and send the fetched definition back. `Imports`, `PulumiConfig`, `EnvironmentVariables`, `Files` and every untouched `fn::` expression pass through unchanged; only `Values` is initialised when the stored definition has none. This is the same read-definition / edit / update flow the `esc` CLI uses for `esc env set`.
- `docs/provider/pulumi.md`: two sentences in the PushSecrets section stating that only the pushed key is written and that the value is stored as a plain literal.
- `providers/v1/pulumi/go.mod`: `sigs.k8s.io/yaml` moves from indirect to direct because the new test uses it to decode the PATCH body (no version change, `go.sum` unchanged).

Behaviour of the pushed key itself is unchanged: it is written as a plain literal, exactly as before. Whether a pushed value should be wrapped in `fn::secret` is the open design question raised in the issue and is intentionally left out of this change so it can be decided separately; this PR only stops the data loss.

Testing: new unit tests `TestPushSecret` and `TestPushSecretEmptyEnvironment` (new environment with no `values` block) in `providers/v1/pulumi/pulumi_test.go`, using the existing `httptest` mux. `GET /environments/foo/default/bar` serves a definition with `imports`, `pulumiConfig`, `environmentVariables`, `files`, an `fn::open::aws-login` block and two `fn::secret` values; the `PATCH` handler captures the YAML body. The test pushes `app.token` and asserts everything else is preserved and only `values.app.token` changed (an existing `fn::secret` at that key is replaced by the pushed literal, which is what mergo does when the destination already holds a non-empty value of a different type).

Before the fix the test fails; the PATCH payload is just the pushed key:

```
--- FAIL: TestPushSecret (0.00s)
    pulumi_test.go:466: Not equal:
        expected: map[string]interface {}{"imports":[]interface {}{"base-env"}, "values":map[string]interface {}{"app":map[string]interface {}{"token":"new-token"}, "aws":..., "db":..., "environmentVariables":..., "files":..., "pulumiConfig":...}}
        actual  : map[string]interface {}{"values":map[string]interface {}{"app":map[string]interface {}{"token":"new-token"}}}
FAIL	github.com/external-secrets/external-secrets/providers/v1/pulumi	0.026s
```

After the fix it passes. Also run in `providers/v1/pulumi`: `go test -race ./...`, `go build ./...`, `go vet ./...`, `gofmt -l .`, `golangci-lint run --config ../../../.golangci.yaml ./...` (0 issues), `go mod tidy` (no further diff).

The mock serves the GET definition as JSON while the real API answers `application/x-yaml`; the esc-sdk decodes YAML responses through `gopkg.in/ghodss/yaml.v1` (YAML converted to JSON, then `json.Unmarshal`), so the same `EnvironmentDefinitionValues.UnmarshalJSON` path runs in both cases and nested maps are `map[string]interface{}` either way. Not exercised against a live Pulumi ESC environment.

Related: #6579, #6598 (merges cleanly on top of this branch). Follow-up for the `fn::secret` question: #6935.

## AI Assistance disclosure

AI assistance used: Yes

Tool(s) used: Claude Code (Anthropic).

Purpose of assistance: locating the defect, drafting the fix, the unit test, the docs note and this description.

Parts of the contribution affected: `providers/v1/pulumi/pulumi.go`, `providers/v1/pulumi/pulumi_test.go`, `providers/v1/pulumi/go.mod`, `docs/provider/pulumi.md`.

Validation performed: the diff was checked against the esc-sdk v0.14.0 sources (`GetEnvironment`, `UpdateEnvironment`, the YAML/JSON decode path, `EnvironmentDefinitionValues`) and the `esc` CLI's `env set` flow, and the failing/passing test cycle, build, vet, lint and tidy listed above were run. The change has not been exercised against a live ESC environment.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [ ] All tests pass with `make test` (not run in full; `go test -race ./...` passes in `providers/v1/pulumi`, and the module builds and tests from the repo root workspace)
- [ ] I ensured my PR is ready for review with `make reviewable` (not run in full; `golangci-lint`, `go vet`, `gofmt` and `go mod tidy` are clean for the changed module)
- [x] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [ ] I have tested my changes on a live environment to confirm they are working (no Pulumi ESC account available; the unit test drives the real esc-sdk client against a mocked API)

This change was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.


