### PR TITLE
fix: do not mark defaulted CRD fields as required

### DIFF
--- a/apis/externalsecrets/v1/secretstore_onboardbase_types.go
+++ b/apis/externalsecrets/v1/secretstore_onboardbase_types.go
@@ -38,15 +38,16 @@ type OnboardbaseProvider struct {
 	Auth *OnboardbaseAuthSecretRef `json:"auth"`
 
 	// APIHost use this to configure the host url for the API for selfhosted installation, default is https://public.onboardbase.com/api/v1/
+	// +optional
 	// +kubebuilder:default:="https://public.onboardbase.com/api/v1/"
-	APIHost string `json:"apiHost"`
+	APIHost string `json:"apiHost,omitempty"`
 
 	// Project is an onboardbase project that the secrets should be pulled from
-	// +kubebuilder:validation:Required
+	// +optional
 	// +kubebuilder:default:="development"
-	Project string `json:"project"`
+	Project string `json:"project,omitempty"`
 	// Environment is the name of an environmnent within a project to pull the secrets from
-	// +kubebuilder:validation:Required
+	// +optional
 	// +kubebuilder:default:="development"
-	Environment string `json:"environment"`
+	Environment string `json:"environment,omitempty"`
 }

--- a/apis/externalsecrets/v1/secretstore_openbao_types.go
+++ b/apis/externalsecrets/v1/secretstore_openbao_types.go
@@ -138,8 +138,9 @@ type OpenBaoUserPassAuth struct {
 	// Path where the UserPassword authentication backend is mounted
 	// in OpenBao, e.g: "userpass"
 	//
+	// +optional
 	// +kubebuilder:default=userpass
-	Path string `json:"path"`
+	Path string `json:"path,omitempty"`
 
 	// Username is a username used to authenticate using the [UserPass
 	// authentication method]
@@ -167,8 +168,9 @@ type OpenBaoAppRole struct {
 	// Path where the App Role authentication backend is mounted
 	// in OpenBao, e.g: "approle"
 	//
+	// +optional
 	// +kubebuilder:default=approle
-	Path string `json:"path"`
+	Path string `json:"path,omitempty"`
 
 	// RoleID configured in the App Role authentication backend when setting
 	// up the authentication backend in OpenBao.
@@ -204,8 +206,9 @@ type OpenBaoAppRole struct {
 type OpenBaoKubernetesAuth struct {
 	// Path where the Kubernetes authentication backend is mounted in OpenBao, e.g:
 	// "kubernetes"
+	// +optional
 	// +kubebuilder:default=kubernetes
-	Path string `json:"path"`
+	Path string `json:"path,omitempty"`
 
 	// Optional service account field containing the name of a Kubernetes ServiceAccount.
 	// If the service account is specified, a token will be requested from the Kubernetes

--- a/apis/externalsecrets/v1/secretstore_vault_types.go
+++ b/apis/externalsecrets/v1/secretstore_vault_types.go
@@ -178,8 +178,9 @@ type VaultAuth struct {
 type VaultAppRole struct {
 	// Path where the App Role authentication backend is mounted
 	// in Vault, e.g: "approle"
+	// +optional
 	// +kubebuilder:default=approle
-	Path string `json:"path"`
+	Path string `json:"path,omitempty"`
 
 	// RoleID configured in the App Role authentication backend when setting
 	// up the authentication backend in Vault.
@@ -205,8 +206,9 @@ type VaultAppRole struct {
 type VaultKubernetesAuth struct {
 	// Path where the Kubernetes authentication backend is mounted in Vault, e.g:
 	// "kubernetes"
+	// +optional
 	// +kubebuilder:default=kubernetes
-	Path string `json:"mountPath"`
+	Path string `json:"mountPath,omitempty"`
 
 	// Optional service account field containing the name of a kubernetes ServiceAccount.
 	// If the service account is specified, the service account secret token JWT will be used
@@ -232,8 +234,9 @@ type VaultKubernetesAuth struct {
 type VaultLdapAuth struct {
 	// Path where the LDAP authentication backend is mounted
 	// in Vault, e.g: "ldap"
+	// +optional
 	// +kubebuilder:default=ldap
-	Path string `json:"path"`
+	Path string `json:"path,omitempty"`
 
 	// Username is an LDAP username used to authenticate using the LDAP Vault
 	// authentication method
@@ -310,8 +313,9 @@ type VaultKubernetesServiceAccountTokenAuth struct {
 type VaultJwtAuth struct {
 	// Path where the JWT authentication backend is mounted
 	// in Vault, e.g: "jwt"
+	// +optional
 	// +kubebuilder:default=jwt
-	Path string `json:"path"`
+	Path string `json:"path,omitempty"`
 
 	// Role is a JWT role to authenticate using the JWT/OIDC Vault
 	// authentication method
@@ -387,8 +391,9 @@ type VaultIamAuth struct {
 type VaultUserPassAuth struct {
 	// Path where the UserPassword authentication backend is mounted
 	// in Vault, e.g: "userpass"
+	// +optional
 	// +kubebuilder:default=userpass
-	Path string `json:"path"`
+	Path string `json:"path,omitempty"`
 
 	// Username is a username used to authenticate using the UserPass Vault
 	// authentication method

--- a/apis/externalsecrets/v1beta1/secretstore_onboardbase_types.go
+++ b/apis/externalsecrets/v1beta1/secretstore_onboardbase_types.go
@@ -38,15 +38,16 @@ type OnboardbaseProvider struct {
 	Auth *OnboardbaseAuthSecretRef `json:"auth"`
 
 	// APIHost use this to configure the host url for the API for selfhosted installation, default is https://public.onboardbase.com/api/v1/
+	// +optional
 	// +kubebuilder:default:="https://public.onboardbase.com/api/v1/"
-	APIHost string `json:"apiHost"`
+	APIHost string `json:"apiHost,omitempty"`
 
 	// Project is an onboardbase project that the secrets should be pulled from
-	// +kubebuilder:validation:Required
+	// +optional
 	// +kubebuilder:default:="development"
-	Project string `json:"project"`
+	Project string `json:"project,omitempty"`
 	// Environment is the name of an environmnent within a project to pull the secrets from
-	// +kubebuilder:validation:Required
+	// +optional
 	// +kubebuilder:default:="development"
-	Environment string `json:"environment"`
+	Environment string `json:"environment,omitempty"`
 }

--- a/apis/externalsecrets/v1beta1/secretstore_vault_types.go
+++ b/apis/externalsecrets/v1beta1/secretstore_vault_types.go
@@ -168,8 +168,9 @@ type VaultAuth struct {
 type VaultAppRole struct {
 	// Path where the App Role authentication backend is mounted
 	// in Vault, e.g: "approle"
+	// +optional
 	// +kubebuilder:default=approle
-	Path string `json:"path"`
+	Path string `json:"path,omitempty"`
 
 	// RoleID configured in the App Role authentication backend when setting
 	// up the authentication backend in Vault.
@@ -194,8 +195,9 @@ type VaultAppRole struct {
 type VaultKubernetesAuth struct {
 	// Path where the Kubernetes authentication backend is mounted in Vault, e.g:
 	// "kubernetes"
+	// +optional
 	// +kubebuilder:default=kubernetes
-	Path string `json:"mountPath"`
+	Path string `json:"mountPath,omitempty"`
 
 	// Optional service account field containing the name of a kubernetes ServiceAccount.
 	// If the service account is specified, the service account secret token JWT will be used
@@ -221,8 +223,9 @@ type VaultKubernetesAuth struct {
 type VaultLdapAuth struct {
 	// Path where the LDAP authentication backend is mounted
 	// in Vault, e.g: "ldap"
+	// +optional
 	// +kubebuilder:default=ldap
-	Path string `json:"path"`
+	Path string `json:"path,omitempty"`
 
 	// Username is an LDAP username used to authenticate using the LDAP Vault
 	// authentication method
@@ -299,8 +302,9 @@ type VaultKubernetesServiceAccountTokenAuth struct {
 type VaultJwtAuth struct {
 	// Path where the JWT authentication backend is mounted
 	// in Vault, e.g: "jwt"
+	// +optional
 	// +kubebuilder:default=jwt
-	Path string `json:"path"`
+	Path string `json:"path,omitempty"`
 
 	// Role is a JWT role to authenticate using the JWT/OIDC Vault
 	// authentication method
@@ -363,8 +367,9 @@ type VaultIamAuth struct {
 type VaultUserPassAuth struct {
 	// Path where the UserPassword authentication backend is mounted
 	// in Vault, e.g: "userpass"
+	// +optional
 	// +kubebuilder:default=userpass
-	Path string `json:"path"`
+	Path string `json:"path,omitempty"`
 
 	// Username is a username used to authenticate using the UserPass Vault
 	// authentication method

--- a/apis/generators/v1alpha1/types_password.go
+++ b/apis/generators/v1alpha1/types_password.go
@@ -25,7 +25,7 @@ type PasswordSpec struct {
 	// Length of the password to be generated.
 	// Defaults to 24
 	// +kubebuilder:default=24
-	Length int `json:"length"`
+	Length int `json:"length,omitempty"`
 
 	// Digits specifies the number of digits in the generated
 	// password. If omitted it defaults to 25% of the length of the password
@@ -41,11 +41,11 @@ type PasswordSpec struct {
 
 	// Set NoUpper to disable uppercase characters
 	// +kubebuilder:default=false
-	NoUpper bool `json:"noUpper"`
+	NoUpper bool `json:"noUpper,omitempty"`
 
 	// set AllowRepeat to true to allow repeating characters.
 	// +kubebuilder:default=false
-	AllowRepeat bool `json:"allowRepeat"`
+	AllowRepeat bool `json:"allowRepeat,omitempty"`
 
 	// SecretKeys defines the keys that will be populated with generated passwords.
 	// Defaults to "password" when not set.

--- a/config/crds/bases/external-secrets.io_clustersecretstores.yaml
+++ b/config/crds/bases/external-secrets.io_clustersecretstores.yaml
@@ -4616,10 +4616,7 @@ spec:
                           should be pulled from
                         type: string
                     required:
-                    - apiHost
                     - auth
-                    - environment
-                    - project
                     type: object
                   onepassword:
                     description: OnePassword configures this store to sync secrets
@@ -4866,7 +4863,6 @@ spec:
                                     type: string
                                 type: object
                             required:
-                            - path
                             - secretRef
                             type: object
                             x-kubernetes-validations:
@@ -4957,7 +4953,6 @@ spec:
                                 - name
                                 type: object
                             required:
-                            - path
                             - role
                             type: object
                             x-kubernetes-validations:
@@ -5053,7 +5048,6 @@ spec:
                                   [UserPass authentication method]: https://openbao.org/docs/auth/userpass/
                                 type: string
                             required:
-                            - path
                             - username
                             type: object
                         type: object
@@ -6293,7 +6287,6 @@ spec:
                                     type: string
                                 type: object
                             required:
-                            - path
                             - secretRef
                             type: object
                           cert:
@@ -6769,8 +6762,6 @@ spec:
                                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                 type: object
-                            required:
-                            - path
                             type: object
                           kubernetes:
                             description: |-
@@ -6853,7 +6844,6 @@ spec:
                                 - name
                                 type: object
                             required:
-                            - mountPath
                             - role
                             type: object
                           ldap:
@@ -6903,7 +6893,6 @@ spec:
                                   authentication method
                                 type: string
                             required:
-                            - path
                             - username
                             type: object
                           namespace:
@@ -6988,7 +6977,6 @@ spec:
                                   authentication method
                                 type: string
                             required:
-                            - path
                             - username
                             type: object
                         type: object
@@ -10358,10 +10346,7 @@ spec:
                           should be pulled from
                         type: string
                     required:
-                    - apiHost
                     - auth
-                    - environment
-                    - project
                     type: object
                   onepassword:
                     description: OnePassword configures this store to sync secrets
@@ -11137,7 +11122,6 @@ spec:
                                     type: string
                                 type: object
                             required:
-                            - path
                             - secretRef
                             type: object
                           cert:
@@ -11463,8 +11447,6 @@ spec:
                                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                 type: object
-                            required:
-                            - path
                             type: object
                           kubernetes:
                             description: |-
@@ -11547,7 +11529,6 @@ spec:
                                 - name
                                 type: object
                             required:
-                            - mountPath
                             - role
                             type: object
                           ldap:
@@ -11597,7 +11578,6 @@ spec:
                                   authentication method
                                 type: string
                             required:
-                            - path
                             - username
                             type: object
                           namespace:
@@ -11682,7 +11662,6 @@ spec:
                                   authentication method
                                 type: string
                             required:
-                            - path
                             - username
                             type: object
                         type: object

--- a/config/crds/bases/external-secrets.io_secretstores.yaml
+++ b/config/crds/bases/external-secrets.io_secretstores.yaml
@@ -4616,10 +4616,7 @@ spec:
                           should be pulled from
                         type: string
                     required:
-                    - apiHost
                     - auth
-                    - environment
-                    - project
                     type: object
                   onepassword:
                     description: OnePassword configures this store to sync secrets
@@ -4866,7 +4863,6 @@ spec:
                                     type: string
                                 type: object
                             required:
-                            - path
                             - secretRef
                             type: object
                             x-kubernetes-validations:
@@ -4957,7 +4953,6 @@ spec:
                                 - name
                                 type: object
                             required:
-                            - path
                             - role
                             type: object
                             x-kubernetes-validations:
@@ -5053,7 +5048,6 @@ spec:
                                   [UserPass authentication method]: https://openbao.org/docs/auth/userpass/
                                 type: string
                             required:
-                            - path
                             - username
                             type: object
                         type: object
@@ -6293,7 +6287,6 @@ spec:
                                     type: string
                                 type: object
                             required:
-                            - path
                             - secretRef
                             type: object
                           cert:
@@ -6769,8 +6762,6 @@ spec:
                                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                 type: object
-                            required:
-                            - path
                             type: object
                           kubernetes:
                             description: |-
@@ -6853,7 +6844,6 @@ spec:
                                 - name
                                 type: object
                             required:
-                            - mountPath
                             - role
                             type: object
                           ldap:
@@ -6903,7 +6893,6 @@ spec:
                                   authentication method
                                 type: string
                             required:
-                            - path
                             - username
                             type: object
                           namespace:
@@ -6988,7 +6977,6 @@ spec:
                                   authentication method
                                 type: string
                             required:
-                            - path
                             - username
                             type: object
                         type: object
@@ -10358,10 +10346,7 @@ spec:
                           should be pulled from
                         type: string
                     required:
-                    - apiHost
                     - auth
-                    - environment
-                    - project
                     type: object
                   onepassword:
                     description: OnePassword configures this store to sync secrets
@@ -11137,7 +11122,6 @@ spec:
                                     type: string
                                 type: object
                             required:
-                            - path
                             - secretRef
                             type: object
                           cert:
@@ -11463,8 +11447,6 @@ spec:
                                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                 type: object
-                            required:
-                            - path
                             type: object
                           kubernetes:
                             description: |-
@@ -11547,7 +11529,6 @@ spec:
                                 - name
                                 type: object
                             required:
-                            - mountPath
                             - role
                             type: object
                           ldap:
@@ -11597,7 +11578,6 @@ spec:
                                   authentication method
                                 type: string
                             required:
-                            - path
                             - username
                             type: object
                           namespace:
@@ -11682,7 +11662,6 @@ spec:
                                   authentication method
                                 type: string
                             required:
-                            - path
                             - username
                             type: object
                         type: object

--- a/config/crds/bases/generators.external-secrets.io_clustergenerators.yaml
+++ b/config/crds/bases/generators.external-secrets.io_clustergenerators.yaml
@@ -1207,10 +1207,6 @@ spec:
                           Symbols specifies the number of symbol characters in the generated
                           password. If omitted it defaults to 25% of the length of the password
                         type: integer
-                    required:
-                    - allowRepeat
-                    - length
-                    - noUpper
                     type: object
                   quayAccessTokenSpec:
                     description: QuayAccessTokenSpec defines the desired state to
@@ -1570,7 +1566,6 @@ spec:
                                         type: string
                                     type: object
                                 required:
-                                - path
                                 - secretRef
                                 type: object
                               cert:
@@ -2050,8 +2045,6 @@ spec:
                                         pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                     type: object
-                                required:
-                                - path
                                 type: object
                               kubernetes:
                                 description: |-
@@ -2134,7 +2127,6 @@ spec:
                                     - name
                                     type: object
                                 required:
-                                - mountPath
                                 - role
                                 type: object
                               ldap:
@@ -2184,7 +2176,6 @@ spec:
                                       authentication method
                                     type: string
                                 required:
-                                - path
                                 - username
                                 type: object
                               namespace:
@@ -2269,7 +2260,6 @@ spec:
                                       authentication method
                                     type: string
                                 required:
-                                - path
                                 - username
                                 type: object
                             type: object

--- a/config/crds/bases/generators.external-secrets.io_passwords.yaml
+++ b/config/crds/bases/generators.external-secrets.io_passwords.yaml
@@ -100,10 +100,6 @@ spec:
                   Symbols specifies the number of symbol characters in the generated
                   password. If omitted it defaults to 25% of the length of the password
                 type: integer
-            required:
-            - allowRepeat
-            - length
-            - noUpper
             type: object
         type: object
     served: true

--- a/config/crds/bases/generators.external-secrets.io_vaultdynamicsecrets.yaml
+++ b/config/crds/bases/generators.external-secrets.io_vaultdynamicsecrets.yaml
@@ -159,7 +159,6 @@ spec:
                                 type: string
                             type: object
                         required:
-                        - path
                         - secretRef
                         type: object
                       cert:
@@ -631,8 +630,6 @@ spec:
                                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                             type: object
-                        required:
-                        - path
                         type: object
                       kubernetes:
                         description: |-
@@ -715,7 +712,6 @@ spec:
                             - name
                             type: object
                         required:
-                        - mountPath
                         - role
                         type: object
                       ldap:
@@ -765,7 +761,6 @@ spec:
                               authentication method
                             type: string
                         required:
-                        - path
                         - username
                         type: object
                       namespace:
@@ -850,7 +845,6 @@ spec:
                               authentication method
                             type: string
                         required:
-                        - path
                         - username
                         type: object
                     type: object

--- a/deploy/crds/bundle.yaml
+++ b/deploy/crds/bundle.yaml
@@ -6622,10 +6622,7 @@ spec:
                           description: Project is an onboardbase project that the secrets should be pulled from
                           type: string
                       required:
-                        - apiHost
                         - auth
-                        - environment
-                        - project
                       type: object
                     onepassword:
                       description: OnePassword configures this store to sync secrets using the 1Password Cloud provider
@@ -6855,7 +6852,6 @@ spec:
                                       type: string
                                   type: object
                               required:
-                                - path
                                 - secretRef
                               type: object
                               x-kubernetes-validations:
@@ -6942,7 +6938,6 @@ spec:
                                     - name
                                   type: object
                               required:
-                                - path
                                 - role
                               type: object
                               x-kubernetes-validations:
@@ -7032,7 +7027,6 @@ spec:
                                     [UserPass authentication method]: https://openbao.org/docs/auth/userpass/
                                   type: string
                               required:
-                                - path
                                 - username
                               type: object
                           type: object
@@ -8184,7 +8178,6 @@ spec:
                                       type: string
                                   type: object
                               required:
-                                - path
                                 - secretRef
                               type: object
                             cert:
@@ -8629,8 +8622,6 @@ spec:
                                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                       type: string
                                   type: object
-                              required:
-                                - path
                               type: object
                             kubernetes:
                               description: |-
@@ -8711,7 +8702,6 @@ spec:
                                     - name
                                   type: object
                               required:
-                                - mountPath
                                 - role
                               type: object
                             ldap:
@@ -8760,7 +8750,6 @@ spec:
                                     authentication method
                                   type: string
                               required:
-                                - path
                                 - username
                               type: object
                             namespace:
@@ -8841,7 +8830,6 @@ spec:
                                     authentication method
                                   type: string
                               required:
-                                - path
                                 - username
                               type: object
                           type: object
@@ -11951,10 +11939,7 @@ spec:
                           description: Project is an onboardbase project that the secrets should be pulled from
                           type: string
                       required:
-                        - apiHost
                         - auth
-                        - environment
-                        - project
                       type: object
                     onepassword:
                       description: OnePassword configures this store to sync secrets using the 1Password Cloud provider
@@ -12673,7 +12658,6 @@ spec:
                                       type: string
                                   type: object
                               required:
-                                - path
                                 - secretRef
                               type: object
                             cert:
@@ -12981,8 +12965,6 @@ spec:
                                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                       type: string
                                   type: object
-                              required:
-                                - path
                               type: object
                             kubernetes:
                               description: |-
@@ -13063,7 +13045,6 @@ spec:
                                     - name
                                   type: object
                               required:
-                                - mountPath
                                 - role
                               type: object
                             ldap:
@@ -13112,7 +13093,6 @@ spec:
                                     authentication method
                                   type: string
                               required:
-                                - path
                                 - username
                               type: object
                             namespace:
@@ -13193,7 +13173,6 @@ spec:
                                     authentication method
                                   type: string
                               required:
-                                - path
                                 - username
                               type: object
                           type: object
@@ -20079,10 +20058,7 @@ spec:
                           description: Project is an onboardbase project that the secrets should be pulled from
                           type: string
                       required:
-                        - apiHost
                         - auth
-                        - environment
-                        - project
                       type: object
                     onepassword:
                       description: OnePassword configures this store to sync secrets using the 1Password Cloud provider
@@ -20312,7 +20288,6 @@ spec:
                                       type: string
                                   type: object
                               required:
-                                - path
                                 - secretRef
                               type: object
                               x-kubernetes-validations:
@@ -20399,7 +20374,6 @@ spec:
                                     - name
                                   type: object
                               required:
-                                - path
                                 - role
                               type: object
                               x-kubernetes-validations:
@@ -20489,7 +20463,6 @@ spec:
                                     [UserPass authentication method]: https://openbao.org/docs/auth/userpass/
                                   type: string
                               required:
-                                - path
                                 - username
                               type: object
                           type: object
@@ -21641,7 +21614,6 @@ spec:
                                       type: string
                                   type: object
                               required:
-                                - path
                                 - secretRef
                               type: object
                             cert:
@@ -22086,8 +22058,6 @@ spec:
                                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                       type: string
                                   type: object
-                              required:
-                                - path
                               type: object
                             kubernetes:
                               description: |-
@@ -22168,7 +22138,6 @@ spec:
                                     - name
                                   type: object
                               required:
-                                - mountPath
                                 - role
                               type: object
                             ldap:
@@ -22217,7 +22186,6 @@ spec:
                                     authentication method
                                   type: string
                               required:
-                                - path
                                 - username
                               type: object
                             namespace:
@@ -22298,7 +22266,6 @@ spec:
                                     authentication method
                                   type: string
                               required:
-                                - path
                                 - username
                               type: object
                           type: object
@@ -25408,10 +25375,7 @@ spec:
                           description: Project is an onboardbase project that the secrets should be pulled from
                           type: string
                       required:
-                        - apiHost
                         - auth
-                        - environment
-                        - project
                       type: object
                     onepassword:
                       description: OnePassword configures this store to sync secrets using the 1Password Cloud provider
@@ -26130,7 +26094,6 @@ spec:
                                       type: string
                                   type: object
                               required:
-                                - path
                                 - secretRef
                               type: object
                             cert:
@@ -26438,8 +26401,6 @@ spec:
                                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                       type: string
                                   type: object
-                              required:
-                                - path
                               type: object
                             kubernetes:
                               description: |-
@@ -26520,7 +26481,6 @@ spec:
                                     - name
                                   type: object
                               required:
-                                - mountPath
                                 - role
                               type: object
                             ldap:
@@ -26569,7 +26529,6 @@ spec:
                                     authentication method
                                   type: string
                               required:
-                                - path
                                 - username
                               type: object
                             namespace:
@@ -26650,7 +26609,6 @@ spec:
                                     authentication method
                                   type: string
                               required:
-                                - path
                                 - username
                               type: object
                           type: object
@@ -28837,10 +28795,6 @@ spec:
                             Symbols specifies the number of symbol characters in the generated
                             password. If omitted it defaults to 25% of the length of the password
                           type: integer
-                      required:
-                        - allowRepeat
-                        - length
-                        - noUpper
                       type: object
                     quayAccessTokenSpec:
                       description: QuayAccessTokenSpec defines the desired state to generate a Quay access token.
@@ -29178,7 +29132,6 @@ spec:
                                           type: string
                                       type: object
                                   required:
-                                    - path
                                     - secretRef
                                   type: object
                                 cert:
@@ -29623,8 +29576,6 @@ spec:
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                       type: object
-                                  required:
-                                    - path
                                   type: object
                                 kubernetes:
                                   description: |-
@@ -29705,7 +29656,6 @@ spec:
                                         - name
                                       type: object
                                   required:
-                                    - mountPath
                                     - role
                                   type: object
                                 ldap:
@@ -29754,7 +29704,6 @@ spec:
                                         authentication method
                                       type: string
                                   required:
-                                    - path
                                     - username
                                   type: object
                                 namespace:
@@ -29835,7 +29784,6 @@ spec:
                                         authentication method
                                       type: string
                                   required:
-                                    - path
                                     - username
                                   type: object
                               type: object
@@ -31464,10 +31412,6 @@ spec:
                     Symbols specifies the number of symbol characters in the generated
                     password. If omitted it defaults to 25% of the length of the password
                   type: integer
-              required:
-                - allowRepeat
-                - length
-                - noUpper
               type: object
           type: object
       served: true
@@ -32049,7 +31993,6 @@ spec:
                                   type: string
                               type: object
                           required:
-                            - path
                             - secretRef
                           type: object
                         cert:
@@ -32494,8 +32437,6 @@ spec:
                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                   type: string
                               type: object
-                          required:
-                            - path
                           type: object
                         kubernetes:
                           description: |-
@@ -32576,7 +32517,6 @@ spec:
                                 - name
                               type: object
                           required:
-                            - mountPath
                             - role
                           type: object
                         ldap:
@@ -32625,7 +32565,6 @@ spec:
                                 authentication method
                               type: string
                           required:
-                            - path
                             - username
                           type: object
                         namespace:
@@ -32706,7 +32645,6 @@ spec:
                                 authentication method
                               type: string
                           required:
-                            - path
                             - username
                           type: object
                       type: object

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -8874,6 +8874,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>APIHost use this to configure the host url for the API for selfhosted installation, default is <a href="https://public.onboardbase.com/api/v1/">https://public.onboardbase.com/api/v1/</a></p>
 </td>
 </tr>
@@ -8885,6 +8886,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Project is an onboardbase project that the secrets should be pulled from</p>
 </td>
 </tr>
@@ -8896,6 +8898,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Environment is the name of an environmnent within a project to pull the secrets from</p>
 </td>
 </tr>
@@ -9171,6 +9174,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Path where the App Role authentication backend is mounted
 in OpenBao, e.g: &ldquo;approle&rdquo;</p>
 </td>
@@ -9370,6 +9374,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Path where the Kubernetes authentication backend is mounted in OpenBao, e.g:
 &ldquo;kubernetes&rdquo;</p>
 </td>
@@ -9565,6 +9570,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Path where the UserPassword authentication backend is mounted
 in OpenBao, e.g: &ldquo;userpass&rdquo;</p>
 </td>
@@ -12875,6 +12881,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Path where the App Role authentication backend is mounted
 in Vault, e.g: &ldquo;approle&rdquo;</p>
 </td>
@@ -13654,6 +13661,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Path where the JWT authentication backend is mounted
 in Vault, e.g: &ldquo;jwt&rdquo;</p>
 </td>
@@ -13751,6 +13759,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Path where the Kubernetes authentication backend is mounted in Vault, e.g:
 &ldquo;kubernetes&rdquo;</p>
 </td>
@@ -13893,6 +13902,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Path where the LDAP authentication backend is mounted
 in Vault, e.g: &ldquo;ldap&rdquo;</p>
 </td>
@@ -14145,6 +14155,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Path where the UserPassword authentication backend is mounted
 in Vault, e.g: &ldquo;userpass&rdquo;</p>
 </td>
@@ -22221,6 +22232,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>APIHost use this to configure the host url for the API for selfhosted installation, default is <a href="https://public.onboardbase.com/api/v1/">https://public.onboardbase.com/api/v1/</a></p>
 </td>
 </tr>
@@ -22232,6 +22244,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Project is an onboardbase project that the secrets should be pulled from</p>
 </td>
 </tr>
@@ -22243,6 +22256,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Environment is the name of an environmnent within a project to pull the secrets from</p>
 </td>
 </tr>
@@ -24939,6 +24953,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Path where the App Role authentication backend is mounted
 in Vault, e.g: &ldquo;approle&rdquo;</p>
 </td>
@@ -25533,6 +25548,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Path where the JWT authentication backend is mounted
 in Vault, e.g: &ldquo;jwt&rdquo;</p>
 </td>
@@ -25631,6 +25647,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Path where the Kubernetes authentication backend is mounted in Vault, e.g:
 &ldquo;kubernetes&rdquo;</p>
 </td>
@@ -25773,6 +25790,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Path where the LDAP authentication backend is mounted
 in Vault, e.g: &ldquo;ldap&rdquo;</p>
 </td>
@@ -26008,6 +26026,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Path where the UserPassword authentication backend is mounted
 in Vault, e.g: &ldquo;userpass&rdquo;</p>
 </td>


### PR DESCRIPTION
## Problem Statement

22 fields across the shipped CRDs have both a `+kubebuilder:default` and a `required`
constraint. The two are independent in controller-gen: a field lands in the schema's
`required` list unless its JSON tag carries `,omitempty` or it is annotated `+optional`.
Several defaulted fields have neither, so they are documented as optional but declared
mandatory.

The API server applies defaults before validation, so a live `kubectl apply` succeeds.
What breaks is client-side validation (kubeconform/kubeval, and the same validators in
Argo CD and Flux pipelines), IDE completion from the CRD schema, and the generated API
reference, which omits `(Optional)`.

## Related Issue

Fixes #6946

## Proposed Changes

Added `+optional` and `,omitempty` to every defaulted field that was still in a `required`
list, and dropped the `+kubebuilder:validation:Required` marker from
`onboardbase.project` / `.environment`, where it sat next to a `"development"` default and
was therefore unreachable. Keeping the default and dropping the marker is the
non-breaking direction; dropping the default instead would change behaviour for existing
users.

Both `+optional` and `,omitempty` are set, per the Kubernetes API conventions and the
existing style in these files (e.g. `PasswordSpec.SecretKeys`). `,omitempty` alone is
enough for controller-gen, but the marker documents the intent and survives a refactor of
the tag.

## AI Assistance disclosure

AI assistance used: Yes

Tool(s) used: Claude Code (Opus 5)

Purpose of assistance: Generation of the issue and PR bodies

Parts of the contribution affected: no  code was authored by the tool. Only the messages

Human validation performed: Yes

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] My changes have reasonable test coverage
- [X] All tests pass with `make test`
- [X] I ensured my PR is ready for review with `make reviewable`
- [X] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [X] I have tested my changes on a live environment to confirm they are working
