### PR TITLE
feat(provider): add custom CA support for Fortanix provider

### DIFF
--- a/apis/externalsecrets/v1/secretstore_fortanix_types.go
+++ b/apis/externalsecrets/v1/secretstore_fortanix_types.go
@@ -25,6 +25,17 @@ type FortanixProvider struct {
 
 	// APIKey is the API token to access SDKMS Applications.
 	APIKey *FortanixProviderSecretRef `json:"apiKey,omitempty"`
+
+	// CABundle is a PEM-encoded CA certificate bundle used to validate
+	// the Fortanix server's TLS certificate. Mutually exclusive with CAProvider.
+	// +optional
+	CABundle []byte `json:"caBundle,omitempty"`
+
+	// CAProvider is a reference to a Secret or ConfigMap that contains a CA certificate.
+	// The certificate is used to validate the Fortanix server's TLS certificate.
+	// Mutually exclusive with CABundle.
+	// +optional
+	CAProvider *CAProvider `json:"caProvider,omitempty"`
 }
 
 // FortanixProviderSecretRef is a secret reference containing the SDKMS API Key.

--- a/apis/externalsecrets/v1beta1/secretstore_fortanix_types.go
+++ b/apis/externalsecrets/v1beta1/secretstore_fortanix_types.go
@@ -25,6 +25,17 @@ type FortanixProvider struct {
 
 	// APIKey is the API token to access SDKMS Applications.
 	APIKey *FortanixProviderSecretRef `json:"apiKey,omitempty"`
+
+	// CABundle is a PEM-encoded CA certificate bundle used to validate
+	// the Fortanix server's TLS certificate. Mutually exclusive with CAProvider.
+	// +optional
+	CABundle []byte `json:"caBundle,omitempty"`
+
+	// CAProvider is a reference to a Secret or ConfigMap that contains a CA certificate.
+	// The certificate is used to validate the Fortanix server's TLS certificate.
+	// Mutually exclusive with CABundle.
+	// +optional
+	CAProvider *CAProvider `json:"caProvider,omitempty"`
 }
 
 // FortanixProviderSecretRef defines a reference to a secret containing credentials for the Fortanix provider.

--- a/docs/provider/fortanix.md
+++ b/docs/provider/fortanix.md
@@ -17,6 +17,7 @@ spec:
   provider:
     fortanix:
       apiUrl: <HOST_OF_SDKMS_API>
+      caBundle: <BASE64_ENCODED_CA_CERT> # or caProvider
       apiKey:
         secretRef:
           name: <NAME_OF_KUBE_SECRET>
@@ -74,5 +75,4 @@ spec:
 
 ## Limitations
 
