### PR TITLE
fix(controllers): ignore NotFound when deleting child ExternalSecret/PushSecret

### DIFF
--- a/pkg/controllers/clusterexternalsecret/clusterexternalsecret_controller.go
+++ b/pkg/controllers/clusterexternalsecret/clusterexternalsecret_controller.go
@@ -472,7 +472,7 @@ func (r *Reconciler) deleteExternalSecret(ctx context.Context, esName, cesName, 
 	}
 
 	err = r.Delete(ctx, &existingES, &client.DeleteOptions{})
-	if err != nil {
+	if client.IgnoreNotFound(err) != nil {
 		return fmt.Errorf("external secret in non matching namespace could not be deleted: %w", err)
 	}
 

--- a/pkg/controllers/clusterexternalsecret/delete_externalsecret_test.go
+++ b/pkg/controllers/clusterexternalsecret/delete_externalsecret_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright © The ESO Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterexternalsecret
+
+import (
+	"context"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
+)
+
+// TestDeleteExternalSecretIgnoresNotFound verifies that a Delete that returns
+// NotFound (e.g. the child ExternalSecret was already removed between the
+// cached Get and the Delete) is treated as a successful cleanup rather than a
+// failure.
+func TestDeleteExternalSecretIgnoresNotFound(t *testing.T) {
+	es := &esv1.ExternalSecret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-es",
+			Namespace: "test-ns",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: esv1.SchemeGroupVersion.String(),
+				Kind:       esv1.ClusterExtSecretKind,
+				Name:       "test-ces",
+				Controller: ptr.To(true),
+			}},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	if err := esv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add scheme: %v", err)
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(es).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, c crclient.WithWatch, obj crclient.Object, opts ...crclient.DeleteOption) error {
+				return apierrors.NewNotFound(schema.GroupResource{Group: esv1.Group, Resource: "externalsecrets"}, obj.GetName())
+			},
+		}).
+		Build()
+
+	r := &Reconciler{Client: cl}
+
+	if err := r.deleteExternalSecret(context.Background(), "test-es", "test-ces", "test-ns"); err != nil {
+		t.Fatalf("expected NotFound on delete to be ignored, got: %v", err)
+	}
+}

--- a/pkg/controllers/clusterpushsecret/clusterpushsecret_controller.go
+++ b/pkg/controllers/clusterpushsecret/clusterpushsecret_controller.go
@@ -255,7 +255,7 @@ func (r *Reconciler) deletePushSecret(ctx context.Context, esName, cesName, name
 	}
 
 	err = r.Delete(ctx, &existingPs, &client.DeleteOptions{})
-	if err != nil {
+	if client.IgnoreNotFound(err) != nil {
 		return fmt.Errorf("external secret in non matching namespace could not be deleted: %w", err)
 	}
 

--- a/pkg/controllers/clusterpushsecret/delete_pushsecret_test.go
+++ b/pkg/controllers/clusterpushsecret/delete_pushsecret_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright © The ESO Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterpushsecret
+
+import (
+	"context"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
+)
+
+// TestDeletePushSecretIgnoresNotFound verifies that a Delete that returns
+// NotFound (e.g. the child PushSecret was already removed between the cached
+// Get and the Delete) is treated as a successful cleanup rather than a failure.
+func TestDeletePushSecretIgnoresNotFound(t *testing.T) {
+	ps := &v1alpha1.PushSecret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ps",
+			Namespace: "test-ns",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: v1alpha1.SchemeGroupVersion.String(),
+				Kind:       "ClusterPushSecret",
+				Name:       "test-cps",
+				Controller: ptr.To(true),
+			}},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add scheme: %v", err)
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(ps).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, c crclient.WithWatch, obj crclient.Object, opts ...crclient.DeleteOption) error {
+				return apierrors.NewNotFound(schema.GroupResource{Group: v1alpha1.Group, Resource: "pushsecrets"}, obj.GetName())
+			},
+		}).
+		Build()
+
+	r := &Reconciler{Client: cl}
+
+	if err := r.deletePushSecret(context.Background(), "test-ps", "test-cps", "test-ns"); err != nil {
+		t.Fatalf("expected NotFound on delete to be ignored, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem Statement

When a `ClusterExternalSecret` or `ClusterPushSecret` stops matching a namespace, the controller deletes the owned child object during cleanup. If the child was already removed between the cached `Get` and the `Delete` call, the `Delete` returns `NotFound`. The cleanup path currently treats that as a failure, so namespace cleanup keeps getting recorded as failed even though the child object is already gone.

## Related Issue

Fixes #6888

## Proposed Changes

Wrap the child `Delete` result with `client.IgnoreNotFound` in `deleteExternalSecret` and `deletePushSecret`. An already-absent child already satisfies the cleanup postcondition, so it should be treated as success. All other delete errors are still returned unchanged.

Added a focused regression test for each controller using the fake client, reproducing the race by returning `NotFound` from `Delete` while the object remains present for `Get`.

## AI Assistance disclosure

AI assistance used: No

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
- [x] I confirm that I understand the submitted changes and can explain them without relying on an AI tool.
- [ ] I have tested my changes on a live environment to confirm they are working

Verification performed: `go build`, `go vet`, and `gofmt` on the affected packages, plus `go test ./pkg/controllers/clusterexternalsecret/... ./pkg/controllers/clusterpushsecret/... -run TestDelete` (both regression tests pass).
