### PR TITLE
feat(charts): add rbac.leaderElection.create toggle

### DIFF
--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -224,6 +224,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | rbac.aggregateToEdit | bool | `true` | Specifies whether permissions are aggregated to the edit ClusterRole |
 | rbac.aggregateToView | bool | `true` | Specifies whether permissions are aggregated to the view ClusterRole |
 | rbac.create | bool | `true` | Specifies whether role and rolebinding resources should be created. |
+| rbac.leaderElection | object | `{"create":true}` | Specifies whether the namespaced leader election Role and RoleBinding are created. These are only used when leaderElect is true; set to false to omit them when running without leader election. Only takes effect when rbac.create is true. |
 | rbac.serviceAccountTokenCreate | bool | `true` | Specifies whether the serviceaccounts/token create permission is included in the controller RBAC. When set to false, users must create per-ServiceAccount Role/RoleBinding with resourceNames constraint to grant ESO token creation for specific ServiceAccounts referenced in SecretStore specs. |
 | rbac.servicebindings.create | bool | `true` | Specifies whether a clusterrole to give servicebindings read access should be created. |
 | readinessProbe.enabled | bool | `false` | Determines whether the readiness probe is enabled. Disabled by default. Enabling this will auto-start the health server (--live-addr) even if livenessProbe is disabled. Health server address/port are configured via livenessProbe.spec.address and livenessProbe.spec.port. |

--- a/deploy/charts/external-secrets/templates/rbac.yaml
+++ b/deploy/charts/external-secrets/templates/rbac.yaml
@@ -396,6 +396,7 @@ subjects:
   - name: {{ include "external-secrets.serviceAccountName" . }}
     namespace: {{ template "external-secrets.namespace" . }}
     kind: ServiceAccount
+{{- if .Values.rbac.leaderElection.create }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -446,6 +447,7 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "external-secrets.serviceAccountName" . }}
     namespace: {{ template "external-secrets.namespace" . }}
+{{- end }}
 {{- if .Values.rbac.servicebindings.create }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/charts/external-secrets/tests/rbac_test.yaml
+++ b/deploy/charts/external-secrets/tests/rbac_test.yaml
@@ -113,6 +113,20 @@ tests:
     asserts:
       - matchSnapshot: {}
 
+  - it: should not create leader election Role and RoleBinding when rbac.leaderElection.create is false
+    set:
+      rbac:
+        leaderElection:
+          create: false
+    documentSelector:
+      path: apiVersion
+      value: rbac.authorization.k8s.io/v1
+      matchMany: true
+    asserts:
+      - notEqual:
+          path: metadata.name
+          value: RELEASE-NAME-external-secrets-leaderelection
+
   - it: should render resourceName as external-secrets-controller by default
     set:
       scopedRBAC: true

--- a/deploy/charts/external-secrets/values.schema.json
+++ b/deploy/charts/external-secrets/values.schema.json
@@ -848,6 +848,14 @@
                 "create": {
                     "type": "boolean"
                 },
+                "leaderElection": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean"
+                        }
+                    }
+                },
                 "serviceAccountTokenCreate": {
                     "type": "boolean"
                 },

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -235,6 +235,12 @@ rbac:
   # -- Specifies whether role and rolebinding resources should be created.
   create: true
 
+  # -- Specifies whether the namespaced leader election Role and RoleBinding are created.
+  # These are only used when leaderElect is true; set to false to omit them when running
+  # without leader election. Only takes effect when rbac.create is true.
+  leaderElection:
+    create: true
+
   # -- Specifies whether the serviceaccounts/token create permission is included in the controller RBAC.
   # When set to false, users must create per-ServiceAccount Role/RoleBinding with resourceNames constraint
   # to grant ESO token creation for specific ServiceAccounts referenced in SecretStore specs.


### PR DESCRIPTION
## Problem Statement

In the Helm chart's `templates/rbac.yaml`, the leader-election `Role` and `RoleBinding` are gated only by `rbac.create`. When leader election is disabled (`leaderElect: false`, the default), these resources are still rendered even though they are unused. There is currently no way to opt out of them without also disabling the rest of the RBAC, since both are controlled by the single `rbac.create` switch.

## Related Issue

Fixes #6949

## Proposed Changes

Add a `rbac.leaderElection.create` value (default `true`) and wrap the existing leader-election `Role`/`RoleBinding` in `{{- if .Values.rbac.leaderElection.create }}`. The block stays nested inside the current `rbac.create` gate, so the effective condition is `rbac.create` AND `rbac.leaderElection.create` — no restructuring of the file.

This gives users who run with `leaderElect: false` an opt-out for the unused leader-election RBAC, and mirrors how `certController.rbac.create` is already independent of `certController.create`.

The change is fully backwards compatible:

- `rbac.create: true` (default): leader-election still renders — output is byte-identical to before.
- `rbac.create: false`: still renders nothing (the block remains inside the `rbac.create` gate).

Only an explicit `rbac.leaderElection.create: false` changes behavior. Gating directly on `leaderElect` was considered but rejected: since `leaderElect: false` is the default, it would remove resources from existing default deployments on upgrade — a breaking change.

A helm-unittest case is added asserting the leader-election `Role`/`RoleBinding` are absent when `rbac.leaderElection.create: false`; the existing default-values snapshot continues to cover the default (rendered) behavior.

## AI Assistance disclosure

Did you use an script, LLM, or AI assisted development tool for this contribution?

AI assistance used: Yes

If yes provide details:

Tool(s) used: Amazon Kiro

Purpose of assistance: Drafting the template change, values entry, and unit test; verifying backwards compatibility by rendering the chart across value combinations.

Parts of the contribution affected: `deploy/charts/external-secrets/templates/rbac.yaml`, `deploy/charts/external-secrets/values.yaml`, `deploy/charts/external-secrets/tests/rbac_test.yaml`, and this PR description.

Human validation performed: Reviewed all changes; confirmed the default `helm template` output of `rbac.yaml` is byte-identical to `main` (BC); ran the `rbac` helm-unittest suite (21 tests + 7 snapshots pass); verified `rbac.leaderElection.create: false` removes only the leader-election Role/RoleBinding while cluster roles remain.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
- [x] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [x] I have tested my changes on a live environment to confirm they are working