-- **Custom CA certificates**: connecting to an SDKMS endpoint that uses a self-signed or custom CA certificate is not currently supported (tracked in [issue #6400](https://github.com/external-secrets/external-secrets/issues/6400)).
 - **Read-only**: this provider only reads secrets. Pushing secrets (`PushSecret`) and discovering secrets (`dataFrom.find`) are not supported.

--- a/providers/v1/fortanix/provider.go
+++ b/providers/v1/fortanix/provider.go
@@ -19,6 +19,8 @@ package fortanix
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"net/http"
@@ -64,8 +66,37 @@ func (p *Provider) NewClient(ctx context.Context, store esv1.GenericStore, kube 
 		return nil, fmt.Errorf(errCannotResolveSecretKeyRef, err)
 	}
 
+	httpClient := http.DefaultClient
+
+	if len(config.CABundle) > 0 || config.CAProvider != nil {
+		cert, err := esutils.FetchCACertFromSource(ctx, esutils.CreateCertOpts{
+			StoreKind:  store.GetKind(),
+			Client:     kube,
+			Namespace:  namespace,
+			CABundle:   config.CABundle,
+			CAProvider: config.CAProvider,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		caCertPool := x509.NewCertPool()
+		if !caCertPool.AppendCertsFromPEM(cert) {
+			return nil, errors.New("failed to append caBundle")
+		}
+
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.TLSClientConfig = &tls.Config{
+			RootCAs:    caCertPool,
+			MinVersion: tls.VersionTLS12,
+		}
+		httpClient = &http.Client{
+			Transport: transport,
+		}
+	}
+
 	sdkmsClient := sdkms.Client{
-		HTTPClient: http.DefaultClient,
+		HTTPClient: httpClient,
 		Auth:       sdkms.APIKey(apiKey),
 		Endpoint:   config.APIURL,
 	}

--- a/providers/v1/fortanix/provider_test.go
+++ b/providers/v1/fortanix/provider_test.go
@@ -18,6 +18,7 @@ package fortanix
 import (
 	"context"
 	"errors"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -177,10 +178,18 @@ QJ85ioEpy00NioqcF0WyMZH80uMsPycfpnl5uF7RkW8u
 		require.NoError(t, esv1.AddToScheme(scheme))
 		require.NoError(t, corev1.AddToScheme(scheme))
 		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret, &s).Build()
-		client, err := p.NewClient(context.Background(), &s, fakeClient, "test")
+		clientInterface, err := p.NewClient(context.Background(), &s, fakeClient, "test")
 
-		assert.NoError(t, err)
-		assert.NotNil(t, client)
+		require.NoError(t, err)
+		require.NotNil(t, clientInterface)
+
+		fortanixClient, ok := clientInterface.(*client)
+		require.True(t, ok)
+
+		transport, ok := fortanixClient.sdkms.HTTPClient.Transport.(*http.Transport)
+		require.True(t, ok, "transport should be *http.Transport")
+		require.NotNil(t, transport.TLSClientConfig, "TLSClientConfig should not be nil")
+		require.NotNil(t, transport.TLSClientConfig.RootCAs, "RootCAs should not be nil")
 	})
 }
 

--- a/providers/v1/fortanix/provider_test.go
+++ b/providers/v1/fortanix/provider_test.go
@@ -128,6 +128,60 @@ func TestNewClient(t *testing.T) {
 
 		assert.ErrorContains(t, err, "failed to decode ca bundle")
 	})
+
+	t.Run("with valid inline CA bundle", func(t *testing.T) {
+		p := &Provider{}
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret-name",
+				Namespace: "test",
+			},
+			Data: map[string][]byte{
+				"apiKey": []byte("apiKey"),
+			},
+		}
+		s := esv1.SecretStore{
+			Spec: esv1.SecretStoreSpec{
+				Provider: &esv1.SecretStoreProvider{
+					Fortanix: &esv1.FortanixProvider{
+						CABundle: []byte(`-----BEGIN CERTIFICATE-----
+MIIDHTCCAgWgAwIBAgIRAKC4yxy9QGocND+6avTf7BgwDQYJKoZIhvcNAQELBQAw
+EjEQMA4GA1UEChMHQWNtZSBDbzAeFw0yMTAzMjAyMDA4MDhaFw0yMTAzMjAyMDM4
+MDhaMBIxEDAOBgNVBAoTB0FjbWUgQ28wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw
+ggEKAoIBAQC3o6/JdZEqNbqNRkopHhJtJG5c4qS5d0tQ/kZYpfD/v/izAYum4Nzj
+aG15owr92/11W0pxPUliRLti3y6iScTs+ofm2D7p4UXj/Fnho/2xoWSOoWAodgvW
+Y8jh8A0LQALZiV/9QsrJdXZdS47DYZLsQ3z9yFC/CdXkg1l7AQ3fIVGKdrQBr9kE
+1gEDqnKfRxXI8DEQKXr+CKPUwCAytegmy0SHp53zNAvY+kopHytzmJpXLoEhxq4e
+ugHe52vXHdh/HJ9VjNp0xOH1waAgAGxHlltCW0PVd5AJ0SXROBS/a3V9sZCbCrJa
+YOOonQSEswveSv6PcG9AHvpNPot2Xs6hAgMBAAGjbjBsMA4GA1UdDwEB/wQEAwIC
+pDATBgNVHSUEDDAKBggrBgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQW
+BBR00805mrpoonp95RmC3B6oLl+cGTAVBgNVHREEDjAMggpnb29ibGUuY29tMA0G
+CSqGSIb3DQEBCwUAA4IBAQAipc1b6JrEDayPjpz5GM5krcI8dCWVd8re0a9bGjjN
+ioWGlu/eTr5El0ffwCNZ2WLmL9rewfHf/bMvYz3ioFZJ2OTxfazqYXNggQz6cMfa
+lbedDCdt5XLVX2TyerGvFram+9Uyvk3l0uM7rZnwAmdirG4Tv94QRaD3q4xTj/c0
+mv+AggtK0aRFb9o47z/BypLdk5mhbf3Mmr88C8XBzEnfdYyf4JpTlZrYLBmDCu5d
+9RLLsjXxhag8xqMtd1uLUM8XOTGzVWacw8iGY+CTtBKqyA+AE6/bDwZvEwVtsKtC
+QJ85ioEpy00NioqcF0WyMZH80uMsPycfpnl5uF7RkW8u
+-----END CERTIFICATE-----`),
+						APIKey: &esv1.FortanixProviderSecretRef{
+							SecretRef: &v1.SecretKeySelector{
+								Name: "secret-name",
+								Key:  "apiKey",
+							},
+						},
+					},
+				},
+			},
+		}
+		scheme := runtime.NewScheme()
+		require.NoError(t, esv1.AddToScheme(scheme))
+		require.NoError(t, corev1.AddToScheme(scheme))
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret, &s).Build()
+		client, err := p.NewClient(context.Background(), &s, fakeClient, "test")
+
+		assert.NoError(t, err)
+		assert.NotNil(t, client)
+	})
 }
 
 func TestValidateStore(t *testing.T) {

--- a/providers/v1/fortanix/provider_test.go
+++ b/providers/v1/fortanix/provider_test.go
@@ -92,6 +92,42 @@ func TestNewClient(t *testing.T) {
 
 		assert.ErrorContains(t, err, "cannot resolve secret key ref")
 	})
