### PR TITLE
fix(vault): restore AWS credential env vars after IAM auth login

### DIFF
--- a/providers/v1/vault/auth_iam.go
+++ b/providers/v1/vault/auth_iam.go
@@ -125,10 +125,16 @@ func (c *client) requestTokenWithIamAuth(
 	if err != nil {
 		return err
 	}
-	// Set environment variables. These would be fetched by Login
-	_ = os.Setenv("AWS_ACCESS_KEY_ID", getCreds.AccessKeyID)
-	_ = os.Setenv("AWS_SECRET_ACCESS_KEY", getCreds.SecretAccessKey)
-	_ = os.Setenv("AWS_SESSION_TOKEN", getCreds.SessionToken)
+	// The hashicorp/vault AWS auth client reads its credentials from the
+	// AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_SESSION_TOKEN environment
+	// variables. Set them temporarily and restore the previous values afterwards
+	// so that unrelated SecretStores handled by the same controller process are
+	// not affected (see #6937).
+	restoreAWSCreds, err := setAWSCredentialEnvVars(getCreds)
+	if err != nil {
+		return err
+	}
+	defer restoreAWSCreds()
 
 	var awsAuthClient *authaws.AWSAuth
 
@@ -156,6 +162,42 @@ func (c *client) requestTokenWithIamAuth(
 		return err
 	}
 	return nil
+}
+
+// setAWSCredentialEnvVars sets the AWS credential environment variables that the
+// hashicorp/vault AWS auth client reads during its IAM login, and returns a
+// function that restores the previous environment. The restore function must be
+// called once the login has completed so that credentials for one SecretStore do
+// not leak into the process environment and affect unrelated SecretStores.
+func setAWSCredentialEnvVars(creds aws.Credentials) (func(), error) {
+	envVars := map[string]string{
+		"AWS_ACCESS_KEY_ID":     creds.AccessKeyID,
+		"AWS_SECRET_ACCESS_KEY": creds.SecretAccessKey,
+		"AWS_SESSION_TOKEN":     creds.SessionToken,
+	}
+
+	prev := make(map[string]string, len(envVars))
+	wasSet := make(map[string]bool, len(envVars))
+	for key, value := range envVars {
+		if old, ok := os.LookupEnv(key); ok {
+			prev[key] = old
+			wasSet[key] = true
+		}
+		if err := os.Setenv(key, value); err != nil {
+			return nil, err
+		}
+	}
+
+	return func() {
+		for key, old := range prev {
+			_ = os.Setenv(key, old)
+		}
+		for key := range envVars {
+			if !wasSet[key] {
+				_ = os.Unsetenv(key)
+			}
+		}
+	}, nil
 }
 
 func (c *client) getRegionOrDefault(region string) string {

--- a/providers/v1/vault/auth_iam_test.go
+++ b/providers/v1/vault/auth_iam_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright © The ESO Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vault
+
+import (
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+)
+
+func TestSetAWSCredentialEnvVars(t *testing.T) {
+	creds := aws.Credentials{
+		AccessKeyID:     "test-access-key",
+		SecretAccessKey: "test-secret-key",
+		SessionToken:    "test-session-token",
+	}
+
+	t.Run("sets the credential environment variables", func(t *testing.T) {
+		restore, err := setAWSCredentialEnvVars(creds)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer restore()
+
+		for key, want := range map[string]string{
+			"AWS_ACCESS_KEY_ID":     creds.AccessKeyID,
+			"AWS_SECRET_ACCESS_KEY": creds.SecretAccessKey,
+			"AWS_SESSION_TOKEN":     creds.SessionToken,
+		} {
+			if got := os.Getenv(key); got != want {
+				t.Errorf("expected %s to be %q, got %q", key, want, got)
+			}
+		}
+	})
+
+	t.Run("restores previously set values", func(t *testing.T) {
+		t.Setenv("AWS_ACCESS_KEY_ID", "previous-access")
+		t.Setenv("AWS_SECRET_ACCESS_KEY", "previous-secret")
+		t.Setenv("AWS_SESSION_TOKEN", "previous-token")
+
+		restore, err := setAWSCredentialEnvVars(creds)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		restore()
+
+		for key, want := range map[string]string{
+			"AWS_ACCESS_KEY_ID":     "previous-access",
+			"AWS_SECRET_ACCESS_KEY": "previous-secret",
+			"AWS_SESSION_TOKEN":     "previous-token",
+		} {
+			if got := os.Getenv(key); got != want {
+				t.Errorf("expected %s to be restored to %q, got %q", key, want, got)
+			}
+		}
+	})
+
+	t.Run("unsets previously unset values on restore", func(t *testing.T) {
+		restore, err := setAWSCredentialEnvVars(creds)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if _, ok := os.LookupEnv("AWS_SESSION_TOKEN"); !ok {
+			t.Errorf("expected AWS_SESSION_TOKEN to be set before restore")
+		}
+
+		restore()
+
+		if _, ok := os.LookupEnv("AWS_SESSION_TOKEN"); ok {
+			t.Errorf("expected AWS_SESSION_TOKEN to be unset after restore")
+		}
+	})
+}


### PR DESCRIPTION
## Problem Statement

The Vault AWS IAM auth path (`auth.iam`) resolves credentials (possibly assuming a role via `stscreds.NewAssumeRoleProvider`), then sets them in the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN` environment variables so the hashicorp/vault AWS auth client can pick them up during `Login`.

These environment variables were set with `os.Setenv` and **never restored**. The assumed-role credentials therefore leaked into the controller process environment permanently, causing unrelated `SecretStore`s (for example AWS Secrets Manager stores using the default credential chain, which reads those same env vars first) to fail with STS `AssumeRole`/`TagSession` `AccessDenied` errors.

## Solution

Save the previous values of the three environment variables before setting them and restore them (including unsetting any that were not previously set) once the Vault login completes.

## Related Issue

Fixes #6937

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/external-secrets/external-secrets/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective.
- [x] I have updated the documentation (if needed).

> **Note:** this fix restores the environment after each login, which resolves the reported cross-store contamination. A further hardening step would be to avoid the environment-variable channel entirely (e.g. pass static credentials directly to the AWS auth client) so concurrent IAM logins cannot race; that requires an upstream change to `hashicorp/vault/api/auth/aws`, which currently exposes no `WithCredentials` option.