+
+	t.Run("should fail to create new client if CABundle is invalid base64", func(t *testing.T) {
+		ctx := context.Background()
+		p := &Provider{}
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret-name",
+				Namespace: "test",
+			},
+			Data: map[string][]byte{
+				"apiKey": []byte("apiKey"),
+			},
+		}
+		s := esv1.SecretStore{
+			Spec: esv1.SecretStoreSpec{
+				Provider: &esv1.SecretStoreProvider{
+					Fortanix: &esv1.FortanixProvider{
+						CABundle: []byte("invalid-base64-!@#$"),
+						APIKey: &esv1.FortanixProviderSecretRef{
+							SecretRef: &v1.SecretKeySelector{
+								Name: "secret-name",
+								Key:  "apiKey",
+							},
+						},
+					},
+				},
+			},
+		}
+		scheme := runtime.NewScheme()
+		require.NoError(t, esv1.AddToScheme(scheme))
+		require.NoError(t, corev1.AddToScheme(scheme))
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret, &s).Build()
+		_, err := p.NewClient(ctx, &s, fakeClient, "test")
+
+		assert.ErrorContains(t, err, "failed to decode ca bundle")
+	})
 }
 
 func TestValidateStore(t *testing.T) {


### PR DESCRIPTION
## Problem Statement

Currently, the Fortanix provider does not support custom CA bundles in any way. Using internally signed certificates for Fortanix appliances causes ESO to fail with x509 errors because the SDK hardcodes `http.DefaultClient`.

## Related Issue

Fixes #6400

## Proposed Changes

This PR adds support for custom CA certificates to the Fortanix provider:
- **API (v1/v1beta1):** Added `CABundle` and `CAProvider` to the `FortanixProvider` CRD.
- **Provider Logic:** Updated `NewClient` to parse the CA using `esutils.FetchCACertFromSource` and inject a custom `tls.Config` into the Fortanix SDK's HTTP client.
- **Tests:** Added tests for invalid CA bundles to ensure validation coverage.
- **Docs:** Updated the Fortanix documentation to showcase the new fields and removed the limitation note.

## AI Assistance disclosure

Did you use an script, LLM, or AI assisted development tool for this contribution?

AI assistance used: Yes

If yes provide details:

Tool(s) used: Antigravity IDE (Gemini)

Purpose of assistance: To help scaffold the CRD additions, modify the provider HTTPClient injection, and generate the unit tests based on existing provider patterns (e.g., Infisical/SecretServer).

Parts of the contribution affected: `apis/externalsecrets/v1/secretstore_fortanix_types.go`, `apis/externalsecrets/v1beta1/secretstore_fortanix_types.go`, `providers/v1/fortanix/provider.go`, `providers/v1/fortanix/provider_test.go`, and documentation.

Human validation performed: Yes, manually verified the code logic matches ESO standards and ensured tests pass locally.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
- [x] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [ ] I have tested my changes on a live environment to confirm they are working